### PR TITLE
Names passwordless always with email

### DIFF
--- a/src/content/docs/fsa/guides/auth-methods.mdx
+++ b/src/content/docs/fsa/guides/auth-methods.mdx
@@ -13,7 +13,7 @@ import { CardGrid, LinkCard, Badge } from '@astrojs/starlight/components';
 
 Authentication is how a user proves their identity before your application grants access. In B2B scenarios the stakes are higher: one user can belong to multiple organizations, each with its own security policy. Scalekit lets you offer several authentication methods so every organization—and every user—can sign in the way that works best for them.
 
-- **Multiple sign-in options**: Offer passwordless (email), passkeys, social logins, or enterprise SSO so users can choose their preferred method.
+- **Multiple sign-in options**: Offer magic link & OTP, passkeys, social logins, or enterprise SSO so users can choose their preferred method.
 - **Admin-enforced policies**: Organization administrators restrict members to specific methods (for example, SSO-only for employees). <Badge type="note" text="Coming soon" />
 - **Bring-your-own login page**: Embed your own UI while Scalekit handles the secure identity verification flow behind the scenes.
 - **Progressive rollout**: Enable additional methods without deploying new code—turn features on or off from the Scalekit dashboard.
@@ -23,9 +23,9 @@ Choose from the following options:
 <CardGrid>
 
   <LinkCard
-    title="Passwordless (Email)"
+    title="Magic link & OTP"
     href="/fsa/guides/passwordless/"
-    description="Users sign in using verification code (OTP) or a secure magic link sent to their email."
+    description="Users sign in using a verification code (OTP) or a secure magic link sent to their email—no password required."
   />
 
   <LinkCard

--- a/src/content/docs/fsa/guides/passwordless.mdx
+++ b/src/content/docs/fsa/guides/passwordless.mdx
@@ -1,8 +1,8 @@
 ---
-title: Enable passwordless sign in
-description: How to configure passwordless authentication for your application
+title: Enable magic link & OTP based sign in
+description: How to configure magic link & OTP based passwordless authentication for your application
 sidebar:
-  label: "Passwordless (Email)"
+  label: "Magic link & OTP"
 head:
   - tag: style
     content: |
@@ -21,21 +21,21 @@ import { Steps, Tabs, TabItem, Aside, LinkButton, LinkCard } from '@astrojs/star
 import InstallSDK from '@components/templates/_installsdk.mdx';
 import CheckItem from '@/components/ui/CheckItem.astro';
 
-Passwordless authentication allows your users to sign in without entering a password. Users can authenticate using any of the following methods:
+Magic link & OTP authentication allows your users to sign in without entering a password. Users can authenticate using any of the following methods:
 
 - A verification code (OTP) sent by email.
 - A magic link sent by email.
 - Both a verification code and a magic link sent by email.
 
-This guide shows you how to enable each passwordless login method. You should complete the [quickstart guide](/fsa/quickstart/) before following this guide, as it covers building a sign-in page that combines Scalekit's hosted UI.
+This guide shows you how to enable each magic link & OTP method. You should complete the [quickstart guide](/fsa/quickstart/) before following this guide, as it covers building a sign-in page that combines Scalekit's hosted UI.
 
-## Configure passwordless login settings
+## Configure magic link & OTP settings
 
-You can modify the passwordless login behavior from the Scalekit dashboard without changing your code.
+You can modify the magic link & OTP behavior from the Scalekit dashboard without changing your code.
 
  ![](@/assets/docs/unlisted/passwordless/1-v2.png)
 
-### Choose a passwordless login method
+### Select magic link & OTP options
 
 <Steps>
 
@@ -66,4 +66,4 @@ To enable this setting, select the **Enable new passwordless credentials on rese
 
 ### Customize email templates
 
-You can customize the emails sent to users to match your brand, or you can [bring your own email provider](/guides/passwordless/custom-email-provider/) to handle email sends related to passwordless login. Scalekit sends the emails when you use it as your email provider.
+You can customize the emails sent to users to match your brand, or you can [bring your own email provider](/guides/passwordless/custom-email-provider/) to handle email sends related to magic link & OTP authentication. Scalekit sends the emails when you use it as your email provider.


### PR DESCRIPTION
This PR adds "Email" to clarify the type of passwordless authetnication