### PR TITLE
Posthog testskit exclusion

### DIFF
--- a/public/js/posthog.js
+++ b/public/js/posthog.js
@@ -11,6 +11,7 @@ const INTERNAL_USER_EMAIL_PATTERNS = [
   /@scalekit\.com$/i,
   /@scalekit\.pro$/i,
   /testskit9/i,
+  /testskit/i,
   /\+sktest/i,
   /amit\.ash/i,
   /kuntal\+testutk/i,


### PR DESCRIPTION
Add `/testskit/i` to `INTERNAL_USER_EMAIL_PATTERNS` to exclude testskit emails from PostHog tracking.

---
[Slack Thread](https://scalekit-inc.slack.com/archives/D092N521Z8X/p1771255925897349?thread_ts=1771255925.897349&cid=D092N521Z8X)

<p><a href="https://cursor.com/background-agent?bcId=bc-aa8a3337-b999-5ca6-93bd-5db57e43beee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aa8a3337-b999-5ca6-93bd-5db57e43beee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended internal user identification configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->