### PR TITLE
FSA quickstart HTTP timeouts

### DIFF
--- a/src/content/docs/authenticate/fsa/quickstart.mdx
+++ b/src/content/docs/authenticate/fsa/quickstart.mdx
@@ -934,21 +934,18 @@ Scalekit handles the complex authentication flow while you focus on your core pr
 
 </Steps>
 
-<details>
-<summary>Common questions</summary>
-
-### Configure HTTP timeouts (Spring Boot 4.x)
-
-<Aside type="caution" title="Spring Boot 4.x timeout configuration">
-Spring Boot 4.x versions require explicit timeout configuration for OAuth2 resource server JWT validation. Without this configuration, your application may hang during startup if the issuer is unreachable.
-</Aside>
-
-When using Spring Security's OAuth2 resource server with JWT validation, the underlying `WebClient` (reactive HTTP client) uses default timeout settings that may cause issues. If Scalekit's authorization server is temporarily unreachable, your application startup can hang indefinitely while waiting for the JWKS endpoint response.
-
-To prevent this, configure explicit HTTP timeouts in your Spring Boot application. See the [Spring Security documentation on JWT timeouts](https://docs.spring.io/spring-security/reference/servlet/oauth2/resource-server/jwt.html#oauth2resourceserver-jwt-timeouts) for the recommended 1-second timeout configuration.
-
-This configuration applies specifically to reactive `WebClient`-based setups used by Spring Security's JWT decoder to fetch the JSON Web Key Set (JWKS) from the issuer.
-
-</details>
 
  This single integration unlocks multiple authentication methods, including Magic Link & OTP, social sign-ins, enterprise single sign-on (SSO), and robust user management features. As you continue working with Scalekit, you'll discover even more features that enhance your authentication workflows.
+
+
+
+## Common integration scenarios
+
+<details>
+<summary>How do I configure HTTP timeouts in Spring Boot?</summary>
+
+Spring Security’s OAuth2 resource server fetches the JWKS from the issuer URL during JWT validation. If the issuer is unreachable, authentication requests will time out.
+
+Use the Spring Security JWT timeout settings for your Spring Boot version. Follow the recommended configuration in the Spring docs: [JWT decoder timeouts](https://docs.spring.io/spring-security/reference/servlet/oauth2/resource-server/jwt.html#oauth2resourceserver-jwt-timeouts)
+
+</details>


### PR DESCRIPTION
Add a "Configure HTTP Timeouts (Spring Boot 4.x)" FAQ section to the FSA quickstart to prevent application startup hangs when the issuer is unreachable.

---
[Slack Thread](https://scalekit-inc.slack.com/archives/D092N521Z8X/p1769071716509549?thread_ts=1769071716.509549&cid=D092N521Z8X)

<a href="https://cursor.com/background-agent?bcId=bc-f36d09b4-0c59-473a-b180-545f52e87973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f36d09b4-0c59-473a-b180-545f52e87973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on configuring HTTP timeouts in Spring Boot and JWT decoder timeout settings to the authentication quickstart documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->