### PR TITLE
Sitemap generation base host

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -18,7 +18,7 @@ import tailwindcss from '@tailwindcss/vite';
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://docs.scalekit.dev',
+  site: 'https://docs.scalekit.com',
   redirects,
   integrations: [
     starlight({


### PR DESCRIPTION
As we did not see any problems with the migration so far, our backup CNAME to .dev will soon be removed. To proactively prepare for it, raising this PR for astro starlight to treat .com and it's sitemap.xml going forward.