### PR TITLE
Passwordless: OIDC flow results user profile without having to create users in Scalekit

### DIFF
--- a/src/configs/sidebar.config.ts
+++ b/src/configs/sidebar.config.ts
@@ -126,10 +126,7 @@ export const sidebar = [
           'guides/webhooks-best-practices',
           {
             label: 'Concepts',
-            items: [
-              'guides/directory/user-provisioning-basics',
-              'guides/directory/scim-protocol',
-            ],
+            items: ['guides/directory/user-provisioning-basics', 'guides/directory/scim-protocol'],
           },
         ],
       },
@@ -153,7 +150,7 @@ export const sidebar = [
         label: 'Email customization',
         items: [
           'guides/passwordless/custom-email-provider',
-          //'guides/passwordless/custom-email-templates',
+          'guides/passwordless/custom-email-templates',
         ],
       },
     ],
@@ -194,11 +191,7 @@ export const sidebar = [
       },
       {
         label: 'Guides',
-        items: [
-          'guides/m2m/m2m-basics',
-          'guides/m2m/scopes',
-          'guides/m2m/api-auth-m2m-clients',
-        ],
+        items: ['guides/m2m/m2m-basics', 'guides/m2m/scopes', 'guides/m2m/api-auth-m2m-clients'],
       },
     ],
   },
@@ -297,7 +290,7 @@ export const sidebar = [
       },
     ],
   },
