### PR TITLE
fix(docs): correct SDK accessor paths for membership methods (membership → user client)

### DIFF
--- a/src/content/docs/authenticate/authz/assign-roles.mdx
+++ b/src/content/docs/authenticate/authz/assign-roles.mdx
@@ -253,7 +253,7 @@ To implement role assignment functionality, follow these essential prerequisites
 
     // Make the API call to update user roles
     try {
-      const result = await scalekit.membership.updateMembership({
+      const result = await scalekit.user.updateMembership({
         user_id: validationResult.data.user_id,
         organization_id: validationResult.data.organization_id,
         roles: validationResult.data.roles
@@ -298,7 +298,7 @@ To implement role assignment functionality, follow these essential prerequisites
 
     # Make the API call to update user roles
     try:
-        from scalekit.v1.memberships.memberships_pb2 import UpdateMembershipRequest
+        from scalekit.v1.users.users_pb2 import UpdateMembershipRequest
 
         request = UpdateMembershipRequest(
             user_id=validation_result['data']['user_id'],
@@ -306,7 +306,7 @@ To implement role assignment functionality, follow these essential prerequisites
             roles=validation_result['data']['roles']
         )
 
-        result = scalekit_client.memberships.update_membership(request=request)
+        result = scalekit_client.users.update_membership(request=request)
         print(f"Role assigned successfully: {result}")
 
         return jsonify({
@@ -394,7 +394,7 @@ To implement role assignment functionality, follow these essential prerequisites
             .addAllRoles((List<String>) data.get("roles"))
             .build();
 
-        UpdateMembershipResponse response = scalekitClient.memberships().updateMembership(updateRequest);
+        UpdateMembershipResponse response = scalekitClient.users().updateMembership(updateRequest);
         System.out.println("Role assigned successfully: " + response);
 
         return ResponseEntity.ok(Map.of(

--- a/src/content/docs/authenticate/manage-organizations/remove-users-from-organization.mdx
+++ b/src/content/docs/authenticate/manage-organizations/remove-users-from-organization.mdx
@@ -32,7 +32,7 @@ When a user is removed from an organization, they immediately lose access to tha
 
 ```javascript title="Remove users from organizations" wrap
 // Use case: Remove user during offboarding workflow triggered by HR system
-await scalekit.users.deleteMembership({
+await scalekit.user.deleteMembership({
   organizationId: 'org_12345',
   userId: 'usr_67890'
 })


### PR DESCRIPTION
## Summary

- Fixes 4 broken SDK accessor paths across `assign-roles.mdx` and `remove-users-from-organization.mdx`
- `membership`/`memberships` sub-client does not exist — methods live on the `user`/`users` client

## Findings fixed (D1–D4 from Phase 4 docs audit)

| ID | File | Language | Fix |
|----|------|----------|-----|
| D1 | `authenticate/authz/assign-roles.mdx` | Node.js | `scalekit.membership.updateMembership` → `scalekit.user.updateMembership` |
| D2 | `authenticate/authz/assign-roles.mdx` | Python | Import from `users_pb2`; `scalekit_client.memberships` → `scalekit_client.users` |
| D3 | `authenticate/authz/assign-roles.mdx` | Java | `scalekitClient.memberships().updateMembership` → `scalekitClient.users().updateMembership` |
| D4 | `authenticate/manage-organizations/remove-users-from-organization.mdx` | Node.js | `scalekit.users.deleteMembership` → `scalekit.user.deleteMembership` (singular) |

## Correct accessor reference

| Language | Correct accessor |
|----------|-----------------|
| Node.js | `scalekit.user` (singular property) |
| Python | `scalekit_client.users` (plural) |
| Go | `scalekitClient.User()` (singular method) |
| Java | `scalekitClient.users()` (plural method) |

## Test plan

- [ ] Verify Node.js code examples in both pages use `scalekit.user` (singular)
- [ ] Verify Python import is from `scalekit.v1.users.users_pb2` and accessor is `scalekit_client.users`
- [ ] Verify Java accessor is `scalekitClient.users().updateMembership(...)`
- [ ] Docs build passes (pre-push hook ran clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SDK code examples across Node.js, Python, Go, and Java to align with current API conventions for membership management operations.
  * Revised authentication and organization management guides with corrected method calls and import paths across all supported language SDKs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->