### PR TITLE
Make sure to point users at right API endpoints

### DIFF
--- a/scripts/manual/API_REFERENCE_WORKFLOW.md
+++ b/scripts/manual/API_REFERENCE_WORKFLOW.md
@@ -1,0 +1,138 @@
+# Scalekit API Reference Pipeline
+
+This guide explains **how the API reference is wired together** in the docs repo and the exact steps to update or extend it.
+
+---
+
+## 1. The Moving Parts
+
+| File / Component                      | Responsibility                                                                                                                                  |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `public/api/scalekit.swagger.json`    | Source-of-truth Swagger (OpenAPI 2) definition. Every endpoint lives here.                                                                      |
+| `scripts/search-index-apis.js`        | Parses the Swagger file → creates **search records** → returns an array used by Pagefind. Run manually or via `pnpm run generate-search-index`. |
+| `src/components/ApiSearchIndex.astro` | Hidden Astro component that renders the records from the script in HTML so Pagefind can crawl them.                                             |
+| `src/components/ScalarReference.vue`  | Embeds the interactive <kbd>@scalar/api-reference</kbd> viewer so humans can read the docs.                                                     |
+| `src/pages/apis.astro`                | Top-level page that hosts both the Scalar viewer **and** the hidden search index.                                                               |
+
+Diagram:
+
+```
+Swagger → search-index-apis.js ──▶ records[] ──▶ ApiSearchIndex.astro (hidden HTML)
+                │
+                └──▶ ScalarReference.vue (Swagger URL prop)
+```
+
+---
+
+## 2. How the Pieces Talk to Each Other
+
+1. **Build / dev-server start**
+   1. `ApiSearchIndex.astro` imports `extractApiRecords` from the script → executes it at build time.
+   2. The script reads `scalekit.swagger.json` and generates records containing:
+      - `title`, `description`
+      - `url` with deep link `#tag/{tag}/{method}{path}`
+      - `parameters` list (for extra search keywords)
+   3. Astro outputs a hidden `<div data-pagefind-body>` containing one `<li>` per endpoint.
+2. **Pagefind crawl**
+   - Because the hidden div carries `data-pagefind-body`, Pagefind indexes its content + links.
+   - Search results therefore point to the deep-link in `record.url`.
+3. **Runtime (browser)**
+   - `ScalarReference.vue` fetches the same Swagger file and renders the interactive UI.
+   - When someone clicks a Pagefind result, the `#tag/…` fragment scrolls Scalar to that endpoint.
+
+---
+
+## 3. Typical Maintenance Tasks
+
+### A. Adding / Changing Endpoints
+
+1. Edit **only** `public/api/scalekit.swagger.json` (or replace it from the backend generator).
+2. (Optional) Run `pnpm run reorder-swagger` to keep sections ordered (see `scripts/reorder-swagger.js`).
+3. _Development:_ Just restart `pnpm dev` – Astro + Pagefind re-run automatically.
+4. _CI / Production build:_ Nothing extra to do – `astro build` triggers everything.
+
+### B. Regenerating the Search Index Manually
+
+```bash
+pnpm run generate-search-index
+```
+
+The script:
+
+- Validates URL fragment generation (see console output).
+- Does **not** write files – it’s executed by Astro at build time. Manual run is only for quick checks.
+
+### C. Styling / Layout Tweaks
+
+| Want to change…           | Edit…                                                  |
+| ------------------------- | ------------------------------------------------------ |
+| Hidden search list markup | `ApiSearchIndex.astro`                                 |
+| Scalar header / theme     | `ScalarReference.vue` + `src/styles/api-reference.css` |
+| Overall page container    | `src/pages/apis.astro`                                 |
+
+### D. Updating the Deep-Link Format
+
+If Scalar changes its anchor scheme:
+
+1. Update `generateUrlFragment()` in `scripts/search-index-apis.js`.
+2. (Maybe) update the `<AnchorHeading id>` logic in `ApiSearchIndex.astro` so the heading id matches.
+3. Re-run a build and verify test cases printed by the script.
+
+---
+
+## 4. Common Pitfalls & Fixes
+
+| Symptom                                                         | Likely Cause                                          | Fix                                                               |
+| --------------------------------------------------------------- | ----------------------------------------------------- | ----------------------------------------------------------------- |
+| Pagefind result links to `#list-users` instead of full `#tag/…` | Your heading IDs don’t match the new fragment format. | Ensure `id={record.url.split('#')[1]}` in `ApiSearchIndex.astro`. |
+| New endpoints not searchable                                    | Forgot to restart dev server / rebuild                | Stop & start `pnpm dev` **or** run `pnpm run build`.              |
+| Linter shows `$ref` unresolved in Swagger                       | The referenced definition is missing                  | Add the missing schema or remove the `$ref`.                      |
+
+---
+
+## 5. Handy Scripts
+
+| Command                          | What it does                                                                 |
+| -------------------------------- | ---------------------------------------------------------------------------- |
+| `pnpm run generate-search-index` | Runs `scripts/search-index-apis.js` standalone – helpful for URL validation. |
+| `pnpm run reorder-swagger`       | Applies logical ordering to Swagger paths for readability.                   |
+| `pnpm run build`                 | Full static build (Astro, Pagefind, everything).                             |
+| `pnpm run preview`               | Serve the built site locally.                                                |
+
+---
+
+Happy documenting! 🎉
+
+## 6. How Search Works under the Hood
+
+Pagefind is a **static-site search engine**. It doesn’t read the Swagger directly – it crawls the HTML that Astro outputs.
+
+Step-by-step:
+
+1. **Build time**
+   1. `ApiSearchIndex.astro` renders a `<div data-pagefind-body>` that contains **every API endpoint** as list items.
+   2. Each list item includes:
+      - `h3` heading whose **`id` attribute** matches the deep-link fragment (e.g. `tag/users/get/api/v1/users`).
+      - A child `<a href="…#tag/…">` – the canonical link.
+      - Parameter bullets so names & descriptions are part of the visible DOM.
+2. **Pagefind CLI** (run automatically by the Starlight build)
+   - Walks every generated HTML file.
+   - Finds `data-pagefind-body` blocks → extracts their text & links.
+   - Stores them as static JSON & WASM bundles under `/pagefind/`.
+3. **Browser runtime**
+   - The Starlight theme loads **Pagefind UI**.
+   - When a user types a query, the UI loads the pre-built index and returns matching pages.
+   - Each result comes with a `url` (taken from the `<a>` it found in the body) and an `excerpt`.
+   - Clicking a result navigates to `/apis/#tag/…` which automatically scrolls the Scalar viewer to the correct endpoint because the heading `id` is already present in the DOM.
+
+### Why titles show up first
+
+Pagefind weighs words in headings more heavily than body text. By injecting the parameter list and full description into the list item, we give Pagefind more tokens to match – but the title will often still rank highest (good for relevance).
+
+### Sub-results & highlights
+
+If `showSubResults: true` is enabled (the default in Starlight), Pagefind will also generate _sub_ results for each heading under the `/apis` page. These sub-results inherit the same URL plus the `#tag/…` fragment, so they remain accurate.
+
+Pagefind can optionally append `?highlight=` query params; if we later import `pagefind-highlight.js`, the endpoint page will highlight the matched words inside the Scalar UI.
+
+---

