### PR TITLE
Avoid fails for Husky v10.0.0

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
+
 
 echo "Pre-commit hook executed successfully"


### PR DESCRIPTION
Husky starts to throw a warning is telling us that the first two lines in the pre-commit hook are deprecated and will fail in Husky v10.0.0. This PR fixes it.