### PR TITLE
Webhooks documentation for connected accounts and users

### DIFF
--- a/public/api/scalekit.scalar.json
+++ b/public/api/scalekit.scalar.json
@@ -1,6 +1,6 @@
 {
   "info": {
-    "description": "# Overview\n\nThe Scalekit API is a RESTful API that enables you to manage organizations, users, and authentication settings. All requests must use HTTPS.\nAll API requests use the following base URLs:\n\n```\nhttps://{your-subdomain}.scalekit.dev (Development)\nhttps://{your-subdomain}.scalekit.com (Production)\nhttps://auth.yourapp.com (Custom domain)\n```\n\nScalekit operates two separate environments: Development and Production. Resources cannot be moved between environments.\n\n## Quickstart\n\nThe Scalekit API uses OAuth 2.0 Client Credentials for authentication.\n\nCopy your API credentials from the Scalekit dashboard's API Config section and set them as environment variables.\n\n```sh\nSCALEKIT_ENVIRONMENT_URL='<YOUR_ENVIRONMENT_URL>'\nSCALEKIT_CLIENT_ID='<ENVIRONMENT_CLIENT_ID>'\nSCALEKIT_CLIENT_SECRET='<ENVIRONMENT_CLIENT_SECRET>'\n```\n\nGetting an access token\n\n1. Get your credentials from the [Scalekit Dashboard](https://app.scalekit.com)\n2. Request an access token:\n\n```sh\ncurl https://<SCALEKIT_ENVIRONMENT_URL>/oauth/token \\\n  -X POST \\\n  -H 'Content-Type: application/x-www-form-urlencoded' \\\n  -d 'client_id={client_id}' \\\n  -d 'client_secret={client_secret}' \\\n  -d 'grant_type=client_credentials'\n```\n\n3. Use the access token in API requests:\n\n```sh\ncurl https://<SCALEKIT_ENVIRONMENT_URL>/api/v1/organizations \\\n  -H 'Content-Type: application/json' \\\n  -H 'Authorization: Bearer {access_token}'\n```\n\nThe response includes an access token:\n\n```json\n{\n\t\"access_token\": \"eyJhbGciOiJSUzI1NiIsImtpZCI6InNua181Ok4OTEyMjU2NiIsInR5cCI6IkpXVCJ9...\",\n\t\"token_type\": \"Bearer\",\n\t\"expires_in\": 86399,\n\t\"scope\": \"openid\"\n}\n```\n\n## SDKs\n\nScalekit provides official SDKs for multiple programming languages. Check the changelog at GitHub repositories for the latest updates.\n\n### Node.js\n\n```sh\nnpm install @scalekit-sdk/node\n```\n\nCreate a new Scalekit client instance after initializing the environment variables\n\n```js\nimport { Scalekit } from \"@scalekit-sdk/node\";\n\nexport let scalekit = new Scalekit(\n\tprocess.env.SCALEKIT_ENVIRONMENT_URL,\n\tprocess.env.SCALEKIT_CLIENT_ID,\n\tprocess.env.SCALEKIT_CLIENT_SECRET\n);\n```\n\n[See the Node SDK changelog](https://github.com/scalekit-inc/scalekit-sdk-node/releases)\n\n### Python\n\n```sh\npip install scalekit-sdk-python\n```\n\nCreate a new Scalekit client instance after initializing the environment variables.\n\n```py\nfrom scalekit import ScalekitClient\nimport os\n\nscalekit_client = ScalekitClient(\n    os.environ.get('SCALEKIT_ENVIRONMENT_URL'),\n    os.environ.get('SCALEKIT_CLIENT_ID'),\n    os.environ.get('SCALEKIT_CLIENT_SECRET')\n)\n```\n\n[See the Python SDK changelog](https://github.com/scalekit-inc/scalekit-sdk-python/releases)\n\n### Go\n\n```sh\ngo get -u github.com/scalekit-inc/scalekit-sdk-go\n```\n\nCreate a new Scalekit client instance after initializing the environment variables.\n\n```go\npackage main\n\nimport (\n    \"os\"\n    \"github.com/scalekit-inc/scalekit-sdk-go\"\n)\n\nscalekitClient := scalekit.NewScalekitClient(\n    os.Getenv(\"SCALEKIT_ENVIRONMENT_URL\"),\n    os.Getenv(\"SCALEKIT_CLIENT_ID\"),\n    os.Getenv(\"SCALEKIT_CLIENT_SECRET\"),\n)\n```\n\n[See the Go SDK changelog](https://github.com/scalekit-inc/scalekit-sdk-go/releases)\n\n### Java\n\n```gradle\n/* Gradle users - add the following to your dependencies in build file */\nimplementation \"com.scalekit:scalekit-sdk-java:2.0.6\"\n```\n\n```xml\n<!-- Maven users - add the following to your `pom.xml` -->\n<dependency>\n    <groupId>com.scalekit</groupId>\n    <artifactId>scalekit-sdk-java</artifactId>\n    <version>2.0.6</version>\n</dependency>\n```\n\n[See the Java SDK changelog](https://github.com/scalekit-inc/scalekit-sdk-java/releases)\n\n### Error handling\n\nThe API uses standard HTTP status codes:\n\n| Code        | Description          |\n| ----------- | -------------------- |\n| 200/201     | Success              |\n| 400         | Invalid request      |\n| 401         | Authentication error |\n| 404         | Resource not found   |\n| 429         | Rate limit exceeded  |\n| 500/501/504 | Server error         |\n\nError responses include detailed information:\n\n```json\n{\n\t\"code\": 16,\n\t\"message\": \"Token empty\",\n\t\"details\": [\n\t\t{\n\t\t\t\"@type\": \"type.googleapis.com/scalekit.v1.errdetails.ErrorInfo\",\n\t\t\t\"error_code\": \"UNAUTHENTICATED\"\n\t\t}\n\t]\n}\n```\n",
+    "description": "# Overview\n\nThe Scalekit API is a RESTful API that enables you to manage organizations, users, and authentication settings. All requests must use HTTPS.\nAll API requests use the following base URLs:\n\n```\nhttps://{your-subdomain}.scalekit.dev (Development)\nhttps://{your-subdomain}.scalekit.com (Production)\nhttps://auth.yourapp.com (Custom domain)\n```\n\nScalekit operates two separate environments: Development and Production. Resources cannot be moved between environments.\n\n## Quickstart\n\nThe Scalekit API uses OAuth 2.0 Client Credentials for authentication.\n\nCopy your API credentials from the Scalekit dashboard's API Config section and set them as environment variables.\n\n```sh\nSCALEKIT_ENVIRONMENT_URL='<YOUR_ENVIRONMENT_URL>'\nSCALEKIT_CLIENT_ID='<ENVIRONMENT_CLIENT_ID>'\nSCALEKIT_CLIENT_SECRET='<ENVIRONMENT_CLIENT_SECRET>'\n```\n\nGetting an access token\n\n1. Get your credentials from the [Scalekit Dashboard](https://app.scalekit.com)\n2. Request an access token:\n\n```sh\ncurl https://<SCALEKIT_ENVIRONMENT_URL>/oauth/token \\\n  -X POST \\\n  -H 'Content-Type: application/x-www-form-urlencoded' \\\n  -d 'client_id={client_id}' \\\n  -d 'client_secret={client_secret}' \\\n  -d 'grant_type=client_credentials'\n```\n\n3. Use the access token in API requests:\n\n```sh\ncurl https://<SCALEKIT_ENVIRONMENT_URL>/api/v1/organizations \\\n  -H 'Content-Type: application/json' \\\n  -H 'Authorization: Bearer {access_token}'\n```\n\nThe response includes an access token:\n\n```json\n{\n\t\"access_token\": \"eyJhbGciOiJSUzI1NiIsImtpZCI6InNua181Ok4OTEyMjU2NiIsInR5cCI6IkpXVCJ9...\",\n\t\"token_type\": \"Bearer\",\n\t\"expires_in\": 86399,\n\t\"scope\": \"openid\"\n}\n```\n\n## SDKs\n\nScalekit provides official SDKs for multiple programming languages. Check the changelog at GitHub repositories for the latest updates.\n\n### Node.js\n\n```sh\nnpm install @scalekit-sdk/node\n```\n\nCreate a new Scalekit client instance after initializing the environment variables\n\n```js\nimport { Scalekit } from \"@scalekit-sdk/node\";\n\nexport let scalekit = new Scalekit(\n\tprocess.env.SCALEKIT_ENVIRONMENT_URL,\n\tprocess.env.SCALEKIT_CLIENT_ID,\n\tprocess.env.SCALEKIT_CLIENT_SECRET\n);\n```\n\n[See the Node SDK changelog](https://github.com/scalekit-inc/scalekit-sdk-node/releases)\n\n### Python\n\n```sh\npip install scalekit-sdk-python\n```\n\nCreate a new Scalekit client instance after initializing the environment variables.\n\n```py\nfrom scalekit import ScalekitClient\nimport os\n\nscalekit_client = ScalekitClient(\n    os.environ.get('SCALEKIT_ENVIRONMENT_URL'),\n    os.environ.get('SCALEKIT_CLIENT_ID'),\n    os.environ.get('SCALEKIT_CLIENT_SECRET')\n)\n```\n\n[See the Python SDK changelog](https://github.com/scalekit-inc/scalekit-sdk-python/releases)\n\n### Go\n\n```sh\ngo get -u github.com/scalekit-inc/scalekit-sdk-go\n```\n\nCreate a new Scalekit client instance after initializing the environment variables.\n\n```go\npackage main\n\nimport (\n    \"os\"\n    \"github.com/scalekit-inc/scalekit-sdk-go\"\n)\n\nscalekitClient := scalekit.NewScalekitClient(\n    os.Getenv(\"SCALEKIT_ENVIRONMENT_URL\"),\n    os.Getenv(\"SCALEKIT_CLIENT_ID\"),\n    os.Getenv(\"SCALEKIT_CLIENT_SECRET\"),\n)\n```\n\n[See the Go SDK changelog](https://github.com/scalekit-inc/scalekit-sdk-go/releases)\n\n### Java\n\n```gradle\n/* Gradle users - add the following to your dependencies in build file */\nimplementation \"com.scalekit:scalekit-sdk-java:2.0.11\"\n```\n\n```xml\n<!-- Maven users - add the following to your `pom.xml` -->\n<dependency>\n    <groupId>com.scalekit</groupId>\n    <artifactId>scalekit-sdk-java</artifactId>\n    <version>2.0.11</version>\n</dependency>\n```\n\n[See the Java SDK changelog](https://github.com/scalekit-inc/scalekit-sdk-java/releases)\n\n### Error handling\n\nThe API uses standard HTTP status codes:\n\n| Code        | Description          |\n| ----------- | -------------------- |\n| 200/201     | Success              |\n| 400         | Invalid request      |\n| 401         | Authentication error |\n| 404         | Resource not found   |\n| 429         | Rate limit exceeded  |\n| 500/501/504 | Server error         |\n\nError responses include detailed information:\n\n```json\n{\n\t\"code\": 16,\n\t\"message\": \"Token empty\",\n\t\"details\": [\n\t\t{\n\t\t\t\"@type\": \"type.googleapis.com/scalekit.v1.errdetails.ErrorInfo\",\n\t\t\t\"error_code\": \"UNAUTHENTICATED\"\n\t\t}\n\t]\n}\n```\n",
     "title": "Scalekit APIs",
     "contact": {
       "name": "Scalekit Inc",
@@ -21,6 +21,880 @@
     ]
   },
   "paths": {
+    "/api/v1/connected_accounts": {
+      "get": {
+        "description": "Retrieves a paginated list of connected accounts for third-party integrations. Filter by organization, user, connector type, provider, or identifier. Returns OAuth tokens, API keys, and connection status for each account. Use pagination tokens to navigate through large result sets.",
+        "tags": ["Connected Accounts"],
+        "summary": "List connected accounts",
+        "operationId": "ConnectedAccountService_ListConnectedAccounts",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by organization ID. Returns only connected accounts associated with this organization.",
+            "name": "organization_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by user ID. Returns only connected accounts associated with this user.",
+            "name": "user_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by connector type. Connector identifier such as 'notion', 'slack', 'google', etc. Alphanumeric with hyphens and underscores allowed.",
+            "name": "connector",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by account identifier. The unique identifier for the connected account within the third-party service (e.g., email address, workspace ID).",
+            "name": "identifier",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by OAuth provider. The authentication provider name such as 'google', 'microsoft', 'github', etc.",
+            "name": "provider",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "Maximum number of connected accounts to return per page. Must be between 0 and 100. Default is typically 10.",
+            "name": "page_size",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Pagination token from a previous response. Use the next_page_token value from ListConnectedAccountsResponse to fetch the next page.",
+            "name": "page_token",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Text search query to filter connected accounts by name, identifier, or other searchable fields. Case-insensitive.",
+            "name": "query",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the list of connected accounts with their authentication details and status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/connected_accountsListConnectedAccountsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request - occurs when query parameters are malformed or validation fails",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required - missing or invalid access token",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Updates authentication credentials and configuration for an existing connected account. Modify OAuth tokens, refresh tokens, access scopes, or API configuration settings. Specify the account by ID, or by combination of organization/user, connector, and identifier. Returns the updated account with new token expiry and status information.",
+        "tags": ["Connected Accounts"],
+        "summary": "Update connected account credentials",
+        "operationId": "ConnectedAccountService_UpdateConnectedAccount",
+        "responses": {
+          "200": {
+            "description": "Connected account updated successfully with new credentials or configuration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/connected_accountsUpdateConnectedAccountResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request - missing required fields, invalid authorization details, or validation failed",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required - missing or invalid access token",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Connected account not found - the specified account does not exist",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/connected_accountsUpdateConnectedAccountRequest"
+              }
+            }
+          },
+          "required": true
+        }
+      },
+      "post": {
+        "description": "Creates a new connected account with OAuth tokens or API credentials for third-party service integration. Supply authorization details including access tokens, refresh tokens, scopes, and optional API configuration. The account can be scoped to an organization or user. Returns the created account with its unique identifier and authentication status.",
+        "tags": ["Connected Accounts"],
+        "summary": "Create a connected account",
+        "operationId": "ConnectedAccountService_CreateConnectedAccount",
+        "responses": {
+          "201": {
+            "description": "Connected account created successfully with authentication credentials stored securely",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/connected_accountsCreateConnectedAccountResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request - missing required fields, invalid authorization details, or validation failed",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required - missing or invalid access token",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict - connected account with the same identifier already exists",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/connected_accountsCreateConnectedAccountRequest"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/api/v1/connected_accounts/auth": {
+      "get": {
+        "description": "Retrieves complete authentication details for a connected account including OAuth tokens, refresh tokens, scopes, and API configuration. Query by account ID or by combination of organization/user, connector, and identifier. Returns sensitive credential information - use appropriate access controls.",
+        "tags": ["Connected Accounts"],
+        "summary": "Get connected account details",
+        "operationId": "ConnectedAccountService_GetConnectedAccountAuth",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Organization ID for the connector",
+            "name": "organization_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "User ID for the connector",
+            "name": "user_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Connector identifier",
+            "name": "connector",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "The unique identifier for the connected account within the third-party service (e.g., email address, user ID, workspace identifier).",
+            "name": "identifier",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier for the connected account",
+            "name": "id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved connected account with full authentication details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/connected_accountsGetConnectedAccountByIdentifierResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request - missing required query parameters",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required - missing or invalid access token",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Connected account not found - no account matches the specified criteria",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/connected_accounts/magic_link": {
+      "post": {
+        "description": "Creates a time-limited magic link for connecting or re-authorizing a third-party account. The link directs users to the OAuth authorization flow for the specified connector. Returns the generated link URL and expiration timestamp. Links typically expire after a short duration for security.",
+        "tags": ["Connected Accounts"],
+        "summary": "Generate authentication magic link",
+        "operationId": "ConnectedAccountService_GetMagicLinkForConnectedAccount",
+        "responses": {
+          "200": {
+            "description": "Magic link generated successfully with authorization URL and expiry time",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/connected_accountsGetMagicLinkForConnectedAccountResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request - missing required parameters or invalid connector",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required - missing or invalid access token",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/connected_accountsGetMagicLinkForConnectedAccountRequest"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/api/v1/connected_accounts:delete": {
+      "post": {
+        "description": "Permanently removes a connected account and revokes all associated authentication credentials. Identify the account by ID, or by combination of organization/user, connector, and identifier. This action cannot be undone. All OAuth tokens and API keys for this account will be invalidated.",
+        "tags": ["Connected Accounts"],
+        "summary": "Delete a connected account",
+        "operationId": "ConnectedAccountService_DeleteConnectedAccount",
+        "responses": {
+          "200": {
+            "description": "Connected account deleted successfully and all credentials revoked",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request - malformed parameters or validation failed",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required - missing or invalid access token",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Connected account not found - the specified account does not exist",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/connected_accountsDeleteConnectedAccountRequest"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/api/v1/connected_accounts:search": {
+      "get": {
+        "description": "Search for connected accounts in your environment using a text query that matches against identifiers, providers, or connectors. The search performs case-insensitive matching across account details. Returns paginated results with account status and authentication type information.",
+        "tags": ["Connected Accounts"],
+        "summary": "Search connected accounts",
+        "operationId": "ConnectedAccountService_SearchConnectedAccounts",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Search term to match against connected account identifiers, providers, or connectors. Must be at least 3 characters. Case insensitive.",
+            "name": "query",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "Maximum number of connected accounts to return per page. Value must be between 1 and 30.",
+            "name": "page_size",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Token from a previous response for pagination. Provide this to retrieve the next page of results.",
+            "name": "page_token",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Connection ID to filter connected accounts",
+            "name": "connection_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved matching connected accounts with pagination support",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/connected_accountsSearchConnectedAccountsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request - query parameter is too short (minimum 3 characters) or validation failed",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required - missing or invalid access token",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/connections": {
+      "get": {
+        "description": "Retrieves a list of connections in the environment",
+        "tags": ["Connections"],
+        "summary": "List connections",
+        "operationId": "ConnectionService_ListConnections",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter connections by organization identifier",
+            "name": "organization_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter connections by email domain associated with the organization",
+            "name": "domain",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter connections by status. Use 'all' to include all connections regardless of status. Default behavior shows only active (completed and enabled) connections",
+            "name": "include",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved connections",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/connectionsListConnectionsResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "// List connections by organization id\nconst connections = await scalekit.connection.listConnections(organizationId);\n\n// List connections by domain\nconst connections = await scalekit.connection.listConnectionsByDomain(domain);"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "# List connections by organization id\nconnections = scalekit_client.connection.list_connections(\n  organization_id\n)\n\n# List connections by domain\nresponse = scalekit_client.connection.list_connections_by_domain(domain=\"example.com\")"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "// List connections by organization id\nconnections, err := scalekitClient.Connection().ListConnections(\n  ctx,\n  organizationId\n)\n\n// List connections by domain\nconnections, err := scalekitClient.Connection().ListConnectionsByDomain(ctx, \n  domain)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "// List connections by organization id\nListConnectionsResponse response = scalekitClient.connections(\n  ).listConnections(organizationId);\n\n// List connections by domain\nListConnectionsResponse response = scalekitClient.connections(\n  ).listConnectionsByDomain(\"your-domain.com\");"
+          }
+        ]
+      }
+    },
+    "/api/v1/execute_tool": {
+      "post": {
+        "description": "Executes a tool action using authentication credentials from a connected account. Specify the tool by name and provide required parameters as JSON. The connected account can be identified by ID, or by combination of organization/user, connector, and identifier. Returns the execution result data and a unique execution ID for tracking. Use this endpoint to perform actions like sending emails, creating calendar events, or managing resources in external services.",
+        "tags": ["Connected Accounts"],
+        "summary": "Execute a tool using a connected account",
+        "operationId": "ToolService_ExecuteTool",
+        "responses": {
+          "200": {
+            "description": "Tool executed successfully with result data and execution ID",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/toolsExecuteToolResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request - occurs when tool name is missing, parameters are malformed, or tool definition validation fails",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required - missing or invalid access token",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Tool or connected account not found - occurs when the specified tool name or connected account does not exist",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "500": {
+            "description": "Tool execution failed - occurs when the external service returns an error or the tool encounters a runtime exception",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/toolsExecuteToolRequest"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/api/v1/invites/organizations/{organization_id}/users/{id}/resend": {
+      "patch": {
+        "description": "Resends an invitation email to a user who has a pending or expired invitation in the specified organization. If the invitation has expired, a new invitation will be automatically created and sent. If the invitation is still valid, a reminder email will be sent instead. Use this endpoint when a user hasn't responded to their initial invitation and you need to send them a reminder or when the original invitation has expired. The invitation email includes a secure magic link that allows the user to complete their account setup and join the organization. Each resend operation increments the resent counter.",
+        "tags": ["Users"],
+        "summary": "Resend user invitation email",
+        "operationId": "UserService_ResendInvite",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier of the organization containing the pending invitation. Must start with 'org_' and be 1-32 characters long.",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "System-generated user ID of the user who has a pending invitation. Must start with 'usr_' and be 19-25 characters long.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully resent the invitation email. Returns the updated invitation object with organization ID, user ID, membership status, timestamps, and resent count. If expired, a new invitation is created; otherwise, the existing one is resent.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/usersResendInviteResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request — common causes include user ID or organization ID is invalid, full-stack authentication is disabled, user profile is missing, invite already accepted, or missing expiry time in user management settings.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errdetailsErrorInfo"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found — the specified user, organization, membership, or invitation could not be found in the specified environment. Verify that all IDs are correct and that the resources exist before attempting to resend an invitation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errdetailsErrorInfo"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error — an unexpected error occurred while processing the invitation resend request. This may be due to database connectivity issues, problems generating the secure magic link, email delivery service failures, or transaction errors during invitation processing. Contact support if the problem persists.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errdetailsErrorInfo"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserServiceResendInviteBody"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/api/v1/memberships/organizations/{organization_id}/users/{id}": {
+      "post": {
+        "description": "Adds an existing user to an organization and assigns them specific roles and permissions. Use this endpoint when you want to grant an existing user access to a particular organization. You can specify roles, metadata, and other membership details during the invitation process.",
+        "tags": ["Users"],
+        "summary": "Add existing user to organization",
+        "operationId": "UserService_CreateMembership",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier of the target organization. Must start with 'org_' and be 1-32 characters long.",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "System-generated user ID. Must start with 'usr_' (19-25 characters)",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "External system identifier from connected directories. Must be unique across the system",
+            "name": "external_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "If true, sends an activation email to the user. Defaults to true.",
+            "name": "send_invitation_email",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "User successfully added to the organization. Returns details of the updated membership details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/usersCreateMembershipResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "import { ScalekitClient } from \"@scalekit-sdk/node\";\nconst scalekit = new ScalekitClient(\n\tprocess.env.SCALEKIT_ENV_URL,\n\tprocess.env.SCALEKIT_CLIENT_ID,\n\tprocess.env.SCALEKIT_CLIENT_SECRET\n);\nawait scalekit.user.createMembership(\"org_123\", \"usr_123\", {\n\troles: [\"admin\"],\n\tmetadata: {\n\t\tdepartment: \"engineering\",\n\t\tlocation: \"nyc-office\",\n\t},\n});"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "import os\nfrom scalekit import ScalekitClient\nscalekit_client = ScalekitClient(\n    env_url=os.getenv(\"SCALEKIT_ENV_URL\"),\n    client_id=os.getenv(\"SCALEKIT_CLIENT_ID\"),\n    client_secret=os.getenv(\"SCALEKIT_CLIENT_SECRET\"),\n)\n# The Python SDK currently exposes a helper that \n  #simply links an existing\n# user to an organization.\nresp, _ = scalekit_client.users.add_user_to_organization(\n    organization_id=\"org_123\",\n    user_id=\"usr_123\",\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "func main() {\n    scalekitClient := scalekit.NewScalekitClient(\n        os.Getenv(\"SCALEKIT_ENV_URL\"),\n        os.Getenv(\"SCALEKIT_CLIENT_ID\"),\n        os.Getenv(\"SCALEKIT_CLIENT_SECRET\"),\n    )\n    membership := &usersv1.CreateMembership{\n        Roles: []*usersv1.Role{{Name: \"admin\"}},\n        Metadata: map[string]string{\n            \"department\": \"engineering\",\n            \"location\":   \"nyc-office\",\n        },\n    }\n    resp, \n      err := scalekitClient.User().CreateMembership(\n        context.Background(), \"org_123\", \n          \"usr_123\", membership, false)\n    if err != nil {\n        panic(err)\n    }\n}"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "import com.scalekit.ScalekitClient;\nimport com.scalekit.api.UserClient;\nimport com.scalekit.grpc.scalekit.v1.users.*;\nScalekitClient scalekitClient = new ScalekitClient(\n    System.getenv(\"SCALEKIT_ENV_URL\"),\n    System.getenv(\"SCALEKIT_CLIENT_ID\"),\n    System.getenv(\"SCALEKIT_CLIENT_SECRET\")\n);\nUserClient users = scalekitClient.users();\nCreateMembershipRequest membershipReq = CreateMemb\n  ershipRequest.newBuilder()\n        .setMembership(\n          CreateMembership.newBuilder()\n                .addRoles(Role.newBuilder(\n                  ).setName(\"admin\").build())\n                .putMetadata(\"department\", \"engineering\")\n                .putMetadata(\"location\", \"nyc-office\")\n                .build())\n        .build();\nCreateMembershipResponse res = users.\n  createMembership(\"org_123\", \"usr_123\", \n    membershipReq);"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Membership details to create. Required fields must be provided.",
+                "$ref": "#/components/schemas/v1usersCreateMembership"
+              }
+            }
+          },
+          "required": true
+        }
+      },
+      "delete": {
+        "description": "Removes a user from an organization by user ID or external ID. If the user has no memberships left and cascade is true, the user is also deleted. This action is irreversible and may also remove related group memberships.",
+        "tags": ["Users"],
+        "summary": "Delete organization membership for user",
+        "operationId": "UserService_DeleteMembership",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique organization identifier. Must start with 'org_' and be 1-32 characters long",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "System-generated user ID. Must start with 'usr_' (19-25 characters)",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "External system identifier from connected directories. Must match existing records",
+            "name": "external_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User successfully marked for deletion. No content returned",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "response = scalekit_client.users.delete_membership(\n  organization_id=org_id,user_id=user_id\n)"
+          }
+        ]
+      },
+      "patch": {
+        "description": "Updates a user's membership details within an organization by user ID or external ID. You can update roles and membership metadata.",
+        "tags": ["Users"],
+        "summary": "Update organization membership for user",
+        "operationId": "UserService_UpdateMembership",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier of the organization containing the membership. Must start with 'org_' and be 1-32 characters long.",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "System-generated user ID. Must start with 'usr_' and be 19-25 characters long.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Your application's unique identifier for this user.",
+            "name": "external_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Membership updated successfully. Returns the updated user object.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/usersUpdateMembershipResponse"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Membership fields to update. Only specified fields will be modified.",
+                "$ref": "#/components/schemas/v1usersUpdateMembership",
+                "examples": [
+                  {
+                    "role": "admin"
+                  }
+                ]
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
     "/api/v1/organizations": {
       "get": {
         "description": "Retrieve a paginated list of organizations within your environment. The response includes a `page_token` that can be used to access subsequent pages of results.",
@@ -207,6 +1081,55 @@
           }
         ]
       },
+      "delete": {
+        "description": "Remove an existing organization from the environment using its unique identifier",
+        "tags": ["Organizations"],
+        "summary": "Delete an organization",
+        "operationId": "OrganizationService_DeleteOrganization",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique scalekit-generated identifier that uniquely references an organization",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Organization successfully deleted and no longer accessible",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await scalekit.organization.deleteOrganization(organizationId);"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "scalekit_client.organization.delete_organization(organization_id)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "err := scalekitClient.Organization.DeleteOrganization(\n  ctx,\n  organizationId\n)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "ScalekitClient scalekitClient = new ScalekitClient(\n  \"<SCALEKIT_ENVIRONMENT_URL>\",\n  \"<SCALEKIT_CLIENT_ID>\",\n  \"<SCALEKIT_CLIENT_SECRET>\"\n);\n\nscalekitClient.organizations().deleteById(organizationId);"
+          }
+        ]
+      },
       "patch": {
         "description": "Updates an organization's display name, external ID, or metadata. Requires a valid organization identifier. Region code cannot be modified through this endpoint.",
         "tags": ["Organizations"],
@@ -268,55 +1191,6 @@
           },
           "required": true
         }
-      },
-      "delete": {
-        "description": "Remove an existing organization from the environment using its unique identifier",
-        "tags": ["Organizations"],
-        "summary": "Delete an organization",
-        "operationId": "OrganizationService_DeleteOrganization",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique scalekit-generated identifier that uniquely references an organization",
-            "name": "id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Organization successfully deleted and no longer accessible",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "await scalekit.organization.deleteOrganization(organizationId);"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "scalekit_client.organization.delete_organization(organization_id)"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "err := scalekitClient.Organization.DeleteOrganization(\n  ctx,\n  organizationId\n)"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "ScalekitClient scalekitClient = new ScalekitClient(\n  \"<SCALEKIT_ENVIRONMENT_URL>\",\n  \"<SCALEKIT_CLIENT_ID>\",\n  \"<SCALEKIT_CLIENT_SECRET>\"\n);\n\nscalekitClient.organizations().deleteById(organizationId);"
-          }
-        ]
       }
     },
     "/api/v1/organizations/{id}/portal_links": {
@@ -478,3011 +1352,6 @@
           },
           "required": true
         }
-      }
-    },
-    "/api/v1/organizations/{organization_id}/clients": {
-      "get": {
-        "description": "Retrieves a paginated list of API clients for a specific organization. Returns client details including metadata, scopes, and secret information (without exposing actual secret values).",
-        "tags": ["API Auth"],
-        "summary": "List organization API clients",
-        "operationId": "ClientService_ListOrganizationClients",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier of the organization whose clients to list. Must start with 'org_' prefix.",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "description": "Maximum number of clients to return per page\n\nMaximum number of API clients to return per page. Must be between 10 and 100",
-            "name": "page_size",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Pagination token from the previous response\n\nPagination token from the previous response. Use to retrieve the next page of organization clients",
-            "name": "page_token",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "List of organization API clients returned successfully. Each client includes its configuration details and metadata.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/clientsListOrganizationClientsResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "# List clients for a specific organization\norg_id = 'SCALEKIT_ORGANIZATION_ID'\n\n# Retrieve all clients with default pagination\nresponse = scalekit_client.m2m_client.list_organization_clients(\n    organization_id=org_id,\n    page_size=30\n)\n\n# Access the clients list\nclients = response.clients\nfor client in clients:\n    print(f\"Client ID: {scalekit_client.id}, Name: {scalekit_client.name}\")"
-          }
-        ]
-      },
-      "post": {
-        "description": "Creates a new API client for an organization. Returns the client details and a plain secret (available only once).",
-        "tags": ["API Auth"],
-        "summary": "Create organization API client",
-        "operationId": "ClientService_CreateOrganizationClient",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier of the organization",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "API client created successfully. Returns the client ID and plain secret (only available at creation time). The client can be configured with scopes, audience values, and custom claims for fine-grained access control.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/clientsCreateOrganizationClientResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "from scalekit.v1.clients.clients_pb2 import OrganizationClient\n\nm2m_client = OrganizationClient(\n    name=\"GitHub Actions Deployment Service\",\n    description=\"Service account for GitHub Actions to deploy applications\nto production\",\n    custom_claims=[\n        {\"key\": \"github_repository\", \"value\": \"acmecorp/inventory-service\"},\n        {\"key\": \"environment\", \"value\": \"production_us\"}\n    ],\n    scopes=[\"deploy:applications\", \"read:deployments\"],\n    audience=[\"deployment-api.acmecorp.com\"],\n    expiry=3600\n)\n\nresponse = scalekit_client.m2m_client.create_organization_client(\n    organization_id=\"SCALEKIT_ORGANIZATION_ID\",\n    m2m_client=m2m_client\n)"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "description": "Details of the client to be created",
-                "$ref": "#/components/schemas/clientsOrganizationClient"
-              }
-            }
-          },
-          "required": true
-        }
-      }
-    },
-    "/api/v1/organizations/{organization_id}/directories": {
-      "get": {
-        "tags": ["Directory"],
-        "summary": "List organization directories",
-        "operationId": "DirectoryService_ListDirectories",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier of the organization",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved the list of directories for the organization",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/directoriesListDirectoriesResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "await scalekit.directory.listDirectories('<organization_id>');"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "directories_list = scalekit_client.directory.list_directories(\n\torganization_id='<organization_id>'\n)"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "directories,err := scalekitClient.Directory().ListDirectories(ctx, organizationId)"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "ListDirectoriesResponse response = scalekitClient.directories().listDirectories(organizationId);"
-          }
-        ]
-      }
-    },
-    "/api/v1/organizations/{organization_id}/clients/{client_id}": {
-      "get": {
-        "description": "Retrieves details of a specific API client in an organization.",
-        "tags": ["API Auth"],
-        "summary": "Get organization API client",
-        "operationId": "ClientService_GetOrganizationClient",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier of the organization",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier of the API client",
-            "name": "client_id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Returns the complete API client configuration, including all current settings and a list of active secrets. Note that secret values are not included in the response for security reasons.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/clientsGetOrganizationClientResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "# Get client ID from environment variables\norg_id = 'SCALEKIT_ORGANIZATION_ID'\nclient_id = os.environ['M2M_CLIENT_ID']\n\n# Fetch client details for the specified organization\nresponse = scalekit_client.m2m_client.get_organization_client(\n    organization_id=org_id,\n    client_id=client_id\n)"
-          }
-        ]
-      },
-      "patch": {
-        "description": "Updates an existing organization API client. Only specified fields are modified.",
-        "tags": ["API Auth"],
-        "summary": "Update organization API client",
-        "operationId": "ClientService_UpdateOrganizationClient",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier of the organization",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier of the client",
-            "name": "client_id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Returns the updated organization API client with all current details reflected in the response, including modified scopes, audience values, and custom claims.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/clientsUpdateOrganizationClientResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "from scalekit.v1.clients.clients_pb2 import OrganizationClient\n\norg_id = '<SCALEKIT_ORGANIZATION_ID>'\nclient_id = os.environ['M2M_CLIENT_ID']\n\nupdate_m2m_client = OrganizationClient(\n    description=\"Service account for GitHub Actions to deploy applications\nto production_eu\",\n    custom_claims=[\n        {\"key\": \"github_repository\", \"value\": \"acmecorp/inventory\"},\n        {\"key\": \"environment\", \"value\": \"production_eu\"}\n    ]\n)\n\nresponse = scalekit_client.m2m_client.update_organization_client(\n    organization_id=org_id,\n    client_id=client_id,\n    m2m_client=update_m2m_client\n)"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "description": "Updated details for the client",
-                "$ref": "#/components/schemas/clientsOrganizationClient"
-              }
-            }
-          },
-          "required": true
-        }
-      },
-      "delete": {
-        "description": "Permanently deletes an API client from an organization. This operation cannot be undone and will revoke all access for the client. All associated secrets will also be invalidated. Use this endpoint to remove unused or compromised clients.",
-        "tags": ["API Auth"],
-        "summary": "Delete organization API client",
-        "operationId": "ClientService_DeleteOrganizationClient",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier of the organization that owns the client. Must start with 'org_' prefix.",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier of the API client to permanently delete. Must start with 'm2morg_' prefix.",
-            "name": "client_id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Organization API client successfully deleted and no longer accessible",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "# Get client ID from environment variables\norg_id = '<SCALEKIT_ORGANIZATION_ID>'\nclient_id = os.environ['M2M_CLIENT_ID']\n\n# Delete the specified client from the organization\nresponse = scalekit_client.m2m_client.delete_organization_client(\n    organization_id=org_id,\n    client_id=client_id\n)"
-          }
-        ]
-      }
-    },
-    "/api/v1/organizations/{organization_id}/directories/{id}": {
-      "get": {
-        "description": "Retrieves detailed information about a specific directory within an organization",
-        "tags": ["Directory"],
-        "summary": "Get directory details",
-        "operationId": "DirectoryService_GetDirectory",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier of the organization",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier of the directory",
-            "name": "id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved directory details",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/directoriesGetDirectoryResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "const { directory } = await scalekit.directory.getDirectory(\n  organizationId,\n  directoryId\n);"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "directory = scalekit_client.directory.get_directory(\n  directory_id='<directory_id>', organization_id='<organization_id>'\n)\nprint(f'Directory details: {directory}')"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "directory, err := scalekitClient.Directory().GetDirectory(ctx, organizationId, directoryId)"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "Directory directory = scalekitClient.directories().getDirectory(directoryId, organizationId);"
-          }
-        ]
-      }
-    },
-    "/api/v1/organizations/{organization_id}/directories/{id}:disable": {
-      "patch": {
-        "description": "Stops synchronization of users and groups from a specified directory within an organization. This operation prevents further updates from the connected Directory provider",
-        "tags": ["Directory"],
-        "summary": "Disable a directory",
-        "operationId": "DirectoryService_DisableDirectory",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "A unique identifier for the organization. The value must begin with 'org_' and be between 1 and 32 characters long",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "A unique identifier for a directory within the organization. The value must begin with 'dir_' and be between 1 and 32 characters long",
-            "name": "id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully disabled the directory",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/directoriesToggleDirectoryResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "await scalekit.directory.disableDirectory(\n  '<organization_id>',\n  '<directory_id>'\n);"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "directory_response = scalekit_client.directory.disable_directory(\n  directory_id='<directory_id>', organization_id='<organization_id>'\n)"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "disable,err := scalekitClient.Directory().DisableDirectory(ctx, organizationId, directoryId)"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "ToggleDirectoryResponse disableResponse = scalekitClient\n  .directories()\n  .disableDirectory(directoryId, organizationId);"
-          }
-        ]
-      }
-    },
-    "/api/v1/organizations/{organization_id}/directories/{id}:enable": {
-      "patch": {
-        "description": "Activates a directory within an organization, allowing it to synchronize users and groups with the connected Directory provider",
-        "tags": ["Directory"],
-        "summary": "Enable a directory",
-        "operationId": "DirectoryService_EnableDirectory",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "A unique identifier for the organization. The value must begin with 'org_' and be between 1 and 32 characters long",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "A unique identifier for a directory within the organization. The value must begin with 'dir_' and be between 1 and 32 characters long",
-            "name": "id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/directoriesToggleDirectoryResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "await scalekit.directory.enableDirectory('<organization_id>', '<directory_id>');"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "directory_response = scalekit_client.directory.enable_directory(\n  directory_id='<directory_id>', organization_id='<organization_id>'\n)"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "enable,err := scalekitClient.Directory().EnableDirectory(ctx, organizationId, directoryId)"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "ToggleDirectoryResponse enableResponse = client\n  .directories()\n  .enableDirectory(directoryId, organizationId);"
-          }
-        ]
-      }
-    },
-    "/api/v1/organizations/{organization_id}/settings/usermanagement": {
-      "patch": {
-        "description": "Upsert user management settings for an organization",
-        "tags": ["Organizations"],
-        "summary": "Upsert organization user setting",
-        "operationId": "OrganizationService_UpsertUserManagementSettings",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "ID of the organization.",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Returns the updated organization setting.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/organizationsUpsertUserManagementSettingsResponse"
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/OrganizationServiceUpsertUserManagementSettingsBody"
-              }
-            }
-          },
-          "required": true
-        }
-      }
-    },
-    "/api/v1/organizations/{organization_id}/clients/{client_id}/secrets": {
-      "post": {
-        "description": "Creates a new secret for an organization API client. Returns the plain secret (available only once).",
-        "tags": ["API Auth"],
-        "summary": "Create organization API client secret",
-        "operationId": "ClientService_CreateOrganizationClientSecret",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier of the organization",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier of the API client",
-            "name": "client_id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "Client secret created successfully. Returns the new secret ID and the plain secret value (only available at creation time). The secret can be used immediately for authentication.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/clientsCreateOrganizationClientSecretResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "# Get client ID from environment variables\norg_id = 'SCALEKIT_ORGANIZATION_ID'\nclient_id = os.environ['M2M_CLIENT_ID']\n\n# Add a new secret to the specified client\nresponse = scalekit_client.m2m_client.add_organization_client_secret(\n    organization_id=org_id,\n    client_id=client_id\n)\n\n# Extract the secret ID from the response\nsecret_id = response[0].secret.id"
-          }
-        ]
-      }
-    },
-    "/api/v1/organizations/{organization_id}/directories/{directory_id}/groups": {
-      "get": {
-        "description": "Retrieves all groups from a specified directory. Use this endpoint to view group structures from your connected identity provider.",
-        "tags": ["Directory"],
-        "summary": "List directory groups",
-        "operationId": "DirectoryService_ListDirectoryGroups",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier of the organization",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier of the directory",
-            "name": "directory_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "description": "Number of groups to return per page. Maximum value is 30. If not specified, defaults to 10",
-            "name": "page_size",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Token for pagination. Use the value returned in the 'next_page_token' field of the previous response",
-            "name": "page_token",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "description": "Filter groups updated after this timestamp. Use ISO 8601 format",
-            "name": "updated_after",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "boolean"
-            },
-            "description": "If true, includes full group details. If false or not specified, returns basic information only",
-            "name": "include_detail",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "boolean"
-            },
-            "description": "If true, returns group and its details from external provider (default: false)",
-            "name": "include_external_groups",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved the list of groups from the specified directory",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/directoriesListDirectoryGroupsResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "const { groups } = await scalekit.directory.listDirectoryGroups(\n  '<organization_id>',\n  '<directory_id>'\n);"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "directory_groups = scalekit_client.directory.list_directory_groups(\n  directory_id='<directory_id>', organization_id='<organization_id>'\n)"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "options := &ListDirectoryGroupsOptions{\n\n\t\tPageSize: 10,\n\n\t\tPageToken:\"\",\n\n\t}\n\n\ndirectoryGroups, err := scalekitClient.Directory().ListDirectoryGroups(ctx, organizationId, directoryId, options)"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "var options = ListDirectoryResourceOptions.builder()\n  .pageSize(10)\n  .pageToken(\"\")\n  .includeDetail(true)\n  .build();\n\nListDirectoryGroupsResponse groupsResponse = scalekitClient\n  .directories()\n  .listDirectoryGroups(directory.getId(), organizationId, options);"
-          }
-        ]
-      }
-    },
-    "/api/v1/organizations/{organization_id}/directories/{directory_id}/users": {
-      "get": {
-        "description": "Retrieves a list of all users within a specified directory for an organization. This endpoint allows you to view user accounts associated with your connected Directory Providers.",
-        "tags": ["Directory"],
-        "summary": "List directory users",
-        "operationId": "DirectoryService_ListDirectoryUsers",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier of the organization",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier of the directory within the organization",
-            "name": "directory_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "description": "Number of users to return per page. Maximum value is 30. If not specified, defaults to 10",
-            "name": "page_size",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Token for pagination. Use the value returned in the 'next_page_token' field of the previous response to retrieve the next page of results",
-            "name": "page_token",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "boolean"
-            },
-            "description": "If set to true, the response will include the full user payload with all available details. If false or not specified, only essential user information will be returned",
-            "name": "include_detail",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Filter users by their membership in a specific directory group",
-            "name": "directory_group_id",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "description": "Filter users that were updated after the specified timestamp. Use ISO 8601 format",
-            "name": "updated_after",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved the list of users from the specified directory",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/directoriesListDirectoryUsersResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "const { users } = await scalekit.directory.listDirectoryUsers(\n  '<organization_id>',\n  '<directory_id>'\n);"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "directory_users = scalekit_client.directory.list_directory_users(\n  directory_id='<directory_id>', organization_id='<organization_id>'\n)"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "options := &ListDirectoryUsersOptions{\n\n\t\tPageSize: 10,\n\n\t\tPageToken: \"\",\n\n\t}\n\ndirectoryUsers,err := scalekitClient.Directory().ListDirectoryUsers(ctx, organizationId, directoryId, options)"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "var options = ListDirectoryResourceOptions.builder()\n  .pageSize(10)\n  .pageToken(\"\")\n  .includeDetail(true)\n  .build();\n\nListDirectoryUsersResponse usersResponse = scalekitClient\n  .directories()\n  .listDirectoryUsers(directory.getId(), organizationId, options);"
-          }
-        ]
-      }
-    },
-    "/api/v1/organizations/{organization_id}/clients/{client_id}/secrets/{secret_id}": {
-      "delete": {
-        "description": "Permanently deletes a secret from an organization API client. This operation cannot be undone.",
-        "tags": ["API Auth"],
-        "summary": "Delete organization API client secret",
-        "operationId": "ClientService_DeleteOrganizationClientSecret",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier of the organization",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier of the API client",
-            "name": "client_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier of the client secret",
-            "name": "secret_id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Client secret successfully deleted and no longer accessible",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "# Get client and secret IDs from environment variables\norg_id = '<SCALEKIT_ORGANIZATION_ID>'\nclient_id = os.environ['M2M_CLIENT_ID']\nsecret_id = os.environ['M2M_SECRET_ID']\n\n# Remove the specified secret from the client\nresponse = scalekit_client.m2m_client.remove_organization_client_secret(\n    organization_id=org_id,\n    client_id=client_id,\n    secret_id=secret_id\n)"
-          }
-        ]
-      }
-    },
-    "/api/v1/users": {
-      "get": {
-        "description": "Retrieves a paginated list of all users across your entire environment. Use this endpoint to view all users regardless of their organization memberships. This is useful for administrative purposes, user audits, or when you need to see all users in your Scalekit environment. Supports pagination for large user bases.",
-        "tags": ["Users"],
-        "summary": "List all users in environment",
-        "operationId": "UserService_ListUsers",
-        "parameters": [
-          {
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "description": "Maximum number of organizations to return per page. Must be between 10 and 100",
-            "name": "page_size",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Pagination token from the previous response. Use to retrieve the next page of organizations",
-            "name": "page_token",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "List of users.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/usersListUsersResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "const response = await scalekit.user.listUsers(\n  { pageSize: 100 });"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "# pass empty org to fetch all users in environment\nresp,_ = scalekit_client.users.list_users(organization_id=\"\", page_size=100)"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "all, err := scalekitClient.User().ListOrganizationUsers(ctx, \"\", &scalekit.ListUsersOptions{PageSize: 100})"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "ListUsersRequest lur = ListUsersRequest.\n  newBuilder().setPageSize(100).build();\nListUsersResponse allUsers = users.listUsers(lur);"
-          }
-        ]
-      }
-    },
-    "/api/v1/users/{id}": {
-      "get": {
-        "description": "Retrieves all details for a user by system-generated user ID or external ID. The response includes organization memberships and user metadata.",
-        "tags": ["Users"],
-        "summary": "Get user",
-        "operationId": "UserService_GetUser",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "System-generated user ID",
-            "name": "id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Your application's unique identifier for this organization, used to link Scalekit with your system.",
-            "name": "external_id",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "User details retrieved successfully. Returns full user object with system-generated fields and timestamps.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/usersGetUserResponse"
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "description": "Modifies user account information including profile details, metadata, and external ID. Use this endpoint to update a user's personal information, contact details, or custom metadata. You can update the user's profile, phone number, and metadata fields. Note that fields like user ID, email address, environment ID, and creation time cannot be modified.",
-        "tags": ["Users"],
-        "summary": "Update user information",
-        "operationId": "UserService_UpdateUser",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "System-generated user ID. Must start with 'usr_' and be 19-25 characters long.",
-            "name": "id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Your application's unique identifier for this organization, used to link Scalekit with your system.",
-            "name": "external_id",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "User updated successfully. Returns the modified user object with updated timestamps.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/usersUpdateUserResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "await scalekit.user.updateUser(\"usr_123\", {\n\tuserProfile: {\n\t\tfirstName: \"John\",\n\t\tlastName: \"Smith\",\n\t},\n\tmetadata: {\n\t\tdepartment: \"sales\",\n\t},\n});"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "import os\nfrom scalekit import ScalekitClient\nfrom scalekit.v1.users.users_pb2 import UpdateUser\nfrom scalekit.v1.commons.commons_pb2 import UserProfile\nscalekit_client = ScalekitClient(\n    env_url=os.getenv(\"SCALEKIT_ENV_URL\"),\n    client_id=os.getenv(\"SCALEKIT_CLIENT_ID\"),\n    client_secret=os.getenv(\"SCALEKIT_CLIENT_SECRET\"),\n)\nupdate_user = UpdateUser(\n    user_profile=UserProfile(\n        first_name=\"John\",\n        last_name=\"Smith\"\n    ),\n    metadata={\"department\": \"sales\"}\n)\nscalekit_client.users.update_user(organization_id=\"org_123\", \n  user=update_user)"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "upd := &usersv1.UpdateUser{\n    UserProfile: &usersv1.UpdateUserProfile{\n        FirstName: \"John\",\n        LastName:  \"Smith\",\n    },\n    Metadata: map[string]string{\n        \"department\": \"sales\",\n    },\n}\nscalekitClient.User().UpdateUser(ctx, \"usr_123\", upd)"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "UpdateUser upd = UpdateUser.newBuilder()\n        .setUserProfile(\n          UpdateUserProfile.newBuilder()\n                .setFirstName(\"John\")\n                .setLastName(\"Smith\")\n                .build())\n        .putMetadata(\"department\", \"sales\")\n        .build();\nUpdateUserRequest updReq = UpdateUserRequest.\n  newBuilder().setUser(upd).build();\nusers.updateUser(\"usr_123\", updReq);"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "description": "User fields to update. Only specified fields will be modified. Required fields must be provided if being changed.",
-                "$ref": "#/components/schemas/v1usersUpdateUser",
-                "examples": [
-                  {
-                    "firstName": "John",
-                    "lastName": "Doe"
-                  }
-                ]
-              }
-            }
-          },
-          "required": true
-        }
-      },
-      "delete": {
-        "description": "Permanently removes a user from your environment and deletes all associated data. Use this endpoint when you need to completely remove a user account. This action deletes the user's profile, memberships, and all related data across all organizations. This operation cannot be undone, so use with caution.",
-        "tags": ["Users"],
-        "summary": "Delete user permanently",
-        "operationId": "UserService_DeleteUser",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "System-generated user ID. Must start with 'usr_' (19-25 characters)",
-            "name": "id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "External system identifier from connected directories. Must match existing records",
-            "name": "external_id",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "User successfully deleted. No content returned",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "await scalekit.user.deleteUser(\"usr_123\");"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "scalekit_client.users.delete_user(organization_id=\"org_123\", \n  user_id=\"usr_123\")"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "if err := scalekitClient.User().DeleteUser(ctx, \n  \"usr_123\"); err != nil {\n    panic(err)\n}"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "users.deleteUser(\"usr_123\");"
-          }
-        ]
-      }
-    },
-    "/api/v1/users/support-hash": {
-      "get": {
-        "description": "Retrieves the support email hash for the current logged in user, used for the Scalekit support system.",
-        "tags": ["Users"],
-        "summary": "Get support hash",
-        "operationId": "UserService_GetSupportHash",
-        "responses": {
-          "200": {
-            "description": "Support hash retrieved successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/usersGetSupportHashResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/organizations/{organization_id}/users": {
-      "get": {
-        "description": "Retrieves a paginated list of all users who are members of the specified organization. Use this endpoint to view all users with access to a particular organization, including their roles, metadata, and membership details. Supports pagination for large user lists.",
-        "tags": ["Users"],
-        "summary": "List organization users",
-        "operationId": "UserService_ListOrganizationUsers",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier of the organization for which to list users. Must start with 'org_' and be 1-32 characters long.",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "description": "Maximum number of users to return in a single response. Valid range: 1-100. Server may return fewer users than specified.",
-            "name": "page_size",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Pagination token from a previous ListUserResponse. Used to retrieve the next page of results. Leave empty for the first request.",
-            "name": "page_token",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved the list of users in the organization",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/usersListOrganizationUsersResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "const response = await scalekit.user.\n  listOrganizationUsers(\"org_123\", {\n\tpageSize: 50,\n});\nconsole.log(response.users);"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "resp, _ = scalekit_client.users.list_users(organization_id=\"org_123\", page_size=50)"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "list, \n  err := scalekitClient.User().ListOrganizationUsers(ctx, \"org_123\", &scalekit.ListUsersOptions{PageSize:\n50}) if err != nil { /* handle error */ }\nfmt.Println(list.Users)"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "ListOrganizationUsersRequest listReq = ListOrganiz\n  ationUsersRequest.newBuilder()\n        .setPageSize(50)\n        .build();\nListOrganizationUsersResponse list = users.\n  listOrganizationUsers(\"org_123\", listReq);"
-          }
-        ]
-      },
-      "post": {
-        "description": "Creates a new user account and immediately adds them to the specified organization. Use this endpoint when you want to create a user and grant them access to an organization in a single operation. You can provide user profile information, assign roles, and configure membership metadata. The user receives an activation email unless this feature is disabled in the organization settings.",
-        "tags": ["Users"],
-        "summary": "Create new user in organization",
-        "operationId": "UserService_CreateUserAndMembership",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "boolean"
-            },
-            "description": "If true, sends an activation email to the user. Defaults to true.",
-            "name": "send_invitation_email",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "User created successfully. Returns the created user object, including system-generated identifiers and timestamps",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/usersCreateUserAndMembershipResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "const {\n   user } = await scalekit.user.\n    createUserAndMembership(\"org_123\", {\n\temail: \"user@example.com\",\n\texternalId: \"ext_12345a67b89c\",\n\tmetadata: { department: \"engineering\", \n\t  location: \"nyc-office\" },\n\tuserProfile: {\n\t\tfirstName: \"John\",\n\t\tlastName: \"Doe\",\n\t},\n});"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "# Create user with membership \nuser = CreateUser(\n    email=\"john.doe@example.com\",\n    external_id=\"ext_john_123\",  # Optional\n    user_profile={\n        \"first_name\": \"John\",\n        \"last_name\": \"Doe\",\n        \"name\": \"John Doe\",\n        \"locale\": \"en-US\",\n        \"phone_number\": \"+14155552671\"\n    },\n    membership={\n        \"roles\": [{\"name\": \"member\"}]  \n    }\n)\n\n# Create user and membership in organization\nresponse = scalekit_client.users.create_user_and_membership(\n    organization_id=\"your_org_id\",\n    user=user,\n    send_invitation_email=True  # Set to False if you don't want to send\nemail )\n\n    user_id = response[0].user.id"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "newUser := &usersv1.CreateUser{\n    Email:      \"user@example.com\",\n    ExternalId: \"ext_12345a67b89c\",\n    Metadata: map[string]string{\n        \"department\": \"engineering\",\n        \"location\":   \"nyc-office\",\n    },\n    UserProfile: &usersv1.CreateUserProfile{\n        FirstName: \"John\",\n        LastName:  \"Doe\",\n    },\n}\ncuResp, \n  err := scalekitClient.User().CreateUserAndMembership(ctx, \"org_123\",\nnewUser, false) if err != nil { /* handle error */ }"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "CreateUser createUser = CreateUser.newBuilder()\n        .setEmail(\"user@example.com\")\n        .setExternalId(\"ext_12345a67b89c\")\n        .putMetadata(\"department\", \"engineering\")\n        .putMetadata(\"location\", \"nyc-office\")\n        .setUserProfile(\n          CreateUserProfile.newBuilder()\n                .setFirstName(\"John\")\n                .setLastName(\"Doe\")\n                .build())\n        .build();\nCreateUserAndMembershipRequest cuReq = CreateUserA\n  ndMembershipRequest.newBuilder()\n        .setUser(createUser)\n        .build();\nCreateUserAndMembershipResponse cuResp = users.\n  createUserAndMembership(\"org_123\", cuReq);\nSystem.out.println(cuResp.getUser().getId());"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/usersCreateUser"
-              }
-            }
-          },
-          "required": true
-        }
-      }
-    },
-    "/api/v1/memberships/organizations/{organization_id}/users/{id}": {
-      "post": {
-        "description": "Adds an existing user to an organization and assigns them specific roles and permissions. Use this endpoint when you want to grant an existing user access to a particular organization. You can specify roles, metadata, and other membership details during the invitation process.",
-        "tags": ["Users"],
-        "summary": "Add existing user to organization",
-        "operationId": "UserService_CreateMembership",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier of the target organization. Must start with 'org_' and be 1-32 characters long.",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "System-generated user ID. Must start with 'usr_' (19-25 characters)",
-            "name": "id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "External system identifier from connected directories. Must be unique across the system",
-            "name": "external_id",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "boolean"
-            },
-            "description": "If true, sends an activation email to the user. Defaults to true.",
-            "name": "send_invitation_email",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "User successfully added to the organization. Returns details of the updated membership details",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/usersCreateMembershipResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "import { ScalekitClient } from \"@scalekit-sdk/node\";\nconst scalekit = new ScalekitClient(\n\tprocess.env.SCALEKIT_ENV_URL,\n\tprocess.env.SCALEKIT_CLIENT_ID,\n\tprocess.env.SCALEKIT_CLIENT_SECRET\n);\nawait scalekit.user.createMembership(\"org_123\", \"usr_123\", {\n\troles: [\"admin\"],\n\tmetadata: {\n\t\tdepartment: \"engineering\",\n\t\tlocation: \"nyc-office\",\n\t},\n});"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "import os\nfrom scalekit import ScalekitClient\nscalekit_client = ScalekitClient(\n    env_url=os.getenv(\"SCALEKIT_ENV_URL\"),\n    client_id=os.getenv(\"SCALEKIT_CLIENT_ID\"),\n    client_secret=os.getenv(\"SCALEKIT_CLIENT_SECRET\"),\n)\n# The Python SDK currently exposes a helper that \n  #simply links an existing\n# user to an organization.\nresp, _ = scalekit_client.users.add_user_to_organization(\n    organization_id=\"org_123\",\n    user_id=\"usr_123\",\n)"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "func main() {\n    scalekitClient := scalekit.NewScalekitClient(\n        os.Getenv(\"SCALEKIT_ENV_URL\"),\n        os.Getenv(\"SCALEKIT_CLIENT_ID\"),\n        os.Getenv(\"SCALEKIT_CLIENT_SECRET\"),\n    )\n    membership := &usersv1.CreateMembership{\n        Roles: []*usersv1.Role{{Name: \"admin\"}},\n        Metadata: map[string]string{\n            \"department\": \"engineering\",\n            \"location\":   \"nyc-office\",\n        },\n    }\n    resp, \n      err := scalekitClient.User().CreateMembership(\n        context.Background(), \"org_123\", \n          \"usr_123\", membership, false)\n    if err != nil {\n        panic(err)\n    }\n}"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "import com.scalekit.ScalekitClient;\nimport com.scalekit.api.UserClient;\nimport com.scalekit.grpc.scalekit.v1.users.*;\nScalekitClient scalekitClient = new ScalekitClient(\n    System.getenv(\"SCALEKIT_ENV_URL\"),\n    System.getenv(\"SCALEKIT_CLIENT_ID\"),\n    System.getenv(\"SCALEKIT_CLIENT_SECRET\")\n);\nUserClient users = scalekitClient.users();\nCreateMembershipRequest membershipReq = CreateMemb\n  ershipRequest.newBuilder()\n        .setMembership(\n          CreateMembership.newBuilder()\n                .addRoles(Role.newBuilder(\n                  ).setName(\"admin\").build())\n                .putMetadata(\"department\", \"engineering\")\n                .putMetadata(\"location\", \"nyc-office\")\n                .build())\n        .build();\nCreateMembershipResponse res = users.\n  createMembership(\"org_123\", \"usr_123\", \n    membershipReq);"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "description": "Membership details to create. Required fields must be provided.",
-                "$ref": "#/components/schemas/v1usersCreateMembership"
-              }
-            }
-          },
-          "required": true
-        }
-      },
-      "patch": {
-        "description": "Updates a user's membership details within an organization by user ID or external ID. You can update roles and membership metadata.",
-        "tags": ["Users"],
-        "summary": "Update organization membership for user",
-        "operationId": "UserService_UpdateMembership",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier of the organization containing the membership. Must start with 'org_' and be 1-32 characters long.",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "System-generated user ID. Must start with 'usr_' and be 19-25 characters long.",
-            "name": "id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Your application's unique identifier for this user.",
-            "name": "external_id",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Membership updated successfully. Returns the updated user object.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/usersUpdateMembershipResponse"
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "description": "Membership fields to update. Only specified fields will be modified.",
-                "$ref": "#/components/schemas/v1usersUpdateMembership",
-                "examples": [
-                  {
-                    "role": "admin"
-                  }
-                ]
-              }
-            }
-          },
-          "required": true
-        }
-      },
-      "delete": {
-        "description": "Removes a user from an organization by user ID or external ID. If the user has no memberships left and cascade is true, the user is also deleted. This action is irreversible and may also remove related group memberships.",
-        "tags": ["Users"],
-        "summary": "Delete organization membership for user",
-        "operationId": "UserService_DeleteMembership",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique organization identifier. Must start with 'org_' and be 1-32 characters long",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "System-generated user ID. Must start with 'usr_' (19-25 characters)",
-            "name": "id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "External system identifier from connected directories. Must match existing records",
-            "name": "external_id",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "User successfully marked for deletion. No content returned",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "response = scalekit_client.users.delete_membership(\n  organization_id=org_id,user_id=user_id\n)"
-          }
-        ]
-      }
-    },
-    "/api/v1/organizations/{organization_id}/users/{user_id}/permissions": {
-      "get": {
-        "description": "Retrieves all permissions a user has access to within a specific organization. This includes permissions from direct role assignments and inherited permissions from role hierarchy.",
-        "tags": ["Users"],
-        "summary": "List user permissions",
-        "operationId": "UserService_ListUserPermissions",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier for the organization",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier for the user",
-            "name": "user_id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved the list of permissions for the user",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/usersListUserPermissionsResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/organizations/{organization_id}/users/{user_id}/roles": {
-      "get": {
-        "description": "Retrieves all roles assigned to a user within a specific organization. This includes both direct role assignments and inherited roles from role hierarchy.",
-        "tags": ["Users"],
-        "summary": "List user roles",
-        "operationId": "UserService_ListUserRoles",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier for the organization",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier for the user",
-            "name": "user_id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved the list of roles assigned to the user",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/usersListUserRolesResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/invites/organizations/{organization_id}/users/{id}/resend": {
-      "patch": {
-        "description": "Resends an invitation email to a user who has a pending or expired invitation in the specified organization. If the invitation has expired, a new invitation will be automatically created and sent. If the invitation is still valid, a reminder email will be sent instead. Use this endpoint when a user hasn't responded to their initial invitation and you need to send them a reminder or when the original invitation has expired. The invitation email includes a secure magic link that allows the user to complete their account setup and join the organization. Each resend operation increments the resent counter.",
-        "tags": ["Users"],
-        "summary": "Resend user invitation email",
-        "operationId": "UserService_ResendInvite",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier of the organization containing the pending invitation. Must start with 'org_' and be 1-32 characters long.",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "System-generated user ID of the user who has a pending invitation. Must start with 'usr_' and be 19-25 characters long.",
-            "name": "id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully resent the invitation email. Returns the updated invitation object with organization ID, user ID, membership status, timestamps, and resent count. If expired, a new invitation is created; otherwise, the existing one is resent.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/usersResendInviteResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid request — common causes include user ID or organization ID is invalid, full-stack authentication is disabled, user profile is missing, invite already accepted, or missing expiry time in user management settings.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/errdetailsErrorInfo"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found — the specified user, organization, membership, or invitation could not be found in the specified environment. Verify that all IDs are correct and that the resources exist before attempting to resend an invitation.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/errdetailsErrorInfo"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal server error — an unexpected error occurred while processing the invitation resend request. This may be due to database connectivity issues, problems generating the secure magic link, email delivery service failures, or transaction errors during invitation processing. Contact support if the problem persists.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/errdetailsErrorInfo"
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UserServiceResendInviteBody"
-              }
-            }
-          },
-          "required": true
-        }
-      }
-    },
-    "/api/v1/passwordless/email/send": {
-      "post": {
-        "description": "Send a verification email containing either a verification code (OTP), magic link, or both to a user's email address",
-        "tags": ["Magic link & OTP"],
-        "summary": "Send passwordless email",
-        "operationId": "PasswordlessService_SendPasswordlessEmail",
-        "responses": {
-          "200": {
-            "description": "Successfully sent passwordless authentication email. Returns the authentication request details including expiration time and auth request ID",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/passwordlessSendPasswordlessResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "const response = await scalekit.passwordless.sendPasswordlessEmail(\n\t\"john.doe@example.com\",\n\t{\n\t\ttemplate: \"SIGNIN\",\n\t\texpiresIn: 100,\n\t\tmagiclinkAuthUri: \"https://www.google.com\",\n\t\ttemplateVariables: {\n\t\t\temployeeID: \"EMP523\",\n\t\t\tteamName: \"Alpha Team\",\n\t\t\tsupportEmail: \"support@yourcompany.com\",\n\t\t},\n\t}\n);"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "response = scalekit_client.passwordless.send_passwordless_email(\n    email=\"john.doe@example.com\",\n    template=\"SIGNIN\",  # or \"SIGNUP\", \"UNSPECIFIED\"\n    expires_in=100,\n    magiclink_auth_uri=\"https://www.google.com\",\n    template_variables={\n        \"employeeID\": \"EMP523\",\n        \"teamName\": \"Alpha Team\",\n        \"supportEmail\": \"support@yourcompany.com\",\n    },\n)\n\n# Extract auth request ID from response\nauth_request_id = response[0].auth_request_id"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "templateType := scalekit.TemplateTypeSignin\nresponse, err := scalekitClient.Passwordless().SendPasswordlessEmail(\n    ctx,\n    \"john.doe@example.com\",\n    &scalekit.SendPasswordlessOptions{\n        Template:         &templateType,\n        ExpiresIn:        100,\n        MagiclinkAuthUri: \"https://www.google.com\",\n        TemplateVariables: map[string]string{\n            \"employeeID\":    \"EMP523\",\n            \"teamName\":      \"Alpha Team\",\n            \"supportEmail\":  \"support@yourcompany.com\",\n        },\n    },\n)\n\nif err != nil {\n    // Handle error\n    return\n}\n\nauthRequestId := response.AuthRequestId"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "TemplateType templateType = TemplateType.SIGNIN;\nMap<String, String> templateVariables = new HashMap<>();\ntemplateVariables.put(\"employeeID\", \"EMP523\");\ntemplateVariables.put(\"teamName\", \"Alpha Team\");\ntemplateVariables.put(\"supportEmail\", \"support@yourcompany.com\");\n\nSendPasswordlessOptions options = new SendPasswordlessOptions();\noptions.setTemplate(templateType);\noptions.setExpiresIn(100);\noptions.setMagiclinkAuthUri(\"https://www.example.com\");\noptions.setTemplateVariables(templateVariables);\n\nSendPasswordlessResponse response = passwordlessClient.sendPasswordlessEmail(\n    \"john.doe@example.com\",\n    options\n);\n\nString authRequestId = response.getAuthRequestId();"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/passwordlessSendPasswordlessRequest"
-              }
-            }
-          },
-          "required": true
-        }
-      }
-    },
-    "/api/v1/passwordless/email/resend": {
-      "post": {
-        "description": "Resend a verification email if the user didn't receive it or if the previous code/link has expired",
-        "tags": ["Magic link & OTP"],
-        "summary": "Resend passwordless email",
-        "operationId": "PasswordlessService_ResendPasswordlessEmail",
-        "responses": {
-          "200": {
-            "description": "Successfully resent the passwordless authentication email. Returns updated authentication request details with new expiration time.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/passwordlessSendPasswordlessResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "const { authRequestId } = sendResponse;\nconst resendResponse = await scalekit.passwordless.resendPasswordlessEmail(\n\n\tauthRequestId\n\n);"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "resend_response = scalekit_client.passwordless.resend_passwordless_email(\n    auth_request_id=auth_request_id,\n)\n\n# New auth request ID from resend\nnew_auth_request_id = resend_response[0].auth_request_id"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "resendResponse, err := scalekitClient.Passwordless().ResendPasswordlessEmail(\n    ctx,\n    authRequestId,\n)\n\nif err != nil {\n    // Handle error\n    return\n}"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "SendPasswordlessResponse resendResponse = passwordlessClient.resendPasswordlessEmail(authRequestId);"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/passwordlessResendPasswordlessRequest"
-              }
-            }
-          },
-          "required": true
-        }
-      }
-    },
-    "/api/v1/passwordless/email/verify": {
-      "post": {
-        "description": "Verify a user's identity using either a verification code or magic link token",
-        "tags": ["Magic link & OTP"],
-        "summary": "Verify passwordless email",
-        "operationId": "PasswordlessService_VerifyPasswordlessEmail",
-        "responses": {
-          "200": {
-            "description": "Successfully verified the passwordless authentication. Returns user email",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/passwordlessVerifyPasswordLessResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "const { authRequestId } = sendResponse;\nconst verifyResponse = await scalekit.passwordless.verifyPasswordlessEmail(\n\n\t// Verification Code (OTP)\n\n\t{ code: \"123456\" },\n\n\t// Magic Link Token\n\n\t{ linkToken: link_token },\n\n\tauthRequestId\n\n);"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "# Verify with OTP code\nverify_response = scalekit_client.passwordless.verify_passwordless_email(\n    code=\"123456\",  # OTP code received via email\n    auth_request_id=auth_request_id,\n)\n\n# Verify with magic link token\nverify_response = scalekit_client.passwordless.verify_passwordless_email(\n    link_token=link_token,  # Magic link token from URL\n)\n\n# User verified successfully\nuser_email = verify_response[0].email"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "// Verify with OTP code\nverifyResponse, err := scalekitClient.Passwordless().VerifyPasswordlessEmail(\n    ctx,\n    &scalekit.VerifyPasswordlessOptions{\n        Code:          \"123456\", // OTP code\n        AuthRequestId: authRequestId,\n    },\n)\n\nif err != nil {\n    // Handle error\n    return\n}\n\n// Verify with magic link token\nverifyResponse, err := scalekitClient.Passwordless().VerifyPasswordlessEmail(\n    ctx,\n    &scalekit.VerifyPasswordlessOptions{\n        LinkToken: linkToken, // Magic link token\n    },\n)\n\nif err != nil {\n    // Handle error\n    return\n}\n\n// User verified successfully\nuserEmail := verifyResponse.Email"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "// Verify with OTP code\nVerifyPasswordlessOptions verifyOptions = new VerifyPasswordlessOptions();\nverifyOptions.setCode(\"123456\"); // OTP code\nverifyOptions.setAuthRequestId(authRequestId);\n\nVerifyPasswordLessResponse verifyResponse = passwordlessClient.verifyPasswordlessEmail(verifyOptions);\n\n// User verified successfully\nString userEmail = verifyResponse.getEmail();\n\n// Verify with magic link token\nVerifyPasswordlessOptions verifyOptions = new VerifyPasswordlessOptions();\nverifyOptions.setLinkToken(linkToken); // Magic link token\n\nVerifyPasswordLessResponse verifyResponse = passwordlessClient.verifyPasswordlessEmail(verifyOptions);\n\n// User verified successfully\nString userEmail = verifyResponse.getEmail();"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/passwordlessVerifyPasswordLessRequest"
-              }
-            }
-          },
-          "required": true
-        }
-      }
-    },
-    "/api/v1/webauthn/credentials": {
-      "get": {
-        "description": "Retrieves all registered passkeys for the current user, including device information, creation timestamps, and display names. Use this to show users their registered authenticators.",
-        "tags": ["Passkeys"],
-        "summary": "List user's passkeys",
-        "operationId": "WebAuthnService_ListCredentials",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "User ID to list credentials for (optional, current user if not provided)",
-            "name": "user_id",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "List of passkeys with metadata",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/webauthnListCredentialsResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "const res = await scalekit.webauthn.listCredentials(\"user_123\");"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "res = scalekit_client.webauthn.list_credentials(user_id=\"user_123\")"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "resp, err := scalekitClient.WebAuthn().ListCredentials(ctx, \"user_123\")\nif err != nil { /* handle err */ }\n_ = resp"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "ListCredentialsResponse res = scalekitClient.webauthn().listCredentials(\"user_123\");"
-          }
-        ]
-      }
-    },
-    "/api/v1/webauthn/credentials/{credential_id}": {
-      "patch": {
-        "description": "Updates the display name of a passkey credential to help users identify their authenticators. Only the display name can be modified.",
-        "tags": ["Passkeys"],
-        "summary": "Rename a passkey",
-        "operationId": "WebAuthnService_UpdateCredential",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "The credential ID to update",
-            "name": "credential_id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Passkey successfully updated with new name",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/webauthnUpdateCredentialResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "const res = await scalekit.webauthn.updateCredential(\n  \"wac_123\",\n  \"Work Laptop Passkey\"\n);"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "res = scalekit_client.webauthn.update_credential(\n    credential_id=\"wac_123\",\n    display_name=\"Work Laptop Passkey\"\n)"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "resp, err := scalekitClient.WebAuthn().UpdateCredential(\n    ctx,\n    \"wac_123\",\n    \"Work Laptop Passkey\",\n)\nif err != nil { /* handle err */ }\n_ = resp"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "UpdateCredentialResponse res = scalekitClient.webauthn()\n    .updateCredential(\"wac_123\", \"Work Laptop Passkey\");"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/WebAuthnServiceUpdateCredentialBody"
-              }
-            }
-          },
-          "required": true
-        }
-      },
-      "delete": {
-        "description": "Deletes a specific passkey credential for the current user. After removal, the authenticator can no longer be used for authentication.",
-        "tags": ["Passkeys"],
-        "summary": "Remove a passkey",
-        "operationId": "WebAuthnService_DeleteCredential",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "The credential ID to delete",
-            "name": "credential_id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Passkey successfully deleted",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/webauthnDeleteCredentialResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "const res = await scalekit.webauthn.deleteCredential(\"wac_123\");"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "res = scalekit_client.webauthn.delete_credential(credential_id=\"wac_123\")"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "resp, err := scalekitClient.WebAuthn().DeleteCredential(ctx, \"wac_123\")\nif err != nil { /* handle err */ }\n_ = resp"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "DeleteCredentialResponse res = scalekitClient.webauthn().deleteCredential(\"wac_123\");"
-          }
-        ]
-      }
-    },
-    "/api/v1/sessions/{session_id}": {
-      "get": {
-        "description": "Retrieves comprehensive details for a specific user session including authentication status, device information, and expiration timelines. Use this endpoint to fetch current session metadata for security audits, session validation, or to display session information in user account management interfaces. Returns all session properties including the user ID, authenticated organizations, device details with browser/OS information, IP address and geolocation, and all relevant timestamps (creation, last activity, idle expiration, absolute expiration, and actual expiration if applicable).",
-        "tags": ["Sessions"],
-        "summary": "Get session details",
-        "operationId": "SessionService_GetSession",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier for the session. Must start with 'ses_' prefix.",
-            "name": "session_id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved session details",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/sessionsSessionDetails"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "const res = await scalekit.session.getSession(\"ses_123456789\");"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "res = scalekit_client.sessions.get_session(session_id=\"ses_123456789\")"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "resp, err := scalekitClient.Session().GetSession(ctx, \"ses_123456789\")\nif err != nil { /* handle err */ }\n_ = resp"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "SessionDetails res = scalekitClient.sessions().getSession(\"ses_123456789\");"
-          }
-        ]
-      }
-    },
-    "/api/v1/sessions/{session_id}/revoke": {
-      "post": {
-        "description": "Immediately invalidates a specific user session by session ID, setting its status to 'revoked'. Once revoked, the session cannot be used for any future API requests or application access. Use this endpoint to implement session-level logout, force a user to reauthenticate on a specific device, or terminate suspicious sessions. The revocation is instantaneous and irreversible. Returns the revoked session details including the session ID, user ID, and the revocation timestamp.",
-        "tags": ["Sessions"],
-        "summary": "Revoke user session",
-        "operationId": "SessionService_RevokeSession",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier for the session to revoke. Must start with 'ses_' prefix.",
-            "name": "session_id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully revoked the session. Returns the revoked session details",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/sessionsRevokeSessionResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "const res = await scalekit.session.revokeSession(\"ses_123456789\");"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "res = scalekit_client.sessions.revoke_session(session_id=\"ses_123456789\")"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "resp, err := scalekitClient.Session().RevokeSession(ctx, \"ses_123456789\")\nif err != nil { /* handle err */ }\n_ = resp"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "RevokeSessionResponse res = scalekitClient.sessions().revokeSession(\"ses_123456789\");"
-          }
-        ]
-      }
-    },
-    "/api/v1/users/{user_id}/sessions": {
-      "get": {
-        "description": "Retrieves a paginated list of all sessions associated with a specific user across all devices and browsers. Use this endpoint to audit user activity, display all active sessions in account management interfaces, or verify user authentication status across devices. Supports filtering by session status (active, expired, revoked, logout) and time range (creation date). Returns session details for each session including device information, IP address, geolocation, and current status. The response includes pagination metadata (page tokens and total count) to handle large session lists efficiently.",
-        "tags": ["Sessions"],
-        "summary": "List user sessions",
-        "operationId": "SessionService_GetUserSessions",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier for the user whose sessions to retrieve. Must start with 'usr_' prefix.",
-            "name": "user_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "description": "Maximum number of sessions to return in a single page. Optional parameter. If not specified, defaults to a server-defined limit. Use smaller values for faster responses, larger values for fewer requests.",
-            "name": "page_size",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Pagination token from the previous response for retrieving the next page of results. Leave empty for the first page. Use the next_page_token from a previous response to fetch subsequent pages.",
-            "name": "page_token",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "style": "form",
-            "explode": true,
-            "description": "Filter sessions by one or more status values. Possible values: 'active', 'expired', 'revoked', 'logout'. Leave empty to include all statuses. Multiple values use OR logic (e.g., status=['active', 'expired'] returns sessions that are either active OR expired).",
-            "name": "filter.status",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "description": "Filter to include only sessions created on or after this timestamp. Optional. Uses RFC 3339 format. Useful for querying sessions within a specific time window.",
-            "name": "filter.start_time",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "description": "Filter to include only sessions created on or before this timestamp. Optional. Uses RFC 3339 format. Must be after start_time if both are specified.",
-            "name": "filter.end_time",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved user sessions. Returns a list of sessions with pagination information",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/sessionsUserSessionDetails"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "// Basic usage\nconst res = await scalekit.session.getUserSessions(\"user_123\");\n\n// With pagination and filtering\nconst res = await scalekit.session.getUserSessions(\"user_123\", {\n  pageSize: 10,\n  pageToken: \"next_page_token\",\n  filter: {\n    status: [\"ACTIVE\"],\n    startTime: new Date(\"2024-01-01\"),\n    endTime: new Date(\"2024-12-31\")\n  }\n});"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "# Basic usage\nres = scalekit_client.sessions.get_user_sessions(user_id=\"user_123\")\n\n# With pagination and filtering\nfrom google.protobuf.timestamp_pb2 import Timestamp\nfrom datetime import datetime\n\nstart_time = Timestamp()\nstart_time.FromDatetime(datetime(2024, 1, 1))\nend_time = Timestamp()\nend_time.FromDatetime(datetime(2024, 12, 31))\n\nfilter_obj = scalekit_client.sessions.create_session_filter(\n    status=[\"ACTIVE\"], start_time=start_time, end_time=end_time\n)\nres = scalekit_client.sessions.get_user_sessions(\n    user_id=\"user_123\", page_size=10, page_token=\"next_page_token\", filter=filter_obj\n)"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "// Basic usage\nresp, err := scalekitClient.Session().GetUserSessions(ctx, \"user_123\", 0, \"\", nil)\nif err != nil { /* handle err */ }\n\n// With pagination and filtering\n// import \"time\", sessionsv1 \"...\", \"google.golang.org/protobuf/types/known/timestamppb\"\nstartTime, _ := time.Parse(time.RFC3339, \"2024-01-01T00:00:00Z\")\nendTime, _ := time.Parse(time.RFC3339, \"2024-12-31T23:59:59Z\")\nfilter := &sessionsv1.UserSessionFilter{\n    Status:    []string{\"ACTIVE\"},\n    StartTime: timestamppb.New(startTime),\n    EndTime:   timestamppb.New(endTime),\n}\nresp, err := scalekitClient.Session().GetUserSessions(ctx, \"user_123\", 10, \"next_page_token\", filter)\nif err != nil { /* handle err */ }"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "// Basic usage\nUserSessionDetails res = scalekitClient.sessions().getUserSessions(\"user_123\", null, null, null);\n\n// With pagination and filtering\n// import UserSessionFilter, Timestamp, Instant\nUserSessionFilter filter = UserSessionFilter.newBuilder()\n    .addStatus(\"ACTIVE\")\n    .setStartTime(Timestamp.newBuilder().setSeconds(Instant.parse(\"2024-01-01T00:00:00Z\").getEpochSecond()).build())\n    .setEndTime(Timestamp.newBuilder().setSeconds(Instant.parse(\"2024-12-31T23:59:59Z\").getEpochSecond()).build())\n    .build();\nUserSessionDetails res = scalekitClient.sessions().getUserSessions(\"user_123\", 10, \"next_page_token\", filter);"
-          }
-        ]
-      }
-    },
-    "/api/v1/users/{user_id}/sessions/revoke": {
-      "post": {
-        "description": "Immediately invalidates all active sessions for a specific user across all devices and browsers, setting their status to 'revoked'. Use this endpoint to implement global logout functionality, force re-authentication after security incidents, or terminate all sessions following a password reset or credential compromise. Only active sessions are revoked; already expired, logout, or previously revoked sessions remain unchanged. The revocation is atomic and instantaneous. Returns a list of all revoked sessions with their details and a total count of sessions revoked.",
-        "tags": ["Sessions"],
-        "summary": "Revoke all user sessions",
-        "operationId": "SessionService_RevokeAllUserSessions",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier for the user whose all sessions will be revoked. Must start with 'usr_' prefix.",
-            "name": "user_id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully revoked all user sessions. Returns the list of revoked sessions and total count",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/sessionsRevokeAllUserSessionsResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "const res = await scalekit.session.revokeAllUserSessions(\"user_123\");"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "res = scalekit_client.sessions.revoke_all_user_sessions(user_id=\"user_123\")"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "resp, err := scalekitClient.Session().RevokeAllUserSessions(ctx, \"user_123\")\nif err != nil { /* handle err */ }\n_ = resp"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "RevokeAllUserSessionsResponse res = scalekitClient.sessions().revokeAllUserSessions(\"user_123\");"
-          }
-        ]
-      }
-    },
-    "/api/v1/roles": {
-      "get": {
-        "description": "Retrieves a comprehensive list of all roles available within the specified environment including organization roles. Use this endpoint to view all role definitions, including custom roles and their configurations. You can optionally include permission details for each role to understand their capabilities. This is useful for role management, auditing organization access controls, or understanding the available access levels within the organization.",
-        "tags": ["Roles"],
-        "summary": "List all roles in environment",
-        "operationId": "RolesService_ListRoles",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Include additional data in the response. Valid values: 'permissions' (direct permissions only), 'permissions:all' (includes inherited permissions from role hierarchy)",
-            "name": "include",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved list of roles. Returns all roles with their metadata and optionally their permissions.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/rolesListRolesResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "const res = await scalekit.role.listRoles();"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "res = scalekit_client.roles.list_roles()"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "resp, err := scalekitClient.Role().ListRoles(ctx)\nif err != nil { /* handle err */ }\n_ = resp"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "ListRolesResponse res = scalekitClient.roles().listRoles();"
-          }
-        ]
-      },
-      "post": {
-        "description": "Creates a new role within the environment with specified permissions and metadata. Use this endpoint to define custom roles that can be assigned to users or groups. You can create hierarchical roles by extending existing roles, assign specific permissions, and configure display information. Roles are the foundation of your access control system and determine what actions users can perform.",
-        "tags": ["Roles"],
-        "summary": "Create new role in environment",
-        "operationId": "RolesService_CreateRole",
-        "responses": {
-          "201": {
-            "description": "Role created successfully. Returns the complete role object with system-generated ID and timestamps.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/rolesCreateRoleResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "await scalekit.role.createRole({\n  name: \"admin\",\n  displayName: \"Admin\",\n  description: \"Environment-level role\",\n  extends: \"base_role\",                // optional\n  permissions: [\"read:users\"]          // optional\n});"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "from scalekit.v1.roles.roles_pb2 import CreateRole\n\nrole = CreateRole(\n    name=\"admin\",\n    display_name=\"Admin\",\n    description=\"Environment-level role\",\n    extends=\"base_role\",                  # optional\n    permissions=[\"read:users\"]           # optional\n)\n\nscalekit_client.roles.create_role(role=role)"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "resp, err := scalekitClient.Role().CreateRole(ctx, &rolesv1.CreateRole{\n\n\tName:        \"admin\",\n\n\tDisplayName: \"Admin\",\n\n\tDescription: \"Environment-level role\",\n\n\tExtends:     proto.String(\"base_role\"),      // optional\n\n\tPermissions: []string{\"read:users\"},        // optional\n\n})"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "CreateRoleResponse res = scalekitClient.roles().createRole(\n    CreateRoleRequest.newBuilder()\n        .setRole(\n            CreateRole.newBuilder()\n                .setName(\"admin\")\n                .setDisplayName(\"Admin\")\n                .setDescription(\"Environment-level role\")\n                // .setExtends(\"base_role\")         // optional\n                // .addPermissions(\"read:users\")    // optional\n                .build()\n        )\n        .build()\n);"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "description": "Role configuration details including name, display name, description, permissions, and inheritance settings.",
-                "$ref": "#/components/schemas/v1rolesCreateRole",
-                "examples": [
-                  {
-                    "description": "Can edit content",
-                    "display_name": "Content Editor",
-                    "name": "content_editor",
-                    "permissions": ["read:content", "write:content"]
-                  }
-                ]
-              }
-            }
-          },
-          "required": true
-        }
-      }
-    },
-    "/api/v1/roles:set_defaults": {
-      "patch": {
-        "description": "Updates the default creator and member roles for the current environment. Use this endpoint to configure which roles are automatically assigned to new users when they join the environment. You can specify role names for both creator and member default roles. The system will validate that the specified roles exist and update the environment settings accordingly. Returns the updated default role objects including their complete role information and permissions.",
-        "tags": ["Roles"],
-        "summary": "Set default creator and member roles",
-        "operationId": "RolesService_UpdateDefaultRoles",
-        "responses": {
-          "200": {
-            "description": "Default roles updated successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/rolesUpdateDefaultRolesResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "const res = await scalekit.role.updateDefaultRoles({\n  defaultMemberRole: \"member\"\n});"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "from scalekit.v1.roles.roles_pb2 import UpdateDefaultRolesRequest\n\nres = scalekit_client.roles.update_default_roles(\n    default_roles=UpdateDefaultRolesRequest(\n        default_member_role=\"member\"\n    )\n)"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "resp, err := scalekitClient.Role().UpdateDefaultRoles(ctx, \"member\")\nif err != nil { /* handle err */ }\n_ = resp"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "UpdateDefaultRolesResponse res = scalekitClient.roles().updateDefaultRoles(\n    UpdateDefaultRolesRequest.newBuilder()\n        .setDefaultMemberRole(\"member\")\n        .build()\n);"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/rolesUpdateDefaultRolesRequest"
-              }
-            }
-          },
-          "required": true
-        }
-      }
-    },
-    "/api/v1/roles/{role_name}": {
-      "get": {
-        "description": "Retrieves complete information for a specific role including metadata and inheritance details (base role and dependent role count). Use this endpoint to audit role configuration and understand the role's place in the hierarchy. To view the role's permissions, use the ListRolePermissions endpoint.",
-        "tags": ["Roles"],
-        "summary": "Get role details",
-        "operationId": "RolesService_GetRole",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique name identifier of the role to retrieve. Must be alphanumeric with underscores, 1-64 characters.",
-            "name": "role_name",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Include additional data in the response. Valid values: 'permissions' (direct permissions only), 'permissions:all' (includes inherited permissions from role hierarchy)",
-            "name": "include",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved role details. Returns the role object including metadata and inheritance details. Permissions are not included.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/rolesGetRoleResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "const res = await scalekit.role.getRole(\"admin\");"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "res = scalekit_client.roles.get_role(role_name=\"admin\")"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "resp, err := scalekitClient.Role().GetRole(ctx, \"admin\")\nif err != nil { /* handle err */ }\n_ = resp"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "GetRoleResponse res = scalekitClient.roles().getRole(\"admin\");"
-          }
-        ]
-      },
-      "put": {
-        "description": "Modifies an existing role's properties including display name, description, permissions, and inheritance. Use this endpoint to update role metadata, change permission assignments, or modify role hierarchy. Only the fields you specify will be updated, leaving other properties unchanged. When updating permissions, the new list replaces all existing permissions for the role.",
-        "tags": ["Roles"],
-        "summary": "Update role information",
-        "operationId": "RolesService_UpdateRole",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique name identifier of the role to update. Must be alphanumeric with underscores, 1-64 characters.",
-            "name": "role_name",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Role updated successfully. Returns the modified role object with updated timestamps.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/rolesUpdateRoleResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "await scalekit.role.updateRole(\"admin\", {\n  displayName: \"Admin (Updated)\",\n  description: \"Updated description\"\n});"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "from scalekit.v1.roles.roles_pb2 import UpdateRole\n\nscalekit_client.roles.update_role(\n    role_name=\"admin\",\n    role=UpdateRole(\n        display_name=\"Admin (Updated)\",\n        description=\"Updated description\"\n    )\n)"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "resp, err := scalekitClient.Role().UpdateRole(ctx, \"admin\", &rolesv1.UpdateRole{\n    DisplayName: \"Admin (Updated)\",\n    Description: \"Updated description\",\n})\nif err != nil { /* handle err */ }\n_ = resp"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "UpdateRoleResponse res = scalekitClient.roles().updateRole(\n    \"admin\",\n    UpdateRoleRequest.newBuilder()\n        .setRole(\n            UpdateRole.newBuilder()\n                .setDisplayName(\"Admin (Updated)\")\n                .setDescription(\"Updated description\")\n                .build()\n        )\n        .build()\n);"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "description": "Role fields to update. Only specified fields will be modified.",
-                "$ref": "#/components/schemas/v1rolesUpdateRole",
-                "examples": [
-                  {
-                    "description": "Can edit and approve content",
-                    "display_name": "Senior Editor"
-                  }
-                ]
-              }
-            }
-          },
-          "required": true
-        }
-      },
-      "delete": {
-        "description": "Permanently removes a role from the environment and reassigns users who had that role to a different role. Use this endpoint when you need to clean up unused roles or restructure your access control system. The role cannot be deleted if it has dependent roles (roles that extend it) unless you specify a replacement role. If users are assigned to the role being deleted, you must provide a reassign_role_name to move those users to a different role before deletion can proceed. This action cannot be undone, so ensure no critical users depend on the role before deletion.",
-        "tags": ["Roles"],
-        "summary": "Delete role and reassign users",
-        "operationId": "RolesService_DeleteRole",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique name identifier of the role to delete. Must be alphanumeric with underscores, 1-64 characters.",
-            "name": "role_name",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Role name to reassign users to when deleting this role",
-            "name": "reassign_role_id",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Role name to reassign users to when deleting this role",
-            "name": "reassign_role_name",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Role successfully deleted and users reassigned. No content returned.",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "// Basic delete\nawait scalekit.role.deleteRole(\"admin\");\n\n// With reassignment\nawait scalekit.role.deleteRole(\"admin\", \"member\");"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "# Basic delete\nscalekit_client.roles.delete_role(role_name=\"admin\")\n\n# With reassignment\nscalekit_client.roles.delete_role(\n    role_name=\"admin\",\n    reassign_role_name=\"member\"\n)"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "// Basic delete\nerr := scalekitClient.Role().DeleteRole(ctx, \"admin\")\nif err != nil { /* handle err */ }\n\n// With reassignment\nerr = scalekitClient.Role().DeleteRole(ctx, \"admin\", \"member\")"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "// Basic delete\nscalekitClient.roles().deleteRole(\"admin\");\n\n// With reassignment\nscalekitClient.roles().deleteRole(\"admin\", \"member\");"
-          }
-        ]
-      }
-    },
-    "/api/v1/roles/default": {
-      "patch": {
-        "description": "Updates the default creator and member roles for the current environment. Use this endpoint to configure which roles are automatically assigned to new users when they join the environment. You can specify role names for both creator and member default roles. The system will validate that the specified roles exist and update the environment settings accordingly. Returns the updated default role objects including their complete role information and permissions.",
-        "tags": ["Roles"],
-        "summary": "Set default creator and member roles",
-        "operationId": "RolesService_UpdateDefaultRoles2",
-        "responses": {
-          "200": {
-            "description": "Default roles updated successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/rolesUpdateDefaultRolesResponse"
-                }
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/rolesUpdateDefaultRolesRequest"
-              }
-            }
-          },
-          "required": true
-        }
-      }
-    },
-    "/api/v1/organizations/{org_id}/roles:set_defaults": {
-      "patch": {
-        "description": "Updates the default member role for the specified organization. Use this endpoint to configure which role is automatically assigned to new users when they join the organization. The system will validate that the specified role exists and update the organization settings accordingly. This configuration affects all new user invitations and memberships within the organization.",
-        "tags": ["Roles"],
-        "summary": "Set default organization roles",
-        "operationId": "RolesService_UpdateDefaultOrganizationRoles",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier of the organization",
-            "name": "org_id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default organization roles updated successfully. Returns the updated default member role object with complete role information.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/rolesUpdateDefaultOrganizationRolesResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "const res = await scalekit.role.updateDefaultOrganizationRoles(\"org_123\", {\n  defaultMemberRole: \"org_member\"\n});"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "from scalekit.v1.roles.roles_pb2 import UpdateDefaultOrganizationRolesRequest\n\nres = scalekit_client.roles.update_default_organization_roles(\n    org_id=\"org_123\",\n    default_roles=UpdateDefaultOrganizationRolesRequest(\n        default_member_role=\"org_member\"\n    )\n)"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "resp, err := scalekitClient.Role().UpdateDefaultOrganizationRoles(ctx, \"org_123\", \"org_member\")\nif err != nil { /* handle err */ }\n_ = resp"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "UpdateDefaultOrganizationRolesResponse res = scalekitClient.roles().updateDefaultOrganizationRoles(\n    \"org_123\",\n    UpdateDefaultOrganizationRolesRequest.newBuilder()\n        .setDefaultMemberRole(\"org_member\")\n        .build()\n);"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RolesServiceUpdateDefaultOrganizationRolesBody"
-              }
-            }
-          },
-          "required": true
-        }
-      }
-    },
-    "/api/v1/roles/{role_name}/base": {
-      "delete": {
-        "description": "Removes the base role inheritance relationship for a specified role, effectively eliminating all inherited permissions from the base role. Use this endpoint when you want to break the hierarchical relationship between roles and remove inherited permissions. The role will retain only its directly assigned permissions after this operation. This action cannot be undone, so ensure the role has sufficient direct permissions before removing inheritance. Returns no content on successful removal of the base relationship.",
-        "tags": ["Roles"],
-        "summary": "Delete role inheritance relationship",
-        "operationId": "RolesService_DeleteRoleBase",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique name identifier of the role whose base inheritance relationship should be removed. Must be alphanumeric with underscores, 1-64 characters.",
-            "name": "role_name",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Base role inheritance relationship successfully removed. The role now has only its directly assigned permissions.",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "await scalekit.role.deleteRoleBase(\"admin\");"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "scalekit_client.roles.delete_role_base(role_name=\"admin\")"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "err := scalekitClient.Role().DeleteRoleBase(ctx, \"admin\")\nif err != nil { /* handle err */ }"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "scalekitClient.roles().deleteRoleBase(\"admin\");"
-          }
-        ]
-      }
-    },
-    "/api/v1/roles/{role_name}/dependents": {
-      "get": {
-        "description": "Retrieves all roles that directly extend the specified base role through inheritance. Use this endpoint to understand the role hierarchy and identify which roles inherit permissions from a particular base role. Provide the base role name as a path parameter, and the response will include all dependent roles with their metadata and permission information. This operation is useful for auditing role inheritance relationships, understanding the impact of changes to base roles, or managing role hierarchies effectively. Returns a list of dependent role objects including their names, display names, descriptions, and permission details.",
-        "tags": ["Roles"],
-        "summary": "List dependent roles",
-        "operationId": "RolesService_ListDependentRoles",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Name of the base role",
-            "name": "role_name",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved dependent roles. Returns a list of all roles that extend the specified base role, including their metadata and permission information.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/rolesListDependentRolesResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "const res = await scalekit.role.listDependentRoles(\"admin\");"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "res = scalekit_client.roles.list_dependent_roles(role_name=\"admin\")"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "resp, err := scalekitClient.Role().ListDependentRoles(ctx, \"admin\")\nif err != nil { /* handle err */ }\n_ = resp"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "ListDependentRolesResponse res = scalekitClient.roles().listDependentRoles(\"admin\");"
-          }
-        ]
-      }
-    },
-    "/api/v1/roles/{role_name}/permissions": {
-      "get": {
-        "description": "Retrieves all permissions directly assigned to the specified role, excluding permissions inherited from base roles. Use this endpoint to view the explicit permission assignments for a role, which is useful for understanding direct role capabilities, auditing permission assignments, or managing role-permission relationships. Provide the role name as a path parameter, and the response will include only the permissions that are directly assigned to that role. This operation does not include inherited permissions from role hierarchies - use ListEffectiveRolePermissions to see the complete set of permissions including inheritance. Returns a list of permission objects with their names, descriptions, and assignment metadata.",
-        "tags": ["Roles"],
-        "summary": "List permissions for role",
-        "operationId": "RolesService_ListRolePermissions",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Name of the role",
-            "name": "role_name",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved role permissions. Returns a list of all permissions directly assigned to the specified role, excluding inherited permissions.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/rolesListRolePermissionsResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "const res = await scalekit.permission.listRolePermissions(\"admin\");"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "res = scalekit_client.permissions.list_role_permissions(role_name=\"admin\")"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "resp, err := scalekitClient.Permission().ListRolePermissions(ctx, \"admin\")\nif err != nil { /* handle err */ }\n_ = resp"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "ListRolePermissionsResponse res = scalekitClient.permissions().listRolePermissions(\"admin\");"
-          }
-        ]
-      },
-      "post": {
-        "description": "Adds one or more permissions to the specified role while preserving existing permission assignments. Use this endpoint to grant additional capabilities to a role without affecting its current permission set. Provide the role name as a path parameter and a list of permission names in the request body. The system will validate that all specified permissions exist in the environment and add them to the role. Existing permission assignments remain unchanged, making this operation safe for incremental permission management. This is useful for gradually expanding role capabilities or adding new permissions as your system evolves. Returns the updated list of all permissions now assigned to the role.",
-        "tags": ["Roles"],
-        "summary": "Add permissions to role",
-        "operationId": "RolesService_AddPermissionsToRole",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Name of the role",
-            "name": "role_name",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Permissions added to role successfully. Returns the complete list of all permissions now assigned to the role, including both existing and newly added permissions.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/rolesAddPermissionsToRoleResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "await scalekit.permission.addPermissionsToRole(\"role_admin\", [\"perm.read\", \"perm.write\"]);"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "scalekit_client.permissions.add_permissions_to_role(\n    role_name=\"role_admin\",\n    permission_names=[\"perm.read\", \"perm.write\"]\n)"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "resp, err := scalekitClient.Permission().AddPermissionsToRole(ctx, \"role_admin\", []string{\"perm.read\", \"perm.write\"})"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "AddPermissionsToRoleResponse res = scalekitClient.permissions().addPermissionsToRole(\n    \"role_admin\",\n    AddPermissionsToRoleRequest.newBuilder()\n        .addPermissionNames(\"perm.read\")\n        .addPermissionNames(\"perm.write\")\n        .build()\n);"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RolesServiceAddPermissionsToRoleBody"
-              }
-            }
-          },
-          "required": true
-        }
-      }
-    },
-    "/api/v1/roles/{role_name}/permissions:all": {
-      "get": {
-        "description": "Retrieves the complete set of effective permissions for a role, including both directly assigned permissions and permissions inherited from base roles through the role hierarchy. Use this endpoint to understand the full scope of capabilities available to users assigned to a specific role. Provide the role name as a path parameter, and the response will include all permissions that apply to the role, accounting for inheritance relationships. This operation is essential for auditing role capabilities, understanding permission inheritance, or verifying the complete access scope before role assignment. Returns a comprehensive list of permission names representing the full set of effective permissions for the specified role.",
-        "tags": ["Roles"],
-        "summary": "List effective permissions for role",
-        "operationId": "RolesService_ListEffectiveRolePermissions",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Name of the role",
-            "name": "role_name",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved effective permissions. Returns the complete list of all permissions that apply to the role, including both direct assignments and inherited permissions from base roles.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/rolesListEffectiveRolePermissionsResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "const res = await scalekit.permission.listEffectiveRolePermissions(\"admin\");"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "res = scalekit_client.permissions.list_effective_role_permissions(role_name=\"admin\")"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "resp, err := scalekitClient.Permission().ListEffectiveRolePermissions(ctx, \"admin\")\nif err != nil { /* handle err */ }\n_ = resp"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "ListEffectiveRolePermissionsResponse res = scalekitClient.permissions().listEffectiveRolePermissions(\"admin\");"
-          }
-        ]
-      }
-    },
-    "/api/v1/roles/{role_name}/users:count": {
-      "get": {
-        "description": "Retrieves the total number of users currently assigned to the specified role within the environment. Use this endpoint to monitor role usage, enforce user limits, or understand the scope of role assignments. Provide the role's unique name as a path parameter, and the response will include the current user count for that role. This operation is read-only and does not modify any data or user assignments. The count reflects all users who have the role either directly assigned or inherited through organization membership. This information is useful for capacity planning, security auditing, or understanding the impact of role changes across your user base.",
-        "tags": ["Roles"],
-        "summary": "Retrieve user count for role",
-        "operationId": "RolesService_GetRoleUsersCount",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique name of the role",
-            "name": "role_name",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved user count for the specified role. Returns the total number of users currently assigned to the role, including both direct assignments and inherited assignments.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/rolesGetRoleUsersCountResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "const res = await scalekit.role.getRoleUsersCount(\"admin\");"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "res = scalekit_client.roles.get_role_users_count(role_name=\"admin\")"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "resp, err := scalekitClient.Role().GetRoleUsersCount(ctx, \"admin\")\nif err != nil { /* handle err */ }\n_ = resp"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "GetRoleUsersCountResponse res = scalekitClient.roles().getRoleUsersCount(\"admin\");"
-          }
-        ]
-      }
-    },
-    "/api/v1/roles/{role_name}/permissions/{permission_name}": {
-      "delete": {
-        "description": "Removes a specific permission from the specified role, revoking that capability from all users assigned to the role. Use this endpoint to restrict role capabilities or remove unnecessary permissions. Provide both the role name and permission name as path parameters. This operation only affects the direct permission assignment and does not impact permissions inherited from base roles. If the permission is inherited through role hierarchy, you may need to modify the base role instead. This is useful for fine-tuning role permissions, implementing least-privilege access controls, or removing deprecated permissions. Returns no content on successful removal.",
-        "tags": ["Roles"],
-        "summary": "Remove permission from role",
-        "operationId": "RolesService_RemovePermissionFromRole",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Name of the role",
-            "name": "role_name",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Name of the permission to remove",
-            "name": "permission_name",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Permission removed from role successfully. No content returned.",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "await scalekit.permission.removePermissionFromRole(\"admin\", \"read:users\");"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "scalekit_client.permissions.remove_permission_from_role(\n    role_name=\"admin\",\n    permission_name=\"read:users\"\n)"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "err := scalekitClient.Permission().RemovePermissionFromRole(ctx, \"admin\", \"read:users\")\nif err != nil { /* handle err */ }"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "scalekitClient.permissions().removePermissionFromRole(\"admin\", \"read:users\");"
-          }
-        ]
       }
     },
     "/api/v1/organizations/{org_id}/roles": {
@@ -3815,47 +1684,30 @@
         ]
       }
     },