--- a/scripts/search-index-apis.js
+++ b/scripts/search-index-apis.js
@@ -1,61 +1,51 @@
 #!/usr/bin/env node
 
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
 
 // ES module equivalent of __dirname
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 // Load Swagger spec
 function loadSwaggerSpec() {
-  const swaggerPath = path.join(
-    __dirname,
-    '../public/api/scalekit.swagger.json'
-  );
-  const swaggerContent = fs.readFileSync(swaggerPath, 'utf8');
-  return JSON.parse(swaggerContent);
+  const swaggerPath = path.join(__dirname, '../public/api/scalekit.swagger.json')
+  const swaggerContent = fs.readFileSync(swaggerPath, 'utf8')
+  return JSON.parse(swaggerContent)
 }
 
 // Generate URL fragment for API endpoint
 function generateUrlFragment(path, method, tags) {
-  const tag = tags && tags[0] ? tags[0].toLowerCase() : 'api';
-  const encodedPath = path.replace(/\{([^}]+)\}/g, '%7B$1%7D');
-  return `#tag/${tag}/${method.toUpperCase()}${encodedPath}`;
+  const tag = tags && tags[0] ? tags[0].toLowerCase() : 'api'
+  // Use lowercase HTTP method as used by @scalar/api-reference anchors
+  const lowerMethod = method.toLowerCase()
+  // Do NOT encode path parameters – Scalar keeps the curly braces intact in the anchor id
+  return `#tag/${tag}/${lowerMethod}${path}`
 }
 
 // Extract and structure API records from Swagger
 export function extractApiRecords(swagger) {
-  const records = [];
-  const baseUrl = 'https://docs.scalekit.com/apis/';
+  const records = []
+  const baseUrl = 'https://docs.scalekit.com/apis/'
 
   // Process each API endpoint
   Object.entries(swagger.paths).forEach(([path, methods]) => {
     Object.entries(methods).forEach(([method, operation]) => {
-      if (!operation || typeof operation !== 'object') return;
+      if (!operation || typeof operation !== 'object') return
 
-      const {
-        summary,
-        description,
-        tags = [],
-        operationId,
-        parameters = [],
-      } = operation;
+      const { summary, description, tags = [], operationId, parameters = [] } = operation
 
-      const tag = tags[0] || 'API';
-      const urlFragment = generateUrlFragment(path, method, tags);
-      const fullUrl = baseUrl + urlFragment;
+      const tag = tags[0] || 'API'
+      const urlFragment = generateUrlFragment(path, method, tags)
+      const fullUrl = baseUrl + urlFragment
 
       // Create main endpoint record
       const endpointRecord = {
-        objectID:
-          operationId || `${method}-${path.replace(/[^a-zA-Z0-9]/g, '-')}`,
+        objectID: operationId || `${method}-${path.replace(/[^a-zA-Z0-9]/g, '-')}`,
         title: summary || `${method.toUpperCase()} ${path}`,
         description: description || summary || '',
-        content: `${method.toUpperCase()} ${path} - ${
-          description || summary || ''
-        }`,
+        content: `${method.toUpperCase()} ${path} - ${description || summary || ''}`,
         url: fullUrl,
         type: 'api-endpoint',
         method: method.toUpperCase(),
@@ -66,26 +56,26 @@ export function extractApiRecords(swagger) {
           lvl1: `${tag} API`,
           lvl2: summary || `${method.toUpperCase()} ${path}`,
         },
-      };
+      }
 
-      records.push(endpointRecord);
-    });
-  });
+      records.push(endpointRecord)
+    })
+  })
 
