### PR TITLE
Add robots.txt file to allow all search engines

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://docs.scalekit.com/sitemap-0.xml

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://docs.scalekit.com/sitemap-0.xml
+Sitemap: https://docs.scalekit.com/sitemap-index.xml


### PR DESCRIPTION
Docs site currently has sitemap already enabled and generated. This PR adds a explicitly measure to allow search engines crawl the docs.scalekit.com 