### PR TITLE
Highlights the right lines in the organization-switching guide (cursor background agent's work)

### DIFF
--- a/src/content/docs/fsa/guides/organization-switching.mdx
+++ b/src/content/docs/fsa/guides/organization-switching.mdx
@@ -162,7 +162,7 @@ To bypass the organization switcher and directly authenticate users into a speci
         ```
       </TabItem>
       <TabItem value="go" label="Go">
-        ```go title="Gin" wrap "authorizationUrl" ins={5,6}
+        ```go title="Gin" wrap "authorizationUrl" ins={4,5}
         redirectUri := "http://localhost:3000/api/callback"
         options := scalekit.AuthorizationUrlOptions{
             Scopes: []string{"openid", "profile", "email", "offline_access"},


### PR DESCRIPTION
Update Go code snippet highlighting in organization-switching guide to correctly show relevant lines.

The previous highlighting `ins={5,6}` was incorrect. This change updates it to `ins={4,5}` to correctly highlight the `Prompt` and `OrganizationId` lines, which are the key additions for direct organization access.
