### PR TITLE
docs(agent-auth): add Node.js SDK tabs and fix SDK method references

### DIFF
--- a/src/content/docs/agent-auth/connected-accounts.mdx
+++ b/src/content/docs/agent-auth/connected-accounts.mdx
@@ -375,7 +375,7 @@ Custom metadata is managed via the Scalekit dashboard.
 
 ### Managing multiple accounts
 
-List and delete connected accounts using the SDK:
+The Python SDK supports per-account retrieval via `actions.get_or_create_connected_account`. Bulk list and delete operations (`connectedAccounts.listConnectedAccounts`, `connectedAccounts.deleteConnectedAccount`) are available in the Node.js SDK, or via the direct API and dashboard.
 
 <Tabs syncKey="tech-stack">
 <TabItem label="Python">

--- a/src/content/docs/agent-auth/connected-accounts.mdx
+++ b/src/content/docs/agent-auth/connected-accounts.mdx
@@ -81,61 +81,29 @@ F -> B
 
 Create connected accounts programmatically:
 
-<Tabs>
-<TabItem value="curl" label="cURL">
-
-```bash
-curl -X POST "https://api.scalekit.com/v1/connect/accounts" \
-  -H "Authorization: Bearer YOUR_API_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "connection_id": "conn_gmail_oauth",
-    "identifier": "user_123",
-    "identifier_type": "user_id",
-    "scopes": ["https://www.googleapis.com/auth/gmail.send"],
-    "settings": {
-      "auto_refresh": true,
-      "expires_in": 3600
-    }
-  }'
-```
-
-</TabItem>
-<TabItem value="javascript" label="JavaScript">
-
-```javascript
-const connectedAccount = await agentConnect.accounts.create({
-  connection_id: 'conn_gmail_oauth',
-  identifier: 'user_123',
-  identifier_type: 'user_id',
-  scopes: ['https://www.googleapis.com/auth/gmail.send'],
-  settings: {
-    auto_refresh: true,
-    expires_in: 3600
-  }
-});
-
-// Generate authorization URL for user
-const authUrl = await agentConnect.accounts.getAuthUrl(connectedAccount.id);
-```
-
-</TabItem>
-<TabItem value="python" label="Python">
+<Tabs syncKey="tech-stack">
+<TabItem label="Python">
 
 ```python
-connected_account = agent_connect.accounts.create(
-    connection_id='conn_gmail_oauth',
-    identifier='user_123',
-    identifier_type='user_id',
-    scopes=['https://www.googleapis.com/auth/gmail.send'],
-    settings={
-        'auto_refresh': True,
-        'expires_in': 3600
-    }
+response = actions.get_or_create_connected_account(
+    connection_name="gmail",
+    identifier="user_123"
 )
+connected_account = response.connected_account
+print(f"Connected account: {connected_account.id}, status: {connected_account.status}")
+```
 
-# Generate authorization URL for user
-auth_url = agent_connect.accounts.get_auth_url(connected_account.id)
+</TabItem>
+<TabItem label="Node.js">
+
+```typescript
+const response = await connectedAccounts.getOrCreateConnectedAccount({
+  connector: 'gmail',
+  identifier: 'user_123',
+});
+
+const connectedAccount = response.connectedAccount;
+console.log('Connected account:', connectedAccount?.id, 'status:', connectedAccount?.status);
 ```
 
 </TabItem>
@@ -160,113 +128,89 @@ For OAuth connections, connected accounts follow the standard OAuth flow:
 
 Generate URLs for users to complete authentication:
 
