### PR TITLE
docs: add custom domain tip to MCP production deployment checklist

### DIFF
--- a/src/content/docs/authenticate/mcp/quickstart.mdx
+++ b/src/content/docs/authenticate/mcp/quickstart.mdx
@@ -554,6 +554,7 @@ Your MCP server now has production-ready OAuth 2.1 authorization! You've success
   - Store client secrets securely using environment variables or secret management systems
   - Configure appropriate token lifetimes based on your security requirements
   - Test with various AI hosts (Claude Desktop, Cursor, VS Code) to verify compatibility
+  - Configure a [custom domain](/agent-auth/advanced/custom-domain) for your Scalekit environment so the OAuth consent screen shows a branded URL (e.g., `auth.yourapp.com`) instead of the auto-generated one
 </Aside>
 
 In summary,


### PR DESCRIPTION
## Summary

- Adds a note to the MCP production deployment checklist about configuring a custom domain so the OAuth consent screen shows a branded URL instead of the auto-generated Scalekit environment URL

Closes issue: #524

## Test plan
- [ ] Verify checklist renders correctly in the MCP quickstart page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance to the production deployment checklist for configuring a custom domain to display a branded OAuth consent URL instead of the auto-generated one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->