### PR TITLE
Update login guide for clarity and add aside note

### DIFF
--- a/src/content/docs/fsa/guides/implement-login.mdx
+++ b/src/content/docs/fsa/guides/implement-login.mdx
@@ -19,7 +19,7 @@ import { Card, CardGrid, Steps, TabItem, Tabs, Aside, LinkCard } from '@astrojs/
 import CheckItem from '@/components/ui/CheckItem.astro';
 import { InstallSDKSection, EnvSection, RedirectAuthPageSection, RetrieveUserDetailsSection, CreateSessionSection, UserProfileSection } from '@components/templates';
 
-log in is how users access your application after verifying their identity. For B2B applications, log in involves additional complexity as users may belong to multiple organizations and each organization may have different authentication requirements.
+Logging in is how users access your application after verifying their identity. For B2B applications, logging in involves additional complexity as users may belong to multiple organizations and each organization may have different authentication requirements.
 
 Here are some common log in use cases:
 
@@ -30,6 +30,12 @@ Here are some common log in use cases:
 - **Enterprise SSO integration**: Users authenticate through their corporate identity provider (e.g., Okta, Azure AD) instead of traditional username/password.
 
 Scalekit helps you implement all such signup flows while handling the complexity of user management and authentication.
+
+<Aside>
+
+sometbing
+
+</Aside>
 
 
 <div>


### PR DESCRIPTION
- Changed "log in" to "Logging in" for grammatical consistency.
- Added an aside section for additional context or tips related to the login process.