-    "/api/v1/permissions": {
-      "get": {
-        "description": "Retrieves a comprehensive, paginated list of all permissions available within the environment. Use this endpoint to view all permission definitions for auditing, role management, or understanding the complete set of available access controls. The response includes pagination tokens to navigate through large sets of permissions efficiently. Each permission object contains the permission name, description, creation time, and last update time. This operation is useful for building permission selection interfaces, auditing permission usage, or understanding the scope of available access controls in your RBAC system.",
-        "tags": ["Permissions"],
-        "summary": "List all permissions",
-        "operationId": "RolesService_ListPermissions",
+    "/api/v1/organizations/{org_id}/roles:set_defaults": {
+      "patch": {
+        "description": "Updates the default member role for the specified organization. Use this endpoint to configure which role is automatically assigned to new users when they join the organization. The system will validate that the specified role exists and update the organization settings accordingly. This configuration affects all new user invitations and memberships within the organization.",
+        "tags": ["Roles"],
+        "summary": "Set default organization roles",
+        "operationId": "RolesService_UpdateDefaultOrganizationRoles",
         "parameters": [
           {
             "schema": {
               "type": "string"
             },
-            "description": "Page token to retrieve next page of results",
-            "name": "page_token",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "description": "Number of permissions to return per page (max 100)",
-            "name": "page_size",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": ["SCALEKIT", "ENVIRONMENT"]
-            },
-            "description": "Filter permissions by type: ALL, SCALEKIT, or ENVIRONMENT, where SCALEKIT are predefined Scalekit permissions and ENVIRONMENT are custom permissions created in the environment, default is ALL",
-            "name": "type",
-            "in": "query"
+            "description": "Unique identifier of the organization",
+            "name": "org_id",
+            "in": "path",
+            "required": true
           }
         ],
         "responses": {
           "200": {
-            "description": "Successfully retrieved the list of permissions. Returns a paginated list of permission objects with metadata and pagination tokens for navigation.",
+            "description": "Default organization roles updated successfully. Returns the updated default member role object with complete role information.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/rolesListPermissionsResponse"
+                  "$ref": "#/components/schemas/rolesUpdateDefaultOrganizationRolesResponse"
                 }
               }
             }
@@ -3865,69 +1717,29 @@
           {
             "label": "Node.js SDK",
             "lang": "javascript",
-            "source": "const res = await scalekit.permission.listPermissions();"
+            "source": "const res = await scalekit.role.updateDefaultOrganizationRoles(\"org_123\", {\n  defaultMemberRole: \"org_member\"\n});"
           },
           {
             "label": "Python SDK",
             "lang": "python",
-            "source": "res = scalekit_client.permissions.list_permissions()"
+            "source": "from scalekit.v1.roles.roles_pb2 import UpdateDefaultOrganizationRolesRequest\n\nres = scalekit_client.roles.update_default_organization_roles(\n    org_id=\"org_123\",\n    default_roles=UpdateDefaultOrganizationRolesRequest(\n        default_member_role=\"org_member\"\n    )\n)"
           },
           {
             "label": "Go SDK",
             "lang": "go",
-            "source": "resp, err := scalekitClient.Permission().ListPermissions(ctx)\nif err != nil { /* handle err */ }\n_ = resp"
+            "source": "resp, err := scalekitClient.Role().UpdateDefaultOrganizationRoles(ctx, \"org_123\", \"org_member\")\nif err != nil { /* handle err */ }\n_ = resp"
           },
           {
             "label": "Java SDK",
             "lang": "java",
-            "source": "ListPermissionsResponse res = scalekitClient.permissions().listPermissions();"
-          }
-        ]
-      },
-      "post": {
-        "description": "Creates a new permission that represents a specific action users can perform within the environment. Use this endpoint to define granular access controls for your RBAC system. You can provide a unique permission name following the format 'action:resource' (for example, 'read:documents', 'write:users') and an optional description explaining the permission's purpose. The permission name must be unique across the environment and follows alphanumeric naming conventions with colons and underscores. Returns the created permission object including system-generated ID and timestamps.",
-        "tags": ["Permissions"],
-        "summary": "Create new permission",
-        "operationId": "RolesService_CreatePermission",
-        "responses": {
-          "201": {
-            "description": "Permission created successfully. Returns the complete permission object with system-generated ID, name, description, and timestamps.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/rolesCreatePermissionResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "await scalekit.permission.createPermission({\n  name: \"read:users\",\n  description: \"Allows reading users\"\n});"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "from scalekit.v1.roles.roles_pb2 import CreatePermission\n\npermission = CreatePermission(\n    name=\"read:users\",\n    description=\"Allows reading users\"\n)\n\nscalekit_client.permissions.create_permission(permission=permission)"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "resp, err := scalekitClient.Permission().CreatePermission(ctx, &rolesv1.CreatePermission{\n\n\tName:        \"read:users\",\n\n\tDescription: \"Allows reading users\",\n\n})\nif err != nil { /* handle err */ }\n_ = resp"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "CreatePermissionResponse res = scalekitClient.permissions().createPermission(\n    CreatePermissionRequest.newBuilder()\n        .setPermission(\n            CreatePermission.newBuilder()\n                .setName(\"read:users\")\n                .setDescription(\"Allows reading users\")\n                .build()\n        )\n        .build()\n);"
+            "source": "UpdateDefaultOrganizationRolesResponse res = scalekitClient.roles().updateDefaultOrganizationRoles(\n    \"org_123\",\n    UpdateDefaultOrganizationRolesRequest.newBuilder()\n        .setDefaultMemberRole(\"org_member\")\n        .build()\n);"
           }
         ],
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/v1rolesCreatePermission"
+                "$ref": "#/components/schemas/RolesServiceUpdateDefaultOrganizationRolesBody"
               }
             }
           },
