### PR TITLE
docs: reorder SSO OIDC integration guides

### DIFF
--- a/src/components/templates/_sso-integrations.mdx
+++ b/src/components/templates/_sso-integrations.mdx
@@ -30,11 +30,11 @@ import FoldCard from '@components/ui/FoldCard.astro';
   <FoldCard title="Generic SAML" href="/guides/integrations/sso-integrations/generic-saml" iconKey="saml">
     Configure SSO with any SAML-compliant identity provider
   </FoldCard>
-  <FoldCard title="Microsoft Entra ID - OIDC" href="/guides/integrations/sso-integrations/microsoft-entraid-oidc" iconKey="microsoft">
-    Set up SSO with Microsoft Entra ID using OpenID Connect
-  </FoldCard>
   <FoldCard title="Okta - OIDC" href="/guides/integrations/sso-integrations/okta-oidc" iconKey="okta">
     Configure SSO with Okta using OpenID Connect
+  </FoldCard>
+  <FoldCard title="Microsoft Entra ID - OIDC" href="/guides/integrations/sso-integrations/microsoft-entraid-oidc" iconKey="microsoft">
+    Set up SSO with Microsoft Entra ID using OpenID Connect
   </FoldCard>
   <FoldCard title="Generic OIDC" href="/guides/integrations/sso-integrations/generic-oidc" iconKey="open-id">
     Configure SSO with any OpenID Connect provider

--- a/src/content/docs/guides/integrations/sso-integrations/generic-oidc.mdx
+++ b/src/content/docs/guides/integrations/sso-integrations/generic-oidc.mdx
@@ -4,7 +4,7 @@ description: "Learn how to configure a generic OIDC identity provider for secure
 prev: false
 next: false
 sidebar:
-  order: 8
+  order: 9
   label: "Generic provider"
   badge:
     variant: note

--- a/src/content/docs/guides/integrations/sso-integrations/microsoft-entraid-oidc.mdx
+++ b/src/content/docs/guides/integrations/sso-integrations/microsoft-entraid-oidc.mdx
@@ -5,7 +5,7 @@ next: false
 description: "Learn how to set up OpenID Connect (OIDC) Single Sign-On (SSO) using Microsoft Entra ID, with step-by-step instructions for app registration and OIDC configuration."
 
 sidebar:
-  order: 7
+  order: 8
   label: "Microsoft Entra ID"
   badge:
     variant: note
@@ -54,9 +54,8 @@ This guide walks you through configuring Microsoft Entra ID as your OIDC identit
 
 4. ## Attribute Mapping
 
-   Go to **Token configuration** and click **Add optional claim**.
+   Go to **Token configuration** and click **Add optional claim**. Select token type **ID**, then add these claims: `email`, `family_name`, and `given_name`.
 
-   Select token type **ID**, then add these claims: `email`, `family_name`, and `given_name`.
    ![Add optional claim dialog with ID token claims email family_name and given_name selected](@/assets/docs/microsoft-entraid-oidc/2026-03-10-18-08-25.png)
    
 


### PR DESCRIPTION
## Summary
- move the `Microsoft Entra ID - OIDC` fold card below `Okta - OIDC` in the SSO integration template list
- update sidebar ordering so Microsoft Entra OIDC is order `8` and Generic OIDC is order `9`
- combine the Microsoft Entra token claim selection instruction into one concise step

## Validation
- `pnpm exec prettier --check src/components/templates/_sso-integrations.mdx src/content/docs/guides/integrations/sso-integrations/generic-oidc.mdx src/content/docs/guides/integrations/sso-integrations/microsoft-entraid-oidc.mdx`
- pre-push hook executed `pnpm run generate-search-index` and `pnpm run build` successfully (including internal link validation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced attribute mapping setup instructions for Microsoft Entra ID OIDC integration, providing clearer step-by-step guidance for token configuration and required claims setup.
  * Reorganized SSO integration documentation structure and navigation order to improve user experience and discoverability of integration guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->