### PR TITLE
Expose delete membership API while hiding cascade

### DIFF
--- a/public/api/scalekit.swagger.json
+++ b/public/api/scalekit.swagger.json
@@ -592,6 +592,47 @@
             }
           }
         }
+      },
+      "delete": {
+        "description": "Removes a user from an organization by user ID or external ID. If the user has no memberships left and cascade is true, the user is also deleted. This action is irreversible and may also remove related group memberships.",
+        "tags": ["Users"],
+        "summary": "Delete organization membership for user",
+        "operationId": "UserService_DeleteMembership",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique organization identifier. Must start with 'org_' and be 1-32 characters long",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "System-generated user ID. Must start with 'usr_' (19-25 characters)",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "External system identifier from connected directories. Must match existing records",
+            "name": "external_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User successfully marked for deletion. No content returned",
+            "schema": {}
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "response = scalekit_client.users.delete_membership(\n  organization_id=org_id,user_id=user_id\n)"
+          }
+        ]
       }
     },
     "/api/v1/organizations/-/connections": {


### PR DESCRIPTION
Cascade behavior of delete membership is undetermined. But given the need for this important use case going forward with this exposing this API without the cascade option for now