### PR TITLE
Description to correctly describe Passwordless

### DIFF
--- a/src/content/docs/passwordless/quickstart.mdx
+++ b/src/content/docs/passwordless/quickstart.mdx
@@ -52,7 +52,7 @@ Before you begin, ensure you have:
 <Card title="Generate Passwordless Auth Code with AI in Minutes" icon="seti:vite" style="background-color: white !important;">
   <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '0.5rem'}}>
     <div style={{flex: '3'}}>
-      Input this prompt in your IDE to analyze your existing code base and generate SCIM implementation code accordingly.
+      Input this prompt in your IDE to analyze your existing code base and generate Passwordless auth implementation code accordingly.
 
       <span style={{fontSize: '0.875rem', color: '#6b7280', fontStyle: 'italic'}}>
         Compatible with Cursor, Windsurf, VS Code, and any AI-powered IDE


### PR DESCRIPTION
The "Copy Prompt" box in passwordless auth description incorrect states SCIM instead of passwordless. 