### PR TITLE
Add pre-commit hook for targeted Prettier formatting and remove global format command

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,18 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+echo "🔧 Running Prettier on changed files..."
+
+# Get list of staged files that match prettier patterns
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(md|mdx)$' | tr '\n' ' ')
+
+if [ -n "$STAGED_FILES" ]; then
+  echo "📝 Formatting files: $STAGED_FILES"
+  npx prettier --write $STAGED_FILES
+
+  # Re-stage the formatted files
+  git add $STAGED_FILES
+  echo "✅ Prettier formatting completed and files re-staged"
+else
+  echo "ℹ️  No markdown files to format"
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,7 +4,7 @@
 echo "🔧 Running Prettier on changed files..."
 
 # Get list of staged files that match prettier patterns
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(md|mdx)$' | tr '\n' ' ')
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(md|mdx|js|ts|astro|css|vue)$' | tr '\n' ' ')
 
 if [ -n "$STAGED_FILES" ]; then
   echo "📝 Formatting files: $STAGED_FILES"
@@ -14,5 +14,5 @@ if [ -n "$STAGED_FILES" ]; then
   git add $STAGED_FILES
   echo "✅ Prettier formatting completed and files re-staged"
 else
-  echo "ℹ️  No markdown files to format"
+  echo "ℹ️  No files to format"
 fi

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "upgrade": "pnpm dlx @astrojs/upgrade",
     "generate-search-index": "node scripts/search-index-apis.js",
     "prepare": "husky",
-    "format:check": "prettier --check '**/*.{md,mdx}'"
+    "format:check": "prettier --check '**/*.{md,mdx,js,ts,astro,css,vue}'"
   },
   "dependencies": {
     "@astrojs/netlify": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "upgrade": "pnpm dlx @astrojs/upgrade",
     "generate-search-index": "node scripts/search-index-apis.js",
     "prepare": "husky",
-    "format": "prettier --write '**/*.{md,mdx}'",
     "format:check": "prettier --check '**/*.{md,mdx}'"
   },
   "dependencies": {

--- a/src/content/docs/fsa/guides/automated-user-provisioning.mdx
+++ b/src/content/docs/fsa/guides/automated-user-provisioning.mdx
@@ -2,8 +2,7 @@
 title: Automated user provisioning
 description: Automatically provision users when they sign up using social logins and passwordless authentication
 sidebar:
-  label: "Automated user provisioning"
-  badge: "Soon"
+  label: 'Automated user provisioning'
 head:
   - tag: style
     content: |
@@ -14,11 +13,11 @@ head:
         font-size: var(--sl-text-lg);
       }
 prev:
-  label: "JIT Provisioning"
-  link: "/fsa/guides/just-in-time-provisioning/"
+  label: 'JIT Provisioning'
+  link: '/fsa/guides/just-in-time-provisioning/'
 next:
-  label: "Organization switching"
-  link: "/fsa/guides/organization-switching/"
+  label: 'Organization switching'
+  link: '/fsa/guides/organization-switching/'
 ---
 
 import { Steps, Aside, LinkCard, Badge } from '@astrojs/starlight/components';

--- a/src/content/docs/fsa/guides/automated-user-provisioning.mdx
+++ b/src/content/docs/fsa/guides/automated-user-provisioning.mdx
@@ -3,6 +3,7 @@ title: Automated user provisioning
 description: Automatically provision users when they sign up using social logins and passwordless authentication
 sidebar:
   label: 'Automated user provisioning'
+  badge: 'Soon'
 head:
   - tag: style
     content: |


### PR DESCRIPTION
Currently, the project uses a global `pnpm run format` command that runs Prettier across all files, which is inefficient and time-consuming for developers who only need to format their changed files.

1. **Created a new pre-commit hook** (`.husky/pre-commit`) that automatically runs Prettier only on staged files with extensions `.md`, `.mdx`, `.js`, `.ts`, `.astro`, `.css`, and `.vue`
2. **Removed the global format command** (`"format": "prettier --write '**/*.{md,mdx}'"`) from `package.json` to eliminate the inefficient all-files formatting
3. **Updated the format check script** to include the same file types for consistency between pre-commit hooks and CI checks
4. **Enhanced developer experience** by automatically re-staging formatted files and providing clear feedback during the commit process