### PR TITLE
Update Node.js docs to use actions API

### DIFF
--- a/src/content/docs/agent-auth/connected-accounts.mdx
+++ b/src/content/docs/agent-auth/connected-accounts.mdx
@@ -99,10 +99,9 @@ print(f"Connected account: {connected_account.id}, status: {connected_account.st
 <TabItem label="Node.js">
 
 ```typescript
-// Requires @scalekit-sdk/node@2.2.0-beta.1: npm install @scalekit-sdk/node@2.2.0-beta.1
-// const { connectedAccounts } = new ScalekitClient(ENV_URL, CLIENT_ID, CLIENT_SECRET)
-const response = await connectedAccounts.getOrCreateConnectedAccount({
-  connector: 'gmail',
+// const actions = new ScalekitClient(ENV_URL, CLIENT_ID, CLIENT_SECRET).actions
+const response = await actions.getOrCreateConnectedAccount({
+  connectionName: 'gmail',
   identifier: 'user_123',
 });
 
@@ -148,9 +147,8 @@ print(f"Authorization URL: {link_response.link}")
 <TabItem label="Node.js">
 
 ```typescript
-// Requires @scalekit-sdk/node@2.2.0-beta.1: npm install @scalekit-sdk/node@2.2.0-beta.1
-const linkResponse = await connectedAccounts.getMagicLinkForConnectedAccount({
-  connector: 'gmail',
+const linkResponse = await actions.getAuthorizationLink({
+  connectionName: 'gmail',
   identifier: 'user_123',
 });
 
@@ -194,8 +192,8 @@ print(f"Status: {connected_account.status}")
 <TabItem label="Node.js">
 
 ```typescript
-const accountResponse = await connectedAccounts.getConnectedAccountByIdentifier({
-  connector: 'gmail',
+const accountResponse = await actions.getConnectedAccount({
+  connectionName: 'gmail',
   identifier: 'user_123',
 });
 
@@ -253,8 +251,8 @@ if connected_account.status != "ACTIVE":
 <TabItem label="Node.js">
 
 ```typescript
-const response = await connectedAccounts.getOrCreateConnectedAccount({
-  connector: 'gmail',
+const response = await actions.getOrCreateConnectedAccount({
+  connectionName: 'gmail',
   identifier: 'user_123',
 });
 
@@ -262,8 +260,8 @@ const connectedAccount = response.connectedAccount;
 
 if (connectedAccount?.status !== 'ACTIVE') {
   // Re-authorize the user to refresh their tokens
-  const linkResponse = await connectedAccounts.getMagicLinkForConnectedAccount({
-    connector: 'gmail',
+  const linkResponse = await actions.getAuthorizationLink({
+    connectionName: 'gmail',
     identifier: 'user_123',
   });
   console.log('Re-authorization required. Send user to:', linkResponse.link);
@@ -300,8 +298,8 @@ print(f"Account status: {connected_account.status}")
 <TabItem label="Node.js">
 
 ```typescript
-const accountResponse = await connectedAccounts.getConnectedAccountByIdentifier({
-  connector: 'gmail',
+const accountResponse = await actions.getConnectedAccount({
+  connectionName: 'gmail',
   identifier: 'user_123',
 });
 
@@ -378,7 +376,7 @@ Custom metadata is managed via the Scalekit dashboard.
 
 ### Managing multiple accounts
 
-The Python SDK supports per-account retrieval via `actions.get_or_create_connected_account`. Bulk list and delete operations (`connectedAccounts.listConnectedAccounts`, `connectedAccounts.deleteConnectedAccount`) are available in the Node.js SDK, or via the direct API and dashboard.
+The Python SDK supports per-account retrieval via `actions.get_or_create_connected_account`. Bulk list and delete operations (`actions.listConnectedAccounts`, `actions.deleteConnectedAccount`) are available in the Node.js SDK, or via the direct API and dashboard.
 
 <Tabs syncKey="tech-stack">
 <TabItem label="Python">
@@ -399,14 +397,14 @@ print(f"Account: {connected_account.id}, Status: {connected_account.status}")
 
 ```typescript
 // List connected accounts
-const listResponse = await connectedAccounts.listConnectedAccounts({
-  connector: 'gmail',
+const listResponse = await actions.listConnectedAccounts({
+  connectionName: 'gmail',
 });
 console.log('Connected accounts:', listResponse);
 
 // Delete a connected account
-await connectedAccounts.deleteConnectedAccount({
-  connector: 'gmail',
+await actions.deleteConnectedAccount({
+  connectionName: 'gmail',
   identifier: 'user_123',
 });
 console.log('Connected account deleted');
@@ -442,8 +440,8 @@ except Exception as e:
 
 ```typescript
 try {
-  const accountResponse = await connectedAccounts.getConnectedAccountByIdentifier({
-    connector: 'gmail',
+  const accountResponse = await actions.getConnectedAccount({
+    connectionName: 'gmail',
     identifier: 'user_123',
   });
   const connectedAccount = accountResponse?.connectedAccount;
@@ -503,7 +501,7 @@ Ensure proper account isolation:
 
 ### Account health monitoring
 
-Monitor the status of connected accounts by calling `get_connected_account` (Python) or `getConnectedAccountByIdentifier` (Node.js) and inspecting the `status` field. Accounts in a non-`ACTIVE` state may require re-authorization.
+Monitor the status of connected accounts by calling `actions.get_connected_account` (Python) or `actions.getConnectedAccount` (Node.js) and inspecting the `status` field. Accounts in a non-`ACTIVE` state may require re-authorization.
 
 ### Usage analytics
 
@@ -556,8 +554,8 @@ print(f"Test account: {test_account.id}, status: {test_account.status}")
 
 ```typescript
 // Create or retrieve a test connected account
-const response = await connectedAccounts.getOrCreateConnectedAccount({
-  connector: 'gmail',
+const response = await actions.getOrCreateConnectedAccount({
+  connectionName: 'gmail',
   identifier: 'test_user',
 });
 

--- a/src/content/docs/agent-auth/connected-accounts.mdx
+++ b/src/content/docs/agent-auth/connected-accounts.mdx
@@ -376,14 +376,13 @@ Custom metadata is managed via the Scalekit dashboard.
 
 ### Managing multiple accounts
 
-The Python SDK supports per-account retrieval via `actions.get_or_create_connected_account`. Bulk list and delete operations (`actions.listConnectedAccounts`, `actions.deleteConnectedAccount`) are available in the Node.js SDK, or via the direct API and dashboard.
+The Python SDK supports read-only retrieval via `actions.get_connected_account` (Python) / `actions.getConnectedAccount` (Node.js). Use `actions.get_or_create_connected_account` when you need create-or-retrieve semantics. Bulk list and delete operations (`actions.listConnectedAccounts`, `actions.deleteConnectedAccount`) are available in the Node.js SDK, or via the direct API and dashboard.
 
 <Tabs syncKey="tech-stack">
 <TabItem label="Python">
 
 ```python
-# Retrieve an individual account by identifier
-# Note: listing all accounts for a connector is available via the dashboard or direct API
+# Get or create a connected account by identifier
 response = actions.get_or_create_connected_account(
     connection_name="gmail",
     identifier="user_123"

--- a/src/content/docs/agent-auth/quickstart.mdx
+++ b/src/content/docs/agent-auth/quickstart.mdx
@@ -79,13 +79,10 @@ In this quickstart, you'll build a simple tool-calling program that:
       </TabItem>
       <TabItem label="Node.js">
         ```sh showLineNumbers=false frame="none"
-        npm install @scalekit-sdk/node@2.2.0-beta.1
+        npm install @scalekit-sdk/node
         ```
       </TabItem>
     </Tabs>
-    <Aside type="note" title="Node.js beta version">
-      Agent Auth features (`connectedAccounts`, `tools`) are available in the Node.js SDK beta. Use `@scalekit-sdk/node@2.2.0-beta.1` until the stable release ships.
-    </Aside>
     <Tabs syncKey="tech-stack">
       <TabItem label="Python">
         ```python showLineNumbers=false frame="none" wrap
@@ -114,7 +111,7 @@ In this quickstart, you'll build a simple tool-calling program that:
           process.env.SCALEKIT_CLIENT_SECRET
         );
 
-        const { connectedAccounts, tools } = scalekit;
+        const actions = scalekit.actions;
         ```
       </TabItem>
     </Tabs>
@@ -138,8 +135,8 @@ In this quickstart, you'll build a simple tool-calling program that:
       <TabItem label="Node.js">
         ```typescript showLineNumbers=false frame="none"
         // Create or retrieve the user's connected Gmail account
-        const response = await connectedAccounts.getOrCreateConnectedAccount({
-          connector: 'gmail',
+        const response = await actions.getOrCreateConnectedAccount({
+          connectionName: 'gmail',
           identifier: 'user_123',  // Replace with your system's unique user ID
         });
 
@@ -175,12 +172,11 @@ In this quickstart, you'll build a simple tool-calling program that:
       </TabItem>
       <TabItem label="Node.js">
         ```typescript showLineNumbers=false frame="none" wrap
-        import { ConnectorStatus } from '@scalekit-sdk/node/pkg/grpc/scalekit/v1/connected_accounts/connected_accounts_pb';
         // Generate authorization link if user hasn't authorized or token is expired
-        if (connectedAccount?.status !== ConnectorStatus.ACTIVE) {
+        if (connectedAccount?.status !== 'ACTIVE') {
           console.log('gmail is not connected:', connectedAccount?.status);
-          const linkResponse = await connectedAccounts.getMagicLinkForConnectedAccount({
-            connector: 'gmail',
+          const linkResponse = await actions.getAuthorizationLink({
+            connectionName: 'gmail',
             identifier: 'user_123',
           });
           console.log('🔗 click on the link to authorize gmail', linkResponse.link);
@@ -221,21 +217,20 @@ In this quickstart, you'll build a simple tool-calling program that:
       </TabItem>
       <TabItem label="Node.js">
         ```typescript showLineNumbers=false frame="none" wrap
-        const accountResponse = await connectedAccounts.getConnectedAccountByIdentifier({
-          connector: 'gmail',
+        const accountResponse = await actions.getConnectedAccount({
+          connectionName: 'gmail',
           identifier: 'user_123',
         });
 
         // Extract OAuth tokens from authorization details
         const authDetails = accountResponse?.connectedAccount?.authorizationDetails;
-        const accessToken = (authDetails && authDetails.details?.case === "oauthToken")
+        const accessToken = (authDetails && authDetails.details?.case === 'oauthToken')
           ? authDetails.details.value?.accessToken
           : undefined;
-        const refreshToken = (authDetails && authDetails.details?.case === "oauthToken")
+        const refreshToken = (authDetails && authDetails.details?.case === 'oauthToken')
           ? authDetails.details.value?.refreshToken
           : undefined;
 
-        console.log('Connected account:', accountResponse);
         console.log('accessToken:', accessToken);
         console.log('refreshToken:', refreshToken);
         ```

--- a/src/content/docs/agent-auth/quickstart.mdx
+++ b/src/content/docs/agent-auth/quickstart.mdx
@@ -231,8 +231,13 @@ In this quickstart, you'll build a simple tool-calling program that:
           ? authDetails.details.value?.refreshToken
           : undefined;
 
-        console.log('accessToken:', accessToken);
-        console.log('refreshToken:', refreshToken);
+        // Security Warning: Never log OAuth tokens in production. Token exposure in logs
+        // or aggregators creates credential leakage risks. Use safe redaction,
+        // conditional debug-only logging, or secure secret storage instead.
+        if (process.env.NODE_ENV === 'development') {
+          console.log('accessToken:', accessToken);
+          console.log('refreshToken:', refreshToken);
+        }
         ```
       </TabItem>
     </Tabs>

--- a/src/content/docs/agent-auth/tools/agent-tools-quickstart.mdx
+++ b/src/content/docs/agent-auth/tools/agent-tools-quickstart.mdx
@@ -44,15 +44,14 @@ print(f'Recent emails: {tool_response.result}')
 <TabItem label="Node.js">
 
 ```typescript
-// Requires @scalekit-sdk/node@2.2.0-beta.1: npm install @scalekit-sdk/node@2.2.0-beta.1
 // Fetch recent emails
-const toolResponse = await tools.executeTool({
+const toolResponse = await actions.executeTool({
   // tool name to execute
   toolName: 'gmail_fetch_mails',
   // connectedAccountId from a prior getOrCreateConnectedAccount call
   connectedAccountId: 'your_connected_account_id',
   // tool input parameters
-  params: {
+  toolInput: {
     query: 'is:unread',
     max_results: 5,
   },

--- a/src/content/docs/agent-auth/tools/authorize.mdx
+++ b/src/content/docs/agent-auth/tools/authorize.mdx
@@ -32,9 +32,9 @@ input(f"Press Enter after authorizing gmail...")
 <TabItem label="Node.js">
 
 ```typescript
-const linkResponse = await connectedAccounts.getMagicLinkForConnectedAccount({
-  connector: 'gmail',      // connection name to which the user needs to grant access
-  identifier: 'user_123', // unique user id
+const linkResponse = await actions.getAuthorizationLink({
+  connectionName: 'gmail',  // connection name to which the user needs to grant access
+  identifier: 'user_123',  // unique user id
 });
 console.log('click on the link to authorize gmail', linkResponse.link);
 // In production, redirect the user to linkResponse.link to complete the OAuth flow
@@ -63,8 +63,8 @@ print(f"Authorization status of the connected account", connected_account.status
 <TabItem label="Node.js">
 
 ```typescript
-const response = await connectedAccounts.getOrCreateConnectedAccount({
-  connector: 'gmail',
+const response = await actions.getOrCreateConnectedAccount({
+  connectionName: 'gmail',
   identifier: 'user_123',
 });
 const connectedAccount = response.connectedAccount;


### PR DESCRIPTION
Update Node.js examples to match the updated SDK API: replace connectedAccounts client with scalekit.actions, rename connector -> connectionName, rename getMagicLinkForConnectedAccount -> getAuthorizationLink, getConnectedAccountByIdentifier -> getConnectedAccount, and update list/delete calls to actions.*. Remove the beta-specific npm install note and use the stable @scalekit-sdk/node package, and simplify status checks to use the 'ACTIVE' string. These changes align the docs with the latest Node SDK method names and usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Node.js examples across connected-accounts, quickstart, and tools guides to use a unified API surface and renamed the connector parameter for consistency.
  * Adjusted tool call payload naming and normalized token/status handling.
  * Removed outdated beta-version install notes and changed sample logging to development-only for safer examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->