### PR TITLE
docs: remove uninstall marketplace section from build-with-ai quickstarts

### DIFF
--- a/src/components/templates/coding-agents/_agent-auth-claude-code.mdx
+++ b/src/components/templates/coding-agents/_agent-auth-claude-code.mdx
@@ -28,12 +28,6 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
    The marketplace provides specialized authentication plugins that understand Agent Auth patterns and OAuth 2.0 security requirements. These plugins guide the coding agent to generate implementation code that matches your project structure.
 
-   To remove the Scalekit Auth Stack marketplace, use the uninstall command:
-
-   ```bash title="Claude REPL" showLineNumbers=false
-   /plugin marketplace remove scalekit-auth-stack
-   ```
-
 2. ## Enable authentication plugins
 
    Select which authentication capabilities to activate in your development environment. Each plugin provides specific skills that the coding agent uses to generate authentication code.

--- a/src/components/templates/coding-agents/_agent-auth-github-copilot-cli.mdx
+++ b/src/components/templates/coding-agents/_agent-auth-github-copilot-cli.mdx
@@ -13,12 +13,6 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
    The marketplace provides specialized plugins that understand Agent Auth patterns and OAuth 2.0 security requirements. These plugins guide GitHub Copilot to generate implementation code that matches your project structure.
 
-   To remove the Scalekit authstack marketplace, use the remove command:
-
-   ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   copilot plugin marketplace remove github-copilot-authstack
-   ```
-
 2. ## Install the Agent Auth plugin
 
    Install the Agent Auth plugin to give GitHub Copilot the skills needed to generate agent authentication code:

--- a/src/components/templates/coding-agents/_fsa-claude-code.mdx
+++ b/src/components/templates/coding-agents/_fsa-claude-code.mdx
@@ -29,12 +29,6 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
    The marketplace provides specialized authentication plugins that understand full-stack auth patterns and OAuth 2.0 security requirements. These plugins guide the coding agent to generate implementation code that matches your project structure.
 
-   To remove the Scalekit Auth Stack marketplace, use the uninstall command:
-
-   ```bash title="Claude REPL" showLineNumbers=false
-   /plugin marketplace remove scalekit-auth-stack
-   ```
-
 2. ## Enable authentication plugins
 
    Select which authentication capabilities to activate in your development environment. Each plugin provides specific skills that the coding agent uses to generate authentication code.

--- a/src/components/templates/coding-agents/_fsa-github-copilot-cli.mdx
+++ b/src/components/templates/coding-agents/_fsa-github-copilot-cli.mdx
@@ -13,12 +13,6 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
    The marketplace provides specialized plugins that understand full-stack auth patterns and OAuth 2.0 security requirements. These plugins guide GitHub Copilot to generate implementation code that matches your project structure.
 
-   To remove the Scalekit authstack marketplace, use the remove command:
-
-   ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   copilot plugin marketplace remove github-copilot-authstack
-   ```
-
 2. ## Install the Full Stack Auth plugin
 
    Install the Full Stack Auth plugin to give GitHub Copilot the skills needed to generate complete authentication code:

--- a/src/components/templates/coding-agents/_mcp-auth-claude-code.mdx
+++ b/src/components/templates/coding-agents/_mcp-auth-claude-code.mdx
@@ -31,12 +31,6 @@ import enableClaudePluginGif from '@/assets/docs/ai-assisted-mcp-quickstart/2.gi
 
    The marketplace provides specialized authentication plugins that understand MCP server architectures and OAuth 2.1 security requirements. These plugins guide the coding agent to generate implementation code that matches your project structure.
 
-   To remove the Scalekit Auth Stack marketplace, use the uninstall command:
-
-   ```bash title="Claude REPL" showLineNumbers=false
-   /plugin marketplace remove scalekit-auth-stack
-   ```
-
 2. ## Enable authentication plugins
 
    Select which authentication capabilities to activate in your development environment. Each plugin provides specific skills that the coding agent uses to generate authentication code.

--- a/src/components/templates/coding-agents/_mcp-auth-github-copilot-cli.mdx
+++ b/src/components/templates/coding-agents/_mcp-auth-github-copilot-cli.mdx
@@ -13,12 +13,6 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
    The marketplace provides specialized plugins that understand MCP server architectures and OAuth 2.1 security requirements. These plugins guide GitHub Copilot to generate implementation code that matches your project structure.
 