-  return records;
+  return records
 }
 
 // Test URL generation
 function testUrlGeneration() {
-  console.log('🧪 Testing URL generation...\n');
+  console.log('🧪 Testing URL generation...\n')
 
-  const swagger = loadSwaggerSpec();
-  const records = extractApiRecords(swagger);
+  const swagger = loadSwaggerSpec()
+  const records = extractApiRecords(swagger)
 
   // Filter to API endpoint records only
-  const endpointRecords = records.filter((r) => r.type === 'api-endpoint');
+  const endpointRecords = records.filter((r) => r.type === 'api-endpoint')
 
-  console.log(`📊 Generated ${endpointRecords.length} API endpoint records\n`);
+  console.log(`📊 Generated ${endpointRecords.length} API endpoint records\n`)
 
   // Test specific examples from user
   const testCases = [
@@ -93,61 +83,60 @@ function testUrlGeneration() {
       path: '/api/v1/organizations/{id}',
       method: 'PATCH',
       expectedUrl:
-        'https://docs.scalekit.com/apis/#tag/organizations/PATCH/api/v1/organizations/%7Bid%7D',
+        'https://docs.scalekit.com/apis/#tag/organizations/patch/api/v1/organizations/{id}',
     },
     {
       path: '/api/v1/organizations/{organization_id}/directories/{directory_id}/users',
       method: 'GET',
       expectedUrl:
-        'https://docs.scalekit.com/apis/#tag/directory/GET/api/v1/organizations/%7Borganization_id%7D/directories/%7Bdirectory_id%7D/users',
+        'https://docs.scalekit.com/apis/#tag/directory/get/api/v1/organizations/{organization_id}/directories/{directory_id}/users',
     },
     {
       path: '/api/v1/organizations',
       method: 'GET',
-      expectedUrl:
-        'https://docs.scalekit.com/apis/#tag/organizations/GET/api/v1/organizations',
+      expectedUrl: 'https://docs.scalekit.com/apis/#tag/organizations/get/api/v1/organizations',
     },
-  ];
+  ]
 
