### PR TITLE
Proxy docs

### DIFF
--- a/src/components/templates/agent-connectors/_usage-airtable.mdx
+++ b/src/components/templates/agent-connectors/_usage-airtable.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Airtable account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with Airtable in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,3 +81,7 @@ Connect a user's Airtable account and make API calls on their behalf — Scaleki
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-asana.mdx
+++ b/src/components/templates/agent-connectors/_usage-asana.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Asana account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with Asana in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,3 +81,7 @@ Connect a user's Asana account and make API calls on their behalf — Scalekit h
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-attention.mdx
+++ b/src/components/templates/agent-connectors/_usage-attention.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Attention account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with Attention in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,3 +81,7 @@ Connect a user's Attention account and make API calls on their behalf — Scalek
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-bigquery.mdx
+++ b/src/components/templates/agent-connectors/_usage-bigquery.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's BigQuery account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with BigQuery in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,3 +81,7 @@ Connect a user's BigQuery account and make API calls on their behalf — Scaleki
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-chorus.mdx
+++ b/src/components/templates/agent-connectors/_usage-chorus.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Chorus account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with Chorus in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,3 +81,7 @@ Connect a user's Chorus account and make API calls on their behalf — Scalekit 
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-clari_copilot.mdx
+++ b/src/components/templates/agent-connectors/_usage-clari_copilot.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Clari Copilot account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with Clari Copilot in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,3 +81,7 @@ Connect a user's Clari Copilot account and make API calls on their behalf — Sc
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-clickup.mdx
+++ b/src/components/templates/agent-connectors/_usage-clickup.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's ClickUp account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with ClickUp in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,3 +81,7 @@ Connect a user's ClickUp account and make API calls on their behalf — Scalekit
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-confluence.mdx
+++ b/src/components/templates/agent-connectors/_usage-confluence.mdx
@@ -4,6 +4,10 @@ Connect a user's Confluence account and make API calls on their behalf — Scale
 
 **Don't worry about the Confluence cloud ID in the path.** Scalekit automatically resolves `{{cloud_id}}` from the connected account's configuration. For example, a request with `path="/wiki/rest/api/user/current"` will be sent to `https://api.atlassian.com/ex/confluence/a1b2c3d4-e5f6-7890-abcd-ef1234567890/wiki/rest/api/user/current` automatically.
 
+You can interact with Confluence in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -79,3 +83,7 @@ Connect a user's Confluence account and make API calls on their behalf — Scale
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-confluence.mdx
+++ b/src/components/templates/agent-connectors/_usage-confluence.mdx
@@ -2,6 +2,8 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Confluence account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+**Don't worry about the Confluence cloud ID in the path.** Scalekit automatically resolves `{{cloud_id}}` from the connected account's configuration. For example, a request with `path="/wiki/rest/api/user/current"` will be sent to `https://api.atlassian.com/ex/confluence/a1b2c3d4-e5f6-7890-abcd-ef1234567890/wiki/rest/api/user/current` automatically.
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">

--- a/src/components/templates/agent-connectors/_usage-dropbox.mdx
+++ b/src/components/templates/agent-connectors/_usage-dropbox.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Dropbox account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with Dropbox in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,3 +81,7 @@ Connect a user's Dropbox account and make API calls on their behalf — Scalekit
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-exa.mdx
+++ b/src/components/templates/agent-connectors/_usage-exa.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem, Aside } from '@astrojs/starlight/components'
 
 Once a connected account is set up, make API calls through the Scalekit proxy. Scalekit injects the Exa API key automatically — you never handle credentials in your application code.
 
+You can interact with Exa in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
   <TabItem label="Python">
     ```python
@@ -36,3 +40,7 @@ Once a connected account is set up, make API calls through the Scalekit proxy. S
 <Aside type="tip">
 Exa uses API key auth — unlike OAuth connectors, there is no authorization link or redirect flow. Once you call `upsert_connected_account` (or add an account via the dashboard), your users can make requests immediately.
 </Aside>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-fathom.mdx
+++ b/src/components/templates/agent-connectors/_usage-fathom.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Fathom account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with Fathom in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,3 +81,7 @@ Connect a user's Fathom account and make API calls on their behalf — Scalekit 
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-freshdesk.mdx
+++ b/src/components/templates/agent-connectors/_usage-freshdesk.mdx
@@ -2,6 +2,8 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Freshdesk account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+**Don't worry about your Freshdesk domain in the path.** Scalekit automatically resolves `{{domain}}` from the connected account's configuration and constructs the full URL for you. For example, if your Freshdesk domain is `mycompany.freshdesk.com`, a request with `path="/v2/agents/me"` will be sent to `https://mycompany.freshdesk.com/api/v2/agents/me` automatically.
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -33,7 +35,7 @@ Connect a user's Freshdesk account and make API calls on their behalf — Scalek
     const result = await actions.request({
       connectionName,
       identifier,
-      path: '/api/v2/agents/me',
+      path: '/v2/agents/me',
       method: 'GET',
     });
     console.log(result);