-```javascript
-// Generate authorization URL
-const authUrl = await agentConnect.accounts.getAuthUrl('account_id', {
-  state: 'custom_state_value',
-  redirect_uri: 'https://your-app.com/callback',
-  scopes: ['additional_scope']
-});
+<Tabs syncKey="tech-stack">
+<TabItem label="Python">
 
-// Example generated URL
-// https://accounts.google.com/oauth/authorize?
-//   client_id=your_client_id&
-//   redirect_uri=https://your-app.com/callback&
-//   scope=https://www.googleapis.com/auth/gmail.send&
-//   response_type=code&
-//   state=custom_state_value
-```
-
-### Handling callbacks
-
-Process the OAuth callback to complete authentication:
-
-<Tabs>
-<TabItem value="javascript" label="JavaScript">
-
-```javascript
-// Handle OAuth callback
-app.get('/callback', async (req, res) => {
-  const { code, state, error } = req.query;
-
-  if (error) {
-    // Handle OAuth error
-    return res.status(400).json({ error: error });
-  }
-
-  try {
-    // Exchange code for tokens
-    const result = await agentConnect.accounts.exchangeCode(
-      'account_id',
-      code,
-      state
-    );
-
-    // Account is now active
-    res.json({ status: 'success', account: result });
-  } catch (err) {
-    res.status(500).json({ error: err.message });
-  }
-});
+```python
+link_response = actions.get_authorization_link(
+    connection_name="gmail",
+    identifier="user_123"
+)
+print(f"Authorization URL: {link_response.link}")
+# Redirect the user to link_response.link to complete OAuth
 ```
 
 </TabItem>
-<TabItem value="python" label="Python">
+<TabItem label="Node.js">
 
-```python
-@app.route('/callback')
-def handle_callback():
-    code = request.args.get('code')
-    state = request.args.get('state')
-    error = request.args.get('error')
+```typescript
+const linkResponse = await connectedAccounts.getMagicLinkForConnectedAccount({
+  connector: 'gmail',
+  identifier: 'user_123',
+});
 
-    if error:
-        return jsonify({'error': error}), 400
-
-    try:
-        # Exchange code for tokens
-        result = agent_connect.accounts.exchange_code(
-            'account_id',
-            code,
-            state
-        )
-
-        # Account is now active
-        return jsonify({'status': 'success', 'account': result})
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+console.log('Authorization URL:', linkResponse.link);
+// Redirect the user to linkResponse.link to complete OAuth
 ```
 
 </TabItem>
 </Tabs>
 
+### Handling callbacks
+
+Scalekit handles the OAuth callback automatically. Once the user completes the authorization flow, Scalekit exchanges the code for tokens and updates the connected account status to `ACTIVE`.
+
 ## Managing connected accounts
 
 ### Account information
 
-Retrieve connected account details:
+Retrieve connected account details and OAuth tokens:
 
-```javascript
-const account = await agentConnect.accounts.get('account_id');
+<Tabs syncKey="tech-stack">
+<TabItem label="Python">
 
-// Account object structure
-{
-  "id": "account_123",
-  "connection_id": "conn_gmail_oauth",
-  "identifier": "user_123",
-  "identifier_type": "user_id",
-  "provider": "gmail",
-  "status": "active",
-  "scopes": ["https://www.googleapis.com/auth/gmail.send"],
-  "created_at": "2024-01-15T10:30:00Z",
-  "updated_at": "2024-01-15T10:45:00Z",
-  "expires_at": "2024-01-15T11:45:00Z",
-  "metadata": {
-    "user_email": "user@example.com",
-    "provider_account_id": "google_user_123"
-  }
-}
+```python
+response = actions.get_connected_account(
+    connection_name="gmail",
+    identifier="user_123"
+)
+connected_account = response.connected_account
+
+# Extract OAuth tokens from authorization details
+tokens = connected_account.authorization_details["oauth_token"]
+access_token = tokens["access_token"]
+refresh_token = tokens["refresh_token"]
+
+print(f"Account ID: {connected_account.id}")
+print(f"Status: {connected_account.status}")
 ```
+
+</TabItem>
+<TabItem label="Node.js">
+
+```typescript
+const accountResponse = await connectedAccounts.getConnectedAccountByIdentifier({
+  connector: 'gmail',
+  identifier: 'user_123',
+});
+
+const connectedAccount = accountResponse?.connectedAccount;
+const authDetails = connectedAccount?.authorizationDetails;
+
+// Extract OAuth tokens from authorization details
+const accessToken = (authDetails && authDetails.details?.case === 'oauthToken')
+  ? authDetails.details.value?.accessToken
+  : undefined;
+const refreshToken = (authDetails && authDetails.details?.case === 'oauthToken')
+  ? authDetails.details.value?.refreshToken
+  : undefined;
+
+console.log('Account ID:', connectedAccount?.id);
+console.log('Status:', connectedAccount?.status);
+```
+
+</TabItem>
+</Tabs>
 
 ### Token management
 
@@ -278,30 +222,97 @@ Connected accounts automatically handle token lifecycle:
 - Failed refresh attempts update account status to expired
 
 **Manual token refresh:**
-```javascript
-// Manually refresh tokens
-const refreshed = await agentConnect.accounts.refreshTokens('account_id');
 
-// Check token status
-const tokenStatus = await agentConnect.accounts.getTokenStatus('account_id');
+There is no SDK method to manually trigger a token refresh. If a connected account's status is `EXPIRED` or `ERROR`, generate a new authorization link and prompt the user to re-authorize:
+
+<Tabs syncKey="tech-stack">
+<TabItem label="Python">
+
+```python
+response = actions.get_or_create_connected_account(
+    connection_name="gmail",
+    identifier="user_123"
+)
+connected_account = response.connected_account
+
+if connected_account.status != "ACTIVE":
+    # Re-authorize the user to refresh their tokens
+    link_response = actions.get_authorization_link(
+        connection_name="gmail",
+        identifier="user_123"
+    )
+    print(f"Re-authorization required. Send user to: {link_response.link}")
 ```
