### PR TITLE
Add “Community” SDK grouping in sidebar and document decoded access/ID tokens

### DIFF
--- a/public/api/scalekit.swagger.json
+++ b/public/api/scalekit.swagger.json
@@ -336,104 +336,6 @@
         ]
       }
     },
-    "/api/v1/organizations/{id}/session-settings": {
-      "get": {
-        "description": "Retrieves the currently configured session timeout policies for a specific organization, including absolute and idle timeout values.",
-        "tags": ["Organizations"],
-        "summary": "Get organization session settings",
-        "operationId": "OrganizationService_GetOrganizationSessionSettings",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "The unique identifier of the organization whose session settings are being requested.",
-            "name": "id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "The environment ID to scope the request. This ensures the settings are retrieved from the correct environment.",
-            "name": "environment_id",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved organization session settings.",
-            "schema": {
-              "$ref": "#/definitions/organizationsGetOrganizationSessionSettingsResponse"
-            }
-          }
-        }
-      },
-      "post": {
-        "description": "Defines session timeout policies for an organization, including absolute and idle timeout durations. This endpoint is used to configure session lifetimes and enhance security by automatically logging out users after a specified period of inactivity.",
-        "tags": ["Organizations"],
-        "summary": "Create organization session settings",
-        "operationId": "OrganizationService_CreateOrganizationSessionSettings",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "The unique identifier of the organization for which to create session settings.",
-            "name": "id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "The environment ID where the organization exists. This scopes the creation of session settings to a specific environment.",
-            "name": "environment_id",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "Session settings created successfully. Returns the newly configured session policies.",
-            "schema": {
-              "$ref": "#/definitions/organizationsCreateOrganizationSessionSettingsResponse"
-            }
-          }
-        }
-      },
-      "patch": {
-        "description": "Modifies the session timeout policies for an organization. Use this to adjust the absolute and idle session timeout durations to enforce different security levels.",
-        "tags": ["Organizations"],
-        "summary": "Update organization session settings",
-        "operationId": "OrganizationService_UpdateOrganizationSessionSettings",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "Unique identifier for the organization, beginning with an 'org_' prefix.",
-            "name": "id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "name": "session_settings",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "description": "The session settings to be applied, including absolute and idle timeout configurations.",
-              "$ref": "#/definitions/organizationsOrganizationSessionSettings"
-            }
-          },
-          {
-            "type": "string",
-            "description": "Unique identifier for the environment where the organization resides, prefixed with 'env_'. This specifies the environment context for the session settings.",
-            "name": "environment_id",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Session settings updated successfully. Returns the modified session policies.",
-            "schema": {
-              "$ref": "#/definitions/organizationsUpdateOrganizationSessionSettingsResponse"
-            }
-          }
-        }
-      }
-    },
     "/api/v1/organizations/{id}/settings": {
       "patch": {
         "description": "Updates configuration settings for an organization. Supports modifying SSO configuration, directory synchronization settings, and session parameters. Requires organization ID and the specific settings to update.",
@@ -3409,25 +3311,6 @@
         }
       }
     },