@@ -70,7 +72,7 @@ Connect a user's Freshdesk account and make API calls on their behalf — Scalek
     result = actions.request(
         connection_name=connection_name,
         identifier=identifier,
-        path="/api/v2/agents/me",
+        path="/v2/agents/me",
         method="GET"
     )
     print(result)

--- a/src/components/templates/agent-connectors/_usage-freshdesk.mdx
+++ b/src/components/templates/agent-connectors/_usage-freshdesk.mdx
@@ -4,6 +4,10 @@ Connect a user's Freshdesk account and make API calls on their behalf — Scalek
 
 **Don't worry about your Freshdesk domain in the path.** Scalekit automatically resolves `{{domain}}` from the connected account's configuration and constructs the full URL for you. For example, if your Freshdesk domain is `mycompany.freshdesk.com`, a request with `path="/v2/agents/me"` will be sent to `https://mycompany.freshdesk.com/api/v2/agents/me` automatically.
 
+You can interact with Freshdesk in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -79,3 +83,7 @@ Connect a user's Freshdesk account and make API calls on their behalf — Scalek
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-github.mdx
+++ b/src/components/templates/agent-connectors/_usage-github.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's GitHub account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with GitHub in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,3 +81,7 @@ Connect a user's GitHub account and make API calls on their behalf — Scalekit 
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-gmail.mdx
+++ b/src/components/templates/agent-connectors/_usage-gmail.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Gmail account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with Gmail in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,3 +81,7 @@ Connect a user's Gmail account and make API calls on their behalf — Scalekit h
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-gmail.mdx
+++ b/src/components/templates/agent-connectors/_usage-gmail.mdx
@@ -33,7 +33,7 @@ Connect a user's Gmail account and make API calls on their behalf — Scalekit h
     const result = await actions.request({
       connectionName,
       identifier,
-      path: '/v1/users/me/profile',
+      path: '/gmail/v1/users/me/profile',
       method: 'GET',
     });
     console.log(result);
@@ -70,7 +70,7 @@ Connect a user's Gmail account and make API calls on their behalf — Scalekit h
     result = actions.request(
         connection_name=connection_name,
         identifier=identifier,
-        path="/v1/users/me/profile",
+        path="/gmail/v1/users/me/profile",
         method="GET"
     )
     print(result)

--- a/src/components/templates/agent-connectors/_usage-gong.mdx
+++ b/src/components/templates/agent-connectors/_usage-gong.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Gong account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with Gong in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,3 +81,7 @@ Connect a user's Gong account and make API calls on their behalf — Scalekit ha
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-google_ads.mdx
+++ b/src/components/templates/agent-connectors/_usage-google_ads.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Google Ads account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with Google Ads in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,3 +81,7 @@ Connect a user's Google Ads account and make API calls on their behalf — Scale
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-googlecalendar.mdx
+++ b/src/components/templates/agent-connectors/_usage-googlecalendar.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Google Calendar account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with Google Calendar in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,3 +81,7 @@ Connect a user's Google Calendar account and make API calls on their behalf — 
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-googledocs.mdx
+++ b/src/components/templates/agent-connectors/_usage-googledocs.mdx
@@ -33,7 +33,7 @@ Connect a user's Google Docs account and make API calls on their behalf — Scal
     const result = await actions.request({
       connectionName,
       identifier,
-      path: '/docs/v1/documents',
+      path: '/v1/documents',
       method: 'GET',
     });
     console.log(result);
