### PR TITLE
Use ConnectorStatus enum in quickstart

### DIFF
--- a/src/content/docs/agent-auth/quickstart.mdx
+++ b/src/content/docs/agent-auth/quickstart.mdx
@@ -140,8 +140,9 @@ In this quickstart, you'll build a simple tool-calling program that:
       </TabItem>
       <TabItem label="Node.js">
         ```typescript showLineNumbers=false frame="none" wrap
+        import { ConnectorStatus } from '@scalekit-sdk/node/pkg/grpc/scalekit/v1/connected_accounts/connected_accounts_pb';
         // Generate authorization link if user hasn't authorized or token is expired
-        if (connectedAccount?.status !== 'ACTIVE') {
+        if (connectedAccount?.status !== ConnectorStatus.ACTIVE) {
           console.log('gmail is not connected:', connectedAccount?.status);
           const linkResponse = await connectedAccounts.getMagicLinkForConnectedAccount({
             connector: 'gmail',


### PR DESCRIPTION
Import ConnectorStatus and update the Node.js quickstart snippet to compare connectedAccount.status against ConnectorStatus.ACTIVE instead of the raw string 'ACTIVE'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication quickstart examples to use proper constant references instead of string literals for improved code clarity and maintainability in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->