-    "organizationsCreateOrganizationSessionSettingsResponse": {
-      "type": "object",
-      "properties": {
-        "environment_id": {
-          "description": "The environment ID where the session settings were created.",
-          "type": "string",
-          "example": "env_59615193906282635"
-        },
-        "organization_id": {
-          "description": "The unique identifier of the organization for which session settings were created.",
-          "type": "string",
-          "example": "org_59615193906282635"
-        },
-        "session_settings": {
-          "description": "The newly created session settings, including timeout policies.",
-          "$ref": "#/definitions/organizationsOrganizationSessionSettings"
-        }
-      }
-    },
     "organizationsFeature": {
       "description": "- dir_sync: dir_sync enables directory synchronization configuration in the portal\n - sso: sso enables Single Sign-On (SSO) configuration in the portal",
       "type": "string",
@@ -3573,33 +3456,6 @@
           "format": "date-time",
           "title": "Updated time",
           "example": "2025-02-15T06:23:44.560Z"
-        }
-      }
-    },
-    "organizationsOrganizationSessionSettings": {
-      "type": "object",
-      "properties": {
-        "absolute_session_timeout": {
-          "description": "The maximum duration in seconds that a session can remain active, regardless of activity. After this time, the user will be required to re-authenticate.",
-          "type": "integer",
-          "format": "int32",
-          "example": 86400
-        },
-        "idle_session_enabled": {
-          "description": "Enables or disables idle session timeout. If true, inactive sessions will be terminated after the specified idle duration.",
-          "type": "boolean",
-          "example": true
-        },
-        "idle_session_timeout": {
-          "description": "The duration in seconds that a session can remain idle before it is automatically terminated. Activity resets the timer.",
-          "type": "integer",
-          "format": "int32",
-          "example": 1800
-        },
-        "session_management_enabled": {
-          "description": "Enables or disables session management features for the organization. When true, session timeout policies are enforced.",
-          "type": "boolean",
-          "example": true
         }
       }
     },

--- a/src/configs/sidebar.config.ts
+++ b/src/configs/sidebar.config.ts
@@ -226,6 +226,16 @@ export const sidebar = [
             link: 'https://github.com/scalekit-inc/scalekit-sdk-java',
             attrs: { target: '_blank', rel: 'noopener' },
           },