@@ -70,7 +70,7 @@ Connect a user's Google Docs account and make API calls on their behalf — Scal
     result = actions.request(
         connection_name=connection_name,
         identifier=identifier,
-        path="/docs/v1/documents",
+        path="/v1/documents",
         method="GET"
     )
     print(result)

--- a/src/components/templates/agent-connectors/_usage-googledocs.mdx
+++ b/src/components/templates/agent-connectors/_usage-googledocs.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Google Docs account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with Google Docs in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,6 +81,8 @@ Connect a user's Google Docs account and make API calls on their behalf — Scal
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
 
 ## `googledocs_create_document`
 

--- a/src/components/templates/agent-connectors/_usage-googledrive.mdx
+++ b/src/components/templates/agent-connectors/_usage-googledrive.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Google Drive account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with Google Drive in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,6 +81,8 @@ Connect a user's Google Drive account and make API calls on their behalf — Sca
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
 
 ## File operations
 

--- a/src/components/templates/agent-connectors/_usage-googleforms.mdx
+++ b/src/components/templates/agent-connectors/_usage-googleforms.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Google Forms account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with Google Forms in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,3 +81,7 @@ Connect a user's Google Forms account and make API calls on their behalf — Sca
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-googlemeet.mdx
+++ b/src/components/templates/agent-connectors/_usage-googlemeet.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Google Meet account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with Google Meet in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,3 +81,7 @@ Connect a user's Google Meet account and make API calls on their behalf — Scal
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-googlesheets.mdx
+++ b/src/components/templates/agent-connectors/_usage-googlesheets.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Google Sheets account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with Google Sheets in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,6 +81,8 @@ Connect a user's Google Sheets account and make API calls on their behalf — Sc
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
 
 ## `googlesheets_create_spreadsheet`
 

--- a/src/components/templates/agent-connectors/_usage-googleslides.mdx
+++ b/src/components/templates/agent-connectors/_usage-googleslides.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Google Slides account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with Google Slides in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,3 +81,7 @@ Connect a user's Google Slides account and make API calls on their behalf — Sc
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-harvestapi.mdx
+++ b/src/components/templates/agent-connectors/_usage-harvestapi.mdx
@@ -23,7 +23,7 @@ Once a connected account is set up, call LinkedIn data tools on behalf of any us
     profile = scalekit_client.actions.request(
         connection_name=connection_name,
         identifier=identifier,
-        path="/profile",
+        path="/linkedin/profile",
         method="GET",
         params={"url": "https://www.linkedin.com/in/satyanadella"}
     )
@@ -33,7 +33,7 @@ Once a connected account is set up, call LinkedIn data tools on behalf of any us
     people = scalekit_client.actions.request(
         connection_name=connection_name,
         identifier=identifier,
-        path="/search/people",
+        path="/linkedin/lead-search",
         method="GET",
         params={"title": "VP of Engineering", "location": "San Francisco, CA"}
     )
@@ -43,7 +43,7 @@ Once a connected account is set up, call LinkedIn data tools on behalf of any us
     company = scalekit_client.actions.request(
         connection_name=connection_name,
         identifier=identifier,
-        path="/company",
+        path="/linkedin/company",
         method="GET",
         params={"url": "https://www.linkedin.com/company/openai"}
     )
@@ -53,7 +53,7 @@ Once a connected account is set up, call LinkedIn data tools on behalf of any us
     jobs = scalekit_client.actions.request(
         connection_name=connection_name,
         identifier=identifier,
-        path="/search/jobs",
+        path="/linkedin/job-search",
         method="GET",
         params={"keywords": "machine learning engineer", "location": "New York, NY"}
     )
@@ -63,7 +63,7 @@ Once a connected account is set up, call LinkedIn data tools on behalf of any us
     job = scalekit_client.actions.request(
         connection_name=connection_name,
         identifier=identifier,
-        path="/job",
+        path="/linkedin/job",
         method="GET",
         params={"url": "https://www.linkedin.com/jobs/view/1234567890"}
     )
