### PR TITLE
Control the order of the API endpoints that come up in the API reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "upgrade": "pnpm dlx @astrojs/upgrade",
     "generate-search-index": "node scripts/search-index-apis.js",
     "postinstall": "node scripts/setup-git-hooks.js",
-    "format:check": "prettier --check '**/*.{md,mdx,js,ts,astro,css,vue}'"
+    "format:check": "prettier --check '**/*.{md,mdx,js,ts,astro,css,vue}'",
+    "reorder-swagger": "node scripts/reorder-swagger.js public/api/scalekit.swagger.json"
   },
   "dependencies": {
     "@astrojs/netlify": "^6.4.0",

--- a/public/api/scalekit.swagger.sorted.json
+++ b/public/api/scalekit.swagger.sorted.json
@@ -1,0 +1,4211 @@
+{
+  "consumes": ["application/json"],
+  "produces": ["application/json"],
+  "schemes": ["https"],
+  "swagger": "2.0",
+  "info": {
+    "description": "# Introduction\n\nThe Scalekit API is a RESTful API that enables you to manage organizations, users, and authentication settings. All requests must use HTTPS.\n\n# Base URL\n\nAll API requests use the following base URLs:\n\n```\nhttps://{environment}.scalekit.dev (Development)\nhttps://{environment}.scalekit.com (Production)\nhttps://auth.example.com (Custom domain)\n```\n\nScalekit operates two separate environments: Development and Production. Resources cannot be moved between environments.\n\n# Authentication\n\nThe Scalekit API uses OAuth 2.0 Client Credentials for authentication.\n\nGetting an access token\n\n1. Get your credentials from the [Scalekit Dashboard](https://app.scalekit.com):\n\n   - environment\n   - client_id\n   - client_secret\n\n2. Request an access token:\n\n```shell\ncurl https://{SCALEKIT_ENVIRONMENT_URL}/oauth/token \\\n  -X POST \\\n  -H 'Content-Type: application/x-www-form-urlencoded' \\\n  -d 'client_id={client_id}' \\\n  -d 'client_secret={client_secret}' \\\n  -d 'grant_type=client_credentials'\n```\n\n3. Use the access token in API requests:\n\n```shell\ncurl https://{SCALEKIT_ENVIRONMENT_URL}/api/v1/organizations \\\n  -H 'Content-Type: application/json' \\\n  -H 'Authorization: Bearer {access_token}'\n```\n\nThe response includes an access token:\n\n```json\n{\n\t\"access_token\": \"eyJhbGciOiJSUzI1NiIsImtpZCI6InNua181Ok4OTEyMjU2NiIsInR5cCI6IkpXVCJ9...\",\n\t\"token_type\": \"Bearer\",\n\t\"expires_in\": 86399,\n\t\"scope\": \"openid\"\n}\n```\n\n# Response Codes\n\nThe API uses standard HTTP status codes:\n\n| Code        | Description          |\n| ----------- | -------------------- |\n| 200/201     | Success              |\n| 400         | Invalid request      |\n| 401         | Authentication error |\n| 404         | Resource not found   |\n| 429         | Rate limit exceeded  |\n| 500/501/504 | Server error         |\n\nError responses include detailed information:\n\n```json\n{\n\t\"code\": 16,\n\t\"message\": \"Token empty\",\n\t\"details\": [\n\t\t{\n\t\t\t\"@type\": \"type.googleapis.com/scalekit.v1.errdetails.ErrorInfo\",\n\t\t\t\"error_code\": \"UNAUTHENTICATED\"\n\t\t}\n\t]\n}\n```\n",
+    "title": "Scalekit APIs",
+    "contact": {
+      "name": "Scalekit Inc",
+      "url": "https://scalekit.com",
+      "email": "support@scalekit.com"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0"
+    },
+    "version": "1.0.0"
+  },
+  "host": "$SCALEKIT_ENVIRONMENT_URL",
+  "paths": {
+    "/api/v1/organizations": {
+      "get": {
+        "description": "Retrieve a paginated list of organizations within your environment. The response includes a `page_token` that can be used to access subsequent pages of results.",
+        "tags": ["Organizations"],
+        "summary": "List organizations",
+        "externalDocs": {
+          "description": "Learn more about organization listing",
+          "url": "https://docs.scalekit.com/"
+        },
+        "operationId": "OrganizationService_ListOrganization",
+        "parameters": [
+          {
+            "type": "integer",
+            "format": "int64",
+            "description": "Maximum number of organizations to return per page. Must be between 10 and 100",
+            "name": "page_size",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Pagination token from the previous response. Use to retrieve the next page of organizations",
+            "name": "page_token",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Your application's unique identifier for this organization, used to link Scalekit with your system",
+            "name": "external_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the list of organizations",
+            "schema": {
+              "$ref": "#/definitions/organizationsListOrganizationsResponse"
+            }
+          },
+          "400": {
+            "description": "Invalid page token",
+            "schema": {}
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const organizations = await scalekit.organization.listOrganization({\n  pageSize: 10,\n});"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "options = ListOrganizationOptions()\noptions.page_size = 10\n\norganizations = sc.organization.list_organizations(\n  options=options\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "organizations, err := sc.Organization.ListOrganizations(\n  ctx,\n  &scalekit.ListOrganizationOptions{\n    PageSize: 10,\n  }\n)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "ListOrganizationsResponse organizations = scalekitClient.organizations().listOrganizations(10, \"\");"
+          }
+        ]
+      },
+      "post": {
+        "description": "Creates a new organization in your environment. Use this endpoint to add a new tenant that can be configured with various settings and metadata",
+        "tags": ["Organizations"],
+        "summary": "Create an organization",
+        "operationId": "OrganizationService_CreateOrganization",
+        "parameters": [
+          {
+            "description": "Organization details",
+            "name": "organization",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "description": "Required parameters for creating a new organization",
+              "$ref": "#/definitions/v1organizationsCreateOrganization"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Returns the newly created organization with its unique identifier and settings",
+            "schema": {
+              "$ref": "#/definitions/organizationsCreateOrganizationResponse"
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const organization = await sc.organization.createOrganization(name, {\n  externalId: 'externalId',\n});"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "options = CreateOrganizationOptions()\noptions.external_id = \"externalId\"\norganization = sc.organization.create_organization(\n  name,\n  options=options\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "organization, err := sc.Organization.CreateOrganization(\n  ctx,\n  name,\n  scalekit.CreateOrganizationOptions{\n    ExternalID: \"externalId\",\n  },\n)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "CreateOrganization createOrganization = CreateOrganization.newBuilder().setDisplayName(\"Test Org\").build();\n\nOrganization createdOrganization = scalekitClient.organizations().create(createOrganization);"
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/{id}": {
+      "get": {
+        "description": "Retrieves organization details by Scalekit ID, including name, region, metadata, and settings",
+        "tags": ["Organizations"],
+        "summary": "Get organization details",
+        "operationId": "OrganizationService_GetOrganization",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique scalekit-generated identifier that uniquely references an organization",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the complete organization object with ID, display name, settings, and metadata",
+            "schema": {
+              "$ref": "#/definitions/organizationsGetOrganizationResponse"
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const sc = new ScalekitClient(\n  <SCALEKIT_ENVIRONMENT_URL>,\n  <SCALEKIT_CLIENT_ID>,\n  <SCALEKIT_CLIENT_SECRET>\n);\n\nconst organization = await sc.organization.getOrganization(organization_id);"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "sc = ScalekitClient(\n  <SCALEKIT_ENVIRONMENT_URL>,\n  <SCALEKIT_CLIENT_ID>,\n  <SCALEKIT_CLIENT_SECRET>\n)\n\norganization = sc.organization.get_organization(\n  organization_id\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "sc := scalekit.NewScalekitClient(\n  <SCALEKIT_ENVIRONMENT_URL>,\n  <SCALEKIT_CLIENT_ID>,\n  <SCALEKIT_CLIENT_SECRET>\n)\n\norganization, err := sc.Organization.GetOrganization(\n  ctx,\n  organizationId\n)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "ScalekitClient scalekitClient = new ScalekitClient(\n  \"<SCALEKIT_ENVIRONMENT_URL>\",\n  \"<SCALEKIT_CLIENT_ID>\",\n  \"<SCALEKIT_CLIENT_SECRET>\"\n);\n\nOrganization organization = scalekitClient.organizations().getById(organizationId);"
+          }
+        ]
+      },
+      "patch": {
+        "description": "Updates an organization's display name, external ID, or metadata. Requires a valid organization identifier. Region code cannot be modified through this endpoint.",
+        "tags": ["Organizations"],
+        "summary": "Update organization details",
+        "operationId": "OrganizationService_UpdateOrganization",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique identifier of the organization to be updated",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "organization",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "description": "Organization Parameters to be updated",
+              "$ref": "#/definitions/v1organizationsUpdateOrganization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the updated organization with all current details reflected in the response.",
+            "schema": {
+              "$ref": "#/definitions/organizationsUpdateOrganizationResponse"
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const organization = await sc.organization.updateOrganization(organization_id, {\n  displayName: 'displayName',\n  externalId: 'externalId',\n});"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "organization = sc.organization.update_organization(organization_id, {\n  display_name: \"display_name\",\n  external_id: \"external_id\"\n})"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "organization, err := sc.Organization.UpdateOrganization(\n  ctx,\n  organizationId,\n  &scalekit.UpdateOrganization{\n    DisplayName: \"displayName\",\n    ExternalId: \"externalId\",\n  },\n)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "UpdateOrganization updateOrganization = UpdateOrganization.newBuilder()\n  .setDisplayName(\"Updated Organization Name\")\n  .build();\n\nOrganization updatedOrganizationById = scalekitClient.organizations().updateById(organizationId, updateOrganization);"
+          }
+        ]
+      },
+      "delete": {
+        "description": "Remove an existing organization from the environment using its unique identifier",
+        "tags": ["Organizations"],
+        "summary": "Delete an organization",
+        "operationId": "OrganizationService_DeleteOrganization",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique scalekit-generated identifier that uniquely references an organization",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Organization successfully deleted and no longer accessible",
+            "schema": {}
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await sc.organization.deleteOrganization(organizationId);"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "sc.organization.delete_organization(organization_id)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "err := sc.Organization.DeleteOrganization(\n  ctx,\n  organizationId\n)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "ScalekitClient scalekitClient = new ScalekitClient(\n  \"<SCALEKIT_ENVIRONMENT_URL>\",\n  \"<SCALEKIT_CLIENT_ID>\",\n  \"<SCALEKIT_CLIENT_SECRET>\"\n);\n\nscalekitClient.organizations().deleteById(organizationId);"
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/-/connections": {
+      "get": {
+        "description": "Retrieves a list of connections for all the organizations",
+        "tags": ["Connections"],
+        "summary": "List organization connections",
+        "operationId": "ConnectionService_ListOrganizationConnections",
+        "parameters": [
+          {
+            "type": "integer",
+            "format": "int64",
+            "description": "Maximum number of organizations to return per page. Value must be between 1 and 30.",
+            "name": "page_size",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Token from a previous response for pagination. Provide this to retrieve the next page of results.",
+            "name": "page_token",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved connections",
+            "schema": {
+              "$ref": "#/definitions/connectionsSearchOrganizationConnectionsResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/organizations/{id}/portal_links": {
+      "put": {
+        "description": "Creates a time-limited Admin Portal URL for IT administrators to configure and manage Single Sign-On (SSO) connections within their organization. Generated links expire after 7 days (168 hours).",
+        "tags": ["Organizations"],
+        "summary": "Generate admin portal link",
+        "operationId": "OrganizationService_GeneratePortalLink",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Organization ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "array",
+            "items": {
+              "enum": ["dir_sync", "sso"],
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "Features to enable in the admin portal link. To enable features, append them as URL parameters:\n\n- Single Sign-On: ?features=sso\n- Directory Sync: ?features=dir_sync\n- Both features: ?features=sso&features=dir_sync\n\nExample URL: https://scalekit.com/portal/lnk_123?features=sso\n\n - dir_sync: dir_sync enables directory synchronization configuration in the portal\n - sso: sso enables Single Sign-On (SSO) configuration in the portal",
+            "name": "features",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Admin Portal link generated successfully. Returns the portal URL and expiration timestamp.",
+            "schema": {
+              "$ref": "#/definitions/organizationsGeneratePortalLinkResponse"
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const link = await sc.organization.generatePortalLink(organization_id);"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "link = sc.organization.generate_portal_link(\n  organization_id\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "link, err := sc.Organization.GeneratePortalLink(\n  ctx,\n  organizationId\n)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "Link portalLink = client\n  .organizations()\n  .generatePortalLink(organizationId, Arrays.asList(Feature.sso, Feature.dir_sync));"
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/{id}/session-settings": {
+      "get": {
+        "description": "Retrieves the currently configured session timeout policies for a specific organization, including absolute and idle timeout values.",
+        "tags": ["Organizations"],
+        "summary": "Get organization session settings",
+        "operationId": "OrganizationService_GetOrganizationSessionSettings",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "The unique identifier of the organization whose session settings are being requested.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "The environment ID to scope the request. This ensures the settings are retrieved from the correct environment.",
+            "name": "environment_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved organization session settings.",
+            "schema": {
+              "$ref": "#/definitions/organizationsGetOrganizationSessionSettingsResponse"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Defines session timeout policies for an organization, including absolute and idle timeout durations. This endpoint is used to configure session lifetimes and enhance security by automatically logging out users after a specified period of inactivity.",
+        "tags": ["Organizations"],
+        "summary": "Create organization session settings",
+        "operationId": "OrganizationService_CreateOrganizationSessionSettings",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "The unique identifier of the organization for which to create session settings.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "The environment ID where the organization exists. This scopes the creation of session settings to a specific environment.",
+            "name": "environment_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Session settings created successfully. Returns the newly configured session policies.",
+            "schema": {
+              "$ref": "#/definitions/organizationsCreateOrganizationSessionSettingsResponse"
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Modifies the session timeout policies for an organization. Use this to adjust the absolute and idle session timeout durations to enforce different security levels.",
+        "tags": ["Organizations"],
+        "summary": "Update organization session settings",
+        "operationId": "OrganizationService_UpdateOrganizationSessionSettings",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique identifier for the organization, beginning with an 'org_' prefix.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "session_settings",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "description": "The session settings to be applied, including absolute and idle timeout configurations.",
+              "$ref": "#/definitions/organizationsOrganizationSessionSettings"
+            }
+          },
+          {
+            "type": "string",
+            "description": "Unique identifier for the environment where the organization resides, prefixed with 'env_'. This specifies the environment context for the session settings.",
+            "name": "environment_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Session settings updated successfully. Returns the modified session policies.",
+            "schema": {
+              "$ref": "#/definitions/organizationsUpdateOrganizationSessionSettingsResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/organizations/{id}/settings": {
+      "patch": {
+        "description": "Updates configuration settings for an organization. Supports modifying SSO configuration, directory synchronization settings, and session parameters. Requires organization ID and the specific settings to update.",
+        "tags": ["Organizations"],
+        "summary": "Toggle organization settings",
+        "operationId": "OrganizationService_UpdateOrganizationSettings",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique identifier of the organization to update settings. Must begin with 'org_' prefix",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "settings",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "description": "Settings configuration to apply to the organization. Contains feature toggles for SSO, directory synchronization, and other organization capabilities",
+              "$ref": "#/definitions/organizationsOrganizationSettings",
+              "example": {
+                "features": [
+                  {
+                    "enabled": true,
+                    "name": "sso"
+                  },
+                  {
+                    "enabled": false,
+                    "name": "directory_sync"
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the complete organization object with updated settings applied. Contains all organization details including ID, display name, and the modified settings.",
+            "schema": {
+              "$ref": "#/definitions/organizationsGetOrganizationResponse"
+            }
+          },
+          "400": {
+            "description": "Invalid request - occurs when the settings payload contains invalid values or unsupported configuration",
+            "schema": {}
+          },
+          "404": {
+            "description": "Organization not found - the specified organization ID doesn't exist",
+            "schema": {}
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const settings = {\n  features: [\n    {\n      name: 'sso',\n      enabled: true,\n    },\n    {\n      name: 'dir_sync',\n      enabled: true,\n    },\n  ],\n};\n\nawait sc.organization.updateOrganizationSettings('<organization_id>', settings);"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "settings = [\n        {\n            \"name\": \"sso\",\n            \"enabled\": true\n        },\n        {\n            \"name\": \"dir_sync\",\n            \"enabled\": true\n        }\n    ]\n\nsc.organization.update_organization_settings(\n  organization_id='<organization_id>', settings=settings\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "settings := OrganizationSettings{\n\t\tFeatures: []Feature{\n\t\t\t{\n\t\t\t\tName:    \"sso\",\n\t\t\t\tEnabled: true,\n\t\t\t},\n\t\t\t{\n\t\t\t\tName:    \"dir_sync\",\n\t\t\t\tEnabled: true,\n\t\t\t},\n\t\t},\n\t}\n\norganization,err := sc.Organization().UpdateOrganizationSettings(ctx, organizationId, settings)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "OrganizationSettingsFeature featureSSO = OrganizationSettingsFeature.newBuilder()\n                .setName(\"sso\")\n                .setEnabled(true)\n                .build();\n\nOrganizationSettingsFeature featureDirectorySync = OrganizationSettingsFeature.newBuilder()\n                .setName(\"dir_sync\")\n                .setEnabled(true)\n                .build();\n\nupdatedOrganization = scalekitClient.organizations()\n                .updateOrganizationSettings(organization.getId(), List.of(featureSSO, featureDirectorySync));"
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/{organization_id}/clients": {
+      "post": {
+        "description": "Creates a new API client for an organization. Returns the client details and a plain secret (available only once).",
+        "tags": ["API Auth"],
+        "summary": "Create organization API client",
+        "operationId": "ClientService_CreateOrganizationClient",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique identifier of the organization",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "client",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "description": "Details of the client to be created",
+              "$ref": "#/definitions/clientsOrganizationClient"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "API client created successfully. Returns the client ID and plain secret (only available at creation time). The client can be configured with scopes, audience values, and custom claims for fine-grained access control.",
+            "schema": {
+              "$ref": "#/definitions/clientsCreateOrganizationClientResponse"
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "from scalekit.v1.clients.clients_pb2 import OrganizationClient\n\nm2m_client = OrganizationClient(\n    name=\"GitHub Actions Deployment Service\",\n    description=\"Service account for GitHub Actions to deploy applications to production\",\n    custom_claims=[\n        {\"key\": \"github_repository\", \"value\": \"acmecorp/inventory-service\"},\n        {\"key\": \"environment\", \"value\": \"production_us\"}\n    ],\n    scopes=[\"deploy:applications\", \"read:deployments\"],\n    audience=[\"deployment-api.acmecorp.com\"],\n    expiry=3600\n)\n\nresponse = sc.m2m_client.create_organization_client(\n    organization_id=\"SCALEKIT_ORGANIZATION_ID\",\n    m2m_client=m2m_client\n)"
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/{organization_id}/directories": {
+      "get": {
+        "tags": ["Directory"],
+        "summary": "List organization directories",
+        "operationId": "DirectoryService_ListDirectories",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique identifier of the organization",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the list of directories for the organization",
+            "schema": {
+              "$ref": "#/definitions/directoriesListDirectoriesResponse"
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await scalekit.directory.listDirectories('<organization_id>');"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "directories_list = sc.directory.list_directories(\n\torganization_id='<organization_id>'\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "directories,err := sc.Directory().ListDirectories(ctx, organizationId)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "ListDirectoriesResponse response = scalekitClient.directories().listDirectories(organizationId);"
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/{organization_id}/users": {
+      "get": {
+        "description": "Retrieves a paginated list of all users who are members of the specified organization. Use this endpoint to view all users with access to a particular organization, including their roles, metadata, and membership details. Supports pagination for large user lists.",
+        "tags": ["Users"],
+        "summary": "List organization users",
+        "operationId": "UserService_ListOrganizationUsers",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique identifier of the organization for which to list users. Must start with 'org_' and be 1-32 characters long.",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "integer",
+            "format": "int64",
+            "description": "Maximum number of users to return in a single response. Valid range: 1-100. Server may return fewer users than specified.",
+            "name": "page_size",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Pagination token from a previous ListUserResponse. Used to retrieve the next page of results. Leave empty for the first request.",
+            "name": "page_token",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the list of users in the organization",
+            "schema": {
+              "$ref": "#/definitions/usersListOrganizationUsersResponse"
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const response = await sc.user.\n  listOrganizationUsers(\"org_123\", {\n\tpageSize: 50,\n});\nconsole.log(response.users);"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "resp, _ = sc.users.list_users(organization_id=\"org_123\", page_size=50)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "list, \n  err := sc.User().ListOrganizationUsers(ctx, \"org_123\", &scalekit.ListUsersOptions{PageSize: 50})\nif err != nil { /* handle error */ }\nfmt.Println(list.Users)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "ListOrganizationUsersRequest listReq = ListOrganiz\n  ationUsersRequest.newBuilder()\n        .setPageSize(50)\n        .build();\nListOrganizationUsersResponse list = users.\n  listOrganizationUsers(\"org_123\", listReq);"
+          }
+        ]
+      },
+      "post": {
+        "description": "Creates a new user account and immediately adds them to the specified organization. Use this endpoint when you want to create a user and grant them access to an organization in a single operation. You can provide user profile information, assign roles, and configure membership metadata. The user receives an activation email unless this feature is disabled in the organization settings.",
+        "tags": ["Users"],
+        "summary": "Create user and add to organization",
+        "operationId": "UserService_CreateUserAndMembership",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "user",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/usersCreateUser"
+            }
+          },
+          {
+            "type": "boolean",
+            "description": "If true, sends an activation email to the user. Defaults to true.",
+            "name": "send_invitation_email",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "User created successfully. Returns the created user object, including system-generated identifiers and timestamps",
+            "schema": {
+              "$ref": "#/definitions/usersCreateUserAndMembershipResponse"
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const {\n   user } = await sc.user.\n    createUserAndMembership(\"org_123\", {\n\temail: \"user@example.com\",\n\texternalId: \"ext_12345a67b89c\",\n\tmetadata: { department: \"engineering\", \n\t  location: \"nyc-office\" },\n\tuserProfile: {\n\t\tfirstName: \"John\",\n\t\tlastName: \"Doe\",\n\t},\n});"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "import os\nfrom scalekit import ScalekitClient\nfrom scalekit.v1.users.users_pb2 import User\nfrom scalekit.v1.commons.\n  commons_pb2 import UserProfile\nsc = ScalekitClient(\n    env_url=os.getenv(\"SCALEKIT_ENV_URL\"),\n    client_id=os.getenv(\"SCALEKIT_CLIENT_ID\"),\n    client_secret=os.getenv(\"SCALEKIT_CLIENT_SECRET\"),\n)\nuser_msg = User(\n    email=\"user@example.com\",\n    external_id=\"ext_12345a67b89c\",\n    metadata={\"department\": \"engineering\", \"location\": \"nyc-office\"},\n    user_profile=UserProfile(\n        first_name=\"John\",\n        last_name=\"Doe\"\n    )\n)\ncreate_resp, \n  _ = sc.users.create_user(\"org_123\", user_msg)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "newUser := &usersv1.CreateUser{\n    Email:      \"user@example.com\",\n    ExternalId: \"ext_12345a67b89c\",\n    Metadata: map[string]string{\n        \"department\": \"engineering\",\n        \"location\":   \"nyc-office\",\n    },\n    UserProfile: &usersv1.CreateUserProfile{\n        FirstName: \"John\",\n        LastName:  \"Doe\",\n    },\n}\ncuResp, \n  err := sc.User().CreateUserAndMembership(ctx, \"org_123\", newUser, false)\nif err != nil { /* handle error */ }"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "CreateUser createUser = CreateUser.newBuilder()\n        .setEmail(\"user@example.com\")\n        .setExternalId(\"ext_12345a67b89c\")\n        .putMetadata(\"department\", \"engineering\")\n        .putMetadata(\"location\", \"nyc-office\")\n        .setUserProfile(\n          CreateUserProfile.newBuilder()\n                .setFirstName(\"John\")\n                .setLastName(\"Doe\")\n                .build())\n        .build();\nCreateUserAndMembershipRequest cuReq = CreateUserA\n  ndMembershipRequest.newBuilder()\n        .setUser(createUser)\n        .build();\nCreateUserAndMembershipResponse cuResp = users.\n  createUserAndMembership(\"org_123\", cuReq);\nSystem.out.println(cuResp.getUser().getId());"
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/{organization_id}/clients/{client_id}": {
+      "get": {
+        "description": "Retrieves details of a specific API client in an organization.",
+        "tags": ["API Auth"],
+        "summary": "Get organization API client",
+        "operationId": "ClientService_GetOrganizationClient",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique identifier of the organization",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Unique identifier of the API client",
+            "name": "client_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the complete API client configuration, including all current settings and a list of active secrets. Note that secret values are not included in the response for security reasons.",
+            "schema": {
+              "$ref": "#/definitions/clientsGetOrganizationClientResponse"
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "# Get client ID from environment variables\norg_id = 'SCALEKIT_ORGANIZATION_ID'\nclient_id = os.environ['M2M_CLIENT_ID']\n\n# Fetch client details for the specified organization\nresponse = sc.m2m_client.get_organization_client(\n    organization_id=org_id,\n    client_id=client_id\n)"
+          }
+        ]
+      },
+      "patch": {
+        "description": "Updates an existing organization API client. Only specified fields are modified.",
+        "tags": ["API Auth"],
+        "summary": "Update organization API client",
+        "operationId": "ClientService_UpdateOrganizationClient",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique identifier of the organization",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Unique identifier of the client",
+            "name": "client_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "client",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "description": "Updated details for the client",
+              "$ref": "#/definitions/clientsOrganizationClient"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the updated organization API client with all current details reflected in the response, including modified scopes, audience values, and custom claims.",
+            "schema": {
+              "$ref": "#/definitions/clientsUpdateOrganizationClientResponse"
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "from scalekit.v1.clients.clients_pb2 import OrganizationClient\n\norg_id = '<SCALEKIT_ORGANIZATION_ID>'\nclient_id = os.environ['M2M_CLIENT_ID']\n\nupdate_m2m_client = OrganizationClient(\n    description=\"Service account for GitHub Actions to deploy applications to production_eu\",\n    custom_claims=[\n        {\"key\": \"github_repository\", \"value\": \"acmecorp/inventory\"},\n        {\"key\": \"environment\", \"value\": \"production_eu\"}\n    ]\n)\n\nresponse = sc.m2m_client.update_organization_client(\n    organization_id=org_id,\n    client_id=client_id,\n    m2m_client=update_m2m_client\n)"
+          }
+        ]
+      },
+      "delete": {
+        "description": "Permanently deletes an API client from an organization. This operation cannot be undone and will revoke all access for the client. All associated secrets will also be invalidated. Use this endpoint to remove unused or compromised clients.",
+        "tags": ["API Auth"],
+        "summary": "Delete organization API client",
+        "operationId": "ClientService_DeleteOrganizationClient",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique identifier of the organization that owns the client. Must start with 'org_' prefix.",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Unique identifier of the API client to permanently delete. Must start with 'm2morg_' prefix.",
+            "name": "client_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Organization API client successfully deleted and no longer accessible",
+            "schema": {}
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "# Get client ID from environment variables\norg_id = '<SCALEKIT_ORGANIZATION_ID>'\nclient_id = os.environ['M2M_CLIENT_ID']\n\n# Delete the specified client from the organization\nresponse = sc.m2m_client.delete_organization_client(\n    organization_id=org_id,\n    client_id=client_id\n)"
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/{organization_id}/connections/{id}": {
+      "get": {
+        "description": "Retrieves the complete configuration and status details for a specific connection by its ID within an organization. Returns all connection properties including provider settings, protocols, and current status.",
+        "tags": ["Connections"],
+        "summary": "Get connection details",
+        "operationId": "ConnectionService_GetConnection",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Organization identifier (required). Specifies which organization owns the connection you want to retrieve.",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Connection identifier (required). Specifies which specific connection to retrieve from the organization.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved connection details for the specified organization",
+            "schema": {
+              "$ref": "#/definitions/connectionsGetConnectionResponse"
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const connection = await sc.connection.getConnection(\n  organizationId,\n  connectionId\n);"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "connection = sc.connection.get_connection(\n  organization_id,\n  connection_id,\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "connection, err := sc.Connection.GetConnection(\n  ctx,\n  organizationId,\n  connectionId,\n)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "Connection connection = client.connections().getConnectionById(connectionId, organizationId);"
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/{organization_id}/connections/{id}:disable": {
+      "patch": {
+        "description": "Deactivate an existing connection for the specified organization. When disabled, users cannot authenticate using this connection. This endpoint changes the connection state from enabled to disabled without modifying other configuration settings",
+        "tags": ["Connections"],
+        "summary": "Disable organization connection",
+        "operationId": "ConnectionService_DisableConnection",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique identifier of the organization associated with the connection",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Unique identifier for the connection to be toggled",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Connection disabled successfully",
+            "schema": {
+              "$ref": "#/definitions/connectionsToggleConnectionResponse"
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await sc.connection.disableConnection(organizationId, connectionId);"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "sc.connection.disable_connection(\n  organization_id,\n  connection_id\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "err := sc.Connection.DisableConnection(\n  ctx,\n  organizationId,\n  connectionId,\n)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "ToggleConnectionResponse response = scalekitClient.connections().disableConnection(connectionId, organizationId);"
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/{organization_id}/connections/{id}:enable": {
+      "patch": {
+        "description": "Activate an existing connection for the specified organization. When enabled, users can authenticate using this connection. This endpoint changes the connection state from disabled to enabled without modifying other configuration settings",
+        "tags": ["Connections"],
+        "summary": "Enable organization connection",
+        "operationId": "ConnectionService_EnableConnection",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique identifier of the organization associated with the connection",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Unique identifier for the connection to be toggled",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Connection enabled successfully",
+            "schema": {
+              "$ref": "#/definitions/connectionsToggleConnectionResponse"
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await sc.connection.enableConnection(organizationId, connectionId);"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "sc.connection.enable_connection(\n  organization_id,\n  connection_id,\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "err := sc.Connection.EnableConnection(\n  ctx,\n  organizationId,\n  connectionId,\n)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "ToggleConnectionResponse response = scalekitClient.connections().enableConnection(connectionId, organizationId);"
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/{organization_id}/directories/{id}": {
+      "get": {
+        "description": "Retrieves detailed information about a specific directory within an organization",
+        "tags": ["Directory"],
+        "summary": "Get directory details",
+        "operationId": "DirectoryService_GetDirectory",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique identifier of the organization",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Unique identifier of the directory",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved directory details",
+            "schema": {
+              "$ref": "#/definitions/directoriesGetDirectoryResponse"
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const { directory } = await scalekit.directory.getDirectory(\n  organizationId,\n  directoryId\n);"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "directory = sc.directory.get_directory(\n  directory_id='<directory_id>', organization_id='<organization_id>'\n)\nprint(f'Directory details: {directory}')"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "directory, err := sc.Directory().GetDirectory(ctx, organizationId, directoryId)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "Directory directory = scalekitClient.directories().getDirectory(directoryId, organizationId);"
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/{organization_id}/directories/{id}:disable": {
+      "patch": {
+        "description": "Stops synchronization of users and groups from a specified directory within an organization. This operation prevents further updates from the connected Directory provider",
+        "tags": ["Directory"],
+        "summary": "Disable a directory",
+        "operationId": "DirectoryService_DisableDirectory",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "A unique identifier for the organization. The value must begin with 'org_' and be between 1 and 32 characters long",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "A unique identifier for a directory within the organization. The value must begin with 'dir_' and be between 1 and 32 characters long",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully disabled the directory",
+            "schema": {
+              "$ref": "#/definitions/directoriesToggleDirectoryResponse"
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await scalekit.directory.disableDirectory(\n  '<organization_id>',\n  '<directory_id>'\n);"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "directory_response = sc.directory.disable_directory(\n  directory_id='<directory_id>', organization_id='<organization_id>'\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "disable,err := sc.Directory().DisableDirectory(ctx, organizationId, directoryId)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "ToggleDirectoryResponse disableResponse = scalekitClient\n  .directories()\n  .disableDirectory(directoryId, organizationId);"
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/{organization_id}/directories/{id}:enable": {
+      "patch": {
+        "description": "Activates a directory within an organization, allowing it to synchronize users and groups with the connected Directory provider",
+        "tags": ["Directory"],
+        "summary": "Enable a directory",
+        "operationId": "DirectoryService_EnableDirectory",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "A unique identifier for the organization. The value must begin with 'org_' and be between 1 and 32 characters long",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "A unique identifier for a directory within the organization. The value must begin with 'dir_' and be between 1 and 32 characters long",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/directoriesToggleDirectoryResponse"
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await sc.directory.enableDirectory('<organization_id>', '<directory_id>');"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "directory_response = sc.directory.enable_directory(\n  directory_id='<directory_id>', organization_id='<organization_id>'\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "enable,err := sc.Directory().EnableDirectory(ctx, organizationId, directoryId)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "ToggleDirectoryResponse enableResponse = client\n  .directories()\n  .enableDirectory(directoryId, organizationId);"
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/{organization_id}/clients/{client_id}/secrets": {
+      "post": {
+        "description": "Creates a new secret for an organization API client. Returns the plain secret (available only once).",
+        "tags": ["API Auth"],
+        "summary": "Create organization API client secret",
+        "operationId": "ClientService_CreateOrganizationClientSecret",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique identifier of the organization",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Unique identifier of the API client",
+            "name": "client_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Client secret created successfully. Returns the new secret ID and the plain secret value (only available at creation time). The secret can be used immediately for authentication.",
+            "schema": {
+              "$ref": "#/definitions/clientsCreateOrganizationClientSecretResponse"
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "# Get client ID from environment variables\norg_id = 'SCALEKIT_ORGANIZATION_ID'\nclient_id = os.environ['M2M_CLIENT_ID']\n\n# Add a new secret to the specified client\nresponse = sc.m2m_client.add_organization_client_secret(\n    organization_id=org_id,\n    client_id=client_id\n)\n\n# Extract the secret ID from the response\nsecret_id = response[0].secret.id"
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/{organization_id}/directories/{directory_id}/groups": {
+      "get": {
+        "description": "Retrieves all groups from a specified directory. Use this endpoint to view group structures from your connected identity provider.",
+        "tags": ["Directory"],
+        "summary": "List directory groups",
+        "operationId": "DirectoryService_ListDirectoryGroups",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique identifier of the organization",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Unique identifier of the directory",
+            "name": "directory_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "integer",
+            "format": "int64",
+            "description": "Number of groups to return per page. Maximum value is 30. If not specified, defaults to 10",
+            "name": "page_size",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Token for pagination. Use the value returned in the 'next_page_token' field of the previous response",
+            "name": "page_token",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "date-time",
+            "description": "Filter groups updated after this timestamp. Use ISO 8601 format",
+            "name": "updated_after",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "description": "If true, includes full group details. If false or not specified, returns basic information only",
+            "name": "include_detail",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "description": "If true, returns group and its details from external provider (default: false)",
+            "name": "include_external_groups",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the list of groups from the specified directory",
+            "schema": {
+              "$ref": "#/definitions/directoriesListDirectoryGroupsResponse"
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const { groups } = await scalekit.directory.listDirectoryGroups(\n  '<organization_id>',\n  '<directory_id>'\n);"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "directory_groups = sc.directory.list_directory_groups(\n  directory_id='<directory_id>', organization_id='<organization_id>'\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "options := &ListDirectoryGroupsOptions{\n\t\tPageSize: 10,\n\t\tPageToken:\"\",\n\t}\n\ndirectoryGroups, err := sc.Directory().ListDirectoryGroups(ctx, organizationId, directoryId, options)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "var options = ListDirectoryResourceOptions.builder()\n  .pageSize(10)\n  .pageToken(\"\")\n  .includeDetail(true)\n  .build();\n\nListDirectoryGroupsResponse groupsResponse = scalekitClient\n  .directories()\n  .listDirectoryGroups(directory.getId(), organizationId, options);"
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/{organization_id}/directories/{directory_id}/users": {
+      "get": {
+        "description": "Retrieves a list of all users within a specified directory for an organization. This endpoint allows you to view user accounts associated with your connected Directory Providers.",
+        "tags": ["Directory"],
+        "summary": "List directory users",
+        "operationId": "DirectoryService_ListDirectoryUsers",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique identifier of the organization",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Unique identifier of the directory within the organization",
+            "name": "directory_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "integer",
+            "format": "int64",
+            "description": "Number of users to return per page. Maximum value is 30. If not specified, defaults to 10",
+            "name": "page_size",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Token for pagination. Use the value returned in the 'next_page_token' field of the previous response to retrieve the next page of results",
+            "name": "page_token",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "description": "If set to true, the response will include the full user payload with all available details. If false or not specified, only essential user information will be returned",
+            "name": "include_detail",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Filter users by their membership in a specific directory group",
+            "name": "directory_group_id",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "date-time",
+            "description": "Filter users that were updated after the specified timestamp. Use ISO 8601 format",
+            "name": "updated_after",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the list of users from the specified directory",
+            "schema": {
+              "$ref": "#/definitions/directoriesListDirectoryUsersResponse"
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const { users } = await scalekit.directory.listDirectoryUsers(\n  '<organization_id>',\n  '<directory_id>'\n);"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "directory_users = sc.directory.list_directory_users(\n  directory_id='<directory_id>', organization_id='<organization_id>'\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "options := &ListDirectoryUsersOptions{\n\t\tPageSize: 10,\n\t\tPageToken: \"\",\n\t}\ndirectoryUsers,err := sc.Directory().ListDirectoryUsers(ctx, organizationId, directoryId, options)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "var options = ListDirectoryResourceOptions.builder()\n  .pageSize(10)\n  .pageToken(\"\")\n  .includeDetail(true)\n  .build();\n\nListDirectoryUsersResponse usersResponse = scalekitClient\n  .directories()\n  .listDirectoryUsers(directory.getId(), organizationId, options);"
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/{organization_id}/clients/{client_id}/secrets/{secret_id}": {
+      "delete": {
+        "description": "Permanently deletes a secret from an organization API client. This operation cannot be undone.",
+        "tags": ["API Auth"],
+        "summary": "Delete organization API client secret",
+        "operationId": "ClientService_DeleteOrganizationClientSecret",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique identifier of the organization",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Unique identifier of the API client",
+            "name": "client_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Unique identifier of the client secret",
+            "name": "secret_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Client secret successfully deleted and no longer accessible",
+            "schema": {}
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "# Get client and secret IDs from environment variables\norg_id = '<SCALEKIT_ORGANIZATION_ID>'\nclient_id = os.environ['M2M_CLIENT_ID']\nsecret_id = os.environ['M2M_SECRET_ID']\n\n# Remove the specified secret from the client\nresponse = sc.m2m_client.remove_organization_client_secret(\n    organization_id=org_id,\n    client_id=client_id,\n    secret_id=secret_id\n)"
+          }
+        ]
+      }
+    },
+    "/api/v1/users": {
+      "get": {
+        "description": "Retrieves a paginated list of all users across your entire environment. Use this endpoint to view all users regardless of their organization memberships. This is useful for administrative purposes, user audits, or when you need to see all users in your Scalekit environment. Supports pagination for large user bases.",
+        "tags": ["Users"],
+        "summary": "List all users in environment",
+        "operationId": "UserService_ListUsers",
+        "parameters": [
+          {
+            "type": "integer",
+            "format": "int64",
+            "description": "Maximum number of organizations to return per page. Must be between 10 and 100",
+            "name": "page_size",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "Pagination token from the previous response. Use to retrieve the next page of organizations",
+            "name": "page_token",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of users.",
+            "schema": {
+              "$ref": "#/definitions/usersListUsersResponse"
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const response = await sc.user.listUsers(\n  { pageSize: 100 });"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "# pass empty org to fetch all users in environment\nresp,_ = sc.users.list_users(organization_id=\"\", page_size=100)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "all, err := sc.User().ListOrganizationUsers(ctx, \"\", &scalekit.ListUsersOptions{PageSize: 100})"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "ListUsersRequest lur = ListUsersRequest.\n  newBuilder().setPageSize(100).build();\nListUsersResponse allUsers = users.listUsers(lur);"
+          }
+        ]
+      }
+    },
+    "/api/v1/users/{id}": {
+      "get": {
+        "description": "Retrieves all details for a user by system-generated user ID or external ID. The response includes organization memberships and user metadata.",
+        "tags": ["Users"],
+        "summary": "Get user details",
+        "operationId": "UserService_GetUser",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "System-generated user ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "Your application's unique identifier for this organization, used to link Scalekit with your system.",
+            "name": "external_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User details retrieved successfully. Returns full user object with system-generated fields and timestamps.",
+            "schema": {
+              "$ref": "#/definitions/usersGetUserResponse"
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const { user } = await sc.user.getUser(user_id);"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "response = users.get_user(organization_id, \n  user_id)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "resp, err := sc.User().GetUser(ctx, userID)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "GetUserResponse resp = scalekit.users().getUser(\n  userId);"
+          }
+        ]
+      },
+      "patch": {
+        "description": "Modifies user account information including profile details, metadata, and external ID. Use this endpoint to update a user's personal information, contact details, or custom metadata. You can update the user's profile, phone number, and metadata fields. Note that fields like user ID, email address, environment ID, and creation time cannot be modified.",
+        "tags": ["Users"],
+        "summary": "Update user details",
+        "operationId": "UserService_UpdateUser",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "System-generated user ID. Must start with 'usr_' and be 19-25 characters long.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "user",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "description": "User fields to update. Only specified fields will be modified. Required fields must be provided if being changed.",
+              "$ref": "#/definitions/v1usersUpdateUser",
+              "example": {
+                "firstName": "John",
+                "lastName": "Doe"
+              }
+            }
+          },
+          {
+            "type": "string",
+            "description": "Your application's unique identifier for this organization, used to link Scalekit with your system.",
+            "name": "external_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User updated successfully. Returns the modified user object with updated timestamps.",
+            "schema": {
+              "$ref": "#/definitions/usersUpdateUserResponse"
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await sc.user.updateUser(\"usr_123\", {\n\tuserProfile: {\n\t\tfirstName: \"John\",\n\t\tlastName: \"Smith\",\n\t},\n\tmetadata: {\n\t\tdepartment: \"sales\",\n\t},\n});"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "import os\nfrom scalekit import ScalekitClient\nfrom scalekit.v1.users.users_pb2 import UpdateUser\nfrom scalekit.v1.commons.\n  commons_pb2 import UserProfile\nsc = ScalekitClient(\n    env_url=os.getenv(\"SCALEKIT_ENV_URL\"),\n    client_id=os.getenv(\"SCALEKIT_CLIENT_ID\"),\n    client_secret=os.getenv(\"SCALEKIT_CLIENT_SECRET\"),\n)\nupdate_user = UpdateUser(\n    user_profile=UserProfile(\n        first_name=\"John\",\n        last_name=\"Smith\"\n    ),\n    metadata={\"department\": \"sales\"}\n)\nsc.users.update_user(organization_id=\"org_123\", \n  user=update_user)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "upd := &usersv1.UpdateUser{\n    UserProfile: &usersv1.UpdateUserProfile{\n        FirstName: \"John\",\n        LastName:  \"Smith\",\n    },\n    Metadata: map[string]string{\n        \"department\": \"sales\",\n    },\n}\nsc.User().UpdateUser(ctx, \"usr_123\", upd)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "UpdateUser upd = UpdateUser.newBuilder()\n        .setUserProfile(\n          UpdateUserProfile.newBuilder()\n                .setFirstName(\"John\")\n                .setLastName(\"Smith\")\n                .build())\n        .putMetadata(\"department\", \"sales\")\n        .build();\nUpdateUserRequest updReq = UpdateUserRequest.\n  newBuilder().setUser(upd).build();\nusers.updateUser(\"usr_123\", updReq);"
+          }
+        ]
+      },
+      "delete": {
+        "description": "Permanently removes a user from your environment and deletes all associated data. Use this endpoint when you need to completely remove a user account. This action deletes the user's profile, memberships, and all related data across all organizations. This operation cannot be undone, so use with caution.",
+        "tags": ["Users"],
+        "summary": "Delete user permanently",
+        "operationId": "UserService_DeleteUser",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "System-generated user ID. Must start with 'usr_' (19-25 characters)",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "External system identifier from connected directories. Must match existing records",
+            "name": "external_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User successfully deleted. No content returned",
+            "schema": {}
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await sc.user.deleteUser(\"usr_123\");"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "sc.users.delete_user(organization_id=\"org_123\", \n  user_id=\"usr_123\")"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "if err := sc.User().DeleteUser(ctx, \n  \"usr_123\"); err != nil {\n    panic(err)\n}"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "users.deleteUser(\"usr_123\");"
+          }
+        ]
+      }
+    },
+    "/api/v1/memberships/organizations/{organization_id}/users/{id}": {
+      "post": {
+        "description": "Adds an existing user to an organization and assigns them specific roles and permissions. Use this endpoint when you want to grant an existing user access to a particular organization. You can specify roles, metadata, and other membership details during the invitation process.",
+        "tags": ["Users"],
+        "summary": "Create membership to add user to organization",
+        "operationId": "UserService_CreateMembership",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique identifier of the target organization. Must start with 'org_' and be 1-32 characters long.",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "System-generated user ID. Must start with 'usr_' (19-25 characters)",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "membership",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "description": "Membership details to create. Required fields must be provided.",
+              "$ref": "#/definitions/v1usersCreateMembership"
+            }
+          },
+          {
+            "type": "string",
+            "description": "External system identifier from connected directories. Must be unique across the system",
+            "name": "external_id",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "description": "If true, sends an activation email to the user. Defaults to true.",
+            "name": "send_invitation_email",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "User successfully added to the organization. Returns details of the updated user membership",
+            "schema": {
+              "$ref": "#/definitions/usersCreateMembershipResponse"
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "import { ScalekitClient } from \"@scalekit-sdk/node\";\nconst sc = new ScalekitClient(\n\tprocess.env.SCALEKIT_ENV_URL,\n\tprocess.env.SCALEKIT_CLIENT_ID,\n\tprocess.env.SCALEKIT_CLIENT_SECRET\n);\nawait sc.user.createMembership(\"org_123\", \"usr_123\", {\n\troles: [\"admin\"],\n\tmetadata: {\n\t\tdepartment: \"engineering\",\n\t\tlocation: \"nyc-office\",\n\t},\n});"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "import os\nfrom scalekit import ScalekitClient\nsc = ScalekitClient(\n    env_url=os.getenv(\"SCALEKIT_ENV_URL\"),\n    client_id=os.getenv(\"SCALEKIT_CLIENT_ID\"),\n    client_secret=os.getenv(\"SCALEKIT_CLIENT_SECRET\"),\n)\n# The Python SDK currently exposes a helper that \n  #simply links an existing\n# user to an organization.\nresp, _ = sc.users.add_user_to_organization(\n    organization_id=\"org_123\",\n    user_id=\"usr_123\",\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "func main() {\n    sc := scalekit.NewScalekitClient(\n        os.Getenv(\"SCALEKIT_ENV_URL\"),\n        os.Getenv(\"SCALEKIT_CLIENT_ID\"),\n        os.Getenv(\"SCALEKIT_CLIENT_SECRET\"),\n    )\n    membership := &usersv1.CreateMembership{\n        Roles: []*usersv1.Role{{Name: \"admin\"}},\n        Metadata: map[string]string{\n            \"department\": \"engineering\",\n            \"location\":   \"nyc-office\",\n        },\n    }\n    resp, \n      err := sc.User().CreateMembership(\n        context.Background(), \"org_123\", \n          \"usr_123\", membership, false)\n    if err != nil {\n        panic(err)\n    }\n}"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "import com.scalekit.ScalekitClient;\nimport com.scalekit.api.UserClient;\nimport com.scalekit.grpc.scalekit.v1.users.*;\nScalekitClient sk = new ScalekitClient(\n    System.getenv(\"SCALEKIT_ENV_URL\"),\n    System.getenv(\"SCALEKIT_CLIENT_ID\"),\n    System.getenv(\"SCALEKIT_CLIENT_SECRET\")\n);\nUserClient users = sk.users();\nCreateMembershipRequest membershipReq = CreateMemb\n  ershipRequest.newBuilder()\n        .setMembership(\n          CreateMembership.newBuilder()\n                .addRoles(Role.newBuilder(\n                  ).setName(\"admin\").build())\n                .putMetadata(\"department\", \"engineering\")\n                .putMetadata(\"location\", \"nyc-office\")\n                .build())\n        .build();\nCreateMembershipResponse res = users.\n  createMembership(\"org_123\", \"usr_123\", \n    membershipReq);"
+          }
+        ]
+      },
+      "patch": {
+        "description": "Updates a user's membership details within an organization by user ID or external ID. You can update roles and membership metadata.",
+        "tags": ["Users"],
+        "summary": "Update user membership details",
+        "operationId": "UserService_UpdateMembership",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique identifier of the organization containing the membership. Must start with 'org_' and be 1-32 characters long.",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "System-generated user ID. Must start with 'usr_' and be 19-25 characters long.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "membership",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "description": "Membership fields to update. Only specified fields will be modified.",
+              "$ref": "#/definitions/v1usersUpdateMembership",
+              "example": {
+                "role": "admin"
+              }
+            }
+          },
+          {
+            "type": "string",
+            "description": "Your application's unique identifier for this user.",
+            "name": "external_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Membership updated successfully. Returns the updated user object.",
+            "schema": {
+              "$ref": "#/definitions/usersUpdateMembershipResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Removes a user from an organization by user ID or external ID. If the user has no memberships left and cascade is true, the user is also deleted. This action is irreversible and may also remove related group memberships.",
+        "tags": ["Users"],
+        "summary": "Delete organization membership for user",
+        "operationId": "UserService_DeleteMembership",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Unique organization identifier. Must start with 'org_' and be 1-32 characters long",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "System-generated user ID. Must start with 'usr_' (19-25 characters)",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "External system identifier from connected directories. Must match existing records",
+            "name": "external_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User successfully marked for deletion. No content returned",
+            "schema": {}
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "response = scalekit_client.users.delete_membership(\n  organization_id=org_id,user_id=user_id\n)"
+          }
+        ]
+      }
+    },
+    "/api/v1/passwordless/email/send": {
+      "post": {
+        "description": "Send a verification email containing either a verification code (OTP), magic link, or both to a user's email address",
+        "tags": ["Passwordless Auth"],
+        "summary": "Send passwordless email",
+        "operationId": "PasswordlessService_SendPasswordlessEmail",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/passwordlessSendPasswordlessRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully sent passwordless authentication email. Returns the authentication request details including expiration time and auth request ID",
+            "schema": {
+              "$ref": "#/definitions/passwordlessSendPasswordlessResponse"
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const response = await scalekit.passwordless.\n  sendPasswordlessEmail(\n\t\"john.doe@example.com\",\n\t{\n\t\ttemplate: \"SIGNIN\",\n\t\texpiresIn: 100,\n\t\tmagiclinkAuthUri: \"https://www.google.com\",\n\t\ttemplateVariables: {\n\t\t\temployeeID: \"EMP523\",\n\t\t\tteamName: \"Alpha Team\",\n\t\t\tsupportEmail: \"support@yourcompany.com\",\n\t\t},\n\t}\n);"
+          }
+        ]
+      }
+    },
+    "/api/v1/passwordless/email/resend": {
+      "post": {
+        "description": "Resend a verification email if the user didn't receive it or if the previous code/link has expired",
+        "tags": ["Passwordless Auth"],
+        "summary": "Resend passwordless email",
+        "operationId": "PasswordlessService_ResendPasswordlessEmail",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/passwordlessResendPasswordlessRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully resent the passwordless authentication email. Returns updated authentication request details with new expiration time.",
+            "schema": {
+              "$ref": "#/definitions/passwordlessSendPasswordlessResponse"
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const { authRequestId } = sendResponse;\nconst resendResponse = await scalekit.passwordless\n.resendPasswordlessEmail(\n    authRequestId\n);"
+          }
+        ]
+      }
+    },
+    "/api/v1/passwordless/email/verify": {
+      "post": {
+        "description": "Verify a user's identity using either a verification code or magic link token",
+        "tags": ["Passwordless Auth"],
+        "summary": "Verify passwordless email",
+        "operationId": "PasswordlessService_VerifyPasswordlessEmail",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/authpasswordlessVerifyPasswordLessRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully verified the passwordless authentication. Returns user email",
+            "schema": {
+              "$ref": "#/definitions/authpasswordlessVerifyPasswordLessResponse"
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const { authRequestId } = sendResponse;\nconst verifyResponse = await scalekit.passwordless.\n  verifyPasswordlessEmail(\n\t// Verification Code (OTP)\n\t{ code: \"123456\" },\n\t// Magic Link Token\n\t{ linkToken: link_token },\n\tauthRequestId\n);"
+          }
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "authpasswordlessPasswordlessType": {
+      "type": "string",
+      "enum": ["OTP", "LINK", "LINK_OTP"]
+    },
+    "authpasswordlessVerifyPasswordLessRequest": {
+      "type": "object",
+      "properties": {
+        "auth_request_id": {
+          "description": "The authentication request identifier returned from the send passwordless email endpoint. Required when verifying OTP codes to link the verification with the original request.",
+          "type": "string",
+          "example": "h5Y8kT5RVwaea5WEgW4n-6C-aO_-fuTUW7Vb9-Rh3AcY9qxZqQ"
+        },
+        "code": {
+          "description": "The Verification Code (OTP) received via email. This is typically a 6-digit numeric code that users enter manually to verify their identity.",
+          "type": "string",
+          "example": "123456"
+        },
+        "link_token": {
+          "description": "The unique token from the magic link URL received via email. Extract this token when users click the magic link and are redirected to your application to later verify the user.",
+          "type": "string",
+          "example": "afe9d61c-d80d-4020-a8ee-61765ab71cb3"
+        }
+      }
+    },
+    "authpasswordlessVerifyPasswordLessResponse": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "description": "Email address of the successfully authenticated user. This confirms which email account was verified through the passwordless flow.",
+          "type": "string",
+          "readOnly": true,
+          "example": "john.doe@example.com"
+        },
+        "passwordless_type": {
+          "description": "The type of passwordless authentication that was successfully verified, confirming which method the user completed.",
+          "$ref": "#/definitions/authpasswordlessPasswordlessType",
+          "example": "OTP"
+        },
+        "state": {
+          "description": "The custom state parameter that was provided in the original authentication request, returned unchanged. Use this to restore your application's context after authentication.",
+          "type": "string",
+          "readOnly": true,
+          "example": "kdt7yiag28t341fr1"
+        },
+        "template": {
+          "description": "Specifies which email template to choose. For User Signin choose SIGNIN and for User Signup use SIGNUP",
+          "$ref": "#/definitions/passwordlessTemplateType",
+          "example": "SIGNIN"
+        }
+      }
+    },
+    "clientsClientSecret": {
+      "description": "A secure credential used for authenticating an API client. Each client can have multiple secrets for key rotation purposes.",
+      "type": "object",
+      "title": "Client Secret",
+      "properties": {
+        "create_time": {
+          "description": "The timestamp when this secret was created. This field is automatically set by the server and cannot be modified.",
+          "type": "string",
+          "format": "date-time",
+          "example": "2024-01-05T14:48:00.000Z"
+        },
+        "created_by": {
+          "description": "The identifier of the user or system that created this secret. This field helps track who created the secret for audit and compliance purposes.",
+          "type": "string",
+          "example": "user_12345"
+        },
+        "expire_time": {
+          "description": "The timestamp when this secret will expire. After this time, the secret cannot be used for authentication regardless of its status. If not set, the secret does not expire.",
+          "type": "string",
+          "format": "date-time",
+          "example": "2025-01-05T14:48:00.000Z"
+        },
+        "id": {
+          "description": "The unique identifier for this client secret. This ID is used to reference the secret in API requests for management operations like updating or deleting the secret.",
+          "type": "string",
+          "example": "sec_1234abcd5678efgh"
+        },
+        "last_used_time": {
+          "description": "The timestamp when this secret was last used for authentication. This field helps track secret usage for security monitoring and identifying unused secrets that may be candidates for rotation.",
+          "type": "string",
+          "format": "date-time",
+          "example": "2024-02-15T10:30:00.000Z"
+        },
+        "plain_secret": {
+          "description": "The full plaintext secret value. This field is only populated when the secret is first created and is never stored by the server. It must be securely stored by the client application as it cannot be retrieved again.",
+          "type": "string",
+          "example": "sec_1234567890abcdefghijklmnopqrstuvwxyz"
+        },
+        "secret_suffix": {
+          "description": "A suffix that helps identify this secret. This is the last few characters of the full secret value but is not sufficient for authentication. Helps identify which secret is being used in logs and debugging.",
+          "type": "string",
+          "example": "xyzw"
+        },
+        "status": {
+          "description": "The current status of this secret. A secret must be ACTIVE to be used for authentication. INACTIVE secrets cannot be used for authentication but are retained for audit purposes.",
+          "$ref": "#/definitions/clientsClientSecretStatus",
+          "example": "ACTIVE"
+        },
+        "update_time": {
+          "description": "The timestamp when this secret was last updated. This field is automatically updated by the server when the secret's status changes or other properties are modified.",
+          "type": "string",
+          "format": "date-time",
+          "example": "2024-01-10T09:12:00.000Z"
+        }
+      }
+    },
+    "clientsClientSecretStatus": {
+      "description": "ClientSecretStatus indicates whether a client secret can be used for authentication.\nACTIVE secrets can be used for authentication while INACTIVE secrets cannot.\n\n - INACTIVE: The secret is inactive and cannot be used for authentication",
+      "type": "string",
+      "enum": ["INACTIVE"]
+    },
+    "clientsCreateOrganizationClientResponse": {
+      "type": "object",
+      "properties": {
+        "client": {
+          "description": "Details of the created client",
+          "$ref": "#/definitions/clientsM2MClient"
+        },
+        "plain_secret": {
+          "description": "Client secret value (only returned once at creation)",
+          "type": "string",
+          "example": "CdExsdErfccxDDssddfffgfeFHH1"
+        }
+      }
+    },
+    "clientsCreateOrganizationClientSecretResponse": {
+      "type": "object",
+      "properties": {
+        "plain_secret": {
+          "description": "Client secret value (only returned once at creation)",
+          "type": "string",
+          "example": "m2morg_client_secret_xyz123"
+        },
+        "secret": {
+          "description": "Details of the created client secret",
+          "$ref": "#/definitions/clientsClientSecret"
+        }
+      }
+    },
+    "clientsCustomClaim": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "description": "The name of the custom claim. Must be between 1 and 128 characters. Use descriptive names that clearly indicate the claim's purpose.",
+          "type": "string",
+          "example": "environment"
+        },
+        "value": {
+          "description": "The value of the custom claim. This value will be included in access tokens issued to the client.",
+          "type": "string",
+          "example": "production"
+        }
+      }
+    },
+    "clientsGetOrganizationClientResponse": {
+      "type": "object",
+      "properties": {
+        "client": {
+          "description": "Details of the requested client",
+          "$ref": "#/definitions/clientsM2MClient"
+        }
+      }
+    },
+    "clientsM2MClient": {
+      "type": "object",
+      "properties": {
+        "application_id": {
+          "description": "The ID of the application associated with this API client. This field is used to link the client to a specific application in the system.",
+          "type": "string",
+          "example": "app_1231234233424344"
+        },
+        "audience": {
+          "description": "The intended recipients of access tokens issued to this client. Each audience value should be a URI that identifies an API or service.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "example": ["https://api.example.com"]
+        },
+        "client_id": {
+          "description": "The unique identifier for this API client. This ID is used to identify the client in API requests and logs. It is automatically generated when the client is created and cannot be modified.",
+          "type": "string",
+          "example": "m2morg_1231234233424344"
+        },
+        "create_time": {
+          "description": "The timestamp when this API client was created. This field is automatically set by the server and cannot be modified.",
+          "type": "string",
+          "format": "date-time",
+          "example": "2024-01-05T14:48:00.000Z"
+        },
+        "custom_claims": {
+          "description": "Additional claims included in access tokens issued to this client. These claims provide context about the client and can be used for authorization decisions.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/clientsCustomClaim"
+          }
+        },
+        "description": {
+          "description": "A detailed description of the client's purpose and usage. This helps administrators understand what the client is used for.",
+          "type": "string",
+          "example": "Service account for automated deployment processes"
+        },
+        "expiry": {
+          "description": "The lifetime of access tokens issued to this client, in seconds. This determines how long a token remains valid before it must be refreshed.",
+          "type": "string",
+          "format": "int64",
+          "example": 3600
+        },
+        "name": {
+          "description": "The display name of the API client. This name helps identify the client in the dashboard and logs.",
+          "type": "string",
+          "example": "GitHub Actions Deployment Service"
+        },
+        "organization_id": {
+          "description": "The ID of the organization that owns this API client. This ID is used to associate the client with the correct organization and enforce organization-specific access controls.",
+          "type": "string",
+          "example": "org_1231234233424344"
+        },
+        "redirect_uris": {
+          "description": "The redirect URI for this API client. This URI is used in the OAuth 2.0 authorization flow to redirect users after authentication.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "example": "https://example.com/callback"
+        },
+        "scopes": {
+          "description": "The OAuth 2.0 scopes granted to this client. These scopes determine what resources and actions the client can access.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "example": ["deploy:applications", "read:deployments"]
+        },
+        "secrets": {
+          "description": "List of client secrets associated with this client. Each secret can be used for authentication, but only the most recently created secret is typically active. Secrets are stored securely and their values are never returned after creation.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/clientsClientSecret"
+          }
+        },
+        "update_time": {
+          "description": "The timestamp when this API client was last updated. This field is automatically updated by the server whenever the client's configuration changes.",
+          "type": "string",
+          "format": "date-time",
+          "example": "2024-01-05T14:48:00.000Z"
+        }
+      }
+    },
+    "clientsOrganizationClient": {
+      "type": "object",
+      "properties": {
+        "audience": {
+          "description": "The intended recipients of the access tokens issued to this client. Each audience value should be a URI that identifies the API or service that will validate the token.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "example": [
+            "https://api.example.com/api/analytics",
+            "https://deployment-api.acmecorp.com"
+          ]
+        },
+        "custom_claims": {
+          "description": "Additional claims to be included in access tokens issued to this client. These claims provide context about the client and can be used for authorization decisions. Keep claims minimal to avoid increasing token size.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/clientsCustomClaim"
+          },
+          "example": [
+            {
+              "key": "environment",
+              "value": "production"
+            },
+            {
+              "key": "service",
+              "value": "deployment"
+            }
+          ]
+        },
+        "description": {
+          "description": "A detailed explanation of the client's purpose and usage. This helps administrators understand what the client is used for and who manages it.",
+          "type": "string",
+          "example": "Service account for GitHub Actions to deploy applications to production"
+        },
+        "expiry": {
+          "description": "The lifetime of access tokens issued to this client, in seconds. This value determines how long a token remains valid before it must be refreshed. Defaults to 3600 (1 hour) if not specified.",
+          "type": "string",
+          "format": "int64",
+          "example": 3600
+        },
+        "name": {
+          "description": "A descriptive name for the API client that helps identify its purpose. This name is displayed in the dashboard and logs. Must be between 1 and 128 characters.",
+          "type": "string",
+          "example": "GitHub Actions Deployment Service"
+        },
+        "scopes": {
+          "description": "OAuth 2.0 scopes that define the permissions granted to this client. Each scope represents a specific permission or set of permissions. The client can only access resources that match its granted scopes.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "example": ["deploy:applications", "read:deployments"]
+        }
+      }
+    },
+    "clientsUpdateOrganizationClientResponse": {
+      "type": "object",
+      "properties": {
+        "client": {
+          "description": "Updated details of the client",
+          "$ref": "#/definitions/clientsM2MClient"
+        }
+      }
+    },
+    "commonsIdentityProviderType": {
+      "type": "string",
+      "enum": [
+        "OKTA",
+        "GOOGLE",
+        "MICROSOFT_AD",
+        "AUTH0",
+        "ONELOGIN",
+        "PING_IDENTITY",
+        "JUMPCLOUD",
+        "CUSTOM",
+        "GITHUB",
+        "GITLAB",
+        "LINKEDIN",
+        "SALESFORCE",
+        "MICROSOFT",
+        "IDP_SIMULATOR",
+        "SCALEKIT",
+        "ADFS"
+      ]
+    },
+    "commonsMembershipStatus": {
+      "type": "string",
+      "enum": ["ACTIVE", "INACTIVE", "PENDING_INVITE"]
+    },
+    "commonsOrganizationMembership": {
+      "type": "object",
+      "properties": {
+        "join_time": {
+          "description": "Timestamp when the membership was created. Automatically set by the server.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "membership_status": {
+          "$ref": "#/definitions/commonsMembershipStatus"
+        },
+        "metadata": {
+          "description": "Custom key-value pairs for storing additional user context. Keys (3-25 chars), values (1-256 chars).",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "example": {
+            "department": "engineering",
+            "location": "nyc-office"
+          }
+        },
+        "name": {
+          "type": "string"
+        },
+        "organization_id": {
+          "description": "Unique identifier for the organization. Immutable and read-only.",
+          "type": "string",
+          "example": "org_1234abcd5678efgh"
+        },
+        "primary_identity_provider": {
+          "$ref": "#/definitions/commonsIdentityProviderType"
+        },
+        "roles": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/commonsRole"
+          }
+        }
+      }
+    },
+    "commonsRegionCode": {
+      "type": "string",
+      "enum": ["US", "EU"]
+    },
+    "commonsRole": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "commonsUserProfile": {
+      "type": "object",
+      "properties": {
+        "custom_attributes": {
+          "description": "Custom attributes for extended user profile data. Keys (3-25 chars), values (1-256 chars).",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "example": {
+            "department": "engineering",
+            "security_clearance": "level2"
+          }
+        },
+        "email_verified": {
+          "description": "Indicates if the user's email address has been verified. Automatically updated by the system.",
+          "type": "boolean",
+          "readOnly": true,
+          "example": true
+        },
+        "first_name": {
+          "description": "User's given name. Maximum 200 characters.",
+          "type": "string",
+          "example": "John"
+        },
+        "id": {
+          "description": "Unique system-generated identifier for the user profile. Immutable and read-only.",
+          "type": "string",
+          "readOnly": true,
+          "example": "usr_profile_1234abcd5678efgh"
+        },
+        "last_name": {
+          "description": "User's family name. Maximum 200 characters.",
+          "type": "string",
+          "example": "Doe"
+        },
+        "locale": {
+          "description": "User's localization preference in BCP-47 format. Defaults to organization settings.",
+          "type": "string",
+          "example": "en-US"
+        },
+        "metadata": {
+          "description": "System-managed key-value pairs for internal tracking. Keys (3-25 chars), values (1-256 chars).",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "example": {
+            "account_status": "active",
+            "signup_source": "mobile_app"
+          }
+        },
+        "name": {
+          "description": "Full name in display format. Typically combines first_name and last_name.",
+          "type": "string",
+          "example": "John Michael Doe"
+        },
+        "phone_number": {
+          "description": "Phone number in E.164 international format. Required for SMS-based authentication.",
+          "type": "string",
+          "example": "+14155552671"
+        }
+      }
+    },
+    "connectionsCodeChallengeType": {
+      "type": "string",
+      "enum": ["NUMERIC", "ALPHANUMERIC"]
+    },
+    "connectionsConfigurationType": {
+      "type": "string",
+      "enum": ["DISCOVERY", "MANUAL"]
+    },
+    "connectionsConnection": {
+      "type": "object",
+      "properties": {
+        "attribute_mapping": {
+          "description": "Maps identity provider attributes to user profile fields. For example, {'email': 'user.mail', 'name': 'user.displayName'}.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "configuration_type": {
+          "description": "How the connection was configured: DISCOVERY (automatic configuration) or MANUAL (administrator configured)",
+          "$ref": "#/definitions/connectionsConfigurationType",
+          "example": "MANUAL"
+        },
+        "debug_enabled": {
+          "description": "Enables testing mode that allows non-HTTPS endpoints. Should only be enabled in development environments, never in production.",
+          "type": "boolean",
+          "example": true
+        },
+        "enabled": {
+          "description": "Controls whether users can sign in using this connection. When false, the connection exists but cannot be used for authentication.",
+          "type": "boolean",
+          "example": false
+        },
+        "id": {
+          "description": "Unique identifier for this connection. Used in API calls to reference this specific connection.",
+          "type": "string",
+          "example": "conn_2123312131125533"
+        },
+        "key_id": {
+          "description": "Alternative identifier for this connection, typically used in frontend applications or URLs.",
+          "type": "string"
+        },
+        "oauth_config": {
+          "description": "Configuration details for OAuth connections. Present only when type is OAUTH.",
+          "$ref": "#/definitions/connectionsOAuthConnectionConfig"
+        },
+        "oidc_config": {
+          "description": "Configuration details for OpenID Connect (OIDC) connections. Present only when type is OIDC.",
+          "$ref": "#/definitions/connectionsOIDCConnectionConfig"
+        },
+        "organization_id": {
+          "description": "Identifier of the organization that owns this connection. Connections are typically scoped to a single organization.",
+          "type": "string",
+          "example": "org_2123312131125533"
+        },
+        "passwordless_config": {
+          "description": "Configuration details for Magic Link authentication. Present only when type is MAGIC_LINK.",
+          "$ref": "#/definitions/connectionsPasswordLessConfig"
+        },
+        "provider": {
+          "description": "Identity provider service that handles authentication (such as OKTA, Google, Azure AD, or a custom provider)",
+          "$ref": "#/definitions/connectionsConnectionProvider",
+          "example": "OKTA"
+        },
+        "saml_config": {
+          "description": "Configuration details for SAML connections. Present only when type is SAML.",
+          "$ref": "#/definitions/connectionsSAMLConnectionConfigResponse"
+        },
+        "status": {
+          "description": "Current configuration status of the connection. Possible values include IN_PROGRESS, CONFIGURED, and ERROR.",
+          "$ref": "#/definitions/connectionsConnectionStatus",
+          "readOnly": true,
+          "example": "IN_PROGRESS"
+        },
+        "test_connection_uri": {
+          "description": "URI that can be used to test this connection. Visit this URL to verify the connection works correctly.",
+          "type": "string",
+          "example": "https://auth.example.com/test-connection/conn_2123312131125533"
+        },
+        "type": {
+          "description": "Authentication protocol used by this connection. Can be OIDC (OpenID Connect), SAML, OAUTH, or MAGIC_LINK.",
+          "$ref": "#/definitions/connectionsConnectionType",
+          "example": "OIDC"
+        }
+      }
+    },
+    "connectionsConnectionProvider": {
+      "type": "string",
+      "enum": [
+        "OKTA",
+        "GOOGLE",
+        "MICROSOFT_AD",
+        "AUTH0",
+        "ONELOGIN",
+        "PING_IDENTITY",
+        "JUMPCLOUD",
+        "CUSTOM",
+        "GITHUB",
+        "GITLAB",
+        "LINKEDIN",
+        "SALESFORCE",
+        "MICROSOFT",
+        "IDP_SIMULATOR",
+        "SCALEKIT",
+        "ADFS"
+      ]
+    },
+    "connectionsConnectionStatus": {
+      "type": "string",
+      "enum": ["DRAFT", "IN_PROGRESS", "COMPLETED"]
+    },
+    "connectionsConnectionType": {
+      "type": "string",
+      "enum": ["OIDC", "SAML", "PASSWORD", "OAUTH", "PASSWORDLESS"]
+    },
+    "connectionsGetConnectionResponse": {
+      "type": "object",
+      "properties": {
+        "connection": {
+          "description": "Complete connection details including provider configuration, protocol settings, status, and all metadata. Contains everything needed to understand the connection's current state.",
+          "$ref": "#/definitions/connectionsConnection"
+        }
+      }
+    },
+    "connectionsIDPCertificate": {
+      "type": "object",
+      "properties": {
+        "certificate": {
+          "description": "IDP Certificate",
+          "type": "string"
+        },
+        "create_time": {
+          "description": "Certificate Creation Time",
+          "type": "string",
+          "format": "date-time",
+          "example": "2021-09-01T00:00:00Z"
+        },
+        "expiry_time": {
+          "description": "Certificate Expiry Time",
+          "type": "string",
+          "format": "date-time",
+          "example": "2021-09-01T00:00:00Z"
+        },
+        "id": {
+          "description": "Certificate ID",
+          "type": "string",
+          "example": "cert_123123123123"
+        },
+        "issuer": {
+          "description": "Certificate Issuer",
+          "type": "string",
+          "example": "https://youridp.com/service/saml"
+        }
+      }
+    },
+    "connectionsListConnection": {
+      "type": "object",
+      "properties": {
+        "domains": {
+          "description": "List of domains configured with this connection",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "example": ["yourapp.com", "yourworkspace.com"]
+        },
+        "enabled": {
+          "description": "Whether the connection is currently active for organization users",
+          "type": "boolean",
+          "example": false
+        },
+        "id": {
+          "description": "Unique identifier of the connection",
+          "type": "string",
+          "example": "conn_2123312131125533"
+        },
+        "organization_id": {
+          "description": "Unique identifier of the organization that owns this connection",
+          "type": "string",
+          "example": "org_2123312131125533"
+        },
+        "organization_name": {
+          "description": "Name of the organization of the connection",
+          "type": "string",
+          "example": "Your Organization"
+        },
+        "provider": {
+          "description": "Identity provider type (e.g., OKTA, Google, Azure AD)",
+          "$ref": "#/definitions/connectionsConnectionProvider",
+          "example": "CUSTOM"
+        },
+        "status": {
+          "description": "Current configuration status of the connection",
+          "$ref": "#/definitions/connectionsConnectionStatus",
+          "readOnly": true,
+          "example": "IN_PROGRESS"
+        },
+        "type": {
+          "description": "Authentication protocol used by the connection",
+          "$ref": "#/definitions/connectionsConnectionType",
+          "example": "OIDC"
+        }
+      }
+    },
+    "connectionsListOrganizationConnectionsResponse": {
+      "type": "object",
+      "properties": {
+        "connections": {
+          "description": "List of connections matching the filter criteria",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/connectionsListConnection"
+          }
+        },
+        "next_page_token": {
+          "type": "string"
+        },
+        "prev_page_token": {
+          "type": "string"
+        },
+        "total_size": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "connectionsNameIdFormat": {
+      "type": "string",
+      "enum": ["UNSPECIFIED", "EMAIL", "TRANSIENT", "PERSISTENT"]
+    },
+    "connectionsOAuthConnectionConfig": {
+      "type": "object",
+      "properties": {
+        "authorize_uri": {
+          "description": "Authorize URI",
+          "type": "string",
+          "example": "https://youridp.com/service/oauth/authorize"
+        },
+        "client_id": {
+          "description": "Client ID",
+          "type": "string",
+          "example": "oauth_client_id"
+        },
+        "client_secret": {
+          "description": "Client Secret",
+          "type": "string",
+          "example": "oauth_client_secret"
+        },
+        "pkce_enabled": {
+          "description": "PKCE Enabled",
+          "type": "boolean",
+          "example": true
+        },
+        "prompt": {
+          "description": "Prompt for the user",
+          "type": "string",
+          "example": "none"
+        },
+        "redirect_uri": {
+          "description": "Redirect URI",
+          "type": "string",
+          "example": "https://yourapp.com/service/oauth/redirect"
+        },
+        "scopes": {
+          "description": "OIDC Scopes",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "example": ["openid", "profile"]
+        },
+        "token_uri": {
+          "description": "Token URI",
+          "type": "string",
+          "example": "https://youridp.com/service/oauth/token"
+        },
+        "use_platform_creds": {
+          "description": "Use Scalekit credentials",
+          "type": "boolean",
+          "example": true
+        },
+        "user_info_uri": {
+          "description": "User Info URI",
+          "type": "string",
+          "example": "https://youridp.com/service/oauth/userinfo"
+        }
+      }
+    },
+    "connectionsOIDCConnectionConfig": {
+      "type": "object",
+      "properties": {
+        "authorize_uri": {
+          "description": "Authorize URI",
+          "type": "string",
+          "example": "https://youridp.com/service/oauth/authorize"
+        },
+        "backchannel_logout_redirect_uri": {
+          "description": "backchannel logout redirect uri where idp sends logout_token",
+          "type": "string",
+          "readOnly": true,
+          "example": "https://yourapp.com/sso/v1/oidc/conn_1234/backchannel-logout"
+        },
+        "client_id": {
+          "description": "Client ID",
+          "type": "string",
+          "example": "oauth_client_id"
+        },
+        "client_secret": {
+          "description": "Client Secret",
+          "type": "string",
+          "example": "oauth_client_secret"
+        },
+        "discovery_endpoint": {
+          "description": "Discovery Endpoint",
+          "type": "string",
+          "example": "https://youridp.com/service/oauth/.well-known/openid-configuration"
+        },
+        "idp_logout_required": {
+          "description": "Enable IDP logout",
+          "type": "boolean",
+          "example": true
+        },
+        "issuer": {
+          "description": "Issuer URL",
+          "type": "string",
+          "example": "https://youridp.com/service/oauth"
+        },
+        "jwks_uri": {
+          "description": "JWKS URI",
+          "type": "string",
+          "example": "https://youridp.com/service/oauth/jwks"
+        },
+        "pkce_enabled": {
+          "description": "PKCE Enabled",
+          "type": "boolean",
+          "example": true
+        },
+        "post_logout_redirect_uri": {
+          "description": "post logout redirect uri",
+          "type": "string",
+          "readOnly": true,
+          "example": "https://yourapp.com/sso/v1/oidc/conn_1234/logout/callback"
+        },
+        "redirect_uri": {
+          "description": "Redirect URI",
+          "type": "string",
+          "example": "https://yourapp.com/sso/v1/oidc/conn_1234/callback"
+        },
+        "scopes": {
+          "description": "OIDC Scopes",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/connectionsOIDCScope"
+          },
+          "example": ["openid", "profile"]
+        },
+        "token_auth_type": {
+          "description": "Token Auth Type",
+          "$ref": "#/definitions/connectionsTokenAuthType",
+          "example": "URL_PARAMS"
+        },
+        "token_uri": {
+          "description": "Token URI",
+          "type": "string",
+          "example": "https://youridp.com/service/oauth/token"
+        },
+        "user_info_uri": {
+          "description": "User Info URI",
+          "type": "string",
+          "example": "https://youridp.com/service/oauth/userinfo"
+        }
+      }
+    },
+    "connectionsOIDCScope": {
+      "type": "string",
+      "enum": ["openid", "profile", "email", "address", "phone"]
+    },
+    "connectionsPasswordLessConfig": {
+      "type": "object",
+      "properties": {
+        "code_challenge_length": {
+          "description": "Code Challenge Length",
+          "type": "integer",
+          "format": "int64",
+          "example": 6
+        },
+        "code_challenge_type": {
+          "description": "Code Challenge Type",
+          "$ref": "#/definitions/connectionsCodeChallengeType",
+          "example": "NUMERIC"
+        },
+        "enforce_same_browser_origin": {
+          "description": "Enforce Same Browser Origin",
+          "type": "boolean",
+          "example": true
+        },
+        "frequency": {
+          "description": "Link Frequency",
+          "type": "integer",
+          "format": "int64",
+          "example": 1
+        },
+        "type": {
+          "description": "Passwordless Type",
+          "$ref": "#/definitions/connectionsPasswordlessType",
+          "example": "LINK"
+        },
+        "validity": {
+          "description": "Link Validity in Seconds",
+          "type": "integer",
+          "format": "int64",
+          "example": "600"
+        }
+      }
+    },
+    "connectionsPasswordlessType": {
+      "type": "string",
+      "enum": ["LINK", "OTP", "LINK_OTP"]
+    },
+    "connectionsRequestBinding": {
+      "type": "string",
+      "enum": ["HTTP_POST", "HTTP_REDIRECT"]
+    },
+    "connectionsSAMLConnectionConfigResponse": {
+      "type": "object",
+      "properties": {
+        "allow_idp_initiated_login": {
+          "description": "Allow IDP Initiated Login",
+          "type": "boolean",
+          "example": true
+        },
+        "assertion_encrypted": {
+          "description": "Assertion Encrypted",
+          "type": "boolean",
+          "example": true
+        },
+        "certificate_id": {
+          "description": "Certificate ID",
+          "type": "string",
+          "example": "cer_35585423166144613"
+        },
+        "default_redirect_uri": {
+          "description": "Default Redirect URI",
+          "type": "string",
+          "example": "https://yourapp.com/service/saml/redirect"
+        },
+        "force_authn": {
+          "description": "Force Authn",
+          "type": "boolean",
+          "example": true
+        },
+        "idp_certificates": {
+          "description": "IDP Certificates",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/connectionsIDPCertificate"
+          }
+        },
+        "idp_entity_id": {
+          "description": "IDP Entity ID",
+          "type": "string",
+          "example": "https://youridp.com/service/saml"
+        },
+        "idp_metadata_url": {
+          "description": "IDP Metadata URL",
+          "type": "string",
+          "example": "https://youridp.com/service/saml/metadata"
+        },
+        "idp_name_id_format": {
+          "description": "IDP Name ID Format",
+          "$ref": "#/definitions/connectionsNameIdFormat",
+          "example": "EMAIL"
+        },
+        "idp_slo_request_binding": {
+          "description": "IDP SLO Request Binding",
+          "$ref": "#/definitions/connectionsRequestBinding",
+          "example": "HTTP_POST"
+        },
+        "idp_slo_required": {
+          "description": "Enable IDP logout",
+          "type": "boolean",
+          "example": true
+        },
+        "idp_slo_url": {
+          "description": "IDP SLO URL",
+          "type": "string",
+          "example": "https://youridp.com/service/saml/slo"
+        },
+        "idp_sso_request_binding": {
+          "description": "IDP SSO Request Binding",
+          "$ref": "#/definitions/connectionsRequestBinding",
+          "example": "HTTP_POST"
+        },
+        "idp_sso_url": {
+          "description": "IDP SSO URL",
+          "type": "string",
+          "example": "https://youridp.com/service/saml/sso"
+        },
+        "saml_signing_option": {
+          "description": "SAML Signing Option",
+          "$ref": "#/definitions/connectionsSAMLSigningOptions",
+          "example": "SAML_ONLY_RESPONSE_SIGNING"
+        },
+        "sp_assertion_url": {
+          "description": "SP Assertion URL",
+          "type": "string",
+          "example": "https://youridp.com/service/saml/assertion"
+        },
+        "sp_entity_id": {
+          "description": "SP Entity ID",
+          "type": "string",
+          "example": "https://yourapp.com/service/saml"
+        },
+        "sp_metadata_url": {
+          "description": "SP Metadata URL",
+          "type": "string",
+          "example": "https://youridp.com/service/saml/metadata"
+        },
+        "sp_slo_url": {
+          "description": "Service Provider SLO url",
+          "type": "string",
+          "readOnly": true,
+          "example": "https://yourapp.com/sso/v1/saml/conn_1234/slo/callback"
+        },
+        "ui_button_title": {
+          "description": "UI Button Title",
+          "type": "string",
+          "example": "Login with SSO"
+        },
+        "want_request_signed": {
+          "description": "Want Request Signed",
+          "type": "boolean",
+          "example": true
+        }
+      }
+    },
+    "connectionsSAMLSigningOptions": {
+      "type": "string",
+      "title": "enums all",
+      "enum": [
+        "NO_SIGNING",
+        "SAML_ONLY_RESPONSE_SIGNING",
+        "SAML_ONLY_ASSERTION_SIGNING",
+        "SAML_RESPONSE_ASSERTION_SIGNING",
+        "SAML_RESPONSE_OR_ASSERTION_SIGNING"
+      ]
+    },
+    "connectionsSearchOrganizationConnectionsResponse": {
+      "type": "object",
+      "properties": {
+        "connections": {
+          "description": "List of connections matching the filter criteria",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/connectionsListConnection"
+          }
+        },
+        "next_page_token": {
+          "type": "string"
+        },
+        "prev_page_token": {
+          "type": "string"
+        },
+        "total_size": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "connectionsToggleConnectionResponse": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Current state of the connection after the operation. True means the connection is now enabled and can be used for authentication.",
+          "type": "boolean",
+          "example": true
+        },
+        "error_message": {
+          "description": "Error message if the operation fails",
+          "type": "string",
+          "example": "placeholder"
+        }
+      }
+    },
+    "connectionsTokenAuthType": {
+      "type": "string",
+      "enum": ["URL_PARAMS", "BASIC_AUTH"]
+    },
+    "directoriesAttributeMapping": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "map_to": {
+          "type": "string"
+        }
+      }
+    },
+    "directoriesAttributeMappings": {
+      "type": "object",
+      "properties": {
+        "attributes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/directoriesAttributeMapping"
+          }
+        }
+      }
+    },
+    "directoriesDirectory": {
+      "type": "object",
+      "properties": {
+        "attribute_mappings": {
+          "description": "Mappings between directory attributes and Scalekit user and group attributes",
+          "$ref": "#/definitions/directoriesAttributeMappings"
+        },
+        "directory_endpoint": {
+          "description": "The endpoint URL generated by Scalekit for synchronizing users and groups from the Directory Provider",
+          "type": "string",
+          "example": "https://yourapp.scalekit.com/api/v1/directoies/dir_123212312/scim/v2"
+        },
+        "directory_provider": {
+          "description": "Identity provider connected to this directory",
+          "$ref": "#/definitions/directoriesDirectoryProvider",
+          "example": "OKTA"
+        },
+        "directory_type": {
+          "description": "Type of the directory, indicating the protocol or standard used for synchronization",
+          "$ref": "#/definitions/directoriesDirectoryType",
+          "example": "SCIM"
+        },
+        "email": {
+          "description": "Email Id associated with Directory whose access will be used for polling",
+          "type": "string",
+          "example": "john.doe@scalekit.cloud"
+        },
+        "enabled": {
+          "description": "Indicates whether the directory is currently enabled and actively synchronizing users and groups",
+          "type": "boolean",
+          "example": true
+        },
+        "groups_tracked": {
+          "description": "It indicates if all groups are tracked or select groups are tracked",
+          "type": "string",
+          "example": "ALL"
+        },
+        "id": {
+          "description": "Unique identifier of the directory",
+          "type": "string",
+          "example": "dir_121312434123312"
+        },
+        "last_synced_at": {
+          "description": "Timestamp of the last successful synchronization of users and groups from the Directory Provider",
+          "type": "string",
+          "format": "date-time",
+          "example": "2024-10-01T00:00:00Z"
+        },
+        "name": {
+          "description": "Name of the directory, typically representing the connected Directory provider",
+          "type": "string",
+          "example": "Azure AD"
+        },
+        "organization_id": {
+          "description": "Unique identifier of the organization to which the directory belongs",
+          "type": "string",
+          "example": "org_121312434123312"
+        },
+        "role_assignments": {
+          "description": "Role assignments associated with the directory, defining group based role assignments",
+          "$ref": "#/definitions/directoriesRoleAssignments"
+        },
+        "secrets": {
+          "description": "List of secrets used for authenticating and synchronizing with the Directory Provider",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/directoriesSecret"
+          }
+        },
+        "stats": {
+          "description": "Statistics and metrics related to the directory, such as synchronization status and error counts",
+          "$ref": "#/definitions/directoriesStats"
+        },
+        "status": {
+          "description": "Directory Status",
+          "type": "string",
+          "example": "IN_PROGRESS"
+        },
+        "total_groups": {
+          "description": "Total number of groups in the directory",
+          "type": "integer",
+          "format": "int32",
+          "example": 10
+        },
+        "total_users": {
+          "description": "Total number of users in the directory",
+          "type": "integer",
+          "format": "int32",
+          "example": 10
+        }
+      }
+    },
+    "directoriesDirectoryGroup": {
+      "type": "object",
+      "properties": {
+        "display_name": {
+          "description": "Display Name",
+          "type": "string",
+          "example": "Admins"
+        },
+        "group_detail": {
+          "description": "Complete Group Details Payload",
+          "type": "object"
+        },
+        "id": {
+          "description": "Group ID",
+          "type": "string",
+          "example": "dirgroup_121312434123312"
+        },
+        "total_users": {
+          "description": "Total Users in the Group",
+          "type": "integer",
+          "format": "int32",
+          "example": 10
+        },
+        "updated_at": {
+          "description": "Updated At",
+          "type": "string",
+          "format": "date-time",
+          "example": "2024-10-01T00:00:00Z"
+        }
+      }
+    },
+    "directoriesDirectoryProvider": {
+      "type": "string",
+      "enum": ["OKTA", "GOOGLE", "MICROSOFT_AD", "AUTH0", "ONELOGIN", "JUMPCLOUD", "PING_IDENTITY"]
+    },
+    "directoriesDirectoryType": {
+      "type": "string",
+      "enum": ["SCIM", "LDAP", "POLL"]
+    },
+    "directoriesDirectoryUser": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "description": "Email",
+          "type": "string",
+          "example": "johndoe"
+        },
+        "emails": {
+          "description": "Emails",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "family_name": {
+          "description": "Last Name",
+          "type": "string",
+          "example": "Doe"
+        },
+        "given_name": {
+          "description": "First Name",
+          "type": "string",
+          "example": "John"
+        },
+        "groups": {
+          "description": "Groups",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/directoriesDirectoryGroup"
+          }
+        },
+        "id": {
+          "description": "User ID",
+          "type": "string",
+          "example": "diruser_121312434123312"
+        },
+        "preferred_username": {
+          "description": "Preferred Username",
+          "type": "string",
+          "example": "johndoe"
+        },
+        "updated_at": {
+          "description": "Updated At",
+          "type": "string",
+          "format": "date-time",
+          "example": "2024-10-01T00:00:00Z"
+        },
+        "user_detail": {
+          "description": "Complete User Details Payload",
+          "type": "object"
+        }
+      }
+    },
+    "directoriesGetDirectoryResponse": {
+      "type": "object",
+      "properties": {
+        "directory": {
+          "description": "Detailed information about the requested directory",
+          "$ref": "#/definitions/directoriesDirectory"
+        }
+      }
+    },
+    "directoriesListDirectoriesResponse": {
+      "type": "object",
+      "properties": {
+        "directories": {
+          "description": "List of directories associated with the organization",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/directoriesDirectory"
+          }
+        }
+      }
+    },
+    "directoriesListDirectoryGroupsResponse": {
+      "type": "object",
+      "properties": {
+        "groups": {
+          "description": "List of directory groups retrieved from the specified directory",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/directoriesDirectoryGroup"
+          }
+        },
+        "next_page_token": {
+          "description": "Token to retrieve the next page of results. Use this token in the 'page_token' field of the next request",
+          "type": "string"
+        },
+        "prev_page_token": {
+          "description": "Token to retrieve the previous page of results. Use this token in the 'page_token' field of the next request",
+          "type": "string"
+        },
+        "total_size": {
+          "description": "Total number of groups matching the request criteria, regardless of pagination",
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "directoriesListDirectoryUsersResponse": {
+      "type": "object",
+      "properties": {
+        "next_page_token": {
+          "description": "Token for pagination. Use this token in the 'page_token' field of the next request to fetch the subsequent page of users",
+          "type": "string"
+        },
+        "prev_page_token": {
+          "description": "Token for pagination. Use this token in the 'page_token' field of the next request to fetch the prior page of users",
+          "type": "string"
+        },
+        "total_size": {
+          "description": "Total number of users available in the directory that match the request criteria",
+          "type": "integer",
+          "format": "int64"
+        },
+        "users": {
+          "description": "List of directory users retrieved from the specified directory",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/directoriesDirectoryUser"
+          }
+        }
+      }
+    },
+    "directoriesRoleAssignment": {
+      "type": "object",
+      "properties": {
+        "group_id": {
+          "description": "group ID for the role mapping",
+          "type": "string",
+          "example": "dirgroup_121312434123"
+        },
+        "role_name": {
+          "type": "string"
+        }
+      }
+    },
+    "directoriesRoleAssignments": {
+      "type": "object",
+      "properties": {
+        "assignments": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/directoriesRoleAssignment"
+          }
+        }
+      }
+    },
+    "directoriesSecret": {
+      "type": "object",
+      "properties": {
+        "create_time": {
+          "description": "Creation Time",
+          "type": "string",
+          "format": "date-time",
+          "example": "2024-10-01T00:00:00Z"
+        },
+        "directory_id": {
+          "description": "Directory ID",
+          "type": "string",
+          "example": "dir_12362474900684814"
+        },
+        "expire_time": {
+          "description": "Expiry Time",
+          "type": "string",
+          "format": "date-time",
+          "example": "2025-10-01T00:00:00Z"
+        },
+        "id": {
+          "type": "string"
+        },
+        "last_used_time": {
+          "description": "Last Used Time",
+          "type": "string",
+          "format": "date-time",
+          "example": "2024-10-01T00:00:00Z"
+        },
+        "secret_suffix": {
+          "description": "Secret Suffix",
+          "type": "string",
+          "example": "Nzg5"
+        },
+        "status": {
+          "description": "Secret Status",
+          "$ref": "#/definitions/directoriesSecretStatus",
+          "example": "ACTIVE"
+        }
+      }
+    },
+    "directoriesSecretStatus": {
+      "type": "string",
+      "enum": ["INACTIVE"]
+    },
+    "directoriesStats": {
+      "type": "object",
+      "properties": {
+        "group_updated_at": {
+          "description": "Max time of Group Updated At for Directory",
+          "type": "string",
+          "format": "date-time",
+          "example": "2024-10-01T00:00:00Z"
+        },
+        "total_groups": {
+          "description": "Total Groups in the Directory",
+          "type": "integer",
+          "format": "int32",
+          "example": 10
+        },
+        "total_users": {
+          "description": "Total Users in the Directory",
+          "type": "integer",
+          "format": "int32",
+          "example": 10
+        },
+        "user_updated_at": {
+          "description": "Max time of User Updated At for Directory",
+          "type": "string",
+          "format": "date-time",
+          "example": "2024-10-01T00:00:00Z"
+        }
+      }
+    },
+    "directoriesToggleDirectoryResponse": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Specifies the directory's state after the toggle operation. A value of `true` indicates that the directory is enabled and actively synchronizing users and groups. A value of `false` means the directory is disabled, halting synchronization",
+          "type": "boolean",
+          "example": true
+        },
+        "error_message": {
+          "description": "Contains a human-readable error message if the toggle operation encountered an issue. If the operation was successful, this field will be empty",
+          "type": "string",
+          "example": "The directory is already enabled"
+        }
+      }
+    },
+    "organizationsCreateOrganizationResponse": {
+      "type": "object",
+      "properties": {
+        "organization": {
+          "description": "The newly created organization containing its ID, settings, and metadata",
+          "$ref": "#/definitions/organizationsOrganization"
+        }
+      }
+    },
+    "organizationsCreateOrganizationSessionSettingsResponse": {
+      "type": "object",
+      "properties": {
+        "environment_id": {
+          "description": "The environment ID where the session settings were created.",
+          "type": "string",
+          "example": "env_59615193906282635"
+        },
+        "organization_id": {
+          "description": "The unique identifier of the organization for which session settings were created.",
+          "type": "string",
+          "example": "org_59615193906282635"
+        },
+        "session_settings": {
+          "description": "The newly created session settings, including timeout policies.",
+          "$ref": "#/definitions/organizationsOrganizationSessionSettings"
+        }
+      }
+    },
+    "organizationsFeature": {
+      "description": "- dir_sync: dir_sync enables directory synchronization configuration in the portal\n - sso: sso enables Single Sign-On (SSO) configuration in the portal",
+      "type": "string",
+      "title": "Feature represents the available features that can be enabled for an organization's portal link",
+      "enum": ["dir_sync", "sso"]
+    },
+    "organizationsGeneratePortalLinkResponse": {
+      "type": "object",
+      "properties": {
+        "link": {
+          "description": "Contains the generated admin portal link details. The link URL can be shared with organization administrators to set up: Single Sign-On (SSO) authentication and directory synchronization",
+          "$ref": "#/definitions/organizationsLink"
+        }
+      }
+    },
+    "organizationsGetOrganizationResponse": {
+      "type": "object",
+      "properties": {
+        "organization": {
+          "description": "The newly created organization",
+          "$ref": "#/definitions/organizationsOrganization"
+        }
+      }
+    },
+    "organizationsGetOrganizationSessionSettingsResponse": {
+      "type": "object",
+      "properties": {
+        "environment_id": {
+          "description": "The environment ID from which the session settings were retrieved.",
+          "type": "string",
+          "example": "env_59615193906282635"
+        },
+        "organization_id": {
+          "description": "The unique identifier of the organization whose session settings are returned.",
+          "type": "string",
+          "example": "org_59615193906282635"
+        },
+        "session_settings": {
+          "description": "The retrieved session timeout policies for the organization.",
+          "$ref": "#/definitions/organizationsOrganizationSessionSettings"
+        }
+      }
+    },
+    "organizationsLink": {
+      "type": "object",
+      "properties": {
+        "expire_time": {
+          "description": "Expiry time of the link. The link is valid for 1 week.",
+          "type": "string",
+          "format": "date-time",
+          "example": "2024-02-06T14:48:00.000Z"
+        },
+        "id": {
+          "description": "Unique Identifier for the link",
+          "type": "string",
+          "example": "lnk_123123123123123"
+        },
+        "location": {
+          "description": "Location of the link. This is the URL that can be used to access the Admin portal. The link is valid for 1 week.",
+          "type": "string",
+          "example": "https://scalekit.com/portal/lnk_123123123123123"
+        }
+      }
+    },
+    "organizationsListOrganizationsResponse": {
+      "type": "object",
+      "properties": {
+        "next_page_token": {
+          "description": "Pagination token for the next page of results. Use this token to fetch the next page.",
+          "type": "string",
+          "example": "<next_page_token>"
+        },
+        "organizations": {
+          "description": "List of organization objects",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/organizationsOrganization"
+          }
+        },
+        "prev_page_token": {
+          "description": "Pagination token for the previous page of results. Use this token to fetch the previous page.",
+          "type": "string",
+          "example": "<prev_page_token>"
+        },
+        "total_size": {
+          "description": "Total number of organizations in the environment.",
+          "type": "integer",
+          "format": "int64",
+          "example": 30
+        }
+      }
+    },
+    "organizationsOrganization": {
+      "type": "object",
+      "required": ["create_time"],
+      "properties": {
+        "create_time": {
+          "description": "Timestamp when the organization was created",
+          "type": "string",
+          "format": "date-time",
+          "title": "Created Time",
+          "example": "2025-02-15T06:23:44.560Z"
+        },
+        "display_name": {
+          "description": "Name of the organization. Must be between 1 and 200 characters",
+          "type": "string",
+          "title": "Name of the org to be used in display",
+          "example": "Megasoft"
+        },
+        "external_id": {
+          "description": "Your application's unique identifier for this organization, used to link Scalekit with your system.",
+          "type": "string",
+          "title": "External Id is useful to store a unique identifier for a given Org that. The unique Identifier can be the id of your tenant / org in your SaaSApp",
+          "example": "my_unique_id"
+        },
+        "id": {
+          "description": "Unique scalekit-generated identifier that uniquely references an organization",
+          "type": "string",
+          "title": "Id",
+          "example": "org_59615193906282635"
+        },
+        "metadata": {
+          "description": "Key value pairs extension attributes.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "region_code": {
+          "description": "Geographic region code for the organization. Currently limited to US.",
+          "title": "Optional regioncode",
+          "$ref": "#/definitions/commonsRegionCode",
+          "example": "US"
+        },
+        "settings": {
+          "title": "Organization Settings",
+          "$ref": "#/definitions/organizationsOrganizationSettings"
+        },
+        "update_time": {
+          "description": "Timestamp when the organization was last updated",
+          "type": "string",
+          "format": "date-time",
+          "title": "Updated time",
+          "example": "2025-02-15T06:23:44.560Z"
+        }
+      }
+    },
+    "organizationsOrganizationSessionSettings": {
+      "type": "object",
+      "properties": {
+        "absolute_session_timeout": {
+          "description": "The maximum duration in seconds that a session can remain active, regardless of activity. After this time, the user will be required to re-authenticate.",
+          "type": "integer",
+          "format": "int32",
+          "example": 86400
+        },
+        "idle_session_enabled": {
+          "description": "Enables or disables idle session timeout. If true, inactive sessions will be terminated after the specified idle duration.",
+          "type": "boolean",
+          "example": true
+        },
+        "idle_session_timeout": {
+          "description": "The duration in seconds that a session can remain idle before it is automatically terminated. Activity resets the timer.",
+          "type": "integer",
+          "format": "int32",
+          "example": 1800
+        },
+        "session_management_enabled": {
+          "description": "Enables or disables session management features for the organization. When true, session timeout policies are enforced.",
+          "type": "boolean",
+          "example": true
+        }
+      }
+    },
+    "organizationsOrganizationSettings": {
+      "description": "Configuration options that control organization-level features and capabilities",
+      "type": "object",
+      "title": "Organization Settings",
+      "properties": {
+        "features": {
+          "description": "List of feature toggles that control organization capabilities such as SSO authentication and directory synchronization",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/organizationsOrganizationSettingsFeature"
+          },
+          "example": [
+            {
+              "enabled": true,
+              "name": "sso"
+            },
+            {
+              "enabled": false,
+              "name": "directory_sync"
+            }
+          ]
+        }
+      },
+      "example": {
+        "features": [
+          {
+            "enabled": true,
+            "name": "sso"
+          },
+          {
+            "enabled": false,
+            "name": "directory_sync"
+          }
+        ]
+      }
+    },
+    "organizationsOrganizationSettingsFeature": {
+      "description": "Controls the activation state of a specific organization feature",
+      "type": "object",
+      "title": "Organization Feature Toggle",
+      "required": ["name", "enabled"],
+      "properties": {
+        "enabled": {
+          "description": "Whether the feature is enabled (true) or disabled (false) for this organization",
+          "type": "boolean",
+          "example": true
+        },
+        "name": {
+          "description": "Feature identifier. Supported values include: \"sso\" (Single Sign-On), \"directory_sync\" (Directory Synchronization)",
+          "type": "string",
+          "example": "sso"
+        }
+      }
+    },
+    "organizationsUpdateOrganizationResponse": {
+      "type": "object",
+      "properties": {
+        "organization": {
+          "description": "Updated organization details",
+          "$ref": "#/definitions/organizationsOrganization"
+        }
+      }
+    },
+    "organizationsUpdateOrganizationSessionSettingsResponse": {
+      "type": "object",
+      "properties": {
+        "environment_id": {
+          "description": "The environment ID where the organization's session settings were updated.",
+          "type": "string",
+          "example": "env_59615193906282635"
+        },
+        "organization_id": {
+          "description": "The unique identifier of the organization whose session settings were updated.",
+          "type": "string",
+          "example": "org_59615193906282635"
+        },
+        "session_settings": {
+          "description": "The updated session settings, reflecting the new timeout policies.",
+          "$ref": "#/definitions/organizationsOrganizationSessionSettings"
+        }
+      }
+    },
+    "passwordlessResendPasswordlessRequest": {
+      "type": "object",
+      "properties": {
+        "auth_request_id": {
+          "description": "The authentication request identifier from the original send passwordless email request. Use this to resend the Verification Code (OTP) or Magic Link to the same email address.",
+          "type": "string",
+          "example": "h5Y8kT5RVwaea5WEgW4n-6C-aO_-fuTUW7Vb9-Rh3AcY9qxZqQ"
+        }
+      }
+    },
+    "passwordlessSendPasswordlessRequest": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "description": "Email address where the passwordless authentication credentials will be sent. Must be a valid email format.",
+          "type": "string",
+          "example": "john.doe@example.com"
+        },
+        "expires_in": {
+          "description": "Time in seconds until the passwordless authentication expires. If not specified, defaults to 300 seconds (5 minutes)",
+          "type": "integer",
+          "format": "int64",
+          "example": 300
+        },
+        "magiclink_auth_uri": {
+          "description": "Your application's callback URL where users will be redirected after clicking the magic link in their email. The link token will be appended as a query parameter as link_token",
+          "type": "string",
+          "example": "https://yourapp.com/auth/passwordless/callback"
+        },
+        "state": {
+          "description": "Custom state parameter that will be returned unchanged in the verification response. Use this to maintain application state between the authentication request and callback, such as the intended destination after login",
+          "type": "string",
+          "example": "d62ivasry29lso"
+        },
+        "template": {
+          "description": "Specifies the authentication intent for the passwordless request. Use SIGNIN for existing users or SIGNUP for new user registration. This affects the email template and user experience flow.",
+          "$ref": "#/definitions/passwordlessTemplateType",
+          "example": "SIGNIN"
+        },
+        "template_variables": {
+          "description": "A set of key-value pairs to personalize the email template.\n\n* You may include up to 30 key-value pairs.\n* The following variable names are reserved by the system and cannot be supplied: `otp`, `expiry_time_relative`, `link`, `expire_time`, `expiry_time`.\n* Every variable referenced in your email template must be included as a key-value pair.\n\nUse these variables to insert custom information, such as a team name, URL or the user's employee ID. All variables are interpolated before the email is sent, regardless of the email provider.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "example": {
+            "custom_variable_key": "custom_variable_value"
+          }
+        }
+      }
+    },
+    "passwordlessSendPasswordlessResponse": {
+      "type": "object",
+      "properties": {
+        "auth_request_id": {
+          "description": "Unique identifier for this passwordless authentication request. Use this ID to resend emails.",
+          "type": "string",
+          "readOnly": true,
+          "example": "h5Y8kT5RVwaea5WEgW4n-6C-aO_-fuTUW7Vb9-Rh3AcY9qxZqQ"
+        },
+        "expires_at": {
+          "description": "Unix timestamp (seconds since epoch) when the passwordless authentication will expire. After this time, the OTP or magic link will no longer be valid.",
+          "type": "string",
+          "format": "int64",
+          "readOnly": true,
+          "example": 1748696575
+        },
+        "expires_in": {
+          "description": "Number of seconds from now until the passwordless authentication expires. This is a convenience field calculated from the expires_at timestamp.",
+          "type": "integer",
+          "format": "int64",
+          "readOnly": true,
+          "example": 300
+        },
+        "passwordless_type": {
+          "description": "Type of passwordless authentication that was sent via email. OTP sends a numeric code, LINK sends a clickable magic link, and LINK_OTP provides both options for user convenience.",
+          "$ref": "#/definitions/authpasswordlessPasswordlessType",
+          "example": "OTP"
+        }
+      }
+    },
+    "passwordlessTemplateType": {
+      "type": "string",
+      "enum": ["SIGNIN", "SIGNUP"]
+    },
+    "protobufNullValue": {
+      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\nThe JSON representation for `NullValue` is JSON `null`.",
+      "type": "string"
+    },
+    "usersCreateMembershipResponse": {
+      "type": "object",
+      "properties": {
+        "user": {
+          "$ref": "#/definitions/usersUser"
+        }
+      }
+    },
+    "usersCreateUser": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "description": "Primary email address for the user. Must be unique across the environment and valid per RFC 5322.",
+          "type": "string",
+          "example": "user@example.com"
+        },
+        "external_id": {
+          "description": "Your application's unique identifier for this organization, used to link Scalekit with your system.",
+          "type": "string",
+          "example": "ext_12345a67b89c"
+        },
+        "membership": {
+          "description": "List of organization memberships. Automatically populated based on group assignments.",
+          "$ref": "#/definitions/v1usersCreateMembership"
+        },
+        "metadata": {
+          "description": "Custom key-value pairs for storing additional user context. Keys (3-25 chars), values (1-256 chars).",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "example": {
+            "department": "engineering",
+            "location": "nyc-office"
+          }
+        },
+        "user_profile": {
+          "description": "User's personal information including name, address, and other profile attributes.",
+          "$ref": "#/definitions/usersCreateUserProfile"
+        }
+      }
+    },
+    "usersCreateUserAndMembershipResponse": {
+      "type": "object",
+      "properties": {
+        "user": {
+          "$ref": "#/definitions/usersUser"
+        }
+      }
+    },
+    "usersCreateUserProfile": {
+      "type": "object",
+      "properties": {
+        "custom_attributes": {
+          "description": "Custom attributes for extended user profile data. Keys (3-25 chars), values (1-256 chars).",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "example": {
+            "department": "engineering",
+            "security_clearance": "level2"
+          }
+        },
+        "first_name": {
+          "description": "User's given name. Maximum 200 characters.",
+          "type": "string",
+          "example": "John"
+        },
+        "last_name": {
+          "description": "User's family name. Maximum 200 characters.",
+          "type": "string",
+          "example": "Doe"
+        },
+        "locale": {
+          "description": "User's localization preference in BCP-47 format. Defaults to organization settings.",
+          "type": "string",
+          "example": "en-US"
+        },
+        "metadata": {
+          "description": "System-managed key-value pairs for internal tracking. Keys (3-25 chars), values (1-256 chars).",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "example": {
+            "account_status": "active",
+            "signup_source": "mobile_app"
+          }
+        },
+        "name": {
+          "description": "Full name in display format. Typically combines first_name and last_name.",
+          "type": "string",
+          "example": "John Michael Doe"
+        },
+        "phone_number": {
+          "description": "Phone number in E.164 international format. Required for SMS-based authentication.",
+          "type": "string",
+          "example": "+14155552671"
+        }
+      }
+    },
+    "usersGetUserResponse": {
+      "type": "object",
+      "properties": {
+        "user": {
+          "$ref": "#/definitions/usersUser"
+        }
+      }
+    },
+    "usersListOrganizationUsersResponse": {
+      "type": "object",
+      "properties": {
+        "next_page_token": {
+          "description": "Opaque token for retrieving the next page of results. Empty if there are no more pages.",
+          "type": "string",
+          "example": "eyJwYWdlIjogMiwgImxhc3RfaWQiOiAidXNyXzEyMzQ1In0="
+        },
+        "prev_page_token": {
+          "description": "Opaque token for retrieving the previous page of results. Empty for the first page.",
+          "type": "string",
+          "example": "eyJwYWdlIjogMCwgImZpcnN0X2lkIjogInVzcl85ODc2NSJ9"
+        },
+        "total_size": {
+          "description": "Total number of users matching the request criteria, regardless of pagination.",
+          "type": "integer",
+          "format": "int64",
+          "example": 1042
+        },
+        "users": {
+          "description": "List of user objects for the current page. May contain fewer entries than requested page_size.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/usersUser"
+          }
+        }
+      }
+    },
+    "usersListUsersResponse": {
+      "type": "object",
+      "properties": {
+        "next_page_token": {
+          "description": "Token for retrieving the next page of results. Empty if there are no more pages.",
+          "type": "string",
+          "example": "eyJwYWdlIjogMiwgImxhc3RfaWQiOiAidXNyXzEyMzQ1In0="
+        },
+        "prev_page_token": {
+          "description": "Token for retrieving the previous page of results. Empty if this is the first page.",
+          "type": "string",
+          "example": "eyJwYWdlIjogMCwgImZpcnN0X2lkIjogInVzcl85ODc2NSJ9"
+        },
+        "total_size": {
+          "description": "Total number of users matching the request criteria, regardless of pagination.",
+          "type": "integer",
+          "format": "int64",
+          "example": 1042
+        },
+        "users": {
+          "description": "List of users.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/usersUser"
+          }
+        }
+      }
+    },
+    "usersUpdateMembershipResponse": {
+      "type": "object",
+      "properties": {
+        "user": {
+          "$ref": "#/definitions/usersUser"
+        }
+      }
+    },
+    "usersUpdateUserProfile": {
+      "type": "object",
+      "properties": {
+        "custom_attributes": {
+          "description": "Custom attributes for extended user profile data. Keys (3-25 chars), values (1-256 chars).",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "example": {
+            "department": "engineering",
+            "security_clearance": "level2"
+          }
+        },
+        "first_name": {
+          "description": "User's given name. Maximum 200 characters.",
+          "type": "string",
+          "example": "John"
+        },
+        "last_name": {
+          "description": "User's family name. Maximum 200 characters.",
+          "type": "string",
+          "example": "Doe"
+        },
+        "locale": {
+          "description": "User's localization preference in BCP-47 format. Defaults to organization settings.",
+          "type": "string",
+          "example": "en-US"
+        },
+        "metadata": {
+          "description": "System-managed key-value pairs for internal tracking. Keys (3-25 chars), values (1-256 chars).",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "example": {
+            "account_status": "active",
+            "signup_source": "mobile_app"
+          }
+        },
+        "name": {
+          "description": "Full name in display format. Typically combines first_name and last_name.",
+          "type": "string",
+          "example": "John Michael Doe"
+        },
+        "phone_number": {
+          "description": "Phone number in E.164 international format. Required for SMS-based authentication.",
+          "type": "string",
+          "example": "+14155552671"
+        }
+      }
+    },
+    "usersUpdateUserResponse": {
+      "type": "object",
+      "properties": {
+        "user": {
+          "$ref": "#/definitions/usersUser"
+        }
+      }
+    },
+    "usersUser": {
+      "type": "object",
+      "properties": {
+        "create_time": {
+          "description": "Timestamp when the user account was initially created. Automatically set by the server.",
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        },
+        "email": {
+          "description": "Primary email address for the user. Must be unique across the environment and valid per RFC 5322.",
+          "type": "string",
+          "example": "user@example.com"
+        },
+        "external_id": {
+          "description": "Your application's unique identifier for this organization, used to link Scalekit with your system.",
+          "type": "string",
+          "example": "ext_12345a67b89c"
+        },
+        "id": {
+          "description": "Unique system-generated identifier for the user. Immutable once created.",
+          "type": "string",
+          "example": "usr_1234abcd5678efgh"
+        },
+        "last_login": {
+          "description": "Timestamp of the user's most recent successful authentication. Updated automatically.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "memberships": {
+          "description": "List of organization memberships. Automatically populated based on group assignments.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/commonsOrganizationMembership"
+          }
+        },
+        "metadata": {
+          "description": "Custom key-value pairs for storing additional user context. Keys (3-25 chars), values (1-256 chars).",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "example": {
+            "department": "engineering",
+            "location": "nyc-office"
+          }
+        },
+        "update_time": {
+          "description": "Timestamp of the last modification to the user account. Automatically updated by the server.",
+          "type": "string",
+          "format": "date-time",
+          "readOnly": true
+        },
+        "user_profile": {
+          "description": "User's personal information including name, address, and other profile attributes.",
+          "$ref": "#/definitions/commonsUserProfile"
+        }
+      }
+    },
+    "v1organizationsCreateOrganization": {
+      "type": "object",
+      "properties": {
+        "display_name": {
+          "description": "Name of the organization. Must be between 1 and 200 characters.",
+          "type": "string",
+          "example": "Megasoft Inc"
+        },
+        "external_id": {
+          "description": "Your application's unique identifier for this organization, used to link Scalekit with your system.",
+          "type": "string",
+          "example": "my_unique_id"
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "v1organizationsUpdateOrganization": {
+      "description": "For update messages ensure the indexes are same as the base model itself.",
+      "type": "object",
+      "properties": {
+        "display_name": {
+          "description": "Name of the organization to display in the UI. Must be between 1 and 200 characters",
+          "type": "string",
+          "example": "Acme Corporation"
+        },
+        "external_id": {
+          "description": "Your application's unique identifier for this organization, used to link Scalekit with your system",
+          "type": "string",
+          "example": "tenant_12345"
+        },
+        "metadata": {
+          "description": "Custom key-value pairs to store with the organization. Keys must be 3-25 characters, values must be 1-256 characters. Maximum 10 pairs allowed.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "example": {
+            "industry": "technology"
+          }
+        }
+      }
+    },
+    "v1usersCreateMembership": {
+      "type": "object",
+      "properties": {
+        "metadata": {
+          "description": "Custom key-value pairs for storing additional user context. Keys (3-25 chars), values (1-256 chars).",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "example": {
+            "department": "engineering",
+            "location": "nyc-office"
+          }
+        },
+        "roles": {
+          "description": "Role to assign to the user within the organization",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/commonsRole"
+          },
+          "example": "admin"
+        }
+      }
+    },
+    "v1usersUpdateMembership": {
+      "type": "object",
+      "properties": {
+        "metadata": {
+          "description": "Custom key-value pairs for storing additional user context. Keys (3-25 chars), values (1-256 chars).",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "example": {
+            "department": "engineering",
+            "location": "nyc-office"
+          }
+        },
+        "roles": {
+          "description": "Role to assign to the user within the organization",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/commonsRole"
+          },
+          "example": "admin"
+        }
+      }
+    },
+    "v1usersUpdateUser": {
+      "type": "object",
+      "properties": {
+        "external_id": {
+          "description": "Your application's unique identifier for this organization, used to link Scalekit with your system.",
+          "type": "string",
+          "example": "ext_12345a67b89c"
+        },
+        "metadata": {
+          "description": "Custom key-value pairs for storing additional user context. Keys (3-25 chars), values (1-256 chars).",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "example": {
+            "department": "engineering",
+            "location": "nyc-office"
+          }
+        },
+        "user_profile": {
+          "description": "User's personal information including name, address, and other profile attributes.",
+          "$ref": "#/definitions/usersUpdateUserProfile"
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "description": "Organization represents a customer or a tenant of your product. This is the top level entity and all resources are mapped to this Organization object. Each organization is uniquely identified by `organization_id`.\n\n<!-- ## Organization Attributes\n\n| Attribute Name             | Attribute Description                                                                                                                        |\n| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |\n| `id`<br>_string_           | Unique ID of an Organization. Required for all API operations against this organization.                                                     |\n| `display_name`<br>_string_ | Name of the Organization                                                                                                                     |\n| `create_time`<br>_string_  | Creation timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.<br>Example: `2011-10-05T14:48:00.000Z`                      |\n| `update_time`<br>_string_  | Last update timestamp in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.<br>Example: `2021-10-05T14:48:00.000Z`                   |\n| `external_id`<br>_string_  | Your system's unique ID for this organization. You can use this to fetch Organization and Connection details without storing Scalekit's IDs. |\n| `metadata`<br>_object_     | Additional organization information stored as JSON.<br>Example: `{\"key\":\"value\"}`                                                            |\n| `region_code`<br>_string_  | Data center region where organization data is stored. Currently always returns `US`.                                                         | -->\n",
+      "name": "Organizations"
+    },
+    {
+      "description": "Complete user lifecycle and organization membership operations. Create, retrieve, update, and delete users. Manage organization memberships and search across your environment.",
+      "name": "Users"
+    },
+    {
+      "name": "Connections"
+    },
+    {
+      "name": "Directory"
+    },
+    {
+      "description": "Endpoints for managing API client applications. API clients enable secure, automated interactions between software systems without human intervention. Each client is uniquely identified by a `client_id` and can be configured with authentication settings, redirect URIs, and security parameters. Use these endpoints to create, manage, and configure API clients for your API clients.",
+      "name": "API Auth",
+      "externalDocs": {
+        "url": "https://docs.scalekit.com/m2m/overview"
+      }
+    },
+    {
+      "description": "Endpoints for sending and verifying passwordless authentication emails. These APIs allow users to authenticate without passwords by receiving a verification code or magic link in their email.",
+      "name": "Passwordless Auth"
+    }
+  ],
+  "externalDocs": {
+    "description": "Scalekit Docs",
+    "url": "https://docs.scalekit.com/"
+  }
+}

--- a/scripts/manual/SWAGGER_REORDERING.md
+++ b/scripts/manual/SWAGGER_REORDERING.md
@@ -1,0 +1,134 @@
+# Swagger API Endpoint Reordering
+
+This project uses automated scripts to maintain logical ordering of API endpoints in the Swagger documentation for better developer experience.
+
+## What the script does:
+
+- **reorder-swagger.js**: Advanced reordering with logical operation flow within resources, tag-based resource detection, and automatic backups
+
+## Resource Priority Order
+
+Endpoints are grouped by resource in this order:
+
+1. **Organizations** - Organization management endpoints
+2. **Users** - User lifecycle and management
+3. **Memberships** - User-organization relationships
+4. **Connections** - SSO and authentication connections
+5. **Directories** - Directory synchronization
+6. **Clients** - API client management
+7. **Passwordless** - Passwordless authentication
+
+## Logical Operation Ordering
+
+Within each resource, operations follow logical flow:
+
+### Passwordless Authentication
+
+- `send` → `resend` → `verify`
+
+### Users
+
+- `list` → `create` → `get` → `update` → `delete`
+
+## Tag-Based Resource Detection
+
+The enhanced script now uses **tags** as the primary method for identifying resource groups, with path segments as fallback. This allows for future categorization like:
+
+- **Admin Portal** - Administrative operations
+- **API Auth** - Authentication and authorization
+- **Passwordless Auth** - Passwordless authentication flows
+
+## Usage
+
+### Automatic Reordering (Recommended)
+
+The script runs automatically when you start the development server:
+
+```bash
+pnpm run dev
+```
+
+This will reorder the swagger endpoints and then start the Astro dev server.
+
+### Manual Reordering
+
+```bash
+# Reorder using the script directly
+node scripts/reorder-swagger.js public/api/scalekit.swagger.json
+
+# Or use the npm script
+pnpm run reorder-swagger
+```
+
+### Output Options
+
+```bash
+# Overwrite original file (creates backup automatically)
+node scripts/reorder-swagger.js public/api/scalekit.swagger.json
+
+# Output to different file
+node scripts/reorder-swagger.js public/api/scalekit.swagger.json public/api/scalekit.swagger.sorted.json
+```
+
+## Automatic Backup
+
+When overwriting the original file, the script automatically creates a timestamped backup:
+
+```
+scalekit.swagger.json.bak.2025-01-15T10-30-45.json
+```
+
+## Adding New Resource Ordering
+
+To add logical ordering for a new resource:
+
+1. **Add to RESOURCE_PRIORITY** (if not already included)
+2. **Add to OPERATION_PRIORITY** with desired keyword order:
+
+```javascript
+const OPERATION_PRIORITY = {
+  passwordless: ['send', 'resend', 'verify'],
+  users: ['list', 'create', 'get', 'update', 'delete'],
+  new_resource: ['create', 'list', 'get', 'update', 'delete'],
+}
+```
+
+## Troubleshooting
+
+### "Wrong order still appears"
+
+1. **Verify script execution**: Check console output for "✅ Swagger reordered and saved to..."
+2. **Check file path**: Ensure you're editing the correct file
+3. **Clear cache**: Restart your development server if using hot reload
+4. **Check dev script**: Ensure you're running `pnpm run dev` which automatically reorders endpoints
+
+### "Resource not recognized"
+
+1. **Check tags**: Ensure endpoints have appropriate tags
+2. **Verify path structure**: Paths should follow `/api/v1/{resource}/...` pattern
+3. **Check slugification**: Tags are converted to lowercase with underscores
+
+### "Operation keywords not found"
+
+1. **Verify keywords**: Ensure operation keywords appear in the path
+2. **Check case sensitivity**: Keywords are matched case-insensitively
+3. **Update OPERATION_PRIORITY**: Add missing keywords to the configuration
+
+## Integration with Scalar
+
+Scalar renders API endpoints in the exact order they appear in the Swagger JSON file. The reordering scripts ensure:
+
+- Logical resource grouping
+- Consistent operation flow
+- Better developer experience
+- Maintainable documentation structure
+
+## Migration Notes
+
+This system was implemented to replace manual endpoint ordering and provides:
+
+- 🔄 **Automated consistency** across all API documentation
+- 🎯 **Logical flow** that matches developer expectations
+- 🏷️ **Tag-based grouping** for flexible categorization
+- 📦 **Automatic backups** to prevent data loss
+- ⚡ **Fast execution** with minimal dependencies

--- a/scripts/reorder-swagger.js
+++ b/scripts/reorder-swagger.js
@@ -62,14 +62,22 @@ const slugify = (str) =>
 // Extract the first path segment after the version prefix (e.g. /api/v1/<segment>/...)
 // UPDATE 3: modify extractResourceKey to accept methodsObj and prefer tags; keep old signature but allow second arg optional
 function extractResourceKey(apiPath, methodsObject = {}) {
-  // Prefer first tag found in any operation within the path
+  // Attempt to use the first tag
+  let tagSlug = ''
   for (const method of Object.keys(methodsObject)) {
     const op = methodsObject[method]
     if (op && Array.isArray(op.tags) && op.tags.length) {
-      return slugify(op.tags[0])
+      tagSlug = slugify(op.tags[0])
+      break
     }
   }
-  // Fallback to path segment
+
+  // Use tag slug only if it is explicitly configured for ordering
+  if (tagSlug && (OPERATION_PRIORITY[tagSlug] || RESOURCE_PRIORITY.includes(tagSlug))) {
+    return tagSlug
+  }
+
+  // Fallback to the 3rd path segment
   const parts = apiPath.split('/').filter(Boolean)
   return parts[2] ? slugify(parts[2]) : ''
 }

--- a/scripts/reorder-swagger.js
+++ b/scripts/reorder-swagger.js
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+
+// Enhanced reordering script that handles logical operation flow within the same HTTP method
+// Reorders the paths in a Swagger (OpenAPI v2) JSON file so that:
+// 1. Resources follow a predefined logical order (e.g. organizations → users → memberships …).
+// 2. Within each resource, paths with fewer segments come first.
+// 3. HTTP operations inside every path object are ordered GET → POST → PUT → PATCH → DELETE → (others alphabetical).
+// 4. Within the same HTTP method, operations follow logical flow (e.g. Send → Resend → Verify for passwordless).
+//
+// Usage:
+//   node scripts/reorder-swagger-enhanced.js <inputPath> [outputPath]
+//
+// If outputPath is omitted, the tool overwrites the original file **after** creating a timestamped backup next
+// to it (e.g. scalekit.swagger.json.bak.2025-07-08T12-34-56.json).
+
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+// ES-module friendly __dirname / __filename
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+/*************************************************************************************************
+ * Configuration                                                                                 *
+ *************************************************************************************************/
+
+// Priority list that decides the order of top-level resources. Anything not listed falls back to
+// alphabetical order **after** the listed resources.
+const RESOURCE_PRIORITY = [
+  'organizations',
+  'users',
+  'memberships',
+  'connections',
+  'directories',
+  'clients',
+  'passwordless',
+]
+
+// Desired order of HTTP verbs inside each path object
+const METHOD_PRIORITY = ['get', 'post', 'put', 'patch', 'delete']
+
+// Logical operation ordering within the same HTTP method and resource
+// Key: resource name, Value: array of operation keywords in desired order
+const OPERATION_PRIORITY = {
+  passwordless: ['send', 'resend', 'verify'],
+  users: ['list', 'create', 'get', 'update', 'delete'],
+  // 'organizations': ['create', 'list', 'get', 'update', 'delete'],
+}
+
+// UPDATE 1: add slugify helper just below CONFIG section
+const slugify = (str) =>
+  str
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+
+/*************************************************************************************************
+ * Helper functions                                                                               *
+ *************************************************************************************************/
+
+// Extract the first path segment after the version prefix (e.g. /api/v1/<segment>/...)
+// UPDATE 3: modify extractResourceKey to accept methodsObj and prefer tags; keep old signature but allow second arg optional
+function extractResourceKey(apiPath, methodsObject = {}) {
+  // Prefer first tag found in any operation within the path
+  for (const method of Object.keys(methodsObject)) {
+    const op = methodsObject[method]
+    if (op && Array.isArray(op.tags) && op.tags.length) {
+      return slugify(op.tags[0])
+    }
+  }
+  // Fallback to path segment
+  const parts = apiPath.split('/').filter(Boolean)
+  return parts[2] ? slugify(parts[2]) : ''
+}
+
+// Extract operation keyword from path (e.g., "send", "resend", "verify" from passwordless paths)
+function extractOperationKey(apiPath) {
+  const parts = apiPath.split('/').filter(Boolean)
+  // Look for operation keywords in the path segments
+  const operationKeywords = Object.values(OPERATION_PRIORITY).flat()
+
+  for (const part of parts) {
+    const lowerPart = part.toLowerCase()
+    if (operationKeywords.includes(lowerPart)) {
+      return lowerPart
+    }
+  }
+
+  // If no specific operation found, return the last meaningful segment
+  return parts[parts.length - 1] || ''
+}
+
+// Compare two resources according to RESOURCE_PRIORITY, then alphabetical
+function compareResources(a, b) {
+  const idxA = RESOURCE_PRIORITY.indexOf(a)
+  const idxB = RESOURCE_PRIORITY.indexOf(b)
+
+  if (idxA === -1 && idxB === -1) {
+    return a.localeCompare(b)
+  }
+  if (idxA === -1) return 1
+  if (idxB === -1) return -1
+  return idxA - idxB
+}
+
+// Compare operations within the same resource and HTTP method
+function compareOperations(pathA, pathB, resource) {
+  const operationPriority = OPERATION_PRIORITY[resource]
+  if (!operationPriority) {
+    // No specific ordering defined, fall back to lexical
+    return pathA.localeCompare(pathB)
+  }
+
+  const opA = extractOperationKey(pathA)
+  const opB = extractOperationKey(pathB)
+
+  const idxA = operationPriority.indexOf(opA)
+  const idxB = operationPriority.indexOf(opB)
+
+  if (idxA === -1 && idxB === -1) {
+    return pathA.localeCompare(pathB)
+  }
+  if (idxA === -1) return 1
+  if (idxB === -1) return -1
+  return idxA - idxB
+}
+
+// Compare two paths according to resource, then depth, then operation, then lexical
+function comparePaths(pathA, pathB) {
+  const resA = extractResourceKey(pathA)
+  const resB = extractResourceKey(pathB)
+
+  const resCmp = compareResources(resA, resB)
+  if (resCmp !== 0) return resCmp
+
+  // path depth (fewer segments first)
+  const depthA = pathA.split('/').length
+  const depthB = pathB.split('/').length
+  if (depthA !== depthB) return depthA - depthB
+
+  // If same resource and depth, check operation ordering
+  if (resA === resB) {
+    const opCmp = compareOperations(pathA, pathB, resA)
+    if (opCmp !== 0) return opCmp
+  }
+
+  // lexical fallback
+  return pathA.localeCompare(pathB)
+}
+
+// Re-order the HTTP method objects inside every path
+function reorderMethods(methodsObject) {
+  const ordered = {}
+
+  METHOD_PRIORITY.forEach((m) => {
+    if (methodsObject[m]) ordered[m] = methodsObject[m]
+  })
+
+  // Append remaining verbs alphabetically
+  Object.keys(methodsObject)
+    .filter((m) => !METHOD_PRIORITY.includes(m))
+    .sort()
+    .forEach((m) => {
+      ordered[m] = methodsObject[m]
+    })
+
+  return ordered
+}
+
+/*************************************************************************************************
+ * Main logic                                                                                     *
+ *************************************************************************************************/
+
+function reorderSwagger(swaggerJson) {
+  const newSwagger = { ...swaggerJson }
+  const paths = swaggerJson.paths || {}
+
+  // Build resource map (path => resourceKey)
+  const resourceMap = {}
+  Object.entries(paths).forEach(([p, methods]) => {
+    resourceMap[p] = extractResourceKey(p, methods)
+  })
+
+  // Custom compare using the map
+  const comparePathsWithMap = (pathA, pathB) => {
+    const resA = resourceMap[pathA] || ''
+    const resB = resourceMap[pathB] || ''
+
+    const resCmp = compareResources(resA, resB)
+    if (resCmp !== 0) return resCmp
+
+    const depthA = pathA.split('/').length
+    const depthB = pathB.split('/').length
+    if (depthA !== depthB) return depthA - depthB
+
+    if (resA === resB) {
+      const opCmp = compareOperations(pathA, pathB, resA)
+      if (opCmp !== 0) return opCmp
+    }
+
+    return pathA.localeCompare(pathB)
+  }
+
+  // Sort using injected comparator
+  const sortedPathKeys = Object.keys(paths).sort(comparePathsWithMap)
+
+  const newPaths = {}
+  sortedPathKeys.forEach((p) => {
+    newPaths[p] = reorderMethods(paths[p])
+  })
+
+  newSwagger.paths = newPaths
+  return newSwagger
+}
+
+function backupOriginal(filePath) {
+  const ts = new Date().toISOString().replace(/[:.]/g, '-')
+  const backupPath = `${filePath}.bak.${ts}`
+  fs.copyFileSync(filePath, backupPath)
+  return backupPath
+}
+
+function main() {
+  const [, , inputArg, outputArg] = process.argv
+
+  if (!inputArg) {
+    console.error('Usage: reorder-swagger-enhanced <inputPath> [outputPath]')
+    process.exit(1)
+  }
+
+  const inputPath = path.resolve(inputArg)
+  const outputPath = outputArg ? path.resolve(outputArg) : inputPath
+
+  if (!fs.existsSync(inputPath)) {
+    console.error(`Input file not found: ${inputPath}`)
+    process.exit(1)
+  }
+
+  const raw = fs.readFileSync(inputPath, 'utf8')
+  let spec
+  try {
+    spec = JSON.parse(raw)
+  } catch (err) {
+    console.error(`Failed to parse JSON from ${inputPath}:`, err.message)
+    process.exit(1)
+  }
+
+  const reordered = reorderSwagger(spec)
+  const outputJson = JSON.stringify(reordered, null, 2) + '\n'
+
+  if (!outputArg) {
+    const backup = backupOriginal(inputPath)
+    console.log(`📦  Backup created at ${backup}`)
+  }
+
+  fs.writeFileSync(outputPath, outputJson, 'utf8')
+  console.log(`✅ Swagger reordered and saved to ${outputPath}`)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
Long standing problem to the docs generated from swagger has been the order of API endpoints. This PR adds a scripts that let's choose the order on how endpoints are presented. 

This is tooling related change