### PR TITLE
Update homepage title and remove title delimiter in Astro config

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -24,7 +24,6 @@ export default defineConfig({
   integrations: [
     starlight({
       title: 'Scalekit Docs',
-      titleDelimiter: '',
       routeMiddleware: './src/routeData.ts',
       lastUpdated: true,
       tableOfContents: {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,7 +8,7 @@ import '@fontsource-variable/geist'
 
 <StarlightPage
   frontmatter={{
-    title: 'Scalekit documentation',
+    title: 'Auth stack for AI apps',
     tableOfContents: false,
     template: 'splash',
     topic: 'dev-kit',


### PR DESCRIPTION
This change corrects the metadata submitted to Google when listing the site in the search results.

Currently,
```
Scalekit documentation Scalekit Docs
```

Now
```
Auth stack for AI apps | Scalekit Docs
```