### PR TITLE
Update the interceptor payloads to use OIDC names

### DIFF
--- a/src/content/docs/guides/auth-flow-interceptors.mdx
+++ b/src/content/docs/guides/auth-flow-interceptors.mdx
@@ -168,8 +168,8 @@ In the Scalekit dashboard, register an interceptor at a trigger point from the *
       "email_verified": true,
       "created_at": "2025-10-06T11:06:49.120Z",
       "updated_at": "2025-10-06T13:33:06.479Z",
-      "first_name": "John",
-      "last_name": "Doe",
+      "given_name": "John",
+      "family_name": "Doe",
       "memberships": [
         {
           "organization_id": "org_93418204671239864",
@@ -235,8 +235,8 @@ In the Scalekit dashboard, register an interceptor at a trigger point from the *
       "email_verified": true,
       "created_at": "2025-10-06T11:06:49.120Z",
       "updated_at": "2025-10-06T13:33:06.479Z",
-      "first_name": "John",
-      "last_name": "Doe",
+      "given_name": "John",
+      "family_name": "Doe",
       "memberships": [
         {
           "organization_id": "org_93418204671239864",


### PR DESCRIPTION


- Changed "first_name" to "given_name" and "last_name" to "family_name" in the example JSON objects to align with the latest user attribute standards.
- This update enhances clarity and consistency in the documentation.