### PR TITLE
fix: resolve OOM (exit code 137) during Netlify builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,11 @@
     "unified": "^11.0.5"
   },
   "pnpm": {
+    "onlyBuiltDependencies": [
+      "sharp",
+      "esbuild",
+      "@parcel/watcher"
+    ],
     "overrides": {
       "@astrojs/starlight-docsearch": "file:./vendor/docsearch",
       "glob": "^11.0.0",

--- a/src/pages/og/[...slug].ts
+++ b/src/pages/og/[...slug].ts
@@ -1,3 +1,5 @@
+export const prerender = true;
+
 import { getCollection } from 'astro:content'
 import { OGImageRoute } from 'astro-og-canvas'
 


### PR DESCRIPTION
Two changes to fix the memory exhaustion during Astro 6 builds:

1. Allow sharp/esbuild/parcel-watcher native build scripts (package.json)
   - pnpm 10.x blocks postinstall scripts by default for security
   - Build log showed: 'Ignored build scripts: sharp@0.34.5, esbuild@...'
   - Without native sharp, canvaskit-wasm handles ALL image processing in pure WASM mode, consuming significantly more memory
   - Adding onlyBuiltDependencies ensures native bindings are compiled

2. Add prerender = true to OG image route (src/pages/og/[...slug].ts)
   - Build warned: 'getStaticPaths() ignored in dynamic page'
   - In Astro 6 with output: 'server', this route was treated as SSR
   - OG images are static by nature and should be prerendered
   - This prevents canvaskit-wasm from being loaded into the SSR bundle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration to optimize dependency handling during builds.

* **New Features**
  * Enabled page prerendering to improve load times and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->