@@ -73,7 +73,7 @@ Once a connected account is set up, call LinkedIn data tools on behalf of any us
     bulk = scalekit_client.actions.request(
         connection_name=connection_name,
         identifier=identifier,
-        path="/profiles/bulk",
+        path="/v2/acts/harvestapi~linkedin-profile-scraper/run-sync-get-dataset-items",
         method="POST",
         json={
             "urls": [

--- a/src/components/templates/agent-connectors/_usage-harvestapi.mdx
+++ b/src/components/templates/agent-connectors/_usage-harvestapi.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Once a connected account is set up, call LinkedIn data tools on behalf of any user — Scalekit injects the stored API key into every request automatically.
 
+You can interact with Harvest API in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
   <TabItem label="Python">
     ```python
@@ -87,3 +91,7 @@ Once a connected account is set up, call LinkedIn data tools on behalf of any us
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-hubspot.mdx
+++ b/src/components/templates/agent-connectors/_usage-hubspot.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's HubSpot account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with HubSpot in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,3 +81,7 @@ Connect a user's HubSpot account and make API calls on their behalf — Scalekit
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-intercom.mdx
+++ b/src/components/templates/agent-connectors/_usage-intercom.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Intercom account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with Intercom in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,3 +81,7 @@ Connect a user's Intercom account and make API calls on their behalf — Scaleki
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-jira.mdx
+++ b/src/components/templates/agent-connectors/_usage-jira.mdx
@@ -2,6 +2,8 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Jira account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+**Don't worry about the Jira cloud ID in the path.** Scalekit automatically resolves `{{cloud_id}}` from the connected account's configuration. For example, a request with `path="/rest/api/3/myself"` will be sent to `https://api.atlassian.com/ex/jira/a1b2c3d4-e5f6-7890-abcd-ef1234567890/rest/api/3/myself` automatically.
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">

--- a/src/components/templates/agent-connectors/_usage-jira.mdx
+++ b/src/components/templates/agent-connectors/_usage-jira.mdx
@@ -4,6 +4,10 @@ Connect a user's Jira account and make API calls on their behalf — Scalekit ha
 
 **Don't worry about the Jira cloud ID in the path.** Scalekit automatically resolves `{{cloud_id}}` from the connected account's configuration. For example, a request with `path="/rest/api/3/myself"` will be sent to `https://api.atlassian.com/ex/jira/a1b2c3d4-e5f6-7890-abcd-ef1234567890/rest/api/3/myself` automatically.
 
+You can interact with Jira in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -79,3 +83,7 @@ Connect a user's Jira account and make API calls on their behalf — Scalekit ha
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-linear.mdx
+++ b/src/components/templates/agent-connectors/_usage-linear.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Linear account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with Linear in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -79,3 +83,7 @@ Connect a user's Linear account and make API calls on their behalf — Scalekit 
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-microsoftword.mdx
+++ b/src/components/templates/agent-connectors/_usage-microsoftword.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Microsoft Word account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with Microsoft Word in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,3 +81,7 @@ Connect a user's Microsoft Word account and make API calls on their behalf — S
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-monday.mdx
+++ b/src/components/templates/agent-connectors/_usage-monday.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Monday.com account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with Monday in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,3 +81,7 @@ Connect a user's Monday.com account and make API calls on their behalf — Scale
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-notion.mdx
+++ b/src/components/templates/agent-connectors/_usage-notion.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Notion account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with Notion in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,3 +81,7 @@ Connect a user's Notion account and make API calls on their behalf — Scalekit 
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-outlook.mdx
+++ b/src/components/templates/agent-connectors/_usage-outlook.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Outlook account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with Outlook in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,3 +81,7 @@ Connect a user's Outlook account and make API calls on their behalf — Scalekit
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-salesforce.mdx
+++ b/src/components/templates/agent-connectors/_usage-salesforce.mdx
@@ -4,6 +4,10 @@ Connect a user's Salesforce account and make API calls on their behalf — Scale
 
 **Don't worry about the Salesforce domain or API version in the path.** Scalekit automatically resolves `{{domain}}` and `{{version}}` from the connected account's configuration. For example, a request with `path="/chatter/users/me"` will be sent to `https://mycompany.my.salesforce.com/services/data/v58.0/chatter/users/me` automatically.
 
+You can interact with Salesforce in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -79,3 +83,7 @@ Connect a user's Salesforce account and make API calls on their behalf — Scale
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-servicenow.mdx
+++ b/src/components/templates/agent-connectors/_usage-servicenow.mdx
@@ -4,6 +4,10 @@ Connect a user's ServiceNow account and make API calls on their behalf — Scale
 
 **Don't worry about your ServiceNow instance domain in the path.** Scalekit automatically resolves `{{domain}}` from the connected account's configuration. For example, a request with `path="/api/now/table/sys_user"` will be sent to `https://mycompany.service-now.com/api/now/table/sys_user` automatically.
 
+You can interact with ServiceNow in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -79,3 +83,7 @@ Connect a user's ServiceNow account and make API calls on their behalf — Scale
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-servicenow.mdx
+++ b/src/components/templates/agent-connectors/_usage-servicenow.mdx
@@ -2,6 +2,8 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's ServiceNow account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+**Don't worry about your ServiceNow instance domain in the path.** Scalekit automatically resolves `{{domain}}` from the connected account's configuration. For example, a request with `path="/api/now/table/sys_user"` will be sent to `https://mycompany.service-now.com/api/now/table/sys_user` automatically.
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">

--- a/src/components/templates/agent-connectors/_usage-sharepoint.mdx
+++ b/src/components/templates/agent-connectors/_usage-sharepoint.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's SharePoint account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with SharePoint in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,6 +81,8 @@ Connect a user's SharePoint account and make API calls on their behalf — Scale
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
 
 ## File operations
 

--- a/src/components/templates/agent-connectors/_usage-slack.mdx
+++ b/src/components/templates/agent-connectors/_usage-slack.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Slack account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with Slack in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,3 +81,7 @@ Connect a user's Slack account and make API calls on their behalf — Scalekit h
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-snowflake.mdx
+++ b/src/components/templates/agent-connectors/_usage-snowflake.mdx
@@ -4,6 +4,10 @@ Connect a user's Snowflake account and make API calls on their behalf — Scalek
 
 **Don't worry about your Snowflake account domain in the path.** Scalekit automatically resolves `{{domain}}` from the connected account's configuration. For example, a request with `path="/api/v2/statements"` will be sent to `https://myorg-myaccount.snowflakecomputing.com/api/v2/statements` automatically.
 
+You can interact with Snowflake in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -79,3 +83,7 @@ Connect a user's Snowflake account and make API calls on their behalf — Scalek
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-snowflake.mdx
+++ b/src/components/templates/agent-connectors/_usage-snowflake.mdx
@@ -2,6 +2,8 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Snowflake account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+**Don't worry about your Snowflake account domain in the path.** Scalekit automatically resolves `{{domain}}` from the connected account's configuration. For example, a request with `path="/api/v2/statements"` will be sent to `https://myorg-myaccount.snowflakecomputing.com/api/v2/statements` automatically.
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">

--- a/src/components/templates/agent-connectors/_usage-snowflakekeyauth.mdx
+++ b/src/components/templates/agent-connectors/_usage-snowflakekeyauth.mdx
@@ -4,6 +4,10 @@ Connect a user's Snowflake account using key-pair authentication and make API ca
 
 **Don't worry about your Snowflake account domain in the path.** Scalekit automatically resolves `{{domain}}` from the connected account's configuration. For example, a request with `path="/api/v2/statements"` will be sent to `https://myorg-myaccount.snowflakecomputing.com/api/v2/statements` automatically.
 
+You can interact with Snowflake in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -81,3 +85,7 @@ Connect a user's Snowflake account using key-pair authentication and make API ca
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-snowflakekeyauth.mdx
+++ b/src/components/templates/agent-connectors/_usage-snowflakekeyauth.mdx
@@ -1,8 +1,8 @@
 import { Tabs, TabItem } from '@astrojs/starlight/components'
 
-Connect a user's Salesforce account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
+Connect a user's Snowflake account using key-pair authentication and make API calls on their behalf — Scalekit handles token management automatically.
 
-**Don't worry about the Salesforce domain or API version in the path.** Scalekit automatically resolves `{{domain}}` and `{{version}}` from the connected account's configuration. For example, a request with `path="/chatter/users/me"` will be sent to `https://mycompany.my.salesforce.com/services/data/v58.0/chatter/users/me` automatically.
+**Don't worry about your Snowflake account domain in the path.** Scalekit automatically resolves `{{domain}}` from the connected account's configuration. For example, a request with `path="/api/v2/statements"` will be sent to `https://myorg-myaccount.snowflakecomputing.com/api/v2/statements` automatically.
 
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
@@ -11,8 +11,8 @@ Connect a user's Salesforce account and make API calls on their behalf — Scale
     import { ScalekitClient } from '@scalekit-sdk/node';
     import 'dotenv/config';
 
-    const connectionName = 'salesforce'; // get your connection name from connection configurations
-    const identifier = 'user_123';  // your unique user identifier
+    const connectionName = 'snowflakekeyauth'; // get your connection name from connection configurations
+    const identifier = 'user_123';             // your unique user identifier
 
     // Get your credentials from app.scalekit.com → Developers → Settings → API Credentials
     const scalekit = new ScalekitClient(
@@ -27,7 +27,7 @@ Connect a user's Salesforce account and make API calls on their behalf — Scale
       connector: connectionName,
       identifier,
     });
-    console.log('🔗 Authorize Salesforce:', link);
+    console.log('🔗 Authorize Snowflake:', link); // present this link to your user for authorization, or click it yourself for testing
     process.stdout.write('Press Enter after authorizing...');
     await new Promise(r => process.stdin.once('data', r));
 
@@ -35,8 +35,9 @@ Connect a user's Salesforce account and make API calls on their behalf — Scale
     const result = await actions.request({
       connectionName,
       identifier,
-      path: '/chatter/users/me',
-      method: 'GET',
+      path: '/api/v2/statements',
+      method: 'POST',
+      body: { statement: 'SELECT CURRENT_USER()', timeout: 60 },
     });
     console.log(result);
     ```
@@ -48,8 +49,8 @@ Connect a user's Salesforce account and make API calls on their behalf — Scale
     from dotenv import load_dotenv
     load_dotenv()
 
-    connection_name = "salesforce"  # get your connection name from connection configurations
-    identifier = "user_123"     # your unique user identifier
+    connection_name = "snowflakekeyauth"  # get your connection name from connection configurations
+    identifier = "user_123"              # your unique user identifier
 
     # Get your credentials from app.scalekit.com → Developers → Settings → API Credentials
     scalekit_client = scalekit.client.ScalekitClient(
@@ -65,15 +66,16 @@ Connect a user's Salesforce account and make API calls on their behalf — Scale
         identifier=identifier
     )
     # present this link to your user for authorization, or click it yourself for testing
-    print("🔗 Authorize Salesforce:", link_response.link)
+    print("🔗 Authorize Snowflake:", link_response.link)
     input("Press Enter after authorizing...")
 
     # Make a request via Scalekit proxy
     result = actions.request(
         connection_name=connection_name,
         identifier=identifier,
-        path="/chatter/users/me",
-        method="GET"
+        path="/api/v2/statements",
+        method="POST",
+        json={"statement": "SELECT CURRENT_USER()", "timeout": 60}
     )
     print(result)
     ```

--- a/src/components/templates/agent-connectors/_usage-trello.mdx
+++ b/src/components/templates/agent-connectors/_usage-trello.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Trello account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with Trello in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,3 +81,7 @@ Connect a user's Trello account and make API calls on their behalf — Scalekit 
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-zendesk.mdx
+++ b/src/components/templates/agent-connectors/_usage-zendesk.mdx
@@ -4,6 +4,10 @@ Connect a user's Zendesk account and make API calls on their behalf — Scalekit
 
 **Don't worry about your Zendesk domain in the path.** Scalekit automatically resolves `{{domain}}` from the connected account's configuration. For example, a request with `path="/v2/users/me"` will be sent to `https://mycompany.zendesk.com/api/v2/users/me` automatically.
 
+You can interact with Zendesk in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -79,3 +83,7 @@ Connect a user's Zendesk account and make API calls on their behalf — Scalekit
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-zendesk.mdx
+++ b/src/components/templates/agent-connectors/_usage-zendesk.mdx
@@ -1,8 +1,8 @@
 import { Tabs, TabItem } from '@astrojs/starlight/components'
 
-Connect a user's Salesforce account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
+Connect a user's Zendesk account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
-**Don't worry about the Salesforce domain or API version in the path.** Scalekit automatically resolves `{{domain}}` and `{{version}}` from the connected account's configuration. For example, a request with `path="/chatter/users/me"` will be sent to `https://mycompany.my.salesforce.com/services/data/v58.0/chatter/users/me` automatically.
+**Don't worry about your Zendesk domain in the path.** Scalekit automatically resolves `{{domain}}` from the connected account's configuration. For example, a request with `path="/v2/users/me"` will be sent to `https://mycompany.zendesk.com/api/v2/users/me` automatically.
 
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
@@ -11,7 +11,7 @@ Connect a user's Salesforce account and make API calls on their behalf — Scale
     import { ScalekitClient } from '@scalekit-sdk/node';
     import 'dotenv/config';
 
-    const connectionName = 'salesforce'; // get your connection name from connection configurations
+    const connectionName = 'zendesk'; // get your connection name from connection configurations
     const identifier = 'user_123';  // your unique user identifier
 
     // Get your credentials from app.scalekit.com → Developers → Settings → API Credentials
@@ -27,7 +27,7 @@ Connect a user's Salesforce account and make API calls on their behalf — Scale
       connector: connectionName,
       identifier,
     });