@@ -3935,30 +1747,47 @@
         }
       }
     },
-    "/api/v1/permissions/{permission_name}": {
+    "/api/v1/organizations/{organization_id}/clients": {
       "get": {
-        "description": "Retrieves complete information for a specific permission by its unique name identifier. Use this endpoint to view permission details including description, creation time, and last update time. Provide the permission name in the path parameter following the format 'action:resource' (for example, 'read:documents'). This operation is useful for auditing permission definitions, understanding permission purposes, or verifying permission existence before assignment. Returns the complete permission object with all metadata and system-generated timestamps.",
-        "tags": ["Permissions"],
-        "summary": "Retrieve permission details",
-        "operationId": "RolesService_GetPermission",
+        "description": "Retrieves a paginated list of API clients for a specific organization. Returns client details including metadata, scopes, and secret information (without exposing actual secret values).",
+        "tags": ["API Auth"],
+        "summary": "List organization API clients",
+        "operationId": "ClientService_ListOrganizationClients",
         "parameters": [
           {
             "schema": {
               "type": "string"
             },
-            "description": "Name of the permission",
-            "name": "permission_name",
+            "description": "Unique identifier of the organization whose clients to list. Must start with 'org_' prefix.",
+            "name": "organization_id",
             "in": "path",
             "required": true
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "Maximum number of clients to return per page\n\nMaximum number of API clients to return per page. Must be between 10 and 100",
+            "name": "page_size",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Pagination token from the previous response\n\nPagination token from the previous response. Use to retrieve the next page of organization clients",
+            "name": "page_token",
+            "in": "query"
           }
         ],
         "responses": {
           "200": {
-            "description": "Successfully retrieved permission details. Returns the complete permission object including name, description, creation time, and update time.",
+            "description": "List of organization API clients returned successfully. Each client includes its configuration details and metadata.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/rolesGetPermissionResponse"
+                  "$ref": "#/components/schemas/clientsListOrganizationClientsResponse"
                 }
               }
             }
@@ -3966,50 +1795,35 @@
         },
         "x-codeSamples": [
           {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "const res = await scalekit.permission.getPermission(\"read:users\");"
-          },
-          {
             "label": "Python SDK",
             "lang": "python",
-            "source": "res = scalekit_client.permissions.get_permission(\n    permission_name=\"read:users\"\n)"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "resp, err := scalekitClient.Permission().GetPermission(ctx, \"read:users\")\nif err != nil { /* handle err */ }\n_ = resp"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "GetPermissionResponse res = scalekitClient.permissions().getPermission(\"read:users\");"
+            "source": "# List clients for a specific organization\norg_id = 'SCALEKIT_ORGANIZATION_ID'\n\n# Retrieve all clients with default pagination\nresponse = scalekit_client.m2m_client.list_organization_clients(\n    organization_id=org_id,\n    page_size=30\n)\n\n# Access the clients list\nclients = response.clients\nfor client in clients:\n    print(f\"Client ID: {scalekit_client.id}, Name: {scalekit_client.name}\")"
           }
         ]
       },
