### PR TITLE
Refactor edit URL construction in PageSidebar component

### DIFF
--- a/src/components/overrides/PageSidebar.astro
+++ b/src/components/overrides/PageSidebar.astro
@@ -7,10 +7,13 @@ const { entry: routeEntry } = Astro.locals.starlightRoute
 const { dir, entry, locale } = Astro.props
 
 // Get edit URL from Starlight's configuration
+// Check if editUrl is disabled in frontmatter, otherwise construct it from the entry id
 const editUrl =
-  entry?.data?.editUrl !== false
-    ? `https://github.com/scalekit-inc/developer-docs/edit/main/src/content/docs/${entry?.id || ''}`
-    : null
+  entry?.data?.editUrl === false
+    ? null
+    : routeEntry?.id
+      ? `https://github.com/scalekit-inc/developer-docs/edit/main/src/content/docs/${routeEntry.id}.mdx`
+      : null
 ---
 
 <div>


### PR DESCRIPTION
- Updated the logic for generating the edit URL in the PageSidebar component to check if the editUrl is disabled in frontmatter.
- Enhanced the URL construction to use the routeEntry ID, improving the accuracy of the edit link for documentation editing.