-    console.log('🔗 Authorize Salesforce:', link);
+    console.log('🔗 Authorize Zendesk:', link); // present this link to your user for authorization, or click it yourself for testing
     process.stdout.write('Press Enter after authorizing...');
     await new Promise(r => process.stdin.once('data', r));
 
@@ -35,7 +35,7 @@ Connect a user's Salesforce account and make API calls on their behalf — Scale
     const result = await actions.request({
       connectionName,
       identifier,
-      path: '/chatter/users/me',
+      path: '/v2/users/me',
       method: 'GET',
     });
     console.log(result);
@@ -48,8 +48,8 @@ Connect a user's Salesforce account and make API calls on their behalf — Scale
     from dotenv import load_dotenv
     load_dotenv()
 
-    connection_name = "salesforce"  # get your connection name from connection configurations
-    identifier = "user_123"     # your unique user identifier
+    connection_name = "zendesk"  # get your connection name from connection configurations
+    identifier = "user_123"      # your unique user identifier
 
     # Get your credentials from app.scalekit.com → Developers → Settings → API Credentials
     scalekit_client = scalekit.client.ScalekitClient(
@@ -65,14 +65,14 @@ Connect a user's Salesforce account and make API calls on their behalf — Scale
         identifier=identifier
     )
     # present this link to your user for authorization, or click it yourself for testing