+
+</TabItem>
+<TabItem label="Node.js">
+
+```typescript
+const response = await connectedAccounts.getOrCreateConnectedAccount({
+  connector: 'gmail',
+  identifier: 'user_123',
+});
+
+const connectedAccount = response.connectedAccount;
+
+if (connectedAccount?.status !== 'ACTIVE') {
+  // Re-authorize the user to refresh their tokens
+  const linkResponse = await connectedAccounts.getMagicLinkForConnectedAccount({
+    connector: 'gmail',
+    identifier: 'user_123',
+  });
+  console.log('Re-authorization required. Send user to:', linkResponse.link);
+}
+```
+
+</TabItem>
+</Tabs>
 
 ### Account status monitoring
 
 Monitor account authentication status:
 
-```javascript
-// Check account status
-const status = await agentConnect.accounts.getStatus('account_id');
+<Tabs syncKey="tech-stack">
+<TabItem label="Python">
+
+```python
+response = actions.get_or_create_connected_account(
+    connection_name="gmail",
+    identifier="user_123"
+)
+connected_account = response.connected_account
+
+# Possible status values:
+# - PENDING: Waiting for user authentication
+# - ACTIVE: Authenticated and ready
+# - EXPIRED: Tokens expired, needs re-authorization
+# - REVOKED: User revoked access
+# - ERROR: Authentication error
+print(f"Account status: {connected_account.status}")
+```
+
+</TabItem>
+<TabItem label="Node.js">
+
+```typescript
+const response = await connectedAccounts.getOrCreateConnectedAccount({
+  connector: 'gmail',
+  identifier: 'user_123',
+});
+
+const connectedAccount = response.connectedAccount;
 
 // Possible status values:
-// - pending: Waiting for user authentication
-// - active: Authenticated and ready
-// - expired: Tokens expired, needs refresh
-// - revoked: User revoked access
-// - error: Authentication error
-// - suspended: Account temporarily disabled
+// - PENDING: Waiting for user authentication
+// - ACTIVE: Authenticated and ready
+// - EXPIRED: Tokens expired, needs re-authorization
+// - REVOKED: User revoked access
+// - ERROR: Authentication error
+console.log('Account status:', connectedAccount?.status);
 ```
+
+</TabItem>
+</Tabs>
 
 ## Account permissions and scopes
 
@@ -356,90 +367,48 @@ These values are returned in API responses when listing or inspecting connection
 
 ### Custom metadata
 
-Store additional information with connected accounts:
-
-```javascript
-// Add custom metadata
-await agentConnect.accounts.updateMetadata('account_id', {
-  user_email: 'user@example.com',
-  department: 'engineering',
-  preferences: {
-    notification_settings: 'email',
-    timezone: 'UTC'
-  }
-});
-
-// Retrieve metadata
-const metadata = await agentConnect.accounts.getMetadata('account_id');
-```
-
-### Account settings
-
-Configure account-specific settings:
-
-```javascript
-// Update account settings
-await agentConnect.accounts.updateSettings('account_id', {
-  auto_refresh: true,
-  rate_limit: 100,
-  timeout: 30,
-  retry_attempts: 3
-});
-```
+Custom metadata is managed via the Scalekit dashboard.
 
 ## Bulk operations
 
 ### Managing multiple accounts
 
-Handle multiple connected accounts efficiently:
+List and delete connected accounts using the SDK:
 
-```javascript
-// Create multiple accounts
-const accounts = await agentConnect.accounts.createBulk([
-  {
-    connection_id: 'conn_gmail_oauth',
-    identifier: 'user_1',
-    identifier_type: 'user_id'
-  },
-  {
-    connection_id: 'conn_gmail_oauth',
-    identifier: 'user_2',
-    identifier_type: 'user_id'
-  }
-]);
+<Tabs syncKey="tech-stack">
+<TabItem label="Python">
 
-// Get accounts by connection
-const gmailAccounts = await agentConnect.accounts.list({
-  connection_id: 'conn_gmail_oauth'
-});
-
-// Get accounts by status
-const activeAccounts = await agentConnect.accounts.list({
-  status: 'active'
-});
+```python
+# List connected accounts for a connector (via dashboard or direct API)
+# Use get_or_create_connected_account to retrieve individual accounts by identifier
+response = actions.get_or_create_connected_account(
+    connection_name="gmail",
+    identifier="user_123"
+)
+connected_account = response.connected_account
+print(f"Account: {connected_account.id}, Status: {connected_account.status}")
 ```
 
-### Batch operations
+</TabItem>
+<TabItem label="Node.js">
 
