### PR TITLE
OTP Attempt Limits & Logout Endpoint Details

### DIFF
--- a/src/content/docs/fsa/guides/logout.mdx
+++ b/src/content/docs/fsa/guides/logout.mdx
@@ -148,6 +148,16 @@ This is the standard flow where a user clicks a "Logout" button in your applicat
 3. #### Invalidate the Scalekit session
    After clearing your local session, redirect the user to the Scalekit logout endpoint. This will invalidate their session on Scalekit's servers and then redirect them back to your application.
 
+   The Scalekit logout endpoint signature is:
+
+   ```text showLineNumbers=false wrap
+   {SCALEKIT_ENV_URL}/oidc/logout?id_token_hint={idToken}&post_logout_redirect_uri={postLogoutRedirectUri}
+   ```
+
+   - Replace `{SCALEKIT_ENV_URL}` with your Scalekit environment URL (e.g., `https://app.scalekit.com`).
+   - `{idToken}` is the user's ID token.
+   - `{postLogoutRedirectUri}` is the URL to redirect to after logout (must be registered in Scalekit).
+
     <Tabs syncKey="tech-stack">
       <TabItem label="Node.js">
         ```javascript title="Express.js"
@@ -254,7 +264,10 @@ This is the standard flow where a user clicks a "Logout" button in your applicat
         ```
       </TabItem>
     </Tabs>
+
     The post logout redirect URI is the destination to which the user will be redirected after logging out. For example, take them to website landing page or a login page again. This must be [registered post-login URL](/fsa/reference/redirects/) in the Scalekit dashboard.
+
+
 </Steps>
 
 ## IdP-initiated logout <Badge text="Coming Soon" />

--- a/src/content/docs/guides/passwordless/oidc.mdx
+++ b/src/content/docs/guides/passwordless/oidc.mdx
@@ -206,10 +206,8 @@ Before you begin, ensure you have:
    After successful user authentication via OTP, Scalekit redirects users to your specified `redirect_uri` with a temporary authorization code parameter. This code must be exchanged for the user's profile information through a secure server-side request.
 
    <Aside type="caution" title="Validation attempt limits">
-     Scalekit tracks OTP validation attempts for each <code>auth_request_id</code>.
-     You can make **up to five** incorrect attempts within a ten-minute window.
-     If you exceed this limit, the <code>/passwordless/email/verify</code> endpoint returns **HTTP&nbsp;429&nbsp;Too&nbsp;Many&nbsp;Requests**.
-     Wait until the window resets, or start a new authentication request to try again.
+     To protect your application, Scalekit limits a user to **five** attempts to enter the correct OTP within a ten-minute window for each authentication request.
+     If the user exceeds this limit, they must restart the authentication process.
    </Aside>
 
     The authorization code exchange process should always be performed server-side to maintain security. This server-side request will:

--- a/src/content/docs/guides/passwordless/oidc.mdx
+++ b/src/content/docs/guides/passwordless/oidc.mdx
@@ -205,6 +205,13 @@ Before you begin, ensure you have:
 
    After successful user authentication via OTP, Scalekit redirects users to your specified `redirect_uri` with a temporary authorization code parameter. This code must be exchanged for the user's profile information through a secure server-side request.
 
+   <Aside type="caution" title="Validation attempt limits">
+     Scalekit tracks OTP validation attempts for each <code>auth_request_id</code>.
+     You can make **up to five** incorrect attempts within a ten-minute window.
+     If you exceed this limit, the <code>/passwordless/email/verify</code> endpoint returns **HTTP&nbsp;429&nbsp;Too&nbsp;Many&nbsp;Requests**.
+     Wait until the window resets, or start a new authentication request to try again.
+   </Aside>
+
     The authorization code exchange process should always be performed server-side to maintain security. This server-side request will:
 
     1. Validate the authorization code

--- a/src/content/docs/guides/passwordless/quickstart.mdx
+++ b/src/content/docs/guides/passwordless/quickstart.mdx
@@ -462,6 +462,13 @@ Before you begin, ensure you have:
        </Tabs>
      </TabItem>
    </Tabs>
+
+   <Aside type="caution" title="Validation attempt limits">
+     Scalekit tracks OTP validation attempts for each <code>auth_request_id</code>.
+     You can make **up to five** incorrect attempts within a ten-minute window.
+     If you exceed this limit, the <code>/passwordless/email/verify</code> endpoint returns **HTTP&nbsp;429&nbsp;Too&nbsp;Many&nbsp;Requests**.
+     Wait until the ten-minute timer resets, or start a new authentication request to try again.
+   </Aside>
 </Steps>
 
 Congratulations! You've successfully implemented passwordless authentication in your application. Users can now sign in securely without passwords by entering a verification code or clicking a magic link sent to their email.

--- a/src/content/docs/guides/passwordless/quickstart.mdx
+++ b/src/content/docs/guides/passwordless/quickstart.mdx
@@ -464,10 +464,9 @@ Before you begin, ensure you have:
    </Tabs>
 
    <Aside type="caution" title="Validation attempt limits">
-     Scalekit tracks OTP validation attempts for each <code>auth_request_id</code>.
-     You can make **up to five** incorrect attempts within a ten-minute window.
-     If you exceed this limit, the <code>/passwordless/email/verify</code> endpoint returns **HTTP&nbsp;429&nbsp;Too&nbsp;Many&nbsp;Requests**.
-     Wait until the ten-minute timer resets, or start a new authentication request to try again.
+     To protect your application, Scalekit allows a user only **five** attempts to enter the correct OTP within a ten-minute window.
+     If the user exceeds this limit for an <code>auth_request_id</code>, the <code>/passwordless/email/verify</code> endpoint returns an **HTTP&nbsp;429&nbsp;Too&nbsp;Many&nbsp;Requests** error.
+     To continue, the user must restart the authentication flow.
    </Aside>
 </Steps>
 


### PR DESCRIPTION
- Adds a caution in passwordless authentication guides about OTP validation attempt limits, including throttling behavior and error messaging for failed attempts.
- Enhances the logout guide by documenting the full signature and usage of the Scalekit logout endpoint, with details about required parameters and the significance of the post_logout_redirect_uri.
