### PR TITLE
fix: disable starlight-markdown route injection for Astro 6 compat

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -96,6 +96,7 @@ export default defineConfig({
         starlightContextualMenu({
           actions: ['copy', 'chatgpt', 'claude'],
           hideMainActionLabel: true,
+          injectMarkdownRoutes: false,
         }),
         // Provide copy-to-clipboard button for inline code snippets site-wide for better UX
         starlightCopyInlineCode({


### PR DESCRIPTION
…lity

starlight-contextual-menu depends on starlight-markdown which injects routes via injectRoute({ entrypoint: 'starlight-markdown/markdown.md.js' }).

In Astro 6, route resolution for bare package specifiers has changed, causing the build to look for the file at the project root instead of node_modules:

  ENOENT: no such file or directory, open
  '/opt/build/repo/starlight-markdown/markdown.md.js'

Both starlight-contextual-menu and starlight-markdown only declare peerDependency on astro ^5.0.0 and haven't been updated for Astro 6.

Setting injectMarkdownRoutes: false disables the broken route injection while keeping the contextual menu functionality (copy, chatgpt, claude actions) fully intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration for the contextual menu to disable automatic Markdown route injection. This adjustment affects how routes are discovered and displayed within the contextual menu interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->