### PR TITLE
Mobile experience improvements

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -35,7 +35,7 @@ export default defineConfig({
       favicon: '/images/favicon.png',
       components: {
         // SocialIcons: './src/components/overrides/SocialIcons.astro',
-        // Sidebar: './src/components/overrides/Sidebar.astro',
+        Sidebar: './src/components/overrides/Sidebar.astro',
         Head: './src/components/overrides/Head.astro',
         Header: './src/components/overrides/Header.astro',
         Footer: './src/components/overrides/Footer.astro',

--- a/src/components/SecondaryNav.astro
+++ b/src/components/SecondaryNav.astro
@@ -216,7 +216,7 @@ const activeId = getActiveSecondaryNavId(Astro.url.pathname, entry)
   }
 
   /* Show the sidebar topics on mobile */
-  @media (max-width: 50rem) {
+  @media (max-width: 48rem) {
     :global(.starlight-sidebar-topics) {
       display: block !important;
     }
@@ -560,7 +560,7 @@ const activeId = getActiveSecondaryNavId(Astro.url.pathname, entry)
   }
 
   /* Responsive adjustments */
-  @media (max-width: 50rem) {
+  @media (max-width: 48rem) {
     .secondary-nav {
       display: none !important;
     }

--- a/src/components/overrides/Header.astro
+++ b/src/components/overrides/Header.astro
@@ -66,7 +66,7 @@ const { dir, entry, lang, locale } = Astro.props
      ============================================================================= */
   @layer header.layout {
     .header {
-      /* position: sticky; */
+      position: sticky;
       top: 0;
       z-index: var(--sl-z-index-navbar);
       background-color: var(--sl-color-bg);
@@ -169,10 +169,20 @@ const { dir, entry, lang, locale } = Astro.props
     }
 
     /* Mobile adjustments */
-    @media (max-width: 47.9375rem) {
+    @media (max-width: 48rem) {
+      .header {
+        position: sticky;
+      }
+
       .top-row {
         height: auto;
         min-height: auto;
+        gap: 0.5rem;
+      }
+
+      .header-left {
+        flex: 0 0 auto;
+        min-width: 0;
       }
     }
   }

--- a/src/configs/sidebar.config.ts
+++ b/src/configs/sidebar.config.ts
@@ -3,7 +3,7 @@ import { createDivider, createSectionHeader } from './sidebar-utils'
 
 export const sidebar = [
   {
-    label: 'Authenticate',
+    label: 'Full stack auth',
     id: 'authenticate',
     link: '/authenticate',
     icon: 'seti:lock',

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -176,6 +176,9 @@ head:
         display: none !important;
         margin-top: none !important;
       }
+      button[aria-label="Menu"].sl-flex.md\:sl-hidden {
+        display: none !important;
+      }
 prev: false
 next: false
 ---


### PR DESCRIPTION
- We are hiding the hamburger menu just for the home page in the mobile version. This is because, disabled sidebar opens up a empty menu. 
- Fixes the size of the logo in local. 