### PR TITLE
Hides the page sidebar actions in mobile and tab layouts

### DIFF
--- a/src/components/overrides/PageSidebar.astro
+++ b/src/components/overrides/PageSidebar.astro
@@ -160,4 +160,10 @@ const editUrl =
   :global([data-theme='dark']) .sidebar-action-link:hover {
     color: var(--sl-color-gray-1);
   }
+
+  @media (max-width: 1024px) {
+    .page-sidebar-actions {
+      display: none;
+    }
+  }
 </style>


### PR DESCRIPTION
Hiding the following options in mobile and tab layouts:

- Edit Page
- Copy the LLM context

These two show up obstructively in mobile/tab layouts and at the same time they are are not useful in these layouts. Hence hiding them in same layouts.