-    print("🔗 Authorize Salesforce:", link_response.link)
+    print("🔗 Authorize Zendesk:", link_response.link)
     input("Press Enter after authorizing...")
 
     # Make a request via Scalekit proxy
     result = actions.request(
         connection_name=connection_name,
         identifier=identifier,
-        path="/chatter/users/me",
+        path="/v2/users/me",
         method="GET"
     )
     print(result)

--- a/src/components/templates/agent-connectors/_usage-zoom.mdx
+++ b/src/components/templates/agent-connectors/_usage-zoom.mdx
@@ -2,6 +2,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Zoom account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+You can interact with Zoom in two ways — via direct proxy API calls or via Scalekit optimized tool calls. Scroll down to see the list of available Scalekit tools.
+
+## Proxy API Calls
+
 <Tabs syncKey="tech-stack">
 {/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
@@ -77,3 +81,7 @@ Connect a user's Zoom account and make API calls on their behalf — Scalekit ha
     ```
   </TabItem>
 </Tabs>
+
+## Scalekit Tools
+
+No Scalekit optimized tools are available for this provider yet.

--- a/src/content/docs/agent-auth/advanced/proxy-api-calls.mdx
+++ b/src/content/docs/agent-auth/advanced/proxy-api-calls.mdx
@@ -21,7 +21,7 @@ emails = actions.tools.execute(
     connected_account_id=connected_account.id,
     tool='gmail_proxy_api',
     parameters={
-        'path': '/api/v1/emails:fetch',
+        'path': '/gmail/v1/users/me/messages',
         'method': 'GET',
         'headers': [{'Content-Type': 'application/json'}],
         'params': [{'max_results': '5'}],


### PR DESCRIPTION
- fixed some mistakes in proxy paths
- split proxy and scalekit tools into 2 sections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated connector guides across 40+ providers to clarify two interaction modes: direct proxy API calls and optimized tool calls
  * Clarified automatic path resolution for domains and IDs across HubSpot, Jira, Confluence, ServiceNow, Salesforce, and Snowflake
  * Corrected API request paths in Freshdesk, Gmail, and other endpoint examples

* **New Features**
  * Added Zendesk connector documentation and integration support
  * Added Snowflake key-pair authentication connector support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->