### PR TITLE
feat(docs): add video tutorial to passwordless quickstart

### DIFF
--- a/src/content/docs/passwordless/quickstart.mdx
+++ b/src/content/docs/passwordless/quickstart.mdx
@@ -20,8 +20,11 @@ tableOfContents:
 
 import { Aside, Steps, Badge, Tabs, TabItem, LinkCard, Card } from '@astrojs/starlight/components';
 import CopyPrompt from '@components/ui/CopyPrompt.astro';
+import { VideoPlayer } from 'starlight-videos/components'
 
 This guide explains how you can implement passwordless authentication using Scalekit's APIs to send either verification codes or magic links to your user's email address and verify their identity.
+
+<VideoPlayer link="https://youtu.be/8e4ZH-Aemg4" />
 
 ### Prerequisites
 


### PR DESCRIPTION
Adds a video tutorial to the passwordless authentication quickstart guide to provide a visual walkthrough of the process.

[View preview](https://preview-include-walkthru-2--scalekit-starlight.netlify.app/passwordless/quickstart/)