### PR TITLE
fix: reduce build memory to resolve OOM (exit code 137)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -89,9 +89,15 @@ export default defineConfig({
           askAi: '8jKZkVuXS0hG',
         }),
         starlightVideos(),
-        starlightLinksValidator({
-          exclude: ['/apis/**'],
-        }),
+        // Links validator disabled in CI to reduce build memory usage.
+        // Run locally with: pnpm astro build (without NETLIFY env var)
+        ...(!process.env.NETLIFY
+          ? [
+              starlightLinksValidator({
+                exclude: ['/apis/**'],
+              }),
+            ]
+          : []),
         starlightLlmsTxt(llmsConfig),
         starlightContextualMenu({
           actions: ['copy', 'chatgpt', 'claude'],

--- a/src/pages/og/[...slug].ts
+++ b/src/pages/og/[...slug].ts
@@ -1,5 +1,3 @@
-export const prerender = true;
-
 import { getCollection } from 'astro:content'
 import { OGImageRoute } from 'astro-og-canvas'
 


### PR DESCRIPTION
Two changes to bring build memory under Netlify's ~8GB limit:

1. Revert prerender on OG image route (src/pages/og/[...slug].ts)
   - With prerender=true, Astro generates all 304 OG images at build time
   - Each image loads canvaskit-wasm (~50MB) and renders via canvas
   - This causes massive memory spikes during the build phase
   - Without prerender, OG images are generated on-demand at request time via SSR, spreading memory usage across individual requests

2. Disable starlight-links-validator on Netlify CI (astro.config.mjs)
   - The plugin invalidates content layer cache on every build
   - It holds the full link graph for 304 pages in memory
   - Combined with Astro 6's higher baseline memory, this pushes past the Netlify build memory limit
   - Validator still runs in local builds for developer workflow
   - CI builds skip it via process.env.NETLIFY check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted build configuration to disable link validation in CI/Netlify builds while maintaining local checks.
  * Modified OG page generation behavior by removing explicit prerender configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->