-   To remove the Scalekit authstack marketplace, use the remove command:
-
-   ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   copilot plugin marketplace remove github-copilot-authstack
-   ```
-
 2. ## Install the MCP Auth plugin
 
    Install the MCP Auth plugin to give GitHub Copilot the skills needed to generate OAuth 2.1 authentication code for MCP servers:

--- a/src/components/templates/coding-agents/_scim-claude-code.mdx
+++ b/src/components/templates/coding-agents/_scim-claude-code.mdx
@@ -29,12 +29,6 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
    The marketplace provides specialized SCIM plugins that understand directory sync patterns and webhook security requirements. These plugins guide the coding agent to generate implementation code that matches your project structure.
 
-   To remove the Scalekit Auth Stack marketplace, use the uninstall command:
-
-   ```bash title="Claude REPL" showLineNumbers=false
-   /plugin marketplace remove scalekit-auth-stack
-   ```
-
 2. ## Enable SCIM plugins
 
    Select which directory sync capabilities to activate in your development environment. Each plugin provides specific skills that the coding agent uses to generate SCIM webhook handling code.

--- a/src/components/templates/coding-agents/_scim-github-copilot-cli.mdx
+++ b/src/components/templates/coding-agents/_scim-github-copilot-cli.mdx
@@ -14,12 +14,6 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
    The marketplace provides specialized plugins that understand directory sync patterns and webhook security requirements. These plugins guide GitHub Copilot to generate implementation code that matches your project structure.
 
-   To remove the Scalekit authstack marketplace, use the remove command:
-
-   ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   copilot plugin marketplace remove github-copilot-authstack
-   ```
-
 2. ## Install the Modular SCIM plugin
 
    Install the Modular SCIM plugin to give GitHub Copilot the skills needed to generate SCIM webhook handling code:

--- a/src/components/templates/coding-agents/_sso-claude-code.mdx
+++ b/src/components/templates/coding-agents/_sso-claude-code.mdx
@@ -29,12 +29,6 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
    The marketplace provides specialized authentication plugins that understand SSO patterns and SAML/OIDC security requirements. These plugins guide the coding agent to generate implementation code that matches your project structure.
 
-   To remove the Scalekit Auth Stack marketplace, use the uninstall command:
-
-   ```bash title="Claude REPL" showLineNumbers=false
-   /plugin marketplace remove scalekit-auth-stack
-   ```
-
 2. ## Enable authentication plugins
 
    Select which authentication capabilities to activate in your development environment. Each plugin provides specific skills that the coding agent uses to generate SSO code.

--- a/src/components/templates/coding-agents/_sso-github-copilot-cli.mdx
+++ b/src/components/templates/coding-agents/_sso-github-copilot-cli.mdx
@@ -13,12 +13,6 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
    The marketplace provides specialized plugins that understand SSO patterns and SAML/OIDC security requirements. These plugins guide GitHub Copilot to generate implementation code that matches your project structure.
 
-   To remove the Scalekit authstack marketplace, use the remove command:
-
-   ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   copilot plugin marketplace remove github-copilot-authstack
-   ```
-
 2. ## Install the Modular SSO plugin
 
    Install the Modular SSO plugin to give GitHub Copilot the skills needed to generate SSO code:


### PR DESCRIPTION
## Summary

Removes the 'To remove the marketplace' sentence and uninstall command block from all 10 coding-agent template files in the build-with-ai quickstart category.

### Files changed
All files under `src/components/templates/coding-agents/`:
- `_agent-auth-claude-code.mdx`
- `_fsa-claude-code.mdx`
- `_mcp-auth-claude-code.mdx`
- `_scim-claude-code.mdx`
- `_sso-claude-code.mdx`
- `_agent-auth-github-copilot-cli.mdx`
- `_fsa-github-copilot-cli.mdx`
- `_mcp-auth-github-copilot-cli.mdx`
- `_scim-github-copilot-cli.mdx`
- `_sso-github-copilot-cli.mdx`

### Change
Removed the sentence and code block that described how to uninstall/remove the plugin marketplace, across all 10 files. 60 lines deleted total.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified coding agent guides by removing marketplace uninstall instructions across multiple platforms and tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->