+          {
+            label: 'Community',
+            items: [
+              {
+                label: 'PHP SDK',
+                link: 'https://github.com/pawan1793/scalekit-php-sdk',
+                attrs: { target: '_blank', rel: 'noopener' },
+              },
+            ],
+          },
         ],
       },
       {

--- a/src/content/docs/dev-kit/index.mdx
+++ b/src/content/docs/dev-kit/index.mdx
@@ -31,7 +31,7 @@ These pages contain the technical descriptions of our APIs, SDKs, webhooks, and 
   <div>
     ## SDKs
 
-    Use our official SDKs for <a href="https://github.com/scalekit-inc/scalekit-sdk-node" target="_blank" rel="noopener noreferrer">Node.js</a>, <a href="https://github.com/scalekit-inc/scalekit-sdk-python" target="_blank" rel="noopener noreferrer">Python</a>, <a href="https://github.com/scalekit-inc/scalekit-sdk-go" target="_blank" rel="noopener noreferrer">Go</a>, and <a href="https://github.com/scalekit-inc/scalekit-sdk-java" target="_blank" rel="noopener noreferrer">Java</a>.
+    Use our official SDKs for <a href="https://github.com/scalekit-inc/scalekit-sdk-node" target="_blank" rel="noopener noreferrer">Node.js</a>, <a href="https://github.com/scalekit-inc/scalekit-sdk-python" target="_blank" rel="noopener noreferrer">Python</a>, <a href="https://github.com/scalekit-inc/scalekit-sdk-go" target="_blank" rel="noopener noreferrer">Go</a>, and <a href="https://github.com/scalekit-inc/scalekit-sdk-java" target="_blank" rel="noopener noreferrer">Java</a>. We also have community-maintained SDKs for <a href="https://github.com/pawan1793/scalekit-php-sdk" target="_blank" rel="noopener noreferrer">PHP</a>.
 
     ---
 

--- a/src/content/docs/fsa/guides/implement-login.mdx
+++ b/src/content/docs/fsa/guides/implement-login.mdx
@@ -157,6 +157,38 @@ Let's get started!
 
       The `authResult` contains the user's profile and the necessary tokens to create a session.
 
+      <details>
+      <summary>View ID token in `authResult`</summary>
+      ```json title="ID Token (decoded JWT) example" showLineNumbers=false
+        {
+          "amr": [
+            "conn_123456789012345678"
+          ],
+          "at_hash": "QwertyUioP",
+          "aud": [
+            "skc_987654321098765432"
+          ],
+          "azp": "skc_987654321098765432",
+          "c_hash": "A1b2C3d4E5",
+          "client_id": "skc_987654321098765432",
+          "email": "john.doe@example.com",
+          "email_verified": true,
+          "exp": 1753441845,
+          "family_name": "Doe",
+          "given_name": "John",
+          "iat": 1750849845,
+          "iss": "http://example.localhost:8889",
+          "name": "John Doe",
+          "oid": "org_987654321098765432",
+          "roles": [
+            "member"
+          ],
+          "sid": "ses_987654321098765432",
+          "sub": "usr_987654321098765432"
+        }
+        ```
+      </details>
+
 4. ## Create a user session
       With the user's identity verified, you can now establish a session. This typically involves storing the tokens securely and using them to manage the user's authenticated state.
 

--- a/src/content/docs/fsa/guides/manage-session.mdx
+++ b/src/content/docs/fsa/guides/manage-session.mdx
@@ -101,6 +101,28 @@ Scalekit provides session management capabilities out of the box. Your applicati
 
    Store each token based on its security requirements:
    - **Access Token**: Store in a secure, HTTP-only cookie to prevent XSS attacks. This token has a short lifespan and provides access to protected resources.
+   <details>
+   <summary>View decoded access token</summary>
+   ```json title="Access Token (decoded JWT) example" showLineNumbers=false
+    {
+      "aud": [
+        "skc_987654321098765432"
+      ],
+      "client_id": "skc_987654321098765432",
+      "exp": 1750850145,
+      "iat": 1750849845,
+      "iss": "http://example.localhost:8889",
+      "jti": "tkn_987654321098765432",
+      "nbf": 1750849845,
+      "roles": [
+        "member"
+      ],
+      "sid": "ses_987654321098765432",
+      "sub": "usr_987654321098765432",
+      "xuid": "john.doe"
+    }
+    ```
+   </details>
    - **Refresh Token**: Store in your backend database or secure server-side storage. This long-lived token generates new access tokens.
 
    Here's how to set secure cookies:

--- a/src/content/docs/reference/glossary.mdx
+++ b/src/content/docs/reference/glossary.mdx
@@ -1,171 +1,231 @@
 ---
 title: Glossary
 tableOfContents: true
+head:
+  - tag: style
+    content: |
+      .sl-markdown-content h2 {
+        font-size: var(--sl-text-xl);
+      }
 prev: false
 next: false
 ---
 
-### Admin Portal
+## Access Token
+- **Definition**: A credential (often a JWT) issued by the authorization server that the client uses to access the resource server. It represents the client's authorization and typically has an expiry time and scopes attached. The resource server validates this token.
+
+## Administrator
+- **Definition**: An IT administrator responsible for managing identity provider configurations within a customer organization.
+
+## Admin Portal
 - **Definition**: A customizable web interface for customers' IT administrators to manage identity provider configurations.
 
-### API Endpoint
+## AI Agent Identity and Attestation
+- **Definition**: A process by which an AI agent proves its identity to an authorization server, often using cryptographic evidence (e.g. signed JWT assertions or hardware-backed keys), so the server can trust requests coming from that agent.
+
+## API Endpoint
 - **Definition**: A specific URL where an API can be accessed to perform specific operations or retrieve data.
 
-### API Key
+## API Key
 - **Definition**: A unique identifier used to authenticate API requests to Scalekit, allowing secure access to the platform's features and services.
 
-### App
+## App
 - **Definition**: Another term for an application, representing the software product or service sold to customers.
 
-### Application
+## Application
 - **Definition**: The software product or service offered by B2B App developers to customers.
 - **Example**: A workspace can contain multiple applications.
 
-### Audit Log
+## Audit Log
 - **Definition**: A record of all activities and changes made within the B2B App, used for security and compliance purposes.
 
-### Authentication
+## Authentication
 - **Definition**: The process of verifying the identity of a user or system attempting to access the B2B App.
 
-### Authorization
+## Authorization
 - **Definition**: The process of determining what actions or resources a user is allowed to access within the B2B App.
 
-### Authorization URL
+## Authorization Server
+- **Definition**: The server in OAuth that authenticates clients and issues tokens (could be a part of your SaaS or a third-party IdP like Okta Azure AD, etc.). It essentially says "Yes, client X, here is a token proving you are authenticated and allowed to do Y."
+
+## Authorization URL
 - **Definition**: The URL to which users are redirected to grant authorization for the B2B App.
 
-### B2B App
+## B2B App
 - **Definition**: An application designed for use by other businesses or organizations to streamline operations.
 
-### B2B SaaS App
+## B2B SaaS App
 - **Definition**: A type of B2B App delivered over the internet, allowing access without local installation.
 
-### Claims
+## Claims
 - **Definition**: Information about a user that is passed from an identity provider to a service provider during authentication.
 
-### Configuration
+## Client Credentials Flow
+- **Definition**: The OAuth process where a machine client exchanges its client ID and secret for an access token from the auth server. No user involved. The resulting token represents the machine and carries scopes for what it can do.
+
+## Configuration
 - **Definition**: The settings and parameters that define how the B2B App interacts with Scalekit and other services.
 
-### Connection
+## Connection
 - **Definition**: A link between the B2B App and a customer's identity provider for enabling Single Sign-On (SSO).
 - **Example**: Each organization can have its own unique connection.
 
-### Customer
+## Customer
 - **Definition**: A business or organization that uses the application to meet specific needs.
 
-### Custom Attribute
+## Custom Attribute
 - **Definition**: Additional fields added to user data in Scalekit for storing extra information.
 
-### Dashboard
+## Dashboard
 - **Definition**: The main control panel within Scalekit for configuring settings, viewing analytics, and managing integrations.
 
-### Deprovisioning
+## Deprovisioning
 - **Definition**: The process of removing user access and accounts when they are no longer needed or authorized.
 
-### Directory Provider
+## Directory Provider
 - **Definition**: An organization offering directory services, including identity providers.
 
-### Directory Sync
+## Directory Sync
 - **Definition**: A module in Scalekit for automatic provisioning and deprovisioning of user accounts.
 
-### Documentation
+## Documentation
 - **Definition**: Comprehensive guides and references that explain how to use and integrate with Scalekit's features and services.
 
-### Environment
+## Dynamic Client Registration
+- **Definition**: A protocol (RFC 7591) that allows a client application to programmatically register itself with an authorization server to obtain credentials (client ID/secret, etc.). Useful for large-scale or third-party ecosystems where manual registration of clients is not feasible or to enable self-service integration in a controlled way.
+
+## Environment
 - **Definition**: Different versions or instances of an application, such as test and live environments.
 - **Example**: Each environment has its own settings and is isolated for security.
 
-### Error Handling
+## Error Handling
 - **Definition**: The process of managing and responding to errors that occur during API calls or application operations.
 
-### Federation
+## Federation
 - **Definition**: The process of establishing trust between different identity providers and service providers for seamless authentication.
 
-### ID Token
+## ID Token
 - **Definition**: A JSON Web Token (JWT) issued by the identity provider containing user identity information.
 
-### Identity Provider (IdP)
+## Identity Provider (IdP)
 - **Definition**: A service that verifies user identity and provides information about user attributes.
 
-### IdP Simulator
+## IdP Simulator
 - **Definition**: A tool that mimics the behavior of an identity provider for testing integrations.
 
-### Integration
+## Integration
 - **Definition**: The process of connecting Scalekit with other systems or services to enable seamless data flow and functionality.
 
-### JWT
+## JWT
 - **Definition**: A standard format for representing claims securely between two parties. It is a compact, URL-safe means of representing claims securely between two parties.
 
-### Logout
+## Logout
 - **Definition**: The process of ending a user's session and revoking their access to the B2B App.
 
-### MFA (Multi-Factor Authentication)
+## Machine-to-Machine (M2M) Authentication
+- **Definition**: Methods for verifying identity between two automated services or software entities without human intervention. Ensures a client program (machine) is trusted by the service it calls, typically via tokens, keys, or certificates.
+
+## MFA (Multi-Factor Authentication)
 - **Definition**: A security feature that requires users to provide multiple forms of verification before accessing the B2B App.
 
-### Normalized Payload
+## Model Context Protocol (MCP)
+- **Definition**: A new protocol (spearheaded by Anthropic and others) to standardize how AI models (assistants) can interact with external tools and data. It defines how AI agents can discover available "tools" (APIs) and the context to call them. For auth, MCP leverages OAuth 2.1 – effectively requiring AI agents to go through a secure authorization process to get access to those tools. Think of it as an evolving standard to make AI to SaaS integrations plug-and-play, with security built-in via OAuth.
+
+## Mutual TLS (mTLS)
+- **Definition**: A transport layer security mechanism where *both client and server present certificates* to mutually authenticate each other during the TLS handshake. Provides strong assurance of identities at connection level and encrypts the traffic. Used in high-security environments and internal service-to-service auth.
+
+## Normalized Payload
 - **Definition**: A standardized format for data sent from Scalekit to the B2B App.
 
-### OAuth
+## OAuth
 - **Definition**: A standard protocol for authorization enabling limited access to user data.
 
-### OIDC
+## OAuth 2.0/OAuth 2.1
+- **Definition**: An authorization framework widely used for granting access to resources. OAuth 2.0 defines various *flows* (grant types) for different scenarios (authorization code, client credentials, etc.). OAuth 2.1 is an incremental update that compiles security best practices (PKCE required, no legacy flows, etc.). In M2M context, OAuth's **Client Credentials Grant** is most relevant, allowing a service to get an access token using its own credentials.
+
+## OAuth 2.0 Token Exchange (RFC 8693)
+- **Definition**: A protocol that lets one token be exchanged for another—for example, an AI agent exchanging its machine-client token for a token scoped to call a downstream service on behalf of a user or another service. Enables delegation and impersonation scenarios.
+
+## OIDC
 - **Definition**: A standard protocol for authentication that builds on OAuth 2.0.
 
-### Organization
+## OpenID Connect (OIDC)
+- **Definition**: An identity layer on top of OAuth 2.0 (often used for user authentication). Mentioned here because the discovery document and id_token concepts come from OIDC. OIDC isn't directly about M2M auth (it's user-centric), but the OIDC discovery (`.well-known`) and JWT usage are leveraged in service auth too.
+
+## Organization
 - **Definition**: The customers of B2B Apps, typically businesses.
 - **Example**: Each business is considered an organization with its own users.
 
