### PR TITLE
Cause of failed deployments: uncommitted changes

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,3 +1,11 @@
+#!/bin/sh
+# Check for uncommitted changes
+if [ -n "$(git status --porcelain)" ]; then
+  echo "❌ Error: You have uncommitted changes. Please commit or stash them before pushing."
+  git status --short
+  exit 1
+fi
+
 echo "Running build before push..."
 pnpm run generate-search-index
 pnpm run build


### PR DESCRIPTION
Sometimes when local build fails, users go ahead and fix it. 

After the fix - The build succeeds, and deployment begins. Eventually it fails. 

The reason — after the fix is applied, and build is successful, these fixed changes are still uncommitted. To prevent this human errors husky pre-push will now begin to check if there are changes still to be commited. 