### PR TITLE
Harvest tools add and enrich all tool documentation

### DIFF
--- a/src/content/docs/reference/agent-connectors/harvestapi.mdx
+++ b/src/content/docs/reference/agent-connectors/harvestapi.mdx
@@ -204,7 +204,7 @@ Search LinkedIn profiles that offer specific services — freelancers, consultan
 | `search` | string | Yes | Service name or keywords (e.g., `"UX design"`, `"tax consulting"`) |
 | `location` | string | No | Location filter by city, state, or country |
 | `geo_id` | string | No | LinkedIn Geo ID for the location — overrides `location` when provided. Use `search_geo_id` to look up Geo IDs. |
-| `page` | string | No | Page number for pagination. Defaults to `1`. |
+| `page` | integer | No | Page number for pagination. Defaults to `1`. |
 
 ## `search_jobs`
 


### PR DESCRIPTION
Add missing tools: search_profiles, search_profile_services, search_companies, search_groups, get_linkedin_group, get_group_posts, get_profile_posts, get_company_posts, search_posts, get_linkedin_post, get_post_comments, get_post_reactions, get_comment_replies, get_comment_reactions, get_profile_comments, get_profile_reactions, search_linkedin_ads, get_linkedin_ad_details, search_geo_id, send_connection_request, get_sent_connection_requests, get_received_connection_requests, accept_connection_request, send_linkedin_message, get_my_api_user, get_private_account_pools

Enrich all tools with developer-facing details:
- Add li_at cookie warning Aside for all connection management tools
- Add search_profiles vs search_people guidance Aside
- Add Apify token setup note for bulk_scrape_profiles
- Add asterisk notes for all tools with alternative required params
- Clarify log_time_entry duration vs timer-based logging modes
- Add search_geo_id usage guidance across other tools
- Improve all parameter descriptions with format examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Harvest reference: clarified time logging modes (duration vs. timer), user permissions, and project/user discovery guidance.
  * Broadened LinkedIn data coverage: live access to profiles, companies, jobs, posts, ads, groups, search, and bulk operations with examples and pricing/credit notes.
  * Added Connection Management guidance and account utilities; standardized parameter rules, mutual-exclusion behavior, pagination, date formats, and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->