-      "put": {
-        "description": "Modifies an existing permission's attributes including description and metadata. Use this endpoint to update permission descriptions or clarify permission purposes after creation. The permission is identified by its unique name in the path parameter, and only the fields you specify in the request body will be updated. Note that the permission name itself cannot be changed as it serves as the immutable identifier. This operation is useful for maintaining clear documentation of permission purposes or updating descriptions to reflect changes in system functionality. Returns the updated permission object with modified timestamps.",
-        "tags": ["Permissions"],
-        "summary": "Update permission details",
-        "operationId": "RolesService_UpdatePermission",
+      "post": {
+        "description": "Creates a new API client for an organization. Returns the client details and a plain secret (available only once).",
+        "tags": ["API Auth"],
+        "summary": "Create organization API client",
+        "operationId": "ClientService_CreateOrganizationClient",
         "parameters": [
           {
             "schema": {
               "type": "string"
             },
-            "description": "Name of the permission",
-            "name": "permission_name",
+            "description": "Unique identifier of the organization",
+            "name": "organization_id",
             "in": "path",
             "required": true
           }
         ],
         "responses": {
-          "200": {
-            "description": "Permission updated successfully. Returns the modified permission object with updated description and timestamps.",
+          "201": {
+            "description": "API client created successfully. Returns the client ID and plain secret (only available at creation time). The client can be configured with scopes, audience values, and custom claims for fine-grained access control.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/rolesUpdatePermissionResponse"
+                  "$ref": "#/components/schemas/clientsCreateOrganizationClientResponse"
                 }
               }
             }
@@ -4017,56 +1831,98 @@
         },
         "x-codeSamples": [
           {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "await scalekit.permission.updatePermission(\"read:users\", {\n  name: \"read:users\",\n  description: \"Allows reading user resources\"\n});"
-          },
-          {
             "label": "Python SDK",
             "lang": "python",
-            "source": "from scalekit.v1.roles.roles_pb2 import CreatePermission\n\nscalekit_client.permissions.update_permission(\n    permission_name=\"read:users\",\n    permission=CreatePermission(\n        name=\"read:users\",\n        description=\"Allows reading user resources\"\n    )\n)"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "resp, err := scalekitClient.Permission().UpdatePermission(ctx, \"read:users\", &rolesv1.CreatePermission{\n    Name:        \"read:users\",\n    Description: \"Allows reading user resources\",\n})\nif err != nil { /* handle err */ }\n_ = resp"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "UpdatePermissionResponse res = scalekitClient.permissions().updatePermission(\n    \"read:users\",\n    UpdatePermissionRequest.newBuilder()\n        .setPermission(\n            CreatePermission.newBuilder()\n                .setName(\"read:users\")\n                .setDescription(\"Allows reading user resources\")\n                .build()\n        )\n        .build()\n);"
+            "source": "from scalekit.v1.clients.clients_pb2 import OrganizationClient\n\nm2m_client = OrganizationClient(\n    name=\"GitHub Actions Deployment Service\",\n    description=\"Service account for GitHub Actions to deploy applications\nto production\",\n    custom_claims=[\n        {\"key\": \"github_repository\", \"value\": \"acmecorp/inventory-service\"},\n        {\"key\": \"environment\", \"value\": \"production_us\"}\n    ],\n    scopes=[\"deploy:applications\", \"read:deployments\"],\n    audience=[\"deployment-api.acmecorp.com\"],\n    expiry=3600\n)\n\nresponse = scalekit_client.m2m_client.create_organization_client(\n    organization_id=\"SCALEKIT_ORGANIZATION_ID\",\n    m2m_client=m2m_client\n)"
           }
         ],
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/v1rolesCreatePermission"
+                "description": "Details of the client to be created",
+                "$ref": "#/components/schemas/clientsOrganizationClient"
               }
             }
           },
           "required": true
         }
