### PR TITLE
llms.txt is now prerenders

### DIFF
--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -7,7 +7,7 @@ import { sidebar } from '../configs/sidebar.config'
  * Uses sidebar configuration for dynamic content generation.
  */
 const BASE_URL = 'https://docs.scalekit.com'
-export const prerender = false
+export const prerender = true
 
 function abs(link: string): string {
   if (link.startsWith('http://') || link.startsWith('https://')) return link


### PR DESCRIPTION
When many requests come together, the llms.txt is not returned fast enough to llms to consume the content. This simple change will make sure the page is prerendered to easily serve. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized page rendering configuration for improved build efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->