### PR TITLE
Add Vimeo setup section to connector docs

### DIFF
--- a/src/content/docs/reference/agent-connectors/vimeo.mdx
+++ b/src/content/docs/reference/agent-connectors/vimeo.mdx
@@ -14,6 +14,7 @@ head:
 ---
 
 import { Badge } from '@astrojs/starlight/components'
+import { SetupVimeoSection } from '@components/templates'
 
 <div class="grid grid-cols-5 gap-4 items-center">
  <div class="col-span-4">
@@ -26,6 +27,10 @@ import { Badge } from '@astrojs/starlight/components'
 
 Supports authentication: <Badge text="OAuth 2.0" />
 
+
+## Set up the agent connector
+
+<SetupVimeoSection />
 
 ## Tool list
 


### PR DESCRIPTION
## Add Vimeo setup section to connector docs


### Summary

  - Wire up the existing SetupVimeoSection component in
  vimeo.mdx — the setup template and screenshots were already
  in the repo but never linked from the connector page


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Set up the agent connector" section to the Vimeo connector documentation with step-by-step setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->