-Perform operations on multiple accounts:
-
-```javascript
-// Refresh tokens for multiple accounts
-const refreshResults = await agentConnect.accounts.refreshTokensBulk([
-  'account_1',
-  'account_2',
-  'account_3'
-]);
-
-// Update settings for multiple accounts
-await agentConnect.accounts.updateSettingsBulk([
-  'account_1',
-  'account_2'
-], {
-  auto_refresh: true,
-  rate_limit: 150
+```typescript
+// List connected accounts
+const listResponse = await connectedAccounts.listConnectedAccounts({
+  connector: 'gmail',
 });
+console.log('Connected accounts:', listResponse);
+
+// Delete a connected account
+await connectedAccounts.deleteConnectedAccount({
+  connector: 'gmail',
+  identifier: 'user_123',
+});
+console.log('Connected account deleted');
 ```
+
+</TabItem>
+</Tabs>
 
 ## Error handling
 
@@ -447,29 +416,42 @@ await agentConnect.accounts.updateSettingsBulk([
 
 Handle common connected account errors:
 
-```javascript
+<Tabs syncKey="tech-stack">
+<TabItem label="Python">
+
+```python
+try:
+    response = actions.get_connected_account(
+        connection_name="gmail",
+        identifier="user_123"
+    )
+    connected_account = response.connected_account
+except Exception as e:
+    print(f"Error retrieving connected account: {e}")
+    # Check connected_account.status for EXPIRED, REVOKED, or ERROR states
+    # and prompt the user to re-authorize if needed
+```
+
+</TabItem>
+<TabItem label="Node.js">
+
+```typescript
 try {
-  const account = await agentConnect.accounts.get('account_id');
+  const accountResponse = await connectedAccounts.getConnectedAccountByIdentifier({
+    connector: 'gmail',
+    identifier: 'user_123',
+  });
+  const connectedAccount = accountResponse?.connectedAccount;
+  console.log('Account status:', connectedAccount?.status);
 } catch (error) {
-  switch (error.code) {
-    case 'ACCOUNT_NOT_FOUND':
-      // Account doesn't exist
-      break;
-    case 'ACCOUNT_EXPIRED':
-      // Tokens expired, refresh needed
-      break;
-    case 'ACCOUNT_REVOKED':
-      // User revoked access
-      break;
-    case 'INVALID_PERMISSIONS':
-      // Insufficient permissions
-      break;
-    default:
-      // Other errors
-      break;
-  }
+  console.error('Error retrieving connected account:', error);
+  // Check connectedAccount?.status for EXPIRED, REVOKED, or ERROR states
+  // and prompt the user to re-authorize if needed
 }
 ```
+
+</TabItem>
+</Tabs>
 
 ### Error recovery
 
@@ -516,36 +498,11 @@ Ensure proper account isolation:
 
 ### Account health monitoring
 
-Monitor connected account health:
-
-```javascript
-// Get account health metrics
-const health = await agentConnect.accounts.getHealth('account_id');
-
-// Health metrics include:
-// - Token expiry status
-// - Authentication success rate
-// - API error rates
-// - Last successful authentication
-```
+Monitor the status of connected accounts by calling `get_or_create_connected_account` (Python) or `getOrCreateConnectedAccount` (Node.js) and inspecting the `status` field. Accounts in a non-`ACTIVE` state may require re-authorization.
 
 ### Usage analytics
 
-Track account usage patterns:
-
-```javascript
-// Get account usage statistics
-const usage = await agentConnect.accounts.getUsage('account_id', {
-  start_date: '2024-01-01',
-  end_date: '2024-01-31'
-});
-
-// Usage data includes:
-// - Total tool executions
-// - API requests made
-// - Error rates
-// - Most used tools
-```
+Track usage patterns and tool execution results through the Scalekit dashboard. SDK methods for usage analytics are not currently available.
 
 ## Best practices
 