-### Provisioning
+## PKCE (Proof Key for Code Exchange)
+- **Definition**: An extension to OAuth used to prevent interception of authorization codes. The client generates a random secret (code verifier) and sends a hashed version (code challenge) in the auth request, then must present the original secret when redeeming the code. Ensures that even if an attacker intercepts the auth code, they can't exchange it without the secret. PKCE is now recommended for any OAuth client that can't secure a client secret – including mobile, SPA, and some machine clients.
+
+## PKI (Public Key Infrastructure)
+- **Definition**: The system of certificate authorities, processes, and tools for managing digital certificates (like those used in mTLS). Involves issuing certs, distributing them, rotating when expired, revoking if compromised, etc. A robust PKI is needed to effectively use certificate-based auth at scale.
+
+## Provisioning
 - **Definition**: The process of creating and managing user accounts and access rights in the B2B App.
 
-### Rate Limiting
+## Rate Limiting
 - **Definition**: A mechanism that controls the rate of requests a user or application can make to the API within a specific time period.
 
-### Role-Based Access Control (RBAC)
+## Refresh Token
+- **Definition**: A long-lived token that can be used to get new access tokens without re-authenticating. In M2M auth, refresh tokens are rarely used because the client can just use its credentials again. Refresh tokens are more for user-based flows to avoid prompting the user frequently.
+
+## Resource Server
+- **Definition**: The API or service that the client wants to use – it receives tokens from clients and decides whether to accept them (by validating them). In our context, your SaaS API is a resource server that expects a valid token for requests.
+
+## Role-Based Access Control (RBAC)
 - **Definition**: A method of regulating access to resources based on the roles of individual users within an organization.
 