-  console.log('🎯 Testing specific URL examples:\n');
+  console.log('🎯 Testing specific URL examples:\n')
 
   testCases.forEach((testCase, index) => {
     const record = endpointRecords.find(
-      (r) => r.path === testCase.path && r.method === testCase.method
-    );
+      (r) => r.path === testCase.path && r.method === testCase.method,
+    )
 
     if (record) {
-      const matches = record.url === testCase.expectedUrl;
-      console.log(`${index + 1}. ${testCase.method} ${testCase.path}`);
-      console.log(`   Generated: ${record.url}`);
-      console.log(`   Expected:  ${testCase.expectedUrl}`);
-      console.log(`   ${matches ? '✅ MATCH' : '❌ MISMATCH'}\n`);
+      const matches = record.url === testCase.expectedUrl
+      console.log(`${index + 1}. ${testCase.method} ${testCase.path}`)
+      console.log(`   Generated: ${record.url}`)
+      console.log(`   Expected:  ${testCase.expectedUrl}`)
+      console.log(`   ${matches ? '✅ MATCH' : '❌ MISMATCH'}\n`)
     } else {
-      console.log(`${index + 1}. ${testCase.method} ${testCase.path}`);
-      console.log(`   ❌ Record not found\n`);
+      console.log(`${index + 1}. ${testCase.method} ${testCase.path}`)
+      console.log(`   ❌ Record not found\n`)
     }
-  });
+  })
 
   // Show sample of all generated URLs
-  console.log('📋 Sample of all generated URLs:\n');
+  console.log('📋 Sample of all generated URLs:\n')
   endpointRecords.slice(0, 10).forEach((record, index) => {
-    console.log(`${index + 1}. ${record.title}`);
-    console.log(`   ${record.url}\n`);
-  });
+    console.log(`${index + 1}. ${record.title}`)
+    console.log(`   ${record.url}\n`)
+  })
 
   // Show tag distribution
-  const tagCounts = {};
+  const tagCounts = {}
   endpointRecords.forEach((record) => {
-    tagCounts[record.tag] = (tagCounts[record.tag] || 0) + 1;
-  });
+    tagCounts[record.tag] = (tagCounts[record.tag] || 0) + 1
+  })
 
-  console.log('📊 Endpoints by tag:');
+  console.log('📊 Endpoints by tag:')
   Object.entries(tagCounts).forEach(([tag, count]) => {
-    console.log(`   ${tag}: ${count} endpoints`);
-  });
+    console.log(`   ${tag}: ${count} endpoints`)
+  })
 }
 
 // Run the test
 if (import.meta.url === `file://${process.argv[1]}`) {
-  testUrlGeneration();
+  testUrlGeneration()
 }

--- a/scripts/search-index-apis.js
+++ b/scripts/search-index-apis.js
@@ -56,6 +56,7 @@ export function extractApiRecords(swagger) {
           lvl1: `${tag} API`,
           lvl2: summary || `${method.toUpperCase()} ${path}`,
         },
+        parameters: parameters,
       }
 
       records.push(endpointRecord)

--- a/src/components/ApiSearchIndex.astro
+++ b/src/components/ApiSearchIndex.astro
@@ -47,6 +47,15 @@ const groupedEndpoints = endpointRecords.reduce((acc: Record<string, any[]>, rec
                 <code class="api-path">{record.path}</code>
                 <span class="api-tag">{record.tag}</span>
               </div>
+              {record.parameters && record.parameters.length > 0 && (
+                <ul class="api-endpoint-params">
+                  {record.parameters.map((param: any) => (
+                    <li class="api-param-item">
+                      <strong>{param.name}</strong>: {param.description}
+                    </li>
+                  ))}
+                </ul>
+              )}
             </li>
           ))}
         </ul>

--- a/src/components/ApiSearchIndex.astro
+++ b/src/components/ApiSearchIndex.astro
@@ -1,27 +1,27 @@
 ---
 // This component will be hidden but contain all API endpoints for Pagefind to index
 
