### PR TITLE
Preview/home v4 changes

### DIFF
--- a/src/configs/sidebar.config.ts
+++ b/src/configs/sidebar.config.ts
@@ -195,10 +195,10 @@ export const sidebar = [
         label: 'User authentication',
         items: [
           'fsa/guides/implement-signup',
+          'guides/dashboard/redirects',
           'guides/user-auth/login-scenarios',
           'guides/user-auth/preserve-intended-destination',
           'guides/security/csrf-protection',
-          'guides/dashboard/redirects',
           'guides/idtoken-claims',
           'guides/accesstoken-claims',
           // 'guides/security/authentication-best-practices',

--- a/src/content/docs/fsa/guides/implement-signup.mdx
+++ b/src/content/docs/fsa/guides/implement-signup.mdx
@@ -21,8 +21,8 @@ prev:
   link: '/guides/accesstoken-claims/'
   label: 'Access token claims reference'
 next:
-  link: '/guides/dashboard/intitate-login-endpoint/'
-  label: 'Configure login endpoint'
+  link: '/guides/user-auth/login-scenarios/'
+  label: 'Customize login flows'
 ---
 import { Card, CardGrid, Steps, TabItem, Tabs, Aside, LinkCard, LinkButton } from '@astrojs/starlight/components';
 import { InstallSDKSection, EnvSection, RedirectAuthPageSection, RetrieveUserDetailsSection, UserProfileSection, CreateUserMembershipSection, CreateOrganizationSection } from '@components/templates';

--- a/src/content/docs/guides/user-auth/login-scenarios.mdx
+++ b/src/content/docs/guides/user-auth/login-scenarios.mdx
@@ -10,8 +10,8 @@ browseCentral:
 sidebar:
   label: 'Customize login flows'
 prev:
-  link: '/guides/dashboard/intitate-login-endpoint/'
-  label: 'Configure login endpoint'
+  link: '/fsa/guides/implement-signup/'
+  label: 'Implement signup flow'
 next:
   link: '/guides/dashboard/redirects/'
   label: 'Configure redirect URLs'


### PR DESCRIPTION
As a user, I was going through the initial steps in the developer resources docs, but I realized that when I clicked the next page in the bottom right of the pages, they lead me to a page that does not appear on the sidebar. I wasnt sure if the documentation was relevant but it was disruptive to the step by step flow. I thought it would be better to change the links in the pages for users to go through a step by step flow of implementing the signup, the redirect URL and the login in that order.