### PR TITLE
Refactor AuthorizationUrlOptions usage in quickstart

### DIFF
--- a/src/content/docs/fsa/quickstart.mdx
+++ b/src/content/docs/fsa/quickstart.mdx
@@ -180,12 +180,11 @@ Let's get started!
         from scalekit import AuthorizationUrlOptions
 
         redirect_uri = 'http://localhost:3000/api/callback'
-        options = AuthorizationUrlOptions(
-            scopes=['openid', 'profile', 'email', 'offline_access']
-        )
-
+        options = AuthorizationUrlOptions()
+        options.scopes = ['openid', 'profile', 'email', 'offline_access']
+        
         authorization_url = scalekit.get_authorization_url(redirect_uri, options)
-
+        
         # For web frameworks like Flask/Django:
         # return redirect(authorization_url)
         ```


### PR DESCRIPTION
Refactor AuthorizationUrlOptions initialization to set scopes separately.