### PR TITLE
Updating docs for token creation in custom auth

### DIFF
--- a/src/content/docs/mcp/auth-methods/custom-auth.mdx
+++ b/src/content/docs/mcp/auth-methods/custom-auth.mdx
@@ -44,14 +44,14 @@ Take the user through your regular authentication logic (e.g., username/password
 
 #### b. Send User Details to Scalekit
 
-Aquire an `access_token` before you could send user details by hitting the `/oauth/token` path. You can get `env_url`, `client_id_value` and `client_secret_value` from _Scalekit Dashboard > Settings_
+Aquire an `access_token` before you could send user details by hitting the `/oauth/token` endpoint. You can get `env_url`, `sk_client_id` and `sk_client_secret` from _Scalekit Dashboard > Settings_
 
 ```bash title="Terminal" frame="terminal"
 curl --location '{{env_url}}/oauth/token' \
 --header 'Content-Type: application/x-www-form-urlencoded' \
 --data-urlencode 'grant_type=client_credentials' \
---data-urlencode 'client_id={{SK_CLIENT_ID}}' \
---data-urlencode 'client_secret={{SK_CLIENT_SECRET}}'
+--data-urlencode 'client_id={{sk_client_id}}' \
+--data-urlencode 'client_secret={{sk_client_secret}}'
 ```
 
 Scalekit responds with a JSON payload similar to:

--- a/src/content/docs/mcp/auth-methods/custom-auth.mdx
+++ b/src/content/docs/mcp/auth-methods/custom-auth.mdx
@@ -44,9 +44,27 @@ Take the user through your regular authentication logic (e.g., username/password
 
 #### b. Send User Details to Scalekit
 
-After successful authentication, make a machine-to-machine POST request to Scalekit with the user's details.
+Aquire an `access_token` before you could send user details by hitting the `/oauth/token` path. You can get `env_url`, `client_id_value` and `client_secret_value` from _Scalekit Dashboard > Settings_
 
-**Example cURL Request:**
+```bash title="Terminal" frame="terminal"
+curl --location '{{env_url}}/oauth/token' \
+--header 'Content-Type: application/x-www-form-urlencoded' \
+--data-urlencode 'grant_type=client_credentials' \
+--data-urlencode 'client_id={{SK_CLIENT_ID}}' \
+--data-urlencode 'client_secret={{SK_CLIENT_SECRET}}'
+```
+
+Scalekit responds with a JSON payload similar to:
+```json
+{
+  "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIn0...",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "scope": "todo:read todo:write"
+}
+```
+
+Use the `access_token` in the `Authorization` header when making a machine-to-machine POST request to Scalekit with the user's details.
 
 ```bash
 curl --location '{{envurl}}/api/v1/connections/{{connection_id}}/auth-requests/{{login_request_id}}/user' \

--- a/src/content/docs/mcp/topologies/agent-mcp.mdx
+++ b/src/content/docs/mcp/topologies/agent-mcp.mdx
@@ -81,7 +81,7 @@ curl --location '{{env_url}}/oauth/token' \
 ```
 
 Scalekit responds with a JSON payload similar to:
-```
+```json
 {
   "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIn0...",
   "token_type": "Bearer",


### PR DESCRIPTION
This is to update the way of token of creation to make post calls user api for mcp custom auth solution