### PR TITLE
Go to Dashboard button in the header

### DIFF
--- a/src/components/overrides/Header.astro
+++ b/src/components/overrides/Header.astro
@@ -78,7 +78,7 @@ const { dir, entry, lang, locale } = Astro.props
   }
 
   .nav-link:hover {
-    color: var(--sl-color-text);
+    color: var(--sl-color-accent);
   }
 
   .right-actions {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d2a2cfa4-78b1-4876-840d-cb26712c4e5a)

- Introduces a button in the header
- This can be changed to "sign up" or "sign in", currently chose to retain as "Go to Dashboard" 
- Irrespective of users session, this button says "Go to Dashboard" (for this iteration)