### PR TITLE
docs: update Google OAuth consent screen documentation

### DIFF
--- a/src/content/docs/guides/integrations/social-connections/google.mdx
+++ b/src/content/docs/guides/integrations/social-connections/google.mdx
@@ -124,7 +124,7 @@ Before using custom credentials in production, understand what users will see on
 
 </Aside>
 
-For Google's verification requirements and timeline, refer to <a href="https://support.google.com/cloud/answer/6158849" target="_blank" rel="noopener">Google's OAuth consent screen verification guide</a>.
+For Google's verification requirements and timeline, refer to <a href="https://support.google.com/cloud/answer/13463073" target="_blank" rel="noopener">Google's OAuth consent screen verification guide</a>.
 
 ![Google OAuth configuration in Scalekit, showing redirect URI, client credentials, and scopes for social login setup.](@/assets/docs/common/social-connections/3-google-oauth-config.png)
 


### PR DESCRIPTION
- Add important note about External audience type requirement for social login
- Add comparison table for Internal vs External audience types
- Explain why Internal cannot be used for public-facing authentication
- Update link to Google's verification guide
- Improve table styling with word-wrap and vertical alignment

See full changes in 2026-W7-hosted-widgets branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Google OAuth integration guide with clearer step-by-step guidance and an explicit “Important” note about External vs Internal audiences
  * Added a titled aside explaining Google OAuth consent screen behavior, when to use External, and verification implications
  * Reworked table layouts for improved readability and word-wrapping
  * Updated references to Google's consent screen verification documentation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->