### PR TITLE
chore: remove custom CSS import and update MarkdownContent component

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -75,7 +75,6 @@ export default defineConfig({
         '@fontsource-variable/geist',
         '@fontsource-variable/geist-mono',
         './src/styles/theme-priority.css',
-        './src/styles/custom.css',
       ],
       plugins: [
         starlightLinksValidator(),

--- a/src/components/overrides/MarkdownContent.astro
+++ b/src/components/overrides/MarkdownContent.astro
@@ -1,7 +1,10 @@
 ---
+import Default from '@astrojs/starlight/components/MarkdownContent.astro'
 import VideosMarkdownContent from 'starlight-videos/components/MarkdownContent.astro'
 import ImageZoom from 'starlight-image-zoom/components/ImageZoom.astro'
 ---
 
 <ImageZoom />
+<p>Custom content in the MarkdownContent override</p>
+<Default><slot /></Default>
 <VideosMarkdownContent><slot /></VideosMarkdownContent>


### PR DESCRIPTION
- Removed the import of './src/styles/custom.css' from astro.config.mjs.
- Enhanced the MarkdownContent component by adding a default wrapper and custom content.