### PR TITLE
refactor: hide HubSpot script loading and iframe detection

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -209,13 +209,27 @@ export default defineConfig({
         },
         {
           tag: 'script',
-          attrs: {
-            type: 'text/javascript',
-            id: 'hs-script-loader',
-            async: true,
-            defer: true,
-            src: '//js-na2.hs-scripts.com/44204598.js',
-          },
+          content: `
+            ;(function () {
+              function inIframe() {
+                try {
+                  return window.self !== window.top
+                } catch (e) {
+                  return true
+                }
+              }
+
+              if (inIframe()) return
+
+              var script = document.createElement('script')
+              script.type = 'text/javascript'
+              script.id = 'hs-script-loader'
+              script.async = true
+              script.defer = true
+              script.src = '//js-na2.hs-scripts.com/44204598.js'
+              document.head.appendChild(script)
+            })()
+          `,
         },
       ],
     }),

--- a/public/js/pylon-widget.js
+++ b/public/js/pylon-widget.js
@@ -96,6 +96,14 @@
     } catch (e) {}
   }
 
+  var inIframe = function () {
+    try {
+      return window.self !== window.top
+    } catch (e) {
+      return true
+    }
+  }
+
   /**
    * Initialize Pylon configuration
    */
@@ -215,6 +223,11 @@
    * Initialize minimal config for anonymous users
    */
   var initializeMinimalConfig = function () {
+    if (inIframe()) {
+      console.log('[chat] iframe detected — skipping HubSpot widget')
+      return
+    }
+
     // Anonymous user: show HubSpot instead of Pylon
     console.log('[chat] anonymous user — loading HubSpot widget')
     if (window.HubSpotConversations) {


### PR DESCRIPTION
- Updated the HubSpot script loading mechanism to check if the page is in an iframe before appending the script.
- Added a new function to detect iframe context in the pylon-widget.js file to prevent loading the HubSpot widget when in an iframe.