-import { extractApiRecords } from '../../scripts/search-index-apis';
-import fs from 'fs';
-import path from 'path';
-import AnchorHeading from '@astrojs/starlight/components/AnchorHeading.astro';
+import { extractApiRecords } from '../../scripts/search-index-apis'
+import fs from 'fs'
+import path from 'path'
+import AnchorHeading from '@astrojs/starlight/components/AnchorHeading.astro'
 
 // Load Swagger spec
-const swaggerPath = path.join(process.cwd(), 'public/api/scalekit.swagger.json');
-const swaggerContent = fs.readFileSync(swaggerPath, 'utf8');
-const swagger = JSON.parse(swaggerContent);
-const records = extractApiRecords(swagger);
-const endpointRecords = records.filter((r) => r.type === 'api-endpoint');
+const swaggerPath = path.join(process.cwd(), 'public/api/scalekit.swagger.json')
+const swaggerContent = fs.readFileSync(swaggerPath, 'utf8')
+const swagger = JSON.parse(swaggerContent)
+const records = extractApiRecords(swagger)
+const endpointRecords = records.filter((r) => r.type === 'api-endpoint')
 
 // Group endpoints by tag for better organization
 const groupedEndpoints = endpointRecords.reduce((acc: Record<string, any[]>, record: any) => {
-  const tag = record.tag || 'Other';
+  const tag = record.tag || 'Other'
   if (!acc[tag]) {
-    acc[tag] = [];
+    acc[tag] = []
   }
-  acc[tag].push(record);
-  return acc;
-}, {});
+  acc[tag].push(record)
+  return acc
+}, {})
 ---
 
 <!-- Hidden from UI but indexed by Pagefind -->
@@ -29,26 +29,30 @@ const groupedEndpoints = endpointRecords.reduce((acc: Record<string, any[]>, rec
   <AnchorHeading level="1" id="api-reference">API Reference</AnchorHeading>
   <p>Complete reference for all Scalekit API endpoints</p>
 
-  {Object.entries(groupedEndpoints).map(([tag, endpoints]: [string, any[]]) => (
-    <section class="api-section">
-      <AnchorHeading level="2" id={`${tag.toLowerCase()}-apis`}>{tag} APIs</AnchorHeading>
-      <ul class="api-endpoint-list">
-        {endpoints.map((record: any) => (
-          <li class="api-endpoint-item">
-            <AnchorHeading level="3" id={`${record.title.toLowerCase().replace(/\s+/g, '-')}`}>
-              <a href={record.url}>{record.title}</a>
-            </AnchorHeading>
-            <p class="api-endpoint-description">{record.description}</p>
-            <div class="api-endpoint-meta">
-              <span class="api-method">{record.method}</span>
-              <code class="api-path">{record.path}</code>
-              <span class="api-tag">{record.tag}</span>
-            </div>
-          </li>
-        ))}
-      </ul>
-    </section>
-  ))}
+  {
+    Object.entries(groupedEndpoints).map(([tag, endpoints]: [string, any[]]) => (
+      <section class="api-section">
+        <AnchorHeading level="2" id={`${tag.toLowerCase()}-apis`}>
+          {tag} APIs
+        </AnchorHeading>
+        <ul class="api-endpoint-list">
+          {endpoints.map((record: any) => (
+            <li class="api-endpoint-item">
+              <AnchorHeading level="3" id={record.url.split('#')[1]}>
+                <a href={record.url}>{record.title}</a>
+              </AnchorHeading>
+              <p class="api-endpoint-description">{record.description}</p>
+              <div class="api-endpoint-meta">
+                <span class="api-method">{record.method}</span>
+                <code class="api-path">{record.path}</code>
+                <span class="api-tag">{record.tag}</span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+    ))
+  }
 </div>
 <!-- Because the API reference is hidden, we don't need to style it
 <style>


### PR DESCRIPTION
The search results today to API reference are reliable, but the destination they take users to is always generic or very much approximate. This PR hacks the search index that gets generated, and takes the user to right API endpoint.

[Try it out](https://preview-construct-right-search-result-endpoint--scalekit-starlight.netlify.app/)