-### SAML Assertion
+## SAML Assertion
 - **Definition**: A statement by an identity provider indicating a user's authentication status.
 
-### SCIM
+## SCIM
 - **Definition**: SCIM (System for Cross-domain Identity Management) is a standard protocol for automating the provisioning and deprovisioning of user accounts and their attributes between an identity provider and a service provider.
 
-### Service Provider
+## Scopes
+- **Definition**: Strings that define what access is being requested or granted in an OAuth token. For example, `read:inventory` or `payments:create`. Scopes let the token carry permissions, enabling the resource server to allow or deny requests based on scope. Principle of least privilege is implemented by granting minimal scopes.
+
+## Service Account
+- **Definition**: A non-human account used by a software service. In context, it's an identity set up for a machine to use. For example, a service account could be created for "Data Sync Service" in a customer's tenant on your app. Service accounts have credentials (like client ID/secret or keys) to authenticate, and usually have roles or scopes assigned just like a user would. They enable organization-level or service-level tokens without tying to an actual person.
+
+## Service Provider
 - **Definition**: An entity offering a product or service to another organization or individual, especially in SSO contexts.
 
-### Session
+## Session
 - **Definition**: A period of interaction between a user and the B2B App, typically starting with authentication and ending with logout.
 
-### Social Connection
+## Social Connection
 - **Definition**: Allows users to sign in using their social media accounts.
 
