### PR TITLE
Performance and build improvements for the docs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -163,6 +163,13 @@ export default defineConfig({
     plugins: [pluginCollapsibleSections(), tailwindcss(), Icons({ compiler: 'astro' })],
     build: {
       chunkSizeWarningLimit: 2000,
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (id.includes('@scalar')) return 'scalar'
+          },
+        },
+      },
     },
   },
 })

--- a/src/components/ScalarReference.vue
+++ b/src/components/ScalarReference.vue
@@ -1,9 +1,13 @@
 <script setup lang="ts">
-import { ApiReference } from '@scalar/api-reference'
+import { defineAsyncComponent, onMounted, onUnmounted, ref } from 'vue'
 import '@fontsource-variable/inter'
 import '@/styles/api-reference.css'
-import { onMounted, onUnmounted, ref } from 'vue'
 import { initializeThemeSync, type ThemeSynchronizer } from '../utils/themeSync'
+
+const AsyncApiReference = defineAsyncComponent(async () => {
+  const mod = await import('@scalar/api-reference')
+  return mod.ApiReference
+})
 
 // Reactive color mode tracking
 const colorMode = ref<string>('light')
@@ -109,7 +113,7 @@ const handleDeepLink = () => {
   <div class="api-reference-wrapper" :class="colorMode + '-mode'">
     <!-- API Reference content (always render; show overlay while loading) -->
     <div class="api-reference-container">
-      <ApiReference
+      <AsyncApiReference
         :configuration="{
           url: '/api/scalekit.swagger.json',
           onLoaded: handleInitialLoad,

--- a/src/components/overrides/MarkdownContent.astro
+++ b/src/components/overrides/MarkdownContent.astro
@@ -1,8 +1,7 @@
 ---
-import Default from '@astrojs/starlight/components/MarkdownContent.astro'
+import VideosMarkdownContent from 'starlight-videos/components/MarkdownContent.astro'
 import ImageZoom from 'starlight-image-zoom/components/ImageZoom.astro'
 ---
 
 <ImageZoom />
-<p>Custom content in the MarkdownContent override</p>
-<Default><slot /></Default>
+<VideosMarkdownContent><slot /></VideosMarkdownContent>

--- a/src/content/docs/apis/index.mdx
+++ b/src/content/docs/apis/index.mdx
@@ -33,7 +33,7 @@ import ScalarReference from '@/components/ScalarReference.vue'
 import ApiSearchIndex from '@/components/ApiSearchIndex.astro'
 
 
-<ScalarReference client:visible />
+<ScalarReference client:only="vue" />
 
 {/* Keep the search index hidden in DOM for indexing */}
 <div style="display: none;">

--- a/src/content/docs/sso/quickstart.mdx
+++ b/src/content/docs/sso/quickstart.mdx
@@ -292,7 +292,7 @@ This quickstart guide walks you through the SSO implementation process. You will
 
     <TabItem value="direct" label="Direct URL (No SDK)">
 
-    ```url title="Direct Authorization URL Construction"
+    ```txt title="Direct Authorization URL Construction"
     https://your-scalekit-environment.scalekit.com/oauth/authorize?
       response_type=code&
       client_id=<SCALEKIT_CLIENT_ID>&
@@ -304,7 +304,7 @@ This quickstart guide walks you through the SSO implementation process. You will
     ```
 
     **Example with actual values:**
-    ```url
+    ```txt
     https://tinotat-dev.scalekit.cloud/oauth/authorize?
       response_type=code&
       client_id=skc_88036702639096097&

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -100,7 +100,7 @@ import '@fontsource-variable/geist'
     display: none;
   }
 
-  div .print:hidden .nova-pagination: {
+  .print\:hidden .nova-pagination {
     display: none;
   }
 </style>


### PR DESCRIPTION
Warnings resolved:
- Expressive Code “language url not found” gone.
- CSS minify error gone.
- Scalar fetch error during build gone

Expected/harmless warnings remain:
- “Generated an empty chunk” for CodeTabs/Quiz (style-only) — safe to ignore.
- Large chunk warning for scalar (~3 MB). We split it into its own chunk; further reduction would require dynamic imports inside ScalarReference.vue or deferring more features. Optional.

[View preview](https://preview-fast-follow-live-1--scalekit-starlight.netlify.app/)