@@ -576,18 +533,35 @@ const usage = await agentConnect.accounts.getUsage('account_id', {
 
 Test connected accounts in development:
 
-```javascript
-// Create test account
-const testAccount = await agentConnect.accounts.create({
-  connection_id: 'conn_test_provider',
+<Tabs syncKey="tech-stack">
+<TabItem label="Python">
+
+```python
+# Create or retrieve a test connected account
+response = actions.get_or_create_connected_account(
+    connection_name="gmail",
+    identifier="test_user"
+)
+test_account = response.connected_account
+print(f"Test account: {test_account.id}, status: {test_account.status}")
+```
+
+</TabItem>
+<TabItem label="Node.js">
+
+```typescript
+// Create or retrieve a test connected account
+const response = await connectedAccounts.getOrCreateConnectedAccount({
+  connector: 'gmail',
   identifier: 'test_user',
-  identifier_type: 'user_id',
-  test_mode: true
 });
 
-// Use test tokens
-const testTokens = await agentConnect.accounts.getTestTokens('account_id');
+const testAccount = response.connectedAccount;
+console.log('Test account:', testAccount?.id, 'status:', testAccount?.status);
 ```
+
+</TabItem>
+</Tabs>
 
 ### Integration testing
 

--- a/src/content/docs/agent-auth/connected-accounts.mdx
+++ b/src/content/docs/agent-auth/connected-accounts.mdx
@@ -14,11 +14,7 @@ next:
   link: "/agent-auth/tools/execute"
 ---
 
-import { Aside, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
-
-<Aside type="note" title="Node.js beta version">
-  The Node.js SDK examples on this page require `@scalekit-sdk/node@2.2.0-beta.1`. Agent Auth features are in beta for Node.js. Install with: `npm install @scalekit-sdk/node@2.2.0-beta.1`
-</Aside>
+import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 
 Connected accounts in Agent Auth represent individual user or organization connections to third-party providers. They contain the authentication state, tokens, and permissions needed to execute tools on behalf of a specific identifier (user_id, org_id, or custom identifier).
 
@@ -102,6 +98,7 @@ print(f"Connected account: {connected_account.id}, status: {connected_account.st
 <TabItem label="Node.js">
 
 ```typescript
+// Requires @scalekit-sdk/node@2.2.0-beta.1: npm install @scalekit-sdk/node@2.2.0-beta.1
 const response = await connectedAccounts.getOrCreateConnectedAccount({
   connector: 'gmail',
   identifier: 'user_123',

--- a/src/content/docs/agent-auth/connected-accounts.mdx
+++ b/src/content/docs/agent-auth/connected-accounts.mdx
@@ -99,6 +99,7 @@ print(f"Connected account: {connected_account.id}, status: {connected_account.st
 
 ```typescript
 // Requires @scalekit-sdk/node@2.2.0-beta.1: npm install @scalekit-sdk/node@2.2.0-beta.1
+// const { connectedAccounts } = new ScalekitClient(ENV_URL, CLIENT_ID, CLIENT_SECRET)
 const response = await connectedAccounts.getOrCreateConnectedAccount({
   connector: 'gmail',
   identifier: 'user_123',
@@ -146,6 +147,7 @@ print(f"Authorization URL: {link_response.link}")
 <TabItem label="Node.js">
 
 ```typescript
+// Requires @scalekit-sdk/node@2.2.0-beta.1: npm install @scalekit-sdk/node@2.2.0-beta.1
 const linkResponse = await connectedAccounts.getMagicLinkForConnectedAccount({
   connector: 'gmail',
   identifier: 'user_123',

--- a/src/content/docs/agent-auth/connected-accounts.mdx
+++ b/src/content/docs/agent-auth/connected-accounts.mdx
@@ -14,7 +14,7 @@ next:
   link: "/agent-auth/tools/execute"
 ---
 
-import { Card, CardGrid, Aside, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Aside, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 
 <Aside type="note" title="Node.js beta version">
   The Node.js SDK examples on this page require `@scalekit-sdk/node@2.2.0-beta.1`. Agent Auth features are in beta for Node.js. Install with: `npm install @scalekit-sdk/node@2.2.0-beta.1`
@@ -89,6 +89,7 @@ Create connected accounts programmatically:
 <TabItem label="Python">
 
 ```python
+# actions = scalekit_client.actions  (initialize ScalekitClient first — see quickstart)
 response = actions.get_or_create_connected_account(
     connection_name="gmail",
     identifier="user_123"
@@ -280,7 +281,7 @@ Monitor account authentication status:
 <TabItem label="Python">
 
 ```python
-response = actions.get_or_create_connected_account(
+response = actions.get_connected_account(
     connection_name="gmail",
     identifier="user_123"
 )
@@ -299,12 +300,12 @@ print(f"Account status: {connected_account.status}")
 <TabItem label="Node.js">
 
 ```typescript
-const response = await connectedAccounts.getOrCreateConnectedAccount({
+const accountResponse = await connectedAccounts.getConnectedAccountByIdentifier({
   connector: 'gmail',
   identifier: 'user_123',
 });
 
-const connectedAccount = response.connectedAccount;
+const connectedAccount = accountResponse?.connectedAccount;
 
 // Possible status values:
 // - PENDING: Waiting for user authentication

--- a/src/content/docs/agent-auth/connected-accounts.mdx
+++ b/src/content/docs/agent-auth/connected-accounts.mdx
@@ -16,6 +16,10 @@ next:
 
 import { Card, CardGrid, Aside, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 
+<Aside type="note" title="Node.js beta version">
+  The Node.js SDK examples on this page require `@scalekit-sdk/node@2.2.0-beta.1`. Agent Auth features are in beta for Node.js. Install with: `npm install @scalekit-sdk/node@2.2.0-beta.1`
+</Aside>
+
 Connected accounts in Agent Auth represent individual user or organization connections to third-party providers. They contain the authentication state, tokens, and permissions needed to execute tools on behalf of a specific identifier (user_id, org_id, or custom identifier).
 
 ## What are connected accounts?

--- a/src/content/docs/agent-auth/connected-accounts.mdx
+++ b/src/content/docs/agent-auth/connected-accounts.mdx
@@ -503,7 +503,7 @@ Ensure proper account isolation:
 
 ### Account health monitoring
 
-Monitor the status of connected accounts by calling `get_or_create_connected_account` (Python) or `getOrCreateConnectedAccount` (Node.js) and inspecting the `status` field. Accounts in a non-`ACTIVE` state may require re-authorization.
+Monitor the status of connected accounts by calling `get_connected_account` (Python) or `getConnectedAccountByIdentifier` (Node.js) and inspecting the `status` field. Accounts in a non-`ACTIVE` state may require re-authorization.
 
 ### Usage analytics
 

--- a/src/content/docs/agent-auth/connected-accounts.mdx
+++ b/src/content/docs/agent-auth/connected-accounts.mdx
@@ -383,8 +383,8 @@ List and delete connected accounts using the SDK:
 <TabItem label="Python">
 
 ```python
-# List connected accounts for a connector (via dashboard or direct API)
-# Use get_or_create_connected_account to retrieve individual accounts by identifier
+# Retrieve an individual account by identifier
+# Note: listing all accounts for a connector is available via the dashboard or direct API
 response = actions.get_or_create_connected_account(
     connection_name="gmail",
     identifier="user_123"

--- a/src/content/docs/agent-auth/quickstart.mdx
+++ b/src/content/docs/agent-auth/quickstart.mdx
@@ -48,6 +48,9 @@ In this quickstart, you'll build a simple tool-calling program that:
         ```
       </TabItem>
     </Tabs>
+    <Aside type="note" title="Node.js beta version">
+      Agent Auth features (`connectedAccounts`, `tools`) are available in the Node.js SDK beta. Use `@scalekit-sdk/node@2.2.0-beta.1` until the stable release ships.
+    </Aside>
     <Tabs syncKey="tech-stack">
       <TabItem label="Python">
         ```python showLineNumbers=false frame="none" wrap

--- a/src/content/docs/agent-auth/quickstart.mdx
+++ b/src/content/docs/agent-auth/quickstart.mdx
@@ -39,7 +39,7 @@ In this quickstart, you'll build a simple tool-calling program that:
     <Tabs syncKey="tech-stack">
       <TabItem label="Python">
         ```sh showLineNumbers=false frame="none"
-        pip install scalekit-sdk-python
+        pip install scalekit-sdk-python python-dotenv requests
         ```
       </TabItem>
       <TabItem label="Node.js">
@@ -56,6 +56,7 @@ In this quickstart, you'll build a simple tool-calling program that:
         ```python showLineNumbers=false frame="none" wrap
         import scalekit.client
         import os
+        import requests
         from dotenv import load_dotenv
         load_dotenv()
 

--- a/src/content/docs/agent-auth/tools/authorize.mdx
+++ b/src/content/docs/agent-auth/tools/authorize.mdx
@@ -2,6 +2,9 @@
 title: Authorize a user
 description: Learn how to authorize users for successful tool execution with Agent Auth.
 ---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
 Scalekit provides a completely managed authentication platform to handle complex OAuth2.0, API Keys, Bearer Tokens and any other API authentication protocols required by third party applications to execute tool calls on behalf of users.
 
 This managed authentication handling enables you to build powerful agents without having to worry about handling user authentication and API authentication across different applications like Salesforce, Hubspot, GMail, Google Calendar etc.
@@ -12,24 +15,60 @@ If you are building an agent that needs to execute actions on behalf of a user, 
 
 The following code sample helps your agent complete user authorization required to make a successful authenticated tool call.
 
+<Tabs syncKey="tech-stack">
+<TabItem label="Python">
+
 ```python
-link_response = connect.get_authorization_link(
-    connection_name="gmail", # connection name to which the user needs to grant access.
-    identifier="user_123" # unique user id
+link_response = actions.get_authorization_link(
+    connection_name="gmail",  # connection name to which the user needs to grant access
+    identifier="user_123"     # unique user id
 )
-print(f"🔗click on the link to authorize gmail", link_response.link)
-input(f"⎆ Press Enter after authorizing gmail...")
+print(f"click on the link to authorize gmail", link_response.link)
+input(f"Press Enter after authorizing gmail...")
 ```
+
+</TabItem>
+<TabItem label="Node.js">
+
+```typescript
+const linkResponse = await connectedAccounts.getMagicLinkForConnectedAccount({
+  connector: 'gmail',      // connection name to which the user needs to grant access
+  identifier: 'user_123', // unique user id
+});
+console.log('click on the link to authorize gmail', linkResponse.link);
+// In production, redirect the user to linkResponse.link to complete the OAuth flow
+```
+
+</TabItem>
+</Tabs>
 
 ## Check Authorization Status
 
 If you would like to check whether the user has completed authorization for a given application,
 
+<Tabs syncKey="tech-stack">
+<TabItem label="Python">
+
 ```python
-response = connect.get_or_create_connected_account(
+response = actions.get_or_create_connected_account(
     connection_name="gmail",
     identifier="user_123"
 )
 connected_account = response.connected_account
-print(f"AUthorization status of the connected account", connected_account.status)
+print(f"Authorization status of the connected account", connected_account.status)
 ```
+
+</TabItem>
+<TabItem label="Node.js">
+
+```typescript
+const response = await connectedAccounts.getOrCreateConnectedAccount({
+  connector: 'gmail',
+  identifier: 'user_123',
+});
+const connectedAccount = response.connectedAccount;
+console.log('Authorization status of the connected account', connectedAccount?.status);
+```
+
+</TabItem>
+</Tabs>

--- a/src/content/docs/agent-auth/tools/execute.mdx
+++ b/src/content/docs/agent-auth/tools/execute.mdx
@@ -3,7 +3,7 @@ title: Tool Calling
 description: Learn how to execute tools in Agent Auth to interact with third-party applications using connected accounts.
 ---
 
-import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 Tool execution is the core functionality of Agent Auth that allows you to perform actions on third-party applications using connected accounts. Tools abstract complex API operations into simple, consistent function calls.
 
@@ -55,6 +55,7 @@ print(f'Recent emails: {tool_response.result}')
 <TabItem label="Node.js">
 
 ```typescript
+// Requires @scalekit-sdk/node@2.2.0-beta.1: npm install @scalekit-sdk/node@2.2.0-beta.1
 // Get the connected account first
 const { connectedAccount } = await connectedAccounts.getOrCreateConnectedAccount({
   connector: 'gmail',
@@ -79,7 +80,3 @@ console.log('Recent emails:', toolResponse.result);
 
 </TabItem>
 </Tabs>
-
-<Aside type="note" title="Node.js beta version">
-  The `tools.executeTool` method requires `@scalekit-sdk/node@2.2.0-beta.1`. Install with: `npm install @scalekit-sdk/node@2.2.0-beta.1`
-</Aside>

--- a/src/content/docs/agent-auth/tools/execute.mdx
+++ b/src/content/docs/agent-auth/tools/execute.mdx
@@ -31,6 +31,9 @@ Using Scalekit SDK, you can execute any action on behalf of a user using the fol
 - tool_name
 - tool_input_parameters
 
+<Tabs syncKey="tech-stack">
+<TabItem label="Python">
+
 ```python
 # Fetch recent emails
 tool_response = actions.execute_tool(
@@ -47,3 +50,26 @@ tool_response = actions.execute_tool(
 
 print(f'Recent emails: {tool_response.result}')
 ```
+
+</TabItem>
+<TabItem label="Node.js">
+
+```typescript
+// Fetch recent emails
+const toolResponse = await tools.executeTool({
+  // tool name to execute
+  toolName: 'gmail_fetch_mails',
+  // connected account gives the user context
+  connectedAccountId: connectedAccount?.id,
+  // tool input parameters
+  params: {
+    query: 'is:unread',
+    max_results: 5,
+  },
+});
+
+console.log('Recent emails:', toolResponse.result);
+```
+
+</TabItem>
+</Tabs>

--- a/src/content/docs/agent-auth/tools/execute.mdx
+++ b/src/content/docs/agent-auth/tools/execute.mdx
@@ -3,7 +3,7 @@ title: Tool Calling
 description: Learn how to execute tools in Agent Auth to interact with third-party applications using connected accounts.
 ---
 
-import { Card, CardGrid, Aside, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
 
 Tool execution is the core functionality of Agent Auth that allows you to perform actions on third-party applications using connected accounts. Tools abstract complex API operations into simple, consistent function calls.
 
@@ -79,3 +79,7 @@ console.log('Recent emails:', toolResponse.result);
 
 </TabItem>
 </Tabs>
+
+<Aside type="note" title="Node.js beta version">
+  The `tools.executeTool` method requires `@scalekit-sdk/node@2.2.0-beta.1`. Install with: `npm install @scalekit-sdk/node@2.2.0-beta.1`
+</Aside>

--- a/src/content/docs/agent-auth/tools/execute.mdx
+++ b/src/content/docs/agent-auth/tools/execute.mdx
@@ -37,15 +37,15 @@ Using Scalekit SDK, you can execute any action on behalf of a user using the fol
 ```python
 # Fetch recent emails
 tool_response = actions.execute_tool(
-    # connected_account gives the user context
-    connected_account_id=connected_account.id,
-    # tool name to execute
-    tool='gmail_fetch_mails',
     # tool input parameters
     tool_input={
         'query': 'is:unread',
         'max_results': 5
-    }
+    },
+    # tool name to execute
+    tool_name='gmail_fetch_mails',
+    # connected_account gives the user context
+    connected_account_id=connected_account.id,
 )
 
 print(f'Recent emails: {tool_response.result}')
@@ -55,6 +55,12 @@ print(f'Recent emails: {tool_response.result}')
 <TabItem label="Node.js">
 
 ```typescript
+// Get the connected account first
+const { connectedAccount } = await connectedAccounts.getOrCreateConnectedAccount({
+  connector: 'gmail',
+  identifier: 'user_123',
+});
+
 // Fetch recent emails
 const toolResponse = await tools.executeTool({
   // tool name to execute

--- a/src/content/docs/agent-auth/tools/execute.mdx
+++ b/src/content/docs/agent-auth/tools/execute.mdx
@@ -56,18 +56,12 @@ print(f'Recent emails: {tool_response.result}')
 
 ```typescript
 // Requires @scalekit-sdk/node@2.2.0-beta.1: npm install @scalekit-sdk/node@2.2.0-beta.1
-// Get the connected account first
-const { connectedAccount } = await connectedAccounts.getOrCreateConnectedAccount({
-  connector: 'gmail',
-  identifier: 'user_123',
-});
-
 // Fetch recent emails
 const toolResponse = await tools.executeTool({
   // tool name to execute
   toolName: 'gmail_fetch_mails',
-  // connected account gives the user context
-  connectedAccountId: connectedAccount?.id,
+  // connectedAccountId from a prior getOrCreateConnectedAccount call
+  connectedAccountId: 'your_connected_account_id',
   // tool input parameters
   params: {
     query: 'is:unread',


### PR DESCRIPTION
## Summary

- Added Node.js SDK tabs to all Agent Auth pages (`quickstart.mdx`, `connected-accounts.mdx`, `tools/authorize.mdx`, `tools/execute.mdx`) using real methods from the `agent-auth-apis` branch (`@scalekit-sdk/node@2.2.0-beta.1`)
- Replaced fictional `agentConnect.accounts.*` methods in `connected-accounts.mdx` with real SDK calls for both Python and Node.js
- Restored `agent-auth/connected-accounts` in the sidebar (was previously commented out)
- Fixed Python `execute_tool` parameter: `tool=` → `tool_name=`
- Fixed status monitoring sections to use read-only lookups (`get_connected_account` / `getConnectedAccountByIdentifier`) instead of mutating `get_or_create` calls
- Added beta version `<Aside>` notes on pages using Node.js Agent Auth methods
- Fixed `tools/authorize.mdx` Python variable: `connect.` → `actions.`
- Added missing `python-dotenv` and `requests` to pip install in quickstart; added `import requests` to the init block
- Removed unused `Card`/`CardGrid` imports from component import lines

## Why

The Agent Auth docs were using a mix of fictional SDK methods and outdated Node.js exclusions. The Node.js SDK methods (`connectedAccounts.*`, `tools.*`) are now available in the `agent-auth-apis` beta branch. This PR aligns all documentation with the actual SDK source for both Python (`feature/api-tokens`) and Node.js (`agent-auth-apis`).

## Test plan

- [x] `pnpm --filter scalekit-docs build` passes
- [x] Pre-push hook build passes
- [ ] Verify all Agent Auth pages render with Python + Node.js tabs
- [ ] Verify `agent-auth/connected-accounts` is visible in the sidebar
- [ ] Smoke-test Python snippets against `scalekit-sdk-python` `feature/api-tokens` branch
- [ ] Smoke-test Node.js snippets against `scalekit-sdk-node` `agent-auth-apis` branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote authentication and connected-accounts docs to use SDK-driven examples instead of cURL/raw API snippets.
  * Reorganized content into per-language tabbed demos (Python, Node.js) covering create/retrieve/authorize/manage flows and tool execution.
  * Updated Python SDK examples to reflect API usage changes and fixed an "Authorization" typo.
  * Added dependency guidance and a Node.js agent-auth beta note; simplified OAuth/token guidance to SDK-managed flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->