-];
+]
 
 export const topics = {
   exclude: [
@@ -316,4 +309,4 @@ export const topics = {
   'dev-kit': ['/dev-kit/**/*', '/guides/unlisted/passwordless-as-service'], // Include all dev-kit pages
   integrations: ['/guides/integrations/**/*'], // Associate all integration pages with the integrations topic
   'full-stack-auth': ['/fsa/**/*'], // Associate all fsa pages with the full-stack-auth topic
-};
+}

--- a/src/content/docs/guides/passwordless/custom-email-templates.mdx
+++ b/src/content/docs/guides/passwordless/custom-email-templates.mdx
@@ -6,33 +6,83 @@ sidebar:
 slug: "guides/passwordless/custom-email-templates"
 tableOfContents: false
 next: false
-draft: true
 ---
 
-import { Badge, LinkCard, CardGrid, Card } from '@astrojs/starlight/components';
+import { Badge, LinkCard, CardGrid, Card, Aside, Steps } from '@astrojs/starlight/components';
 
-Scalekit uses default email templates to send emails to your users based on the scenario. But, we also support you customizing the email templates with your branding and content so that you can customize the email content to your branding and needs.
-
-To customize the email templates, navigate to _Branding > Email Templates_.
-
-On this page, you can customize the email templates by providing the following information:
-
-- **Subject**: The subject line of the email
-- **Body**: The body of the email
-- **Sender Name**: The name that will be displayed as the sender of the email
-- **Sender Email**: The email address that will be used as the sender of the email
-- **Reply To Email**: The email address that will be used as the reply to email address
-
-You can also use placeholders in the body of the email to customize the email content for each user. The placeholders are:
-
-- `{{user.name}}`: The name of the user
-- `{{user.email}}`: The email address of the user
-- `{{auth_request_id}}`: The authentication request ID
-- `{{otp}}`: The one-time passcode sent to the user
-- `{{magic_link}}`: The magic link sent to the user
-
-Once you have customized your email templates, all the emails that are sent to your users will use your customized emails.
-
-<Card title="Contact Support" icon="slack">
-    This feature is currently available upon request. [Contact our support team](/support/contact-us) to have this feature enabled for your account.
+<Card title="Feature availability" icon="slack">
+    Custom email templates are currently available upon request. [Contact our support team](/support/contact-us) to have this feature enabled for your account.
 </Card>
+
+Scalekit uses default email templates to send authentication emails to your users. You can customize these templates with your own branding and content to provide a consistent experience for your users.
+
+## Customize your email templates
+
+To customize your email templates:
+
+1. Navigate to _Branding > Email Templates_ in your Scalekit dashboard
+2. Customize the following fields:
+   - **Subject**: The subject line of the email
+   - **Body**: The body content of the email
+   - **Sender name**: The display name for the sender
+   - **Sender email**: The email address used as the sender
+   - **Reply to email**: The email address for replies
+
+Once saved, all subsequent emails will use your customized templates.
+
+## Use basic placeholders to personalize emails
+
+You can personalize emails using built-in placeholders. These placeholders are automatically replaced with user-specific information when the email is sent:
+
+- `{{user.name}}`: The user's name
+- `{{user.email}}`: The user's email address
+- `{{auth_request_id}}`: The authentication request ID
+- `{{otp}}`: The one-time passcode
+- `{{magic_link}}`: The magic link for authentication
+
+## Add template variables for advanced customization
+
+For more advanced personalization, you can use template variables to include custom dynamic content in your emails.
+
+### Template variable requirements
+
+- Each variable must be a key-value pair
+- Maximum of 30 variables per template
+- All template variables must have corresponding values in the request
+- Avoid using reserved names: `otp`, `expiry_time_relative`, `link`, `expire_time`, `expiry_time`
+
+### Implement template variables in three steps
+
+<Steps>
+  1. Create your email template with variables:
+     ```html title="Example email template" showLineNumbers=false
+     <p>Hello {{ first_name }},</p>
+     <p>Welcome to {{ company_name }}.</p>
+     <p>Find your onboarding kit: {{ onboarding_resources }}</p>
+     ```
+
+  2. Include variable values in your authentication request:
+     ```js ins={3-8} showLineNumbers=false
+     const sendResponse = await scalekit.passwordless.sendPasswordlessEmail(
+       "<john.doe@example.com>",
+       {
+         templateVariables: {
+           first_name: "John",
+           company_name: "Acme Corp",
+           onboarding_resources: "https://acme.com/onboarding"
+         }
+       }
+     );
+     ```
+
+  3. The sent email will include the replaced values:
+     ```html title="Example email preview" showLineNumbers=false
+     Hello John,
+     Welcome to Acme Corp.
+     Find your onboarding kit: https://acme.com/onboarding
+     ```
+</Steps>
+
+<Aside type="caution">
+  The API will return a 400 status code if your template references any variables that aren't provided in the request.
+</Aside>

--- a/src/content/docs/guides/passwordless/oidc.mdx
+++ b/src/content/docs/guides/passwordless/oidc.mdx
@@ -303,25 +303,72 @@ Before you begin, ensure you have:
 
     The `result` object
 
-    ```js title="Result object" showLineNumbers=false
-    {
-      user: {
-        email: "john.doe@example.com"  // User's email address
-      },
-      idToken: "<USER_PROFILE_JWT>",   // JWT containing user profile information
-      accessToken: "<API_CALL_JWT>",   // Temporary Access Token for accessing user's email
-      expiresIn: 899                    // Token expiration time in seconds
-    }
-    ```
+    <Tabs>
+      <TabItem value="result" label="Result object">
+        ```js showLineNumbers=false wrap
+        {
+          user: {
+            email: "john.doe@example.com"  // User's email address
+          },
+          idToken: "<USER_PROFILE_JWT>",   // JWT containing user profile information
+          accessToken: "<API_CALL_JWT>",   // Temporary Access Token for accessing user's email
+          expiresIn: 899                    // Token expiration time in seconds
+        }
+        ```
+      </TabItem>
+      <TabItem value="idToken" label="Decoded idToken">
+        ```json showLineNumbers=false
+        {
+          "alg": "RS256",
+          "kid": "snk_82937465019283746",
+          "typ": "JWT"
+        }.{
+          "amr": [
+            "conn_92847563920187364"
+          ],
+          "at_hash": "j8kqPm3nRt5Kx2Vy9wL_Zp",
+          "aud": [
+            "skc_73645291837465928"
+          ],
+          "azp": "skc_73645291837465928",
+          "c_hash": "Hy4k2M9pWnX7vqR8_Jt3bg",
+          "client_id": "skc_73645291837465928",
+          "email": "alice.smith@example.com",
+          "email_verified": true,
+          "exp": 1751697469,
+          "iat": 1751438269,
+          "iss": "https://demo-company-dev.scalekit.cloud",
+          "sid": "ses_83746592018273645",
+          "sub": "conn_92847563920187364;alice.smith@example.com" // A scalekit user ID is sent if user management is enabled
+        }.[Signature]
+        ```
+      </TabItem>
+       <TabItem value="idToken" label="Decoded access token">
+        ```json showLineNumbers=false
+        {
+          "alg": "RS256",
+          "kid": "snk_794467716206433",
+          "typ": "JWT"
+        }.{
+          "iss": "https://acme-corp-dev.scalekit.cloud",
+          "sub": "conn_794467724427269;robert.wilson@acme.com",
+          "aud": [
+            "skc_794467724259497"
+          ],
+          "exp": 1751439169,
+          "iat": 1751438269,
+          "nbf": 1751438269,
+          "client_id": "skc_794467724259497",
+          "jti": "tkn_794754665320942"
+        }.[Signature]
+        ```
+      </TabItem>
+    </Tabs>
 
 </Steps>
 
 Congratulations! You've successfully implemented passwordless authentication in your application. Users can now sign in securely without passwords by entering a verification code or clicking a magic link sent to their email.
 
-### Next steps
-
-- Bring your own email provider <Badge variant="note" text="Coming soon" />
-- Customize the email templates to match your brand <Badge variant="note" text="Coming soon" />
 
 <LinkCard
   title="Need more help?"

--- a/src/content/docs/guides/passwordless/quickstart.mdx
+++ b/src/content/docs/guides/passwordless/quickstart.mdx
@@ -466,54 +466,6 @@ Before you begin, ensure you have:
 
 Congratulations! You've successfully implemented passwordless authentication in your application. Users can now sign in securely without passwords by entering a verification code or clicking a magic link sent to their email.
 
-## Customize authentication emails with template variables
-
-Email templates support dynamic content through template variables. Use these variables to personalize authentication emails with custom information like welcome messages, user details, or application-specific data.
-
-Before using template variables:
-1. Configure your custom email template in your [own email provider](/guides/passwordless/custom-email-provider/) or Scalekit's email provider.
-2. Identify the variables you want to replace in your template
-3. Make sure none of your variables use these reserved names (they are reserved and cannot be used): `otp`, `expiry_time_relative`, `link`, `expire_time`, `expiry_time`
-
-**Requirements:**
-- Each template variable must be a key-value pair
-- You can define up to 30 variables per template
-- All variables referenced in your template must have corresponding template variables in the request defined
-
-This is how you can use template variables in your email template:
-
-<Steps>
-  1. Write an email template and use the `{{` and `}}` delimiters to reference the variables.<br />
-     For example:
-     ```html title="Example email template" showLineNumbers=false
-     <p>Hello {{ first_name }},</p>
-     <p>Welcome to {{ company_name }}.</p>
-     <p>Find your onboarding kit: {{ onboarding_resources }}</p>
-     ```
-  2. When sending the passwordless email, pass the template variables in the request.
-     ```js ins={3-8} showLineNumbers=false
-     const sendResponse = await scalekit.passwordless.sendPasswordlessEmail(
-       "<john.doe@example.com>",
-       {
-         templateVariables: {
-           first_name: "John",
-           company_name: "Acme Corp",
-           onboarding_resources: "https://acme.com/onboarding"
-         }
-       }
-     );
-     ```
-  3. The email will be sent with the variables substituted.
-     ```html title="Example email preview" showLineNumbers=false
-     Hello John,
-     Welcome to Acme Corp.
-     Find your onboarding kit: https://acme.com/onboarding
-     ```
-</Steps>
-
-<Aside type="caution">
-  If your email template references a variable that is not provided in the request, the API will return a 400 status code.
-</Aside>
 
 
 ## Next steps


### PR DESCRIPTION
- Open a separate page to document the email templates
- Add a section that lists `idToken` and `accessToken`