-### SSO (Single Sign-On)
+## SSO (Single Sign-On)
 - **Definition**: An authentication method that allows users to access multiple applications with a single set of credentials.
 
-### Team Member
+## Team Member
 - **Definition**: Individuals from the B2B App developer's company who use Scalekit to manage applications.
 - **Roles**: Can include developers, product managers, or customer support staff.
 
-### Tenant
+## Tenant
 - **Definition**: An isolated instance of the B2B App for a specific customer organization, with its own data and configurations.
 
-### Token
+## Token
 - **Definition**: A piece of data that represents a user's authentication status and permissions, used for accessing protected resources.
 
-### User
+## User
 - **Definition**: An individual who uses the B2B App, typically belonging to a customer organization.
 
-### User Attribute
+## User Attribute
 - **Definition**: Properties describing a user's identity, used for authentication and access control.
 
-### Webhook
+## Webhook
 - **Definition**: A mechanism for the B2B App to receive notifications or updates from Scalekit.
 
-### Webhook Payload
+## Webhook Payload
 - **Definition**: The data sent by Scalekit to the B2B App when a webhook is triggered, containing information about the event.
 
-### Workspace
+## Workspace
 - **Definition**: A centralized hub for B2B App developers to manage applications and settings.
 - **Example**: Think of it as a command center for efficient application management.
 
-### Administrator
-- **Definition**: An IT administrator responsible for managing identity provider configurations within a customer organization.
+## Zero Trust Security
+- **Definition**: A security model where no user or device is inherently trusted, even if inside the network. Every access request must be authenticated, authorized, and continuously validated. For M2M, this means authenticating every service communication, minimizing implicit trust, and verifying identities at multiple layers (network & application). It often involves micro-segmentation and strict identity and access management for every machine identity.


### PR DESCRIPTION
- Refactored the SDKs section in the documentation sidebar to introduce a clearly labeled “Community” group, distinguishing community-contributed SDKs (e.g., PHP SDK) from official ones.
- Updated the SDKs documentation to mention available community-maintained SDKs.
- Added code examples and expandable details sections showing decoded access tokens and decoded ID tokens in relevant Auth guides, improving transparency for implementers.
- These changes help clarify SDK sources and provide better context for token contents, supporting developers with both integration discoverability and practical JWT usage.