### PR TITLE
Update 'Initiate-login URL' description for clarity

### DIFF
--- a/src/content/docs/authenticate/fsa/quickstart.mdx
+++ b/src/content/docs/authenticate/fsa/quickstart.mdx
@@ -102,7 +102,7 @@ Scalekit handles the complex authentication flow while you focus on your core pr
    Before creating the authorization URL, register redirect URLs in your Scalekit dashboard. Go to **Scalekit dashboard** → **Authentication** → **Redirect URLs** and configure:
 
    - **Allowed callback URL**: The endpoint where Scalekit sends users after successful authentication. The `redirect_uri` in your code must match this URL exactly. [Learn more](/guides/dashboard/redirects/#allowed-callback-urls)
-   - **Initiate-login URL**: Required when authentication is not initiated from your app. Identity providers like Okta use this URL to let employees access your app through a dedicated employee portal. [Learn more](/guides/dashboard/redirects/#initiate-login-url)
+   - **Initiate-login URL**: Required when authentication is not initiated from your app-for example, when a user accepts an organization invitation or starts sign-in directly from their identity provider (IdP-initiated SSO). [Learn more](/guides/dashboard/redirects/#initiate-login-url)
 
    Now, you can create an authorization URL to redirect users to the login  page.
 


### PR DESCRIPTION
Clarified the explanation of the 'Initiate-login URL' in the documentation.