### PR TITLE
Preview/home v4 improvements

### DIFF
--- a/src/content/docs/fsa/guides/onboard-enterprise-customers.mdx
+++ b/src/content/docs/fsa/guides/onboard-enterprise-customers.mdx
@@ -23,8 +23,8 @@ prev:
   link: '/guides/admin-portal/'
   label: 'Admin portal implementation'
 next:
-  link: '/fsa/guides/signup-restrictions/'
-  label: 'Configure signup restrictions'
+  link: '/sso/guides/sso-basics/'
+  label: 'Get Started with SSO'
 seeAlso:
   expanded: true
   items:

--- a/src/content/docs/fsa/guides/onboard-enterprise-customers.mdx
+++ b/src/content/docs/fsa/guides/onboard-enterprise-customers.mdx
@@ -23,8 +23,8 @@ prev:
   link: '/guides/admin-portal/'
   label: 'Admin portal implementation'
 next:
-  link: '/sso/guides/sso-basics/'
-  label: 'Get Started with SSO'
+  link: '/sso/guides/test-sso/'
+  label: 'Test your enterprise SSO connection'
 seeAlso:
   expanded: true
   items:


### PR DESCRIPTION
I was going through the the Onboarding Enterprise Overview in the docs, and it basically tells the reader how to implement the SSO connection in their application. I felt that having the test SSO page as the next step made more sense than configuring sign up restrictions since it ensures the connections works before they want to implement any specific features for their connection. 

Also, it feels like we have already covered setting up SSO in another section. Is this Onboarding Enterprise section necessary? It feels like we're repeating the same information in a different page.