-      },
-      "delete": {
-        "description": "Permanently removes a permission from the environment using its unique name identifier. Use this endpoint when you need to clean up unused permissions or remove access controls that are no longer relevant. The permission is identified by its name in the path parameter following the format 'action:resource'. This operation cannot be undone, so ensure no active roles depend on the permission before deletion. If the permission is currently assigned to any roles, you may need to remove those assignments first or update the roles to use alternative permissions. Returns no content on successful deletion.",
-        "tags": ["Permissions"],
-        "summary": "Delete permission",
-        "operationId": "RolesService_DeletePermission",
+      }
+    },
+    "/api/v1/organizations/{organization_id}/clients/{client_id}": {
+      "get": {
+        "description": "Retrieves details of a specific API client in an organization.",
+        "tags": ["API Auth"],
+        "summary": "Get organization API client",
+        "operationId": "ClientService_GetOrganizationClient",
         "parameters": [
           {
             "schema": {
               "type": "string"
             },
-            "description": "Name of the permission",
-            "name": "permission_name",
+            "description": "Unique identifier of the organization",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier of the API client",
+            "name": "client_id",
             "in": "path",
             "required": true
           }
         ],
         "responses": {
           "200": {
-            "description": "Permission successfully deleted. No content returned.",
+            "description": "Returns the complete API client configuration, including all current settings and a list of active secrets. Note that secret values are not included in the response for security reasons.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/clientsGetOrganizationClientResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "# Get client ID from environment variables\norg_id = 'SCALEKIT_ORGANIZATION_ID'\nclient_id = os.environ['M2M_CLIENT_ID']\n\n# Fetch client details for the specified organization\nresponse = scalekit_client.m2m_client.get_organization_client(\n    organization_id=org_id,\n    client_id=client_id\n)"
+          }
+        ]
+      },
+      "delete": {
+        "description": "Permanently deletes an API client from an organization. This operation cannot be undone and will revoke all access for the client. All associated secrets will also be invalidated. Use this endpoint to remove unused or compromised clients.",
+        "tags": ["API Auth"],
+        "summary": "Delete organization API client",
+        "operationId": "ClientService_DeleteOrganizationClient",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier of the organization that owns the client. Must start with 'org_' prefix.",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier of the API client to permanently delete. Must start with 'm2morg_' prefix.",
+            "name": "client_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Organization API client successfully deleted and no longer accessible",
             "content": {
               "application/json": {
                 "schema": {}
@@ -4076,24 +1932,798 @@
         },
         "x-codeSamples": [
           {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "# Get client ID from environment variables\norg_id = '<SCALEKIT_ORGANIZATION_ID>'\nclient_id = os.environ['M2M_CLIENT_ID']\n\n# Delete the specified client from the organization\nresponse = scalekit_client.m2m_client.delete_organization_client(\n    organization_id=org_id,\n    client_id=client_id\n)"
+          }
+        ]
+      },
+      "patch": {
+        "description": "Updates an existing organization API client. Only specified fields are modified.",
+        "tags": ["API Auth"],
+        "summary": "Update organization API client",
+        "operationId": "ClientService_UpdateOrganizationClient",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier of the organization",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier of the client",
+            "name": "client_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the updated organization API client with all current details reflected in the response, including modified scopes, audience values, and custom claims.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/clientsUpdateOrganizationClientResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "from scalekit.v1.clients.clients_pb2 import OrganizationClient\n\norg_id = '<SCALEKIT_ORGANIZATION_ID>'\nclient_id = os.environ['M2M_CLIENT_ID']\n\nupdate_m2m_client = OrganizationClient(\n    description=\"Service account for GitHub Actions to deploy applications\nto production_eu\",\n    custom_claims=[\n        {\"key\": \"github_repository\", \"value\": \"acmecorp/inventory\"},\n        {\"key\": \"environment\", \"value\": \"production_eu\"}\n    ]\n)\n\nresponse = scalekit_client.m2m_client.update_organization_client(\n    organization_id=org_id,\n    client_id=client_id,\n    m2m_client=update_m2m_client\n)"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Updated details for the client",
+                "$ref": "#/components/schemas/clientsOrganizationClient"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/api/v1/organizations/{organization_id}/clients/{client_id}/secrets": {
+      "post": {
+        "description": "Creates a new secret for an organization API client. Returns the plain secret (available only once).",
+        "tags": ["API Auth"],
+        "summary": "Create organization API client secret",
+        "operationId": "ClientService_CreateOrganizationClientSecret",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier of the organization",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier of the API client",
+            "name": "client_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Client secret created successfully. Returns the new secret ID and the plain secret value (only available at creation time). The secret can be used immediately for authentication.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/clientsCreateOrganizationClientSecretResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "# Get client ID from environment variables\norg_id = 'SCALEKIT_ORGANIZATION_ID'\nclient_id = os.environ['M2M_CLIENT_ID']\n\n# Add a new secret to the specified client\nresponse = scalekit_client.m2m_client.add_organization_client_secret(\n    organization_id=org_id,\n    client_id=client_id\n)\n\n# Extract the secret ID from the response\nsecret_id = response[0].secret.id"
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/{organization_id}/clients/{client_id}/secrets/{secret_id}": {
+      "delete": {
+        "description": "Permanently deletes a secret from an organization API client. This operation cannot be undone.",
+        "tags": ["API Auth"],
+        "summary": "Delete organization API client secret",
+        "operationId": "ClientService_DeleteOrganizationClientSecret",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier of the organization",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier of the API client",
+            "name": "client_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier of the client secret",
+            "name": "secret_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Client secret successfully deleted and no longer accessible",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "# Get client and secret IDs from environment variables\norg_id = '<SCALEKIT_ORGANIZATION_ID>'\nclient_id = os.environ['M2M_CLIENT_ID']\nsecret_id = os.environ['M2M_SECRET_ID']\n\n# Remove the specified secret from the client\nresponse = scalekit_client.m2m_client.remove_organization_client_secret(\n    organization_id=org_id,\n    client_id=client_id,\n    secret_id=secret_id\n)"
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/{organization_id}/connections/{id}": {
+      "get": {
+        "description": "Retrieves the complete configuration and status details for a specific connection by its ID within an organization. Returns all connection properties including provider settings, protocols, and current status.",
+        "tags": ["Connections"],
+        "summary": "Get connection details",
+        "operationId": "ConnectionService_GetConnection",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Organization identifier (required). Specifies which organization owns the connection you want to retrieve.",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Connection identifier (required). Specifies which specific connection to retrieve from the organization.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved connection details for the specified organization",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/connectionsGetConnectionResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
             "label": "Node.js SDK",
             "lang": "javascript",
-            "source": "await scalekit.permission.deletePermission(\"read:users\");"
+            "source": "const connection = await scalekit.connection.getConnection(\n  organizationId,\n  connectionId\n);"
           },
           {
             "label": "Python SDK",
             "lang": "python",
-            "source": "scalekit_client.permissions.delete_permission(\n    permission_name=\"read:users\"\n)"
+            "source": "connection = scalekit_client.connection.get_connection(\n  organization_id,\n  connection_id,\n)"
           },
           {
             "label": "Go SDK",
             "lang": "go",
-            "source": "err := scalekitClient.Permission().DeletePermission(ctx, \"read:users\")\nif err != nil { /* handle err */ }"
+            "source": "connection, err := scalekitClient.Connection.GetConnection(\n  ctx,\n  organizationId,\n  connectionId,\n)"
           },
           {
             "label": "Java SDK",
             "lang": "java",
-            "source": "scalekitClient.permissions().deletePermission(\"read:users\");"
+            "source": "Connection connection = scalekitClient.connections().getConnectionById(connectionId, organizationId);"
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/{organization_id}/connections/{id}:disable": {
+      "patch": {
+        "description": "Deactivate an existing connection for the specified organization. When disabled, users cannot authenticate using this connection. This endpoint changes the connection state from enabled to disabled without modifying other configuration settings",
+        "tags": ["Connections"],
+        "summary": "Disable organization connection",
+        "operationId": "ConnectionService_DisableConnection",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier of the organization associated with the connection",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier for the connection to be toggled",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Connection disabled successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/connectionsToggleConnectionResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await scalekit.connection.disableConnection(organizationId, connectionId);"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "scalekit_client.connection.disable_connection(\n  organization_id,\n  connection_id\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "err := scalekitClient.Connection.DisableConnection(\n  ctx,\n  organizationId,\n  connectionId,\n)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "ToggleConnectionResponse response = scalekitClient.connections().disableConnection(connectionId, organizationId);"
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/{organization_id}/connections/{id}:enable": {
+      "patch": {
+        "description": "Activate an existing connection for the specified organization. When enabled, users can authenticate using this connection. This endpoint changes the connection state from disabled to enabled without modifying other configuration settings",
+        "tags": ["Connections"],
+        "summary": "Enable organization connection",
+        "operationId": "ConnectionService_EnableConnection",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier of the organization associated with the connection",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier for the connection to be toggled",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Connection enabled successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/connectionsToggleConnectionResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await scalekit.connection.enableConnection(organizationId, connectionId);"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "scalekit_client.connection.enable_connection(\n  organization_id,\n  connection_id,\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "err := scalekitClient.Connection.EnableConnection(\n  ctx,\n  organizationId,\n  connectionId,\n)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "ToggleConnectionResponse response = scalekitClient.connections().enableConnection(connectionId, organizationId);"
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/{organization_id}/directories": {
+      "get": {
+        "tags": ["Directory"],
+        "summary": "List organization directories",
+        "operationId": "DirectoryService_ListDirectories",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier of the organization",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the list of directories for the organization",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/directoriesListDirectoriesResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await scalekit.directory.listDirectories('<organization_id>');"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "directories_list = scalekit_client.directory.list_directories(\n\torganization_id='<organization_id>'\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "directories,err := scalekitClient.Directory().ListDirectories(ctx, organizationId)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "ListDirectoriesResponse response = scalekitClient.directories().listDirectories(organizationId);"
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/{organization_id}/directories/{directory_id}/groups": {
+      "get": {
+        "description": "Retrieves all groups from a specified directory. Use this endpoint to view group structures from your connected identity provider.",
+        "tags": ["Directory"],
+        "summary": "List directory groups",
+        "operationId": "DirectoryService_ListDirectoryGroups",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier of the organization",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier of the directory",
+            "name": "directory_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "Number of groups to return per page. Maximum value is 30. If not specified, defaults to 10",
+            "name": "page_size",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Token for pagination. Use the value returned in the 'next_page_token' field of the previous response",
+            "name": "page_token",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "description": "Filter groups updated after this timestamp. Use ISO 8601 format",
+            "name": "updated_after",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "If true, includes full group details. If false or not specified, returns basic information only",
+            "name": "include_detail",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "If true, returns group and its details from external provider (default: false)",
+            "name": "include_external_groups",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the list of groups from the specified directory",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/directoriesListDirectoryGroupsResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const { groups } = await scalekit.directory.listDirectoryGroups(\n  '<organization_id>',\n  '<directory_id>'\n);"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "directory_groups = scalekit_client.directory.list_directory_groups(\n  directory_id='<directory_id>', organization_id='<organization_id>'\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "options := &ListDirectoryGroupsOptions{\n\n\t\tPageSize: 10,\n\n\t\tPageToken:\"\",\n\n\t}\n\n\ndirectoryGroups, err := scalekitClient.Directory().ListDirectoryGroups(ctx, organizationId, directoryId, options)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "var options = ListDirectoryResourceOptions.builder()\n  .pageSize(10)\n  .pageToken(\"\")\n  .includeDetail(true)\n  .build();\n\nListDirectoryGroupsResponse groupsResponse = scalekitClient\n  .directories()\n  .listDirectoryGroups(directory.getId(), organizationId, options);"
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/{organization_id}/directories/{directory_id}/users": {
+      "get": {
+        "description": "Retrieves a list of all users within a specified directory for an organization. This endpoint allows you to view user accounts associated with your connected Directory Providers.",
+        "tags": ["Directory"],
+        "summary": "List directory users",
+        "operationId": "DirectoryService_ListDirectoryUsers",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier of the organization",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier of the directory within the organization",
+            "name": "directory_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "Number of users to return per page. Maximum value is 30. If not specified, defaults to 10",
+            "name": "page_size",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Token for pagination. Use the value returned in the 'next_page_token' field of the previous response to retrieve the next page of results",
+            "name": "page_token",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "If set to true, the response will include the full user payload with all available details. If false or not specified, only essential user information will be returned",
+            "name": "include_detail",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter users by their membership in a specific directory group",
+            "name": "directory_group_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "description": "Filter users that were updated after the specified timestamp. Use ISO 8601 format",
+            "name": "updated_after",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the list of users from the specified directory",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/directoriesListDirectoryUsersResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const { users } = await scalekit.directory.listDirectoryUsers(\n  '<organization_id>',\n  '<directory_id>'\n);"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "directory_users = scalekit_client.directory.list_directory_users(\n  directory_id='<directory_id>', organization_id='<organization_id>'\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "options := &ListDirectoryUsersOptions{\n\n\t\tPageSize: 10,\n\n\t\tPageToken: \"\",\n\n\t}\n\ndirectoryUsers,err := scalekitClient.Directory().ListDirectoryUsers(ctx, organizationId, directoryId, options)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "var options = ListDirectoryResourceOptions.builder()\n  .pageSize(10)\n  .pageToken(\"\")\n  .includeDetail(true)\n  .build();\n\nListDirectoryUsersResponse usersResponse = scalekitClient\n  .directories()\n  .listDirectoryUsers(directory.getId(), organizationId, options);"
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/{organization_id}/directories/{id}": {
+      "get": {
+        "description": "Retrieves detailed information about a specific directory within an organization",
+        "tags": ["Directory"],
+        "summary": "Get directory details",
+        "operationId": "DirectoryService_GetDirectory",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier of the organization",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier of the directory",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved directory details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/directoriesGetDirectoryResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const { directory } = await scalekit.directory.getDirectory(\n  organizationId,\n  directoryId\n);"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "directory = scalekit_client.directory.get_directory(\n  directory_id='<directory_id>', organization_id='<organization_id>'\n)\nprint(f'Directory details: {directory}')"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "directory, err := scalekitClient.Directory().GetDirectory(ctx, organizationId, directoryId)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "Directory directory = scalekitClient.directories().getDirectory(directoryId, organizationId);"
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/{organization_id}/directories/{id}:disable": {
+      "patch": {
+        "description": "Stops synchronization of users and groups from a specified directory within an organization. This operation prevents further updates from the connected Directory provider",
+        "tags": ["Directory"],
+        "summary": "Disable a directory",
+        "operationId": "DirectoryService_DisableDirectory",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "A unique identifier for the organization. The value must begin with 'org_' and be between 1 and 32 characters long",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "A unique identifier for a directory within the organization. The value must begin with 'dir_' and be between 1 and 32 characters long",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully disabled the directory",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/directoriesToggleDirectoryResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await scalekit.directory.disableDirectory(\n  '<organization_id>',\n  '<directory_id>'\n);"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "directory_response = scalekit_client.directory.disable_directory(\n  directory_id='<directory_id>', organization_id='<organization_id>'\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "disable,err := scalekitClient.Directory().DisableDirectory(ctx, organizationId, directoryId)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "ToggleDirectoryResponse disableResponse = scalekitClient\n  .directories()\n  .disableDirectory(directoryId, organizationId);"
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/{organization_id}/directories/{id}:enable": {
+      "patch": {
+        "description": "Activates a directory within an organization, allowing it to synchronize users and groups with the connected Directory provider",
+        "tags": ["Directory"],
+        "summary": "Enable a directory",
+        "operationId": "DirectoryService_EnableDirectory",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "A unique identifier for the organization. The value must begin with 'org_' and be between 1 and 32 characters long",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "A unique identifier for a directory within the organization. The value must begin with 'dir_' and be between 1 and 32 characters long",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/directoriesToggleDirectoryResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await scalekit.directory.enableDirectory('<organization_id>', '<directory_id>');"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "directory_response = scalekit_client.directory.enable_directory(\n  directory_id='<directory_id>', organization_id='<organization_id>'\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "enable,err := scalekitClient.Directory().EnableDirectory(ctx, organizationId, directoryId)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "ToggleDirectoryResponse enableResponse = client\n  .directories()\n  .enableDirectory(directoryId, organizationId);"
           }
         ]
       }
@@ -4378,45 +3008,727 @@
         ]
       }
     },
-    "/api/v1/connections": {
-      "get": {
-        "description": "Retrieves a list of connections in the environment",
-        "tags": ["Connections"],
-        "summary": "List connections",
-        "operationId": "ConnectionService_ListConnections",
+    "/api/v1/organizations/{organization_id}/settings/usermanagement": {
+      "patch": {
+        "description": "Upsert user management settings for an organization",
+        "tags": ["Organizations"],
+        "summary": "Upsert organization user setting",
+        "operationId": "OrganizationService_UpsertUserManagementSettings",
         "parameters": [
           {
             "schema": {
               "type": "string"
             },
-            "description": "Filter connections by organization identifier",
+            "description": "ID of the organization.",
             "name": "organization_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the updated organization setting.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/organizationsUpsertUserManagementSettingsResponse"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrganizationServiceUpsertUserManagementSettingsBody"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/api/v1/organizations/{organization_id}/users": {
+      "get": {
+        "description": "Retrieves a paginated list of all users who are members of the specified organization. Use this endpoint to view all users with access to a particular organization, including their roles, metadata, and membership details. Supports pagination for large user lists.",
+        "tags": ["Users"],
+        "summary": "List organization users",
+        "operationId": "UserService_ListOrganizationUsers",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier of the organization for which to list users. Must start with 'org_' and be 1-32 characters long.",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "Maximum number of users to return in a single response. Valid range: 1-100. Server may return fewer users than specified.",
+            "name": "page_size",
             "in": "query"
           },
           {
             "schema": {
               "type": "string"
             },
-            "description": "Filter connections by email domain associated with the organization",
-            "name": "domain",
+            "description": "Pagination token from a previous ListUserResponse. Used to retrieve the next page of results. Leave empty for the first request.",
+            "name": "page_token",
             "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the list of users in the organization",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/usersListOrganizationUsersResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const response = await scalekit.user.\n  listOrganizationUsers(\"org_123\", {\n\tpageSize: 50,\n});\nconsole.log(response.users);"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "resp, _ = scalekit_client.users.list_users(organization_id=\"org_123\", page_size=50)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "list, \n  err := scalekitClient.User().ListOrganizationUsers(ctx, \"org_123\", &scalekit.ListUsersOptions{PageSize:\n50}) if err != nil { /* handle error */ }\nfmt.Println(list.Users)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "ListOrganizationUsersRequest listReq = ListOrganiz\n  ationUsersRequest.newBuilder()\n        .setPageSize(50)\n        .build();\nListOrganizationUsersResponse list = users.\n  listOrganizationUsers(\"org_123\", listReq);"
+          }
+        ]
+      },
+      "post": {
+        "description": "Creates a new user account and immediately adds them to the specified organization. Use this endpoint when you want to create a user and grant them access to an organization in a single operation. You can provide user profile information, assign roles, and configure membership metadata. The user receives an activation email unless this feature is disabled in the organization settings.",
+        "tags": ["Users"],
+        "summary": "Create new user in organization",
+        "operationId": "UserService_CreateUserAndMembership",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "If true, sends an activation email to the user. Defaults to true.",
+            "name": "send_invitation_email",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "User created successfully. Returns the created user object, including system-generated identifiers and timestamps",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/usersCreateUserAndMembershipResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const {\n   user } = await scalekit.user.\n    createUserAndMembership(\"org_123\", {\n\temail: \"user@example.com\",\n\texternalId: \"ext_12345a67b89c\",\n\tmetadata: { department: \"engineering\", \n\t  location: \"nyc-office\" },\n\tuserProfile: {\n\t\tfirstName: \"John\",\n\t\tlastName: \"Doe\",\n\t},\n});"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "# Create user with membership \nuser = CreateUser(\n    email=\"john.doe@example.com\",\n    external_id=\"ext_john_123\",  # Optional\n    user_profile={\n        \"first_name\": \"John\",\n        \"last_name\": \"Doe\",\n        \"name\": \"John Doe\",\n        \"locale\": \"en-US\",\n        \"phone_number\": \"+14155552671\"\n    },\n    membership={\n        \"roles\": [{\"name\": \"member\"}]  \n    }\n)\n\n# Create user and membership in organization\nresponse = scalekit_client.users.create_user_and_membership(\n    organization_id=\"your_org_id\",\n    user=user,\n    send_invitation_email=True  # Set to False if you don't want to send\nemail )\n\n    user_id = response[0].user.id"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "newUser := &usersv1.CreateUser{\n    Email:      \"user@example.com\",\n    ExternalId: \"ext_12345a67b89c\",\n    Metadata: map[string]string{\n        \"department\": \"engineering\",\n        \"location\":   \"nyc-office\",\n    },\n    UserProfile: &usersv1.CreateUserProfile{\n        FirstName: \"John\",\n        LastName:  \"Doe\",\n    },\n}\ncuResp, \n  err := scalekitClient.User().CreateUserAndMembership(ctx, \"org_123\",\nnewUser, false) if err != nil { /* handle error */ }"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "CreateUser createUser = CreateUser.newBuilder()\n        .setEmail(\"user@example.com\")\n        .setExternalId(\"ext_12345a67b89c\")\n        .putMetadata(\"department\", \"engineering\")\n        .putMetadata(\"location\", \"nyc-office\")\n        .setUserProfile(\n          CreateUserProfile.newBuilder()\n                .setFirstName(\"John\")\n                .setLastName(\"Doe\")\n                .build())\n        .build();\nCreateUserAndMembershipRequest cuReq = CreateUserA\n  ndMembershipRequest.newBuilder()\n        .setUser(createUser)\n        .build();\nCreateUserAndMembershipResponse cuResp = users.\n  createUserAndMembership(\"org_123\", cuReq);\nSystem.out.println(cuResp.getUser().getId());"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/usersCreateUser"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/api/v1/organizations/{organization_id}/users/{user_id}/permissions": {
+      "get": {
+        "description": "Retrieves all permissions a user has access to within a specific organization. This includes permissions from direct role assignments and inherited permissions from role hierarchy.",
+        "tags": ["Users"],
+        "summary": "List user permissions",
+        "operationId": "UserService_ListUserPermissions",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier for the organization",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
           },
           {
             "schema": {
               "type": "string"
             },
-            "description": "Filter connections by status. Use 'all' to include all connections regardless of status. Default behavior shows only active (completed and enabled) connections",
+            "description": "Unique identifier for the user",
+            "name": "user_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the list of permissions for the user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/usersListUserPermissionsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/organizations/{organization_id}/users/{user_id}/roles": {
+      "get": {
+        "description": "Retrieves all roles assigned to a user within a specific organization. This includes both direct role assignments and inherited roles from role hierarchy.",
+        "tags": ["Users"],
+        "summary": "List user roles",
+        "operationId": "UserService_ListUserRoles",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier for the organization",
+            "name": "organization_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier for the user",
+            "name": "user_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the list of roles assigned to the user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/usersListUserRolesResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/passwordless/email/resend": {
+      "post": {
+        "description": "Resend a verification email if the user didn't receive it or if the previous code/link has expired",
+        "tags": ["Magic link & OTP"],
+        "summary": "Resend passwordless email",
+        "operationId": "PasswordlessService_ResendPasswordlessEmail",
+        "responses": {
+          "200": {
+            "description": "Successfully resent the passwordless authentication email. Returns updated authentication request details with new expiration time.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/passwordlessSendPasswordlessResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const { authRequestId } = sendResponse;\nconst resendResponse = await scalekit.passwordless.resendPasswordlessEmail(\n\n\tauthRequestId\n\n);"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "resend_response = scalekit_client.passwordless.resend_passwordless_email(\n    auth_request_id=auth_request_id,\n)\n\n# New auth request ID from resend\nnew_auth_request_id = resend_response[0].auth_request_id"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "resendResponse, err := scalekitClient.Passwordless().ResendPasswordlessEmail(\n    ctx,\n    authRequestId,\n)\n\nif err != nil {\n    // Handle error\n    return\n}"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "SendPasswordlessResponse resendResponse = passwordlessClient.resendPasswordlessEmail(authRequestId);"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/passwordlessResendPasswordlessRequest"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/api/v1/passwordless/email/send": {
+      "post": {
+        "description": "Send a verification email containing either a verification code (OTP), magic link, or both to a user's email address",
+        "tags": ["Magic link & OTP"],
+        "summary": "Send passwordless email",
+        "operationId": "PasswordlessService_SendPasswordlessEmail",
+        "responses": {
+          "200": {
+            "description": "Successfully sent passwordless authentication email. Returns the authentication request details including expiration time and auth request ID",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/passwordlessSendPasswordlessResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const response = await scalekit.passwordless.sendPasswordlessEmail(\n\t\"john.doe@example.com\",\n\t{\n\t\ttemplate: \"SIGNIN\",\n\t\texpiresIn: 100,\n\t\tmagiclinkAuthUri: \"https://www.google.com\",\n\t\ttemplateVariables: {\n\t\t\temployeeID: \"EMP523\",\n\t\t\tteamName: \"Alpha Team\",\n\t\t\tsupportEmail: \"support@yourcompany.com\",\n\t\t},\n\t}\n);"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "response = scalekit_client.passwordless.send_passwordless_email(\n    email=\"john.doe@example.com\",\n    template=\"SIGNIN\",  # or \"SIGNUP\", \"UNSPECIFIED\"\n    expires_in=100,\n    magiclink_auth_uri=\"https://www.google.com\",\n    template_variables={\n        \"employeeID\": \"EMP523\",\n        \"teamName\": \"Alpha Team\",\n        \"supportEmail\": \"support@yourcompany.com\",\n    },\n)\n\n# Extract auth request ID from response\nauth_request_id = response[0].auth_request_id"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "templateType := scalekit.TemplateTypeSignin\nresponse, err := scalekitClient.Passwordless().SendPasswordlessEmail(\n    ctx,\n    \"john.doe@example.com\",\n    &scalekit.SendPasswordlessOptions{\n        Template:         &templateType,\n        ExpiresIn:        100,\n        MagiclinkAuthUri: \"https://www.google.com\",\n        TemplateVariables: map[string]string{\n            \"employeeID\":    \"EMP523\",\n            \"teamName\":      \"Alpha Team\",\n            \"supportEmail\":  \"support@yourcompany.com\",\n        },\n    },\n)\n\nif err != nil {\n    // Handle error\n    return\n}\n\nauthRequestId := response.AuthRequestId"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "TemplateType templateType = TemplateType.SIGNIN;\nMap<String, String> templateVariables = new HashMap<>();\ntemplateVariables.put(\"employeeID\", \"EMP523\");\ntemplateVariables.put(\"teamName\", \"Alpha Team\");\ntemplateVariables.put(\"supportEmail\", \"support@yourcompany.com\");\n\nSendPasswordlessOptions options = new SendPasswordlessOptions();\noptions.setTemplate(templateType);\noptions.setExpiresIn(100);\noptions.setMagiclinkAuthUri(\"https://www.example.com\");\noptions.setTemplateVariables(templateVariables);\n\nSendPasswordlessResponse response = passwordlessClient.sendPasswordlessEmail(\n    \"john.doe@example.com\",\n    options\n);\n\nString authRequestId = response.getAuthRequestId();"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/passwordlessSendPasswordlessRequest"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/api/v1/passwordless/email/verify": {
+      "post": {
+        "description": "Verify a user's identity using either a verification code or magic link token",
+        "tags": ["Magic link & OTP"],
+        "summary": "Verify passwordless email",
+        "operationId": "PasswordlessService_VerifyPasswordlessEmail",
+        "responses": {
+          "200": {
+            "description": "Successfully verified the passwordless authentication. Returns user email",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/passwordlessVerifyPasswordLessResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const { authRequestId } = sendResponse;\nconst verifyResponse = await scalekit.passwordless.verifyPasswordlessEmail(\n\n\t// Verification Code (OTP)\n\n\t{ code: \"123456\" },\n\n\t// Magic Link Token\n\n\t{ linkToken: link_token },\n\n\tauthRequestId\n\n);"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "# Verify with OTP code\nverify_response = scalekit_client.passwordless.verify_passwordless_email(\n    code=\"123456\",  # OTP code received via email\n    auth_request_id=auth_request_id,\n)\n\n# Verify with magic link token\nverify_response = scalekit_client.passwordless.verify_passwordless_email(\n    link_token=link_token,  # Magic link token from URL\n)\n\n# User verified successfully\nuser_email = verify_response[0].email"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "// Verify with OTP code\nverifyResponse, err := scalekitClient.Passwordless().VerifyPasswordlessEmail(\n    ctx,\n    &scalekit.VerifyPasswordlessOptions{\n        Code:          \"123456\", // OTP code\n        AuthRequestId: authRequestId,\n    },\n)\n\nif err != nil {\n    // Handle error\n    return\n}\n\n// Verify with magic link token\nverifyResponse, err := scalekitClient.Passwordless().VerifyPasswordlessEmail(\n    ctx,\n    &scalekit.VerifyPasswordlessOptions{\n        LinkToken: linkToken, // Magic link token\n    },\n)\n\nif err != nil {\n    // Handle error\n    return\n}\n\n// User verified successfully\nuserEmail := verifyResponse.Email"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "// Verify with OTP code\nVerifyPasswordlessOptions verifyOptions = new VerifyPasswordlessOptions();\nverifyOptions.setCode(\"123456\"); // OTP code\nverifyOptions.setAuthRequestId(authRequestId);\n\nVerifyPasswordLessResponse verifyResponse = passwordlessClient.verifyPasswordlessEmail(verifyOptions);\n\n// User verified successfully\nString userEmail = verifyResponse.getEmail();\n\n// Verify with magic link token\nVerifyPasswordlessOptions verifyOptions = new VerifyPasswordlessOptions();\nverifyOptions.setLinkToken(linkToken); // Magic link token\n\nVerifyPasswordLessResponse verifyResponse = passwordlessClient.verifyPasswordlessEmail(verifyOptions);\n\n// User verified successfully\nString userEmail = verifyResponse.getEmail();"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/passwordlessVerifyPasswordLessRequest"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/api/v1/permissions": {
+      "get": {
+        "description": "Retrieves a comprehensive, paginated list of all permissions available within the environment. Use this endpoint to view all permission definitions for auditing, role management, or understanding the complete set of available access controls. The response includes pagination tokens to navigate through large sets of permissions efficiently. Each permission object contains the permission name, description, creation time, and last update time. This operation is useful for building permission selection interfaces, auditing permission usage, or understanding the scope of available access controls in your RBAC system.",
+        "tags": ["Permissions"],
+        "summary": "List all permissions",
+        "operationId": "RolesService_ListPermissions",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Page token to retrieve next page of results",
+            "name": "page_token",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "Number of permissions to return per page (max 100)",
+            "name": "page_size",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": ["SCALEKIT", "ENVIRONMENT"]
+            },
+            "description": "Filter permissions by type: ALL, SCALEKIT, or ENVIRONMENT, where SCALEKIT are predefined Scalekit permissions and ENVIRONMENT are custom permissions created in the environment, default is ALL",
+            "name": "type",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the list of permissions. Returns a paginated list of permission objects with metadata and pagination tokens for navigation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rolesListPermissionsResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const res = await scalekit.permission.listPermissions();"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "res = scalekit_client.permissions.list_permissions()"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "resp, err := scalekitClient.Permission().ListPermissions(ctx)\nif err != nil { /* handle err */ }\n_ = resp"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "ListPermissionsResponse res = scalekitClient.permissions().listPermissions();"
+          }
+        ]
+      },
+      "post": {
+        "description": "Creates a new permission that represents a specific action users can perform within the environment. Use this endpoint to define granular access controls for your RBAC system. You can provide a unique permission name following the format 'action:resource' (for example, 'read:documents', 'write:users') and an optional description explaining the permission's purpose. The permission name must be unique across the environment and follows alphanumeric naming conventions with colons and underscores. Returns the created permission object including system-generated ID and timestamps.",
+        "tags": ["Permissions"],
+        "summary": "Create new permission",
+        "operationId": "RolesService_CreatePermission",
+        "responses": {
+          "201": {
+            "description": "Permission created successfully. Returns the complete permission object with system-generated ID, name, description, and timestamps.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rolesCreatePermissionResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await scalekit.permission.createPermission({\n  name: \"read:users\",\n  description: \"Allows reading users\"\n});"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "from scalekit.v1.roles.roles_pb2 import CreatePermission\n\npermission = CreatePermission(\n    name=\"read:users\",\n    description=\"Allows reading users\"\n)\n\nscalekit_client.permissions.create_permission(permission=permission)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "resp, err := scalekitClient.Permission().CreatePermission(ctx, &rolesv1.CreatePermission{\n\n\tName:        \"read:users\",\n\n\tDescription: \"Allows reading users\",\n\n})\nif err != nil { /* handle err */ }\n_ = resp"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "CreatePermissionResponse res = scalekitClient.permissions().createPermission(\n    CreatePermissionRequest.newBuilder()\n        .setPermission(\n            CreatePermission.newBuilder()\n                .setName(\"read:users\")\n                .setDescription(\"Allows reading users\")\n                .build()\n        )\n        .build()\n);"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1rolesCreatePermission"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/api/v1/permissions/{permission_name}": {
+      "get": {
+        "description": "Retrieves complete information for a specific permission by its unique name identifier. Use this endpoint to view permission details including description, creation time, and last update time. Provide the permission name in the path parameter following the format 'action:resource' (for example, 'read:documents'). This operation is useful for auditing permission definitions, understanding permission purposes, or verifying permission existence before assignment. Returns the complete permission object with all metadata and system-generated timestamps.",
+        "tags": ["Permissions"],
+        "summary": "Retrieve permission details",
+        "operationId": "RolesService_GetPermission",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Name of the permission",
+            "name": "permission_name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved permission details. Returns the complete permission object including name, description, creation time, and update time.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rolesGetPermissionResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const res = await scalekit.permission.getPermission(\"read:users\");"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "res = scalekit_client.permissions.get_permission(\n    permission_name=\"read:users\"\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "resp, err := scalekitClient.Permission().GetPermission(ctx, \"read:users\")\nif err != nil { /* handle err */ }\n_ = resp"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "GetPermissionResponse res = scalekitClient.permissions().getPermission(\"read:users\");"
+          }
+        ]
+      },
+      "put": {
+        "description": "Modifies an existing permission's attributes including description and metadata. Use this endpoint to update permission descriptions or clarify permission purposes after creation. The permission is identified by its unique name in the path parameter, and only the fields you specify in the request body will be updated. Note that the permission name itself cannot be changed as it serves as the immutable identifier. This operation is useful for maintaining clear documentation of permission purposes or updating descriptions to reflect changes in system functionality. Returns the updated permission object with modified timestamps.",
+        "tags": ["Permissions"],
+        "summary": "Update permission details",
+        "operationId": "RolesService_UpdatePermission",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Name of the permission",
+            "name": "permission_name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Permission updated successfully. Returns the modified permission object with updated description and timestamps.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rolesUpdatePermissionResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await scalekit.permission.updatePermission(\"read:users\", {\n  name: \"read:users\",\n  description: \"Allows reading user resources\"\n});"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "from scalekit.v1.roles.roles_pb2 import CreatePermission\n\nscalekit_client.permissions.update_permission(\n    permission_name=\"read:users\",\n    permission=CreatePermission(\n        name=\"read:users\",\n        description=\"Allows reading user resources\"\n    )\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "resp, err := scalekitClient.Permission().UpdatePermission(ctx, \"read:users\", &rolesv1.CreatePermission{\n    Name:        \"read:users\",\n    Description: \"Allows reading user resources\",\n})\nif err != nil { /* handle err */ }\n_ = resp"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "UpdatePermissionResponse res = scalekitClient.permissions().updatePermission(\n    \"read:users\",\n    UpdatePermissionRequest.newBuilder()\n        .setPermission(\n            CreatePermission.newBuilder()\n                .setName(\"read:users\")\n                .setDescription(\"Allows reading user resources\")\n                .build()\n        )\n        .build()\n);"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1rolesCreatePermission"
+              }
+            }
+          },
+          "required": true
+        }
+      },
+      "delete": {
+        "description": "Permanently removes a permission from the environment using its unique name identifier. Use this endpoint when you need to clean up unused permissions or remove access controls that are no longer relevant. The permission is identified by its name in the path parameter following the format 'action:resource'. This operation cannot be undone, so ensure no active roles depend on the permission before deletion. If the permission is currently assigned to any roles, you may need to remove those assignments first or update the roles to use alternative permissions. Returns no content on successful deletion.",
+        "tags": ["Permissions"],
+        "summary": "Delete permission",
+        "operationId": "RolesService_DeletePermission",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Name of the permission",
+            "name": "permission_name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Permission successfully deleted. No content returned.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await scalekit.permission.deletePermission(\"read:users\");"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "scalekit_client.permissions.delete_permission(\n    permission_name=\"read:users\"\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "err := scalekitClient.Permission().DeletePermission(ctx, \"read:users\")\nif err != nil { /* handle err */ }"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "scalekitClient.permissions().deletePermission(\"read:users\");"
+          }
+        ]
+      }
+    },
+    "/api/v1/roles": {
+      "get": {
+        "description": "Retrieves a comprehensive list of all roles available within the specified environment including organization roles. Use this endpoint to view all role definitions, including custom roles and their configurations. You can optionally include permission details for each role to understand their capabilities. This is useful for role management, auditing organization access controls, or understanding the available access levels within the organization.",
+        "tags": ["Roles"],
+        "summary": "List all roles in environment",
+        "operationId": "RolesService_ListRoles",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Include additional data in the response. Valid values: 'permissions' (direct permissions only), 'permissions:all' (includes inherited permissions from role hierarchy)",
             "name": "include",
             "in": "query"
           }
         ],
         "responses": {
           "200": {
-            "description": "Successfully retrieved connections",
+            "description": "Successfully retrieved list of roles. Returns all roles with their metadata and optionally their permissions.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/connectionsListConnectionsResponse"
+                  "$ref": "#/components/schemas/rolesListRolesResponse"
                 }
               }
             }
@@ -4426,351 +3738,99 @@
           {
             "label": "Node.js SDK",
             "lang": "javascript",
-            "source": "// List connections by organization id\nconst connections = await scalekit.connection.listConnections(organizationId);\n\n// List connections by domain\nconst connections = await scalekit.connection.listConnectionsByDomain(domain);"
+            "source": "const res = await scalekit.role.listRoles();"
           },
           {
             "label": "Python SDK",
             "lang": "python",
-            "source": "# List connections by organization id\nconnections = scalekit_client.connection.list_connections(\n  organization_id\n)\n\n# List connections by domain\nresponse = scalekit_client.connection.list_connections_by_domain(domain=\"example.com\")"
+            "source": "res = scalekit_client.roles.list_roles()"
           },
           {
             "label": "Go SDK",
             "lang": "go",
-            "source": "// List connections by organization id\nconnections, err := scalekitClient.Connection().ListConnections(\n  ctx,\n  organizationId\n)\n\n// List connections by domain\nconnections, err := scalekitClient.Connection().ListConnectionsByDomain(ctx, \n  domain)"
+            "source": "resp, err := scalekitClient.Role().ListRoles(ctx)\nif err != nil { /* handle err */ }\n_ = resp"
           },
           {
             "label": "Java SDK",
             "lang": "java",
-            "source": "// List connections by organization id\nListConnectionsResponse response = scalekitClient.connections(\n  ).listConnections(organizationId);\n\n// List connections by domain\nListConnectionsResponse response = scalekitClient.connections(\n  ).listConnectionsByDomain(\"your-domain.com\");"
+            "source": "ListRolesResponse res = scalekitClient.roles().listRoles();"
           }
         ]
-      }
-    },
-    "/api/v1/organizations/{organization_id}/connections/{id}": {
-      "get": {
-        "description": "Retrieves the complete configuration and status details for a specific connection by its ID within an organization. Returns all connection properties including provider settings, protocols, and current status.",
-        "tags": ["Connections"],
-        "summary": "Get connection details",
-        "operationId": "ConnectionService_GetConnection",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Organization identifier (required). Specifies which organization owns the connection you want to retrieve.",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Connection identifier (required). Specifies which specific connection to retrieve from the organization.",
-            "name": "id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved connection details for the specified organization",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/connectionsGetConnectionResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "const connection = await scalekit.connection.getConnection(\n  organizationId,\n  connectionId\n);"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "connection = scalekit_client.connection.get_connection(\n  organization_id,\n  connection_id,\n)"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "connection, err := scalekitClient.Connection.GetConnection(\n  ctx,\n  organizationId,\n  connectionId,\n)"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "Connection connection = scalekitClient.connections().getConnectionById(connectionId, organizationId);"
-          }
-        ]
-      }
-    },
-    "/api/v1/organizations/{organization_id}/connections/{id}:disable": {
-      "patch": {
-        "description": "Deactivate an existing connection for the specified organization. When disabled, users cannot authenticate using this connection. This endpoint changes the connection state from enabled to disabled without modifying other configuration settings",
-        "tags": ["Connections"],
-        "summary": "Disable organization connection",
-        "operationId": "ConnectionService_DisableConnection",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier of the organization associated with the connection",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier for the connection to be toggled",
-            "name": "id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Connection disabled successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/connectionsToggleConnectionResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "await scalekit.connection.disableConnection(organizationId, connectionId);"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "scalekit_client.connection.disable_connection(\n  organization_id,\n  connection_id\n)"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "err := scalekitClient.Connection.DisableConnection(\n  ctx,\n  organizationId,\n  connectionId,\n)"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "ToggleConnectionResponse response = scalekitClient.connections().disableConnection(connectionId, organizationId);"
-          }
-        ]
-      }
-    },
-    "/api/v1/organizations/{organization_id}/connections/{id}:enable": {
-      "patch": {
-        "description": "Activate an existing connection for the specified organization. When enabled, users can authenticate using this connection. This endpoint changes the connection state from disabled to enabled without modifying other configuration settings",
-        "tags": ["Connections"],
-        "summary": "Enable organization connection",
-        "operationId": "ConnectionService_EnableConnection",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier of the organization associated with the connection",
-            "name": "organization_id",
-            "in": "path",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier for the connection to be toggled",
-            "name": "id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Connection enabled successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/connectionsToggleConnectionResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-codeSamples": [
-          {
-            "label": "Node.js SDK",
-            "lang": "javascript",
-            "source": "await scalekit.connection.enableConnection(organizationId, connectionId);"
-          },
-          {
-            "label": "Python SDK",
-            "lang": "python",
-            "source": "scalekit_client.connection.enable_connection(\n  organization_id,\n  connection_id,\n)"
-          },
-          {
-            "label": "Go SDK",
-            "lang": "go",
-            "source": "err := scalekitClient.Connection.EnableConnection(\n  ctx,\n  organizationId,\n  connectionId,\n)"
-          },
-          {
-            "label": "Java SDK",
-            "lang": "java",
-            "source": "ToggleConnectionResponse response = scalekitClient.connections().enableConnection(connectionId, organizationId);"
-          }
-        ]
-      }
-    },
-    "/api/v1/connected_accounts": {
-      "get": {
-        "description": "Retrieves a paginated list of connected accounts for third-party integrations. Filter by organization, user, connector type, provider, or identifier. Returns OAuth tokens, API keys, and connection status for each account. Use pagination tokens to navigate through large result sets.",
-        "tags": ["Connected Accounts"],
-        "summary": "List connected accounts",
-        "operationId": "ConnectedAccountService_ListConnectedAccounts",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Filter by organization ID. Returns only connected accounts associated with this organization.",
-            "name": "organization_id",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Filter by user ID. Returns only connected accounts associated with this user.",
-            "name": "user_id",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Filter by connector type. Connector identifier such as 'notion', 'slack', 'google', etc. Alphanumeric with hyphens and underscores allowed.",
-            "name": "connector",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Filter by account identifier. The unique identifier for the connected account within the third-party service (e.g., email address, workspace ID).",
-            "name": "identifier",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Filter by OAuth provider. The authentication provider name such as 'google', 'microsoft', 'github', etc.",
-            "name": "provider",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "description": "Maximum number of connected accounts to return per page. Must be between 0 and 100. Default is typically 10.",
-            "name": "page_size",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Pagination token from a previous response. Use the next_page_token value from ListConnectedAccountsResponse to fetch the next page.",
-            "name": "page_token",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Text search query to filter connected accounts by name, identifier, or other searchable fields. Case-insensitive.",
-            "name": "query",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully retrieved the list of connected accounts with their authentication details and status",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/connected_accountsListConnectedAccountsResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid request - occurs when query parameters are malformed or validation fails",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required - missing or invalid access token",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          }
-        }
       },
       "post": {
-        "description": "Creates a new connected account with OAuth tokens or API credentials for third-party service integration. Supply authorization details including access tokens, refresh tokens, scopes, and optional API configuration. The account can be scoped to an organization or user. Returns the created account with its unique identifier and authentication status.",
-        "tags": ["Connected Accounts"],
-        "summary": "Create a connected account",
-        "operationId": "ConnectedAccountService_CreateConnectedAccount",
+        "description": "Creates a new role within the environment with specified permissions and metadata. Use this endpoint to define custom roles that can be assigned to users or groups. You can create hierarchical roles by extending existing roles, assign specific permissions, and configure display information. Roles are the foundation of your access control system and determine what actions users can perform.",
+        "tags": ["Roles"],
+        "summary": "Create new role in environment",
+        "operationId": "RolesService_CreateRole",
         "responses": {
           "201": {
-            "description": "Connected account created successfully with authentication credentials stored securely",
+            "description": "Role created successfully. Returns the complete role object with system-generated ID and timestamps.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/connected_accountsCreateConnectedAccountResponse"
+                  "$ref": "#/components/schemas/rolesCreateRoleResponse"
                 }
               }
             }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await scalekit.role.createRole({\n  name: \"admin\",\n  displayName: \"Admin\",\n  description: \"Environment-level role\",\n  extends: \"base_role\",                // optional\n  permissions: [\"read:users\"]          // optional\n});"
           },
-          "400": {
-            "description": "Invalid request - missing required fields, invalid authorization details, or validation failed",
-            "content": {
-              "application/json": {
-                "schema": {}
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "from scalekit.v1.roles.roles_pb2 import CreateRole\n\nrole = CreateRole(\n    name=\"admin\",\n    display_name=\"Admin\",\n    description=\"Environment-level role\",\n    extends=\"base_role\",                  # optional\n    permissions=[\"read:users\"]           # optional\n)\n\nscalekit_client.roles.create_role(role=role)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "resp, err := scalekitClient.Role().CreateRole(ctx, &rolesv1.CreateRole{\n\n\tName:        \"admin\",\n\n\tDisplayName: \"Admin\",\n\n\tDescription: \"Environment-level role\",\n\n\tExtends:     proto.String(\"base_role\"),      // optional\n\n\tPermissions: []string{\"read:users\"},        // optional\n\n})"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "CreateRoleResponse res = scalekitClient.roles().createRole(\n    CreateRoleRequest.newBuilder()\n        .setRole(\n            CreateRole.newBuilder()\n                .setName(\"admin\")\n                .setDisplayName(\"Admin\")\n                .setDescription(\"Environment-level role\")\n                // .setExtends(\"base_role\")         // optional\n                // .addPermissions(\"read:users\")    // optional\n                .build()\n        )\n        .build()\n);"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Role configuration details including name, display name, description, permissions, and inheritance settings.",
+                "$ref": "#/components/schemas/v1rolesCreateRole",
+                "examples": [
+                  {
+                    "description": "Can edit content",
+                    "display_name": "Content Editor",
+                    "name": "content_editor",
+                    "permissions": ["read:content", "write:content"]
+                  }
+                ]
               }
             }
           },
-          "401": {
-            "description": "Authentication required - missing or invalid access token",
+          "required": true
+        }
+      }
+    },
+    "/api/v1/roles/default": {
+      "patch": {
+        "description": "Updates the default creator and member roles for the current environment. Use this endpoint to configure which roles are automatically assigned to new users when they join the environment. You can specify role names for both creator and member default roles. The system will validate that the specified roles exist and update the environment settings accordingly. Returns the updated default role objects including their complete role information and permissions.",
+        "tags": ["Roles"],
+        "summary": "Set default creator and member roles",
+        "operationId": "RolesService_UpdateDefaultRoles2",
+        "responses": {
+          "200": {
+            "description": "Default roles updated successfully",
             "content": {
               "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict - connected account with the same identifier already exists",
-            "content": {
-              "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/rolesUpdateDefaultRolesResponse"
+                }
               }
             }
           }
@@ -4779,179 +3839,177 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/connected_accountsCreateConnectedAccountRequest"
+                "$ref": "#/components/schemas/rolesUpdateDefaultRolesRequest"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/api/v1/roles/{role_name}": {
+      "get": {
+        "description": "Retrieves complete information for a specific role including metadata and inheritance details (base role and dependent role count). Use this endpoint to audit role configuration and understand the role's place in the hierarchy. To view the role's permissions, use the ListRolePermissions endpoint.",
+        "tags": ["Roles"],
+        "summary": "Get role details",
+        "operationId": "RolesService_GetRole",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique name identifier of the role to retrieve. Must be alphanumeric with underscores, 1-64 characters.",
+            "name": "role_name",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Include additional data in the response. Valid values: 'permissions' (direct permissions only), 'permissions:all' (includes inherited permissions from role hierarchy)",
+            "name": "include",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved role details. Returns the role object including metadata and inheritance details. Permissions are not included.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rolesGetRoleResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const res = await scalekit.role.getRole(\"admin\");"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "res = scalekit_client.roles.get_role(role_name=\"admin\")"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "resp, err := scalekitClient.Role().GetRole(ctx, \"admin\")\nif err != nil { /* handle err */ }\n_ = resp"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "GetRoleResponse res = scalekitClient.roles().getRole(\"admin\");"
+          }
+        ]
+      },
+      "put": {
+        "description": "Modifies an existing role's properties including display name, description, permissions, and inheritance. Use this endpoint to update role metadata, change permission assignments, or modify role hierarchy. Only the fields you specify will be updated, leaving other properties unchanged. When updating permissions, the new list replaces all existing permissions for the role.",
+        "tags": ["Roles"],
+        "summary": "Update role information",
+        "operationId": "RolesService_UpdateRole",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique name identifier of the role to update. Must be alphanumeric with underscores, 1-64 characters.",
+            "name": "role_name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Role updated successfully. Returns the modified role object with updated timestamps.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rolesUpdateRoleResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await scalekit.role.updateRole(\"admin\", {\n  displayName: \"Admin (Updated)\",\n  description: \"Updated description\"\n});"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "from scalekit.v1.roles.roles_pb2 import UpdateRole\n\nscalekit_client.roles.update_role(\n    role_name=\"admin\",\n    role=UpdateRole(\n        display_name=\"Admin (Updated)\",\n        description=\"Updated description\"\n    )\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "resp, err := scalekitClient.Role().UpdateRole(ctx, \"admin\", &rolesv1.UpdateRole{\n    DisplayName: \"Admin (Updated)\",\n    Description: \"Updated description\",\n})\nif err != nil { /* handle err */ }\n_ = resp"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "UpdateRoleResponse res = scalekitClient.roles().updateRole(\n    \"admin\",\n    UpdateRoleRequest.newBuilder()\n        .setRole(\n            UpdateRole.newBuilder()\n                .setDisplayName(\"Admin (Updated)\")\n                .setDescription(\"Updated description\")\n                .build()\n        )\n        .build()\n);"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "description": "Role fields to update. Only specified fields will be modified.",
+                "$ref": "#/components/schemas/v1rolesUpdateRole",
+                "examples": [
+                  {
+                    "description": "Can edit and approve content",
+                    "display_name": "Senior Editor"
+                  }
+                ]
               }
             }
           },
           "required": true
         }
       },
-      "put": {
-        "description": "Updates authentication credentials and configuration for an existing connected account. Modify OAuth tokens, refresh tokens, access scopes, or API configuration settings. Specify the account by ID, or by combination of organization/user, connector, and identifier. Returns the updated account with new token expiry and status information.",
-        "tags": ["Connected Accounts"],
-        "summary": "Update connected account credentials",
-        "operationId": "ConnectedAccountService_UpdateConnectedAccount",
-        "responses": {
-          "200": {
-            "description": "Connected account updated successfully with new credentials or configuration",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/connected_accountsUpdateConnectedAccountResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid request - missing required fields, invalid authorization details, or validation failed",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required - missing or invalid access token",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "404": {
-            "description": "Connected account not found - the specified account does not exist",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/connected_accountsUpdateConnectedAccountRequest"
-              }
-            }
-          },
-          "required": true
-        }
-      }
-    },
-    "/api/v1/connected_accounts/auth": {
-      "get": {
-        "description": "Retrieves complete authentication details for a connected account including OAuth tokens, refresh tokens, scopes, and API configuration. Query by account ID or by combination of organization/user, connector, and identifier. Returns sensitive credential information - use appropriate access controls.",
-        "tags": ["Connected Accounts"],
-        "summary": "Get connected account details",
-        "operationId": "ConnectedAccountService_GetConnectedAccountAuth",
+      "delete": {
+        "description": "Permanently removes a role from the environment and reassigns users who had that role to a different role. Use this endpoint when you need to clean up unused roles or restructure your access control system. The role cannot be deleted if it has dependent roles (roles that extend it) unless you specify a replacement role. If users are assigned to the role being deleted, you must provide a reassign_role_name to move those users to a different role before deletion can proceed. This action cannot be undone, so ensure no critical users depend on the role before deletion.",
+        "tags": ["Roles"],
+        "summary": "Delete role and reassign users",
+        "operationId": "RolesService_DeleteRole",
         "parameters": [
           {
             "schema": {
               "type": "string"
             },
-            "description": "Organization ID for the connector",
-            "name": "organization_id",
+            "description": "Unique name identifier of the role to delete. Must be alphanumeric with underscores, 1-64 characters.",
+            "name": "role_name",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Role name to reassign users to when deleting this role",
+            "name": "reassign_role_id",
             "in": "query"
           },
           {
             "schema": {
               "type": "string"
             },
-            "description": "User ID for the connector",
-            "name": "user_id",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Connector identifier",
-            "name": "connector",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "The unique identifier for the connected account within the third-party service (e.g., email address, user ID, workspace identifier).",
-            "name": "identifier",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Unique identifier for the connected account",
-            "name": "id",
+            "description": "Role name to reassign users to when deleting this role",
+            "name": "reassign_role_name",
             "in": "query"
           }
         ],
         "responses": {
           "200": {
-            "description": "Successfully retrieved connected account with full authentication details",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/connected_accountsGetConnectedAccountByIdentifierResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid request - missing required query parameters",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required - missing or invalid access token",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "404": {
-            "description": "Connected account not found - no account matches the specified criteria",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/connected_accounts/magic_link": {
-      "post": {
-        "description": "Creates a time-limited magic link for connecting or re-authorizing a third-party account. The link directs users to the OAuth authorization flow for the specified connector. Returns the generated link URL and expiration timestamp. Links typically expire after a short duration for security.",
-        "tags": ["Connected Accounts"],
-        "summary": "Generate authentication magic link",
-        "operationId": "ConnectedAccountService_GetMagicLinkForConnectedAccount",
-        "responses": {
-          "200": {
-            "description": "Magic link generated successfully with authorization URL and expiry time",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/connected_accountsGetMagicLinkForConnectedAccountResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid request - missing required parameters or invalid connector",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required - missing or invalid access token",
+            "description": "Role successfully deleted and users reassigned. No content returned.",
             "content": {
               "application/json": {
                 "schema": {}
@@ -4959,91 +4017,585 @@
             }
           }
         },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/connected_accountsGetMagicLinkForConnectedAccountRequest"
-              }
-            }
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "// Basic delete\nawait scalekit.role.deleteRole(\"admin\");\n\n// With reassignment\nawait scalekit.role.deleteRole(\"admin\", \"member\");"
           },
-          "required": true
-        }
-      }
-    },
-    "/api/v1/connected_accounts:delete": {
-      "post": {
-        "description": "Permanently removes a connected account and revokes all associated authentication credentials. Identify the account by ID, or by combination of organization/user, connector, and identifier. This action cannot be undone. All OAuth tokens and API keys for this account will be invalidated.",
-        "tags": ["Connected Accounts"],
-        "summary": "Delete a connected account",
-        "operationId": "ConnectedAccountService_DeleteConnectedAccount",
-        "responses": {
-          "200": {
-            "description": "Connected account deleted successfully and all credentials revoked",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "# Basic delete\nscalekit_client.roles.delete_role(role_name=\"admin\")\n\n# With reassignment\nscalekit_client.roles.delete_role(\n    role_name=\"admin\",\n    reassign_role_name=\"member\"\n)"
           },
-          "400": {
-            "description": "Invalid request - malformed parameters or validation failed",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "// Basic delete\nerr := scalekitClient.Role().DeleteRole(ctx, \"admin\")\nif err != nil { /* handle err */ }\n\n// With reassignment\nerr = scalekitClient.Role().DeleteRole(ctx, \"admin\", \"member\")"
           },
-          "401": {
-            "description": "Authentication required - missing or invalid access token",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "404": {
-            "description": "Connected account not found - the specified account does not exist",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "// Basic delete\nscalekitClient.roles().deleteRole(\"admin\");\n\n// With reassignment\nscalekitClient.roles().deleteRole(\"admin\", \"member\");"
           }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/connected_accountsDeleteConnectedAccountRequest"
-              }
-            }
-          },
-          "required": true
-        }
+        ]
       }
     },
-    "/api/v1/connected_accounts:search": {
-      "get": {
-        "description": "Search for connected accounts in your environment using a text query that matches against identifiers, providers, or connectors. The search performs case-insensitive matching across account details. Returns paginated results with account status and authentication type information.",
-        "tags": ["Connected Accounts"],
-        "summary": "Search connected accounts",
-        "operationId": "ConnectedAccountService_SearchConnectedAccounts",
+    "/api/v1/roles/{role_name}/base": {
+      "delete": {
+        "description": "Removes the base role inheritance relationship for a specified role, effectively eliminating all inherited permissions from the base role. Use this endpoint when you want to break the hierarchical relationship between roles and remove inherited permissions. The role will retain only its directly assigned permissions after this operation. This action cannot be undone, so ensure the role has sufficient direct permissions before removing inheritance. Returns no content on successful removal of the base relationship.",
+        "tags": ["Roles"],
+        "summary": "Delete role inheritance relationship",
+        "operationId": "RolesService_DeleteRoleBase",
         "parameters": [
           {
             "schema": {
               "type": "string"
             },
-            "description": "Search term to match against connected account identifiers, providers, or connectors. Must be at least 3 characters. Case insensitive.",
-            "name": "query",
-            "in": "query"
+            "description": "Unique name identifier of the role whose base inheritance relationship should be removed. Must be alphanumeric with underscores, 1-64 characters.",
+            "name": "role_name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Base role inheritance relationship successfully removed. The role now has only its directly assigned permissions.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await scalekit.role.deleteRoleBase(\"admin\");"
           },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "scalekit_client.roles.delete_role_base(role_name=\"admin\")"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "err := scalekitClient.Role().DeleteRoleBase(ctx, \"admin\")\nif err != nil { /* handle err */ }"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "scalekitClient.roles().deleteRoleBase(\"admin\");"
+          }
+        ]
+      }
+    },
+    "/api/v1/roles/{role_name}/dependents": {
+      "get": {
+        "description": "Retrieves all roles that directly extend the specified base role through inheritance. Use this endpoint to understand the role hierarchy and identify which roles inherit permissions from a particular base role. Provide the base role name as a path parameter, and the response will include all dependent roles with their metadata and permission information. This operation is useful for auditing role inheritance relationships, understanding the impact of changes to base roles, or managing role hierarchies effectively. Returns a list of dependent role objects including their names, display names, descriptions, and permission details.",
+        "tags": ["Roles"],
+        "summary": "List dependent roles",
+        "operationId": "RolesService_ListDependentRoles",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Name of the base role",
+            "name": "role_name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved dependent roles. Returns a list of all roles that extend the specified base role, including their metadata and permission information.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rolesListDependentRolesResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const res = await scalekit.role.listDependentRoles(\"admin\");"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "res = scalekit_client.roles.list_dependent_roles(role_name=\"admin\")"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "resp, err := scalekitClient.Role().ListDependentRoles(ctx, \"admin\")\nif err != nil { /* handle err */ }\n_ = resp"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "ListDependentRolesResponse res = scalekitClient.roles().listDependentRoles(\"admin\");"
+          }
+        ]
+      }
+    },
+    "/api/v1/roles/{role_name}/permissions": {
+      "get": {
+        "description": "Retrieves all permissions directly assigned to the specified role, excluding permissions inherited from base roles. Use this endpoint to view the explicit permission assignments for a role, which is useful for understanding direct role capabilities, auditing permission assignments, or managing role-permission relationships. Provide the role name as a path parameter, and the response will include only the permissions that are directly assigned to that role. This operation does not include inherited permissions from role hierarchies - use ListEffectiveRolePermissions to see the complete set of permissions including inheritance. Returns a list of permission objects with their names, descriptions, and assignment metadata.",
+        "tags": ["Roles"],
+        "summary": "List permissions for role",
+        "operationId": "RolesService_ListRolePermissions",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Name of the role",
+            "name": "role_name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved role permissions. Returns a list of all permissions directly assigned to the specified role, excluding inherited permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rolesListRolePermissionsResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const res = await scalekit.permission.listRolePermissions(\"admin\");"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "res = scalekit_client.permissions.list_role_permissions(role_name=\"admin\")"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "resp, err := scalekitClient.Permission().ListRolePermissions(ctx, \"admin\")\nif err != nil { /* handle err */ }\n_ = resp"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "ListRolePermissionsResponse res = scalekitClient.permissions().listRolePermissions(\"admin\");"
+          }
+        ]
+      },
+      "post": {
+        "description": "Adds one or more permissions to the specified role while preserving existing permission assignments. Use this endpoint to grant additional capabilities to a role without affecting its current permission set. Provide the role name as a path parameter and a list of permission names in the request body. The system will validate that all specified permissions exist in the environment and add them to the role. Existing permission assignments remain unchanged, making this operation safe for incremental permission management. This is useful for gradually expanding role capabilities or adding new permissions as your system evolves. Returns the updated list of all permissions now assigned to the role.",
+        "tags": ["Roles"],
+        "summary": "Add permissions to role",
+        "operationId": "RolesService_AddPermissionsToRole",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Name of the role",
+            "name": "role_name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Permissions added to role successfully. Returns the complete list of all permissions now assigned to the role, including both existing and newly added permissions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rolesAddPermissionsToRoleResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await scalekit.permission.addPermissionsToRole(\"role_admin\", [\"perm.read\", \"perm.write\"]);"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "scalekit_client.permissions.add_permissions_to_role(\n    role_name=\"role_admin\",\n    permission_names=[\"perm.read\", \"perm.write\"]\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "resp, err := scalekitClient.Permission().AddPermissionsToRole(ctx, \"role_admin\", []string{\"perm.read\", \"perm.write\"})"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "AddPermissionsToRoleResponse res = scalekitClient.permissions().addPermissionsToRole(\n    \"role_admin\",\n    AddPermissionsToRoleRequest.newBuilder()\n        .addPermissionNames(\"perm.read\")\n        .addPermissionNames(\"perm.write\")\n        .build()\n);"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RolesServiceAddPermissionsToRoleBody"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/api/v1/roles/{role_name}/permissions/{permission_name}": {
+      "delete": {
+        "description": "Removes a specific permission from the specified role, revoking that capability from all users assigned to the role. Use this endpoint to restrict role capabilities or remove unnecessary permissions. Provide both the role name and permission name as path parameters. This operation only affects the direct permission assignment and does not impact permissions inherited from base roles. If the permission is inherited through role hierarchy, you may need to modify the base role instead. This is useful for fine-tuning role permissions, implementing least-privilege access controls, or removing deprecated permissions. Returns no content on successful removal.",
+        "tags": ["Roles"],
+        "summary": "Remove permission from role",
+        "operationId": "RolesService_RemovePermissionFromRole",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Name of the role",
+            "name": "role_name",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Name of the permission to remove",
+            "name": "permission_name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Permission removed from role successfully. No content returned.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await scalekit.permission.removePermissionFromRole(\"admin\", \"read:users\");"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "scalekit_client.permissions.remove_permission_from_role(\n    role_name=\"admin\",\n    permission_name=\"read:users\"\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "err := scalekitClient.Permission().RemovePermissionFromRole(ctx, \"admin\", \"read:users\")\nif err != nil { /* handle err */ }"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "scalekitClient.permissions().removePermissionFromRole(\"admin\", \"read:users\");"
+          }
+        ]
+      }
+    },
+    "/api/v1/roles/{role_name}/permissions:all": {
+      "get": {
+        "description": "Retrieves the complete set of effective permissions for a role, including both directly assigned permissions and permissions inherited from base roles through the role hierarchy. Use this endpoint to understand the full scope of capabilities available to users assigned to a specific role. Provide the role name as a path parameter, and the response will include all permissions that apply to the role, accounting for inheritance relationships. This operation is essential for auditing role capabilities, understanding permission inheritance, or verifying the complete access scope before role assignment. Returns a comprehensive list of permission names representing the full set of effective permissions for the specified role.",
+        "tags": ["Roles"],
+        "summary": "List effective permissions for role",
+        "operationId": "RolesService_ListEffectiveRolePermissions",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Name of the role",
+            "name": "role_name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved effective permissions. Returns the complete list of all permissions that apply to the role, including both direct assignments and inherited permissions from base roles.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rolesListEffectiveRolePermissionsResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const res = await scalekit.permission.listEffectiveRolePermissions(\"admin\");"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "res = scalekit_client.permissions.list_effective_role_permissions(role_name=\"admin\")"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "resp, err := scalekitClient.Permission().ListEffectiveRolePermissions(ctx, \"admin\")\nif err != nil { /* handle err */ }\n_ = resp"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "ListEffectiveRolePermissionsResponse res = scalekitClient.permissions().listEffectiveRolePermissions(\"admin\");"
+          }
+        ]
+      }
+    },
+    "/api/v1/roles/{role_name}/users:count": {
+      "get": {
+        "description": "Retrieves the total number of users currently assigned to the specified role within the environment. Use this endpoint to monitor role usage, enforce user limits, or understand the scope of role assignments. Provide the role's unique name as a path parameter, and the response will include the current user count for that role. This operation is read-only and does not modify any data or user assignments. The count reflects all users who have the role either directly assigned or inherited through organization membership. This information is useful for capacity planning, security auditing, or understanding the impact of role changes across your user base.",
+        "tags": ["Roles"],
+        "summary": "Retrieve user count for role",
+        "operationId": "RolesService_GetRoleUsersCount",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique name of the role",
+            "name": "role_name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved user count for the specified role. Returns the total number of users currently assigned to the role, including both direct assignments and inherited assignments.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rolesGetRoleUsersCountResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const res = await scalekit.role.getRoleUsersCount(\"admin\");"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "res = scalekit_client.roles.get_role_users_count(role_name=\"admin\")"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "resp, err := scalekitClient.Role().GetRoleUsersCount(ctx, \"admin\")\nif err != nil { /* handle err */ }\n_ = resp"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "GetRoleUsersCountResponse res = scalekitClient.roles().getRoleUsersCount(\"admin\");"
+          }
+        ]
+      }
+    },
+    "/api/v1/roles:set_defaults": {
+      "patch": {
+        "description": "Updates the default creator and member roles for the current environment. Use this endpoint to configure which roles are automatically assigned to new users when they join the environment. You can specify role names for both creator and member default roles. The system will validate that the specified roles exist and update the environment settings accordingly. Returns the updated default role objects including their complete role information and permissions.",
+        "tags": ["Roles"],
+        "summary": "Set default creator and member roles",
+        "operationId": "RolesService_UpdateDefaultRoles",
+        "responses": {
+          "200": {
+            "description": "Default roles updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/rolesUpdateDefaultRolesResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const res = await scalekit.role.updateDefaultRoles({\n  defaultMemberRole: \"member\"\n});"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "from scalekit.v1.roles.roles_pb2 import UpdateDefaultRolesRequest\n\nres = scalekit_client.roles.update_default_roles(\n    default_roles=UpdateDefaultRolesRequest(\n        default_member_role=\"member\"\n    )\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "resp, err := scalekitClient.Role().UpdateDefaultRoles(ctx, \"member\")\nif err != nil { /* handle err */ }\n_ = resp"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "UpdateDefaultRolesResponse res = scalekitClient.roles().updateDefaultRoles(\n    UpdateDefaultRolesRequest.newBuilder()\n        .setDefaultMemberRole(\"member\")\n        .build()\n);"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/rolesUpdateDefaultRolesRequest"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/api/v1/sessions/{session_id}": {
+      "get": {
+        "description": "Retrieves comprehensive details for a specific user session including authentication status, device information, and expiration timelines. Use this endpoint to fetch current session metadata for security audits, session validation, or to display session information in user account management interfaces. Returns all session properties including the user ID, authenticated organizations, device details with browser/OS information, IP address and geolocation, and all relevant timestamps (creation, last activity, idle expiration, absolute expiration, and actual expiration if applicable).",
+        "tags": ["Sessions"],
+        "summary": "Get session details",
+        "operationId": "SessionService_GetSession",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier for the session. Must start with 'ses_' prefix.",
+            "name": "session_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved session details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sessionsSessionDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const res = await scalekit.session.getSession(\"ses_123456789\");"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "res = scalekit_client.sessions.get_session(session_id=\"ses_123456789\")"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "resp, err := scalekitClient.Session().GetSession(ctx, \"ses_123456789\")\nif err != nil { /* handle err */ }\n_ = resp"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "SessionDetails res = scalekitClient.sessions().getSession(\"ses_123456789\");"
+          }
+        ]
+      }
+    },
+    "/api/v1/sessions/{session_id}/revoke": {
+      "post": {
+        "description": "Immediately invalidates a specific user session by session ID, setting its status to 'revoked'. Once revoked, the session cannot be used for any future API requests or application access. Use this endpoint to implement session-level logout, force a user to reauthenticate on a specific device, or terminate suspicious sessions. The revocation is instantaneous and irreversible. Returns the revoked session details including the session ID, user ID, and the revocation timestamp.",
+        "tags": ["Sessions"],
+        "summary": "Revoke user session",
+        "operationId": "SessionService_RevokeSession",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier for the session to revoke. Must start with 'ses_' prefix.",
+            "name": "session_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully revoked the session. Returns the revoked session details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sessionsRevokeSessionResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const res = await scalekit.session.revokeSession(\"ses_123456789\");"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "res = scalekit_client.sessions.revoke_session(session_id=\"ses_123456789\")"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "resp, err := scalekitClient.Session().RevokeSession(ctx, \"ses_123456789\")\nif err != nil { /* handle err */ }\n_ = resp"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "RevokeSessionResponse res = scalekitClient.sessions().revokeSession(\"ses_123456789\");"
+          }
+        ]
+      }
+    },
+    "/api/v1/users": {
+      "get": {
+        "description": "Retrieves a paginated list of all users across your entire environment. Use this endpoint to view all users regardless of their organization memberships. This is useful for administrative purposes, user audits, or when you need to see all users in your Scalekit environment. Supports pagination for large user bases.",
+        "tags": ["Users"],
+        "summary": "List all users in environment",
+        "operationId": "UserService_ListUsers",
+        "parameters": [
           {
             "schema": {
               "type": "integer",
               "format": "int64"
             },
-            "description": "Maximum number of connected accounts to return per page. Value must be between 1 and 30.",
+            "description": "Maximum number of organizations to return per page. Must be between 10 and 100",
             "name": "page_size",
             "in": "query"
           },
@@ -5051,92 +4603,132 @@
             "schema": {
               "type": "string"
             },
-            "description": "Token from a previous response for pagination. Provide this to retrieve the next page of results.",
+            "description": "Pagination token from the previous response. Use to retrieve the next page of organizations",
             "name": "page_token",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "description": "Connection ID to filter connected accounts",
-            "name": "connection_id",
             "in": "query"
           }
         ],
         "responses": {
           "200": {
-            "description": "Successfully retrieved matching connected accounts with pagination support",
+            "description": "List of users.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/connected_accountsSearchConnectedAccountsResponse"
+                  "$ref": "#/components/schemas/usersListUsersResponse"
                 }
               }
             }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const response = await scalekit.user.listUsers(\n  { pageSize: 100 });"
           },
-          "400": {
-            "description": "Invalid request - query parameter is too short (minimum 3 characters) or validation failed",
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "# pass empty org to fetch all users in environment\nresp,_ = scalekit_client.users.list_users(organization_id=\"\", page_size=100)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "all, err := scalekitClient.User().ListOrganizationUsers(ctx, \"\", &scalekit.ListUsersOptions{PageSize: 100})"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "ListUsersRequest lur = ListUsersRequest.\n  newBuilder().setPageSize(100).build();\nListUsersResponse allUsers = users.listUsers(lur);"
+          }
+        ]
+      }
+    },
+    "/api/v1/users/support-hash": {
+      "get": {
+        "description": "Retrieves the support email hash for the current logged in user, used for the Scalekit support system.",
+        "tags": ["Users"],
+        "summary": "Get support hash",
+        "operationId": "UserService_GetSupportHash",
+        "responses": {
+          "200": {
+            "description": "Support hash retrieved successfully.",
             "content": {
               "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required - missing or invalid access token",
-            "content": {
-              "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/usersGetSupportHashResponse"
+                }
               }
             }
           }
         }
       }
     },
-    "/api/v1/execute_tool": {
-      "post": {
-        "description": "Executes a tool action using authentication credentials from a connected account. Specify the tool by name and provide required parameters as JSON. The connected account can be identified by ID, or by combination of organization/user, connector, and identifier. Returns the execution result data and a unique execution ID for tracking. Use this endpoint to perform actions like sending emails, creating calendar events, or managing resources in external services.",
-        "tags": ["Connected Accounts"],
-        "summary": "Execute a tool using a connected account",
-        "operationId": "ToolService_ExecuteTool",
+    "/api/v1/users/{id}": {
+      "get": {
+        "description": "Retrieves all details for a user by system-generated user ID or external ID. The response includes organization memberships and user metadata.",
+        "tags": ["Users"],
+        "summary": "Get user",
+        "operationId": "UserService_GetUser",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "System-generated user ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Your application's unique identifier for this organization, used to link Scalekit with your system.",
+            "name": "external_id",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
-            "description": "Tool executed successfully with result data and execution ID",
+            "description": "User details retrieved successfully. Returns full user object with system-generated fields and timestamps.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/toolsExecuteToolResponse"
+                  "$ref": "#/components/schemas/usersGetUserResponse"
                 }
               }
             }
+          }
+        }
+      },
+      "delete": {
+        "description": "Permanently removes a user from your environment and deletes all associated data. Use this endpoint when you need to completely remove a user account. This action deletes the user's profile, memberships, and all related data across all organizations. This operation cannot be undone, so use with caution.",
+        "tags": ["Users"],
+        "summary": "Delete user permanently",
+        "operationId": "UserService_DeleteUser",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "System-generated user ID. Must start with 'usr_' (19-25 characters)",
+            "name": "id",
+            "in": "path",
+            "required": true
           },
-          "400": {
-            "description": "Invalid request - occurs when tool name is missing, parameters are malformed, or tool definition validation fails",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required - missing or invalid access token",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "404": {
-            "description": "Tool or connected account not found - occurs when the specified tool name or connected account does not exist",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "500": {
-            "description": "Tool execution failed - occurs when the external service returns an error or the tool encounters a runtime exception",
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "External system identifier from connected directories. Must match existing records",
+            "name": "external_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User successfully deleted. No content returned",
             "content": {
               "application/json": {
                 "schema": {}
@@ -5144,11 +4736,419 @@
             }
           }
         },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await scalekit.user.deleteUser(\"usr_123\");"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "scalekit_client.users.delete_user(organization_id=\"org_123\", \n  user_id=\"usr_123\")"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "if err := scalekitClient.User().DeleteUser(ctx, \n  \"usr_123\"); err != nil {\n    panic(err)\n}"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "users.deleteUser(\"usr_123\");"
+          }
+        ]
+      },
+      "patch": {
+        "description": "Modifies user account information including profile details, metadata, and external ID. Use this endpoint to update a user's personal information, contact details, or custom metadata. You can update the user's profile, phone number, and metadata fields. Note that fields like user ID, email address, environment ID, and creation time cannot be modified.",
+        "tags": ["Users"],
+        "summary": "Update user information",
+        "operationId": "UserService_UpdateUser",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "System-generated user ID. Must start with 'usr_' and be 19-25 characters long.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Your application's unique identifier for this organization, used to link Scalekit with your system.",
+            "name": "external_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User updated successfully. Returns the modified user object with updated timestamps.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/usersUpdateUserResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await scalekit.user.updateUser(\"usr_123\", {\n\tuserProfile: {\n\t\tfirstName: \"John\",\n\t\tlastName: \"Smith\",\n\t},\n\tmetadata: {\n\t\tdepartment: \"sales\",\n\t},\n});"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "import os\nfrom scalekit import ScalekitClient\nfrom scalekit.v1.users.users_pb2 import UpdateUser\nfrom scalekit.v1.commons.commons_pb2 import UserProfile\nscalekit_client = ScalekitClient(\n    env_url=os.getenv(\"SCALEKIT_ENV_URL\"),\n    client_id=os.getenv(\"SCALEKIT_CLIENT_ID\"),\n    client_secret=os.getenv(\"SCALEKIT_CLIENT_SECRET\"),\n)\nupdate_user = UpdateUser(\n    user_profile=UserProfile(\n        first_name=\"John\",\n        last_name=\"Smith\"\n    ),\n    metadata={\"department\": \"sales\"}\n)\nscalekit_client.users.update_user(organization_id=\"org_123\", \n  user=update_user)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "upd := &usersv1.UpdateUser{\n    UserProfile: &usersv1.UpdateUserProfile{\n        FirstName: \"John\",\n        LastName:  \"Smith\",\n    },\n    Metadata: map[string]string{\n        \"department\": \"sales\",\n    },\n}\nscalekitClient.User().UpdateUser(ctx, \"usr_123\", upd)"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "UpdateUser upd = UpdateUser.newBuilder()\n        .setUserProfile(\n          UpdateUserProfile.newBuilder()\n                .setFirstName(\"John\")\n                .setLastName(\"Smith\")\n                .build())\n        .putMetadata(\"department\", \"sales\")\n        .build();\nUpdateUserRequest updReq = UpdateUserRequest.\n  newBuilder().setUser(upd).build();\nusers.updateUser(\"usr_123\", updReq);"
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/toolsExecuteToolRequest"
+                "description": "User fields to update. Only specified fields will be modified. Required fields must be provided if being changed.",
+                "$ref": "#/components/schemas/v1usersUpdateUser",
+                "examples": [
+                  {
+                    "firstName": "John",
+                    "lastName": "Doe"
+                  }
+                ]
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/api/v1/users/{user_id}/sessions": {
+      "get": {
+        "description": "Retrieves a paginated list of all sessions associated with a specific user across all devices and browsers. Use this endpoint to audit user activity, display all active sessions in account management interfaces, or verify user authentication status across devices. Supports filtering by session status (active, expired, revoked, logout) and time range (creation date). Returns session details for each session including device information, IP address, geolocation, and current status. The response includes pagination metadata (page tokens and total count) to handle large session lists efficiently.",
+        "tags": ["Sessions"],
+        "summary": "List user sessions",
+        "operationId": "SessionService_GetUserSessions",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier for the user whose sessions to retrieve. Must start with 'usr_' prefix.",
+            "name": "user_id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "Maximum number of sessions to return in a single page. Optional parameter. If not specified, defaults to a server-defined limit. Use smaller values for faster responses, larger values for fewer requests.",
+            "name": "page_size",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Pagination token from the previous response for retrieving the next page of results. Leave empty for the first page. Use the next_page_token from a previous response to fetch subsequent pages.",
+            "name": "page_token",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "style": "form",
+            "explode": true,
+            "description": "Filter sessions by one or more status values. Possible values: 'active', 'expired', 'revoked', 'logout'. Leave empty to include all statuses. Multiple values use OR logic (e.g., status=['active', 'expired'] returns sessions that are either active OR expired).",
+            "name": "filter.status",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "description": "Filter to include only sessions created on or after this timestamp. Optional. Uses RFC 3339 format. Useful for querying sessions within a specific time window.",
+            "name": "filter.start_time",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "description": "Filter to include only sessions created on or before this timestamp. Optional. Uses RFC 3339 format. Must be after start_time if both are specified.",
+            "name": "filter.end_time",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved user sessions. Returns a list of sessions with pagination information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sessionsUserSessionDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "// Basic usage\nconst res = await scalekit.session.getUserSessions(\"user_123\");\n\n// With pagination and filtering\nconst res = await scalekit.session.getUserSessions(\"user_123\", {\n  pageSize: 10,\n  pageToken: \"next_page_token\",\n  filter: {\n    status: [\"ACTIVE\"],\n    startTime: new Date(\"2024-01-01\"),\n    endTime: new Date(\"2024-12-31\")\n  }\n});"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "# Basic usage\nres = scalekit_client.sessions.get_user_sessions(user_id=\"user_123\")\n\n# With pagination and filtering\nfrom google.protobuf.timestamp_pb2 import Timestamp\nfrom datetime import datetime\n\nstart_time = Timestamp()\nstart_time.FromDatetime(datetime(2024, 1, 1))\nend_time = Timestamp()\nend_time.FromDatetime(datetime(2024, 12, 31))\n\nfilter_obj = scalekit_client.sessions.create_session_filter(\n    status=[\"ACTIVE\"], start_time=start_time, end_time=end_time\n)\nres = scalekit_client.sessions.get_user_sessions(\n    user_id=\"user_123\", page_size=10, page_token=\"next_page_token\", filter=filter_obj\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "// Basic usage\nresp, err := scalekitClient.Session().GetUserSessions(ctx, \"user_123\", 0, \"\", nil)\nif err != nil { /* handle err */ }\n\n// With pagination and filtering\n// import \"time\", sessionsv1 \"...\", \"google.golang.org/protobuf/types/known/timestamppb\"\nstartTime, _ := time.Parse(time.RFC3339, \"2024-01-01T00:00:00Z\")\nendTime, _ := time.Parse(time.RFC3339, \"2024-12-31T23:59:59Z\")\nfilter := &sessionsv1.UserSessionFilter{\n    Status:    []string{\"ACTIVE\"},\n    StartTime: timestamppb.New(startTime),\n    EndTime:   timestamppb.New(endTime),\n}\nresp, err := scalekitClient.Session().GetUserSessions(ctx, \"user_123\", 10, \"next_page_token\", filter)\nif err != nil { /* handle err */ }"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "// Basic usage\nUserSessionDetails res = scalekitClient.sessions().getUserSessions(\"user_123\", null, null, null);\n\n// With pagination and filtering\n// import UserSessionFilter, Timestamp, Instant\nUserSessionFilter filter = UserSessionFilter.newBuilder()\n    .addStatus(\"ACTIVE\")\n    .setStartTime(Timestamp.newBuilder().setSeconds(Instant.parse(\"2024-01-01T00:00:00Z\").getEpochSecond()).build())\n    .setEndTime(Timestamp.newBuilder().setSeconds(Instant.parse(\"2024-12-31T23:59:59Z\").getEpochSecond()).build())\n    .build();\nUserSessionDetails res = scalekitClient.sessions().getUserSessions(\"user_123\", 10, \"next_page_token\", filter);"
+          }
+        ]
+      }
+    },
+    "/api/v1/users/{user_id}/sessions/revoke": {
+      "post": {
+        "description": "Immediately invalidates all active sessions for a specific user across all devices and browsers, setting their status to 'revoked'. Use this endpoint to implement global logout functionality, force re-authentication after security incidents, or terminate all sessions following a password reset or credential compromise. Only active sessions are revoked; already expired, logout, or previously revoked sessions remain unchanged. The revocation is atomic and instantaneous. Returns a list of all revoked sessions with their details and a total count of sessions revoked.",
+        "tags": ["Sessions"],
+        "summary": "Revoke all user sessions",
+        "operationId": "SessionService_RevokeAllUserSessions",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique identifier for the user whose all sessions will be revoked. Must start with 'usr_' prefix.",
+            "name": "user_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully revoked all user sessions. Returns the list of revoked sessions and total count",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sessionsRevokeAllUserSessionsResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const res = await scalekit.session.revokeAllUserSessions(\"user_123\");"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "res = scalekit_client.sessions.revoke_all_user_sessions(user_id=\"user_123\")"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "resp, err := scalekitClient.Session().RevokeAllUserSessions(ctx, \"user_123\")\nif err != nil { /* handle err */ }\n_ = resp"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "RevokeAllUserSessionsResponse res = scalekitClient.sessions().revokeAllUserSessions(\"user_123\");"
+          }
+        ]
+      }
+    },
+    "/api/v1/webauthn/credentials": {
+      "get": {
+        "description": "Retrieves all registered passkeys for the current user, including device information, creation timestamps, and display names. Use this to show users their registered authenticators.",
+        "tags": ["Passkeys"],
+        "summary": "List user's passkeys",
+        "operationId": "WebAuthnService_ListCredentials",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "User ID to list credentials for (optional, current user if not provided)",
+            "name": "user_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of passkeys with metadata",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/webauthnListCredentialsResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const res = await scalekit.webauthn.listCredentials(\"user_123\");"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "res = scalekit_client.webauthn.list_credentials(user_id=\"user_123\")"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "resp, err := scalekitClient.WebAuthn().ListCredentials(ctx, \"user_123\")\nif err != nil { /* handle err */ }\n_ = resp"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "ListCredentialsResponse res = scalekitClient.webauthn().listCredentials(\"user_123\");"
+          }
+        ]
+      }
+    },
+    "/api/v1/webauthn/credentials/{credential_id}": {
+      "delete": {
+        "description": "Deletes a specific passkey credential for the current user. After removal, the authenticator can no longer be used for authentication.",
+        "tags": ["Passkeys"],
+        "summary": "Remove a passkey",
+        "operationId": "WebAuthnService_DeleteCredential",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "The credential ID to delete",
+            "name": "credential_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Passkey successfully deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/webauthnDeleteCredentialResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const res = await scalekit.webauthn.deleteCredential(\"wac_123\");"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "res = scalekit_client.webauthn.delete_credential(credential_id=\"wac_123\")"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "resp, err := scalekitClient.WebAuthn().DeleteCredential(ctx, \"wac_123\")\nif err != nil { /* handle err */ }\n_ = resp"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "DeleteCredentialResponse res = scalekitClient.webauthn().deleteCredential(\"wac_123\");"
+          }
+        ]
+      },
+      "patch": {
+        "description": "Updates the display name of a passkey credential to help users identify their authenticators. Only the display name can be modified.",
+        "tags": ["Passkeys"],
+        "summary": "Rename a passkey",
+        "operationId": "WebAuthnService_UpdateCredential",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "description": "The credential ID to update",
+            "name": "credential_id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Passkey successfully updated with new name",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/webauthnUpdateCredentialResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const res = await scalekit.webauthn.updateCredential(\n  \"wac_123\",\n  \"Work Laptop Passkey\"\n);"
+          },
+          {
+            "label": "Python SDK",
+            "lang": "python",
+            "source": "res = scalekit_client.webauthn.update_credential(\n    credential_id=\"wac_123\",\n    display_name=\"Work Laptop Passkey\"\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "resp, err := scalekitClient.WebAuthn().UpdateCredential(\n    ctx,\n    \"wac_123\",\n    \"Work Laptop Passkey\",\n)\nif err != nil { /* handle err */ }\n_ = resp"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "UpdateCredentialResponse res = scalekitClient.webauthn()\n    .updateCredential(\"wac_123\", \"Work Laptop Passkey\");"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WebAuthnServiceUpdateCredentialBody"
               }
             }
           },
@@ -5163,28 +5163,12 @@
       "name": "Organizations"
     },
     {
-      "description": "Comprehensive user management operations including user lifecycle, organization memberships, and invitation workflows. This service provides endpoints for creating, retrieving, updating, and deleting user accounts across your Scalekit environment. It supports both individual user operations and bulk operations for user administration, including user search, pagination, and metadata management. The service also handles user invitations and organization membership management.",
-      "name": "Users"
-    },
-    {
-      "description": "Endpoints for passkey-based authentication using WebAuthn/FIDO2 standards.",
-      "name": "Passkeys"
-    },
-    {
-      "description": "Comprehensive session management for user authentication and authorization. This service provides endpoints for retrieving session details, managing user sessions across devices, revoking individual sessions, and terminating all active sessions for a user. It supports session auditing, device tracking, and security monitoring with detailed session metadata including device information, IP geolocation, and activity timestamps.",
-      "name": "Sessions"
-    },
-    {
-      "description": "Role-based access control (RBAC) for defining and managing permissions in an environment. Create and update custom roles with explicit permissions, model role hierarchies through inheritance, view dependent roles, manage role-permission assignments, and list roles and permissions. Also provides a utility to count users assigned to a role.",
-      "name": "Roles"
-    },
-    {
       "description": "Permission management for defining and controlling access to system resources. Create, retrieve, update, and delete granular permissions that represent specific actions users can perform. Permissions are the building blocks of role-based access control (RBAC) and can be assigned to roles to grant users the ability to perform specific operations. Use this service to define custom permissions for your application's unique access control requirements.",
       "name": "Permissions"
     },
     {
-      "description": "Manage organization-level domains. Scalekit supports two domain types:\n\n- ORGANIZATION_DOMAIN: Used for SSO domain discovery. When a user signs in with a matching email domain, Scalekit routes them to the organization’s SSO provider and enforces SSO.\n- ALLOWED_EMAIL_DOMAIN: Used to mark trusted email domains for an organization. When a user signs in or signs up with a matching domain, Scalekit suggests the organization in the organization switcher (authentication-method agnostic).\n",
-      "name": "Domains"
+      "description": "Comprehensive user management operations including user lifecycle, organization memberships, and invitation workflows. This service provides endpoints for creating, retrieving, updating, and deleting user accounts across your Scalekit environment. It supports both individual user operations and bulk operations for user administration, including user search, pagination, and metadata management. The service also handles user invitations and organization membership management.",
+      "name": "Users"
     },
     {
       "description": "Manage enterprise connections for your Scalekit environment. This service provides endpoints for retrieving, and updating connections.",
@@ -5195,6 +5179,18 @@
       "name": "Directory"
     },
     {
+      "description": "Role-based access control (RBAC) for defining and managing permissions in an environment. Create and update custom roles with explicit permissions, model role hierarchies through inheritance, view dependent roles, manage role-permission assignments, and list roles and permissions. Also provides a utility to count users assigned to a role.",
+      "name": "Roles"
+    },
+    {
+      "description": "Comprehensive session management for user authentication and authorization. This service provides endpoints for retrieving session details, managing user sessions across devices, revoking individual sessions, and terminating all active sessions for a user. It supports session auditing, device tracking, and security monitoring with detailed session metadata including device information, IP geolocation, and activity timestamps.",
+      "name": "Sessions"
+    },
+    {
+      "description": "Manage organization-level domains. Scalekit supports two domain types:\n\n- ORGANIZATION_DOMAIN: Used for SSO domain discovery. When a user signs in with a matching email domain, Scalekit routes them to the organization’s SSO provider and enforces SSO.\n- ALLOWED_EMAIL_DOMAIN: Used to mark trusted email domains for an organization. When a user signs in or signs up with a matching domain, Scalekit suggests the organization in the organization switcher (authentication-method agnostic).\n",
+      "name": "Domains"
+    },
+    {
       "description": "Endpoints for managing API client applications. API clients enable secure, automated interactions between software systems without human intervention. Each client is uniquely identified by a `client_id` and can be configured with authentication settings, redirect URIs, and security parameters. Use these endpoints to create, manage, and configure API clients for your API clients.",
       "name": "API Auth",
       "externalDocs": {
@@ -5202,12 +5198,16 @@
       }
     },
     {
-      "description": "Manage connected accounts for third-party integrations and OAuth connections. Connected accounts represent authenticated access to external services like Google, Notion, Slack, and other applications.",
-      "name": "Connected Accounts"
-    },
-    {
       "description": "Endpoints for sending and verifying passwordless authentication emails. These APIs allow users to authenticate without passwords by receiving a verification code or magic link in their email.",
       "name": "Magic link & OTP"
+    },
+    {
+      "description": "Endpoints for passkey-based authentication using WebAuthn/FIDO2 standards.",
+      "name": "Passkeys"
+    },
+    {
+      "description": "Manage connected accounts for third-party integrations and OAuth connections. Connected accounts represent authenticated access to external services like Google, Notion, Slack, and other applications.",
+      "name": "Connected Accounts"
     }
   ],
   "externalDocs": {
@@ -10144,15 +10144,7 @@
               "role.deleted",
               "permission.created",
               "permission.updated",
-              "permission.deleted",
-              "connected_account.created",
-              "connected_account.updated",
-              "connected_account.deleted",
-              "connected_account.magic_link_generated",
-              "connected_account.oauth_tokens_fetched",
-              "connected_account.token_refresh_succeeded",
-              "connected_account.token_refresh_failed",
-              "connected_account.oauth_succeeded"
+              "permission.deleted"
             ]
           },
           "occurred_at": {
@@ -10189,8 +10181,7 @@
               "DirectoryGroup",
               "Permission",
               "OrgMembership",
-              "User",
-              "ConnectedAccount"
+              "User"
             ],
             "example": "Organization"
           },

--- a/public/api/scalekit.scalar.yaml
+++ b/public/api/scalekit.scalar.yaml
@@ -132,7 +132,7 @@ info:
 
     ```gradle
     /* Gradle users - add the following to your dependencies in build file */
-    implementation "com.scalekit:scalekit-sdk-java:2.0.6"
+    implementation "com.scalekit:scalekit-sdk-java:2.0.11"
     ```
 
     ```xml
@@ -140,7 +140,7 @@ info:
     <dependency>
         <groupId>com.scalekit</groupId>
         <artifactId>scalekit-sdk-java</artifactId>
-        <version>2.0.6</version>
+        <version>2.0.11</version>
     </dependency>
     ```
 
@@ -10761,15 +10761,6 @@ components:
             - 'permission.created'
             - 'permission.updated'
             - 'permission.deleted'
-            # Connected Account events
-            - 'connected_account.created'
-            - 'connected_account.updated'
-            - 'connected_account.deleted'
-            - 'connected_account.magic_link_generated'
-            - 'connected_account.oauth_tokens_fetched'
-            - 'connected_account.token_refresh_succeeded'
-            - 'connected_account.token_refresh_failed'
-            - 'connected_account.oauth_succeeded'
         occurred_at:
           type: string
           format: date-time
@@ -10802,7 +10793,6 @@ components:
             - 'Permission'
             - 'OrgMembership'
             - 'User'
-            - 'ConnectedAccount'
           example: 'Organization'
         data:
           type: object


### PR DESCRIPTION
- Standardized the formatting of tags in the API schema for connected accounts and user endpoints to improve consistency and readability.
- Added a new query parameter for filtering permissions by type in the permissions endpoint.
- Introduced a new endpoint to retrieve the support email hash for the current logged-in user.
- Removed the deprecated endpoint for retrieving the authenticated user details.

These changes enhance the clarity and maintainability of the Scalekit API documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added support hash retrieval endpoint for enhanced user support workflows
* Introduced connected accounts management capabilities (create, read, update, delete operations)
* Added domain management endpoints with improved domain-type semantics
* Enhanced session responses with authenticated client information
* Expanded organization membership data with detailed permission listings and permission type distinctions
* Introduced new permission and connector status enums for improved data modeling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->