### PR TITLE
Reduce automatic formatting issues during collaborations

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,34 @@
+# Dependencies
+node_modules/
+pnpm-lock.yaml
+
+# Build outputs
+dist/
+.astro/
+.netlify/
+
+# Generated files
+*.min.js
+*.min.css
+
+# Logs
+*.log
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# IDE files
+.vscode/
+.cursor/
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# Git
+.git/
+
+# Archives
+archives/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,15 @@
+{
+  "semi": true,
+  "trailingComma": "es5",
+  "singleQuote": true,
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "bracketSpacing": true,
+  "bracketSameLine": false,
+  "arrowParens": "avoid",
+  "endOfLine": "lf",
+  "quoteProps": "as-needed",
+  "jsxSingleQuote": true,
+  "proseWrap": "preserve"
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "astro": "astro",
     "upgrade": "pnpm dlx @astrojs/upgrade",
     "generate-search-index": "node scripts/search-index-apis.js",
-    "prepare": "husky"
+    "prepare": "husky",
+    "format": "prettier --write '**/*.{md,mdx}'",
+    "format:check": "prettier --check '**/*.{md,mdx}'"
   },
   "dependencies": {
     "@astrojs/netlify": "^6.4.0",
@@ -44,6 +46,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.3",
-    "husky": "^9.1.7"
+    "husky": "^9.1.7",
+    "prettier": "^3.6.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      prettier:
+        specifier: ^3.6.1
+        version: 3.6.1
 
 packages:
 
@@ -3750,6 +3753,11 @@ packages:
   precinct@12.2.0:
     resolution: {integrity: sha512-NFBMuwIfaJ4SocE9YXPU/n4AcNSoFMVFjP72nvl3cx69j/ke61/hPOWFREVxLkFhhEGnA8ZuVfTqJBa+PK3b5w==}
     engines: {node: '>=18'}
+    hasBin: true
+
+  prettier@3.6.1:
+    resolution: {integrity: sha512-5xGWRa90Sp2+x1dQtNpIpeOQpTDBs9cZDmA/qs2vDNN2i18PdapqY7CmBeyLlMuGqXJRIOPaCaVZTLNQRWUH/A==}
+    engines: {node: '>=14'}
     hasBin: true
 
   pretty-bytes@6.1.1:
@@ -9347,6 +9355,8 @@ snapshots:
       typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
+
+  prettier@3.6.1: {}
 
   pretty-bytes@6.1.1: {}
 


### PR DESCRIPTION
**Specifics**
- Introduced .prettierignore to exclude specific files and directories from formatting.
- Added .prettierrc with custom formatting options for consistent code style.
- Updated package.json to include Prettier as a development dependency and added format scripts for Markdown files.

**Problem**
All of us use our own code editors and they come with settings that formats the code. I couple of instances in the past, there are changes shown in the git diff that are purely formatting and aesthetic. To reduce such changes creeping into the PR updates, prettier allows to keep that uniformity. This is not enforced, but only available as a option.