### PR TITLE
docs: document offline_access scope requirement and refresh token rotation

### DIFF
--- a/src/content/docs/authenticate/fsa/manage-session.mdx
+++ b/src/content/docs/authenticate/fsa/manage-session.mdx
@@ -56,11 +56,11 @@ This guide shows you how to store these tokens securely with encryption and prop
    <Aside type="caution" title="Request offline_access to receive a refresh token">
    A refresh token is only included in the authentication response when you include the `offline_access` scope in your authorization URL. If your authorization URL does not include `offline_access`, `authResult.refreshToken` will be `null` or undefined.
 
-   Always include `offline_access` alongside `openid`, `profile`, and `email` when building your authorization URL:
+    Always include `offline_access` alongside `openid`, `profile`, and `email` when building your authorization URL:
 
-   ```
-   scopes: ['openid', 'profile', 'email', 'offline_access']
-   ```
+    ```js
+    scopes: ['openid', 'profile', 'email', 'offline_access']
+    ```
 
    Additionally, Scalekit **rotates refresh tokens** — every time you use a refresh token to get a new access token, you receive a new refresh token. Store the new refresh token immediately and discard the old one. Replaying a used refresh token will result in an error.
    </Aside>


### PR DESCRIPTION
## Summary

- Adds a caution callout in the session management guide explaining that `offline_access` must be included in the authorization URL scopes to receive a refresh token (`authResult.refreshToken` is `null` without it)
- Documents that Scalekit rotates refresh tokens on every use — the old token must be replaced immediately or reuse will fail
- Adds a collapsible TypeScript tip showing how to use generic types with `validateToken` (`JWTPayload` for access tokens, `IdTokenClaim` for ID tokens) to avoid `unknown` type errors

Closes issues: #450, #404, #402

## Test plan
- [ ] Verify callout renders correctly in the session management page
- [ ] Confirm collapsible details/summary works as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on requesting offline_access and refresh token rotation; clarified refresh token issuance and rotation requirements.
  * Added TypeScript examples showing how to obtain typed claims from token validation.
  * Added multi-language (Node.js, Python, Go, Java) examples for securely storing/encrypting tokens in cookies.
  * Minor wording corrections and enhanced example presentation for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->