### PR TITLE
Update Node.js examples in connector docs

### DIFF
--- a/src/components/templates/agent-connectors/_usage-airtable.mdx
+++ b/src/components/templates/agent-connectors/_usage-airtable.mdx
@@ -7,7 +7,6 @@ You can interact with Airtable in two ways — via direct proxy API calls or via
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with Airtable in two ways — via direct proxy API calls or via
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Airtable:', link);
@@ -43,7 +42,6 @@ You can interact with Airtable in two ways — via direct proxy API calls or via
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-apollo.mdx
+++ b/src/components/templates/agent-connectors/_usage-apollo.mdx
@@ -19,23 +19,28 @@ Connect a user's Apollo account and make API calls on their behalf — Scalekit 
     );
     const actions = scalekit.actions;
 
-    // Get authorization link and send it to your user
-    const { link } = await actions.getAuthorizationLink({
-      connectionName,
-      identifier,
-    });
-    console.log('Authorize Apollo:', link); // present this link to your user for authorization, or click it yourself for testing
-    process.stdout.write('Press Enter after authorizing...');
-    await new Promise(r => process.stdin.once('data', r));
+    try {
+      // Get authorization link and send it to your user
+      const { link } = await actions.getAuthorizationLink({
+        connectionName,
+        identifier,
+      });
+      console.log('Authorize Apollo:', link); // present this link to your user for authorization, or click it yourself for testing
+      process.stdout.write('Press Enter after authorizing...');
+      await new Promise(r => process.stdin.once('data', r));
 
-    // After the user authorizes, make API calls via Scalekit proxy
-    const result = await actions.request({
-      connectionName,
-      identifier,
-      path: '/api/v1/contacts/search',
-      method: 'POST',
-    });
-    console.log(result.data);
+      // After the user authorizes, make API calls via Scalekit proxy
+      const result = await actions.request({
+        connectionName,
+        identifier,
+        path: '/api/v1/contacts/search',
+        method: 'POST',
+      });
+      console.log(result.data);
+    } catch (err) {
+      console.error('Apollo request failed:', err);
+      process.exit(1);
+    }
     ```
   </TabItem>
   <TabItem label="Python">
@@ -60,6 +65,7 @@ Connect a user's Apollo account and make API calls on their behalf — Scalekit 
         identifier=identifier
     )
     print("Authorize Apollo:", link_response.link)
+    input("Press Enter after authorizing...")
 
     # After the user authorizes, make API calls via Scalekit proxy
     result = scalekit_client.actions.request(

--- a/src/components/templates/agent-connectors/_usage-apollo.mdx
+++ b/src/components/templates/agent-connectors/_usage-apollo.mdx
@@ -24,7 +24,9 @@ Connect a user's Apollo account and make API calls on their behalf — Scalekit 
       connectionName,
       identifier,
     });
-    console.log('Authorize Apollo:', link);
+    console.log('Authorize Apollo:', link); // present this link to your user for authorization, or click it yourself for testing
+    process.stdout.write('Press Enter after authorizing...');
+    await new Promise(r => process.stdin.once('data', r));
 
     // After the user authorizes, make API calls via Scalekit proxy
     const result = await actions.request({

--- a/src/components/templates/agent-connectors/_usage-apollo.mdx
+++ b/src/components/templates/agent-connectors/_usage-apollo.mdx
@@ -3,6 +3,39 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 Connect a user's Apollo account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
 <Tabs syncKey="tech-stack">
+  <TabItem label="Node.js">
+    ```typescript
+    import { ScalekitClient } from '@scalekit-sdk/node';
+    import 'dotenv/config';
+
+    const connectionName = 'apollo';  // connection name from Scalekit dashboard
+    const identifier = 'user_123';    // your unique user identifier
+
+    // Get credentials from app.scalekit.com → Developers → API Credentials
+    const scalekit = new ScalekitClient(
+      process.env.SCALEKIT_ENV_URL,
+      process.env.SCALEKIT_CLIENT_ID,
+      process.env.SCALEKIT_CLIENT_SECRET
+    );
+    const actions = scalekit.actions;
+
+    // Get authorization link and send it to your user
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
+      identifier,
+    });
+    console.log('Authorize Apollo:', link);
+
+    // After the user authorizes, make API calls via Scalekit proxy
+    const result = await actions.request({
+      connectionName,
+      identifier,
+      path: '/api/v1/contacts/search',
+      method: 'POST',
+    });
+    console.log(result.data);
+    ```
+  </TabItem>
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-apollo.mdx
+++ b/src/components/templates/agent-connectors/_usage-apollo.mdx
@@ -45,7 +45,7 @@ Connect a user's Apollo account and make API calls on their behalf — Scalekit 
   </TabItem>
   <TabItem label="Python">
     ```python
-    import scalekit.client, os
+    import scalekit.client, os, sys
     from dotenv import load_dotenv
     load_dotenv()
 
@@ -59,22 +59,26 @@ Connect a user's Apollo account and make API calls on their behalf — Scalekit 
         env_url=os.getenv("SCALEKIT_ENV_URL"),
     )
 
-    # Get authorization link and send it to your user
-    link_response = scalekit_client.actions.get_authorization_link(
-        connection_name=connection_name,
-        identifier=identifier
-    )
-    print("Authorize Apollo:", link_response.link)
-    input("Press Enter after authorizing...")
+    try:
+        # Get authorization link and send it to your user
+        link_response = scalekit_client.actions.get_authorization_link(
+            connection_name=connection_name,
+            identifier=identifier
+        )
+        print("Authorize Apollo:", link_response.link)
+        input("Press Enter after authorizing...")
 
-    # After the user authorizes, make API calls via Scalekit proxy
-    result = scalekit_client.actions.request(
-        connection_name=connection_name,
-        identifier=identifier,
-        path="/api/v1/contacts/search",
-        method="POST"
-    )
-    print(result)
+        # After the user authorizes, make API calls via Scalekit proxy
+        result = scalekit_client.actions.request(
+            connection_name=connection_name,
+            identifier=identifier,
+            path="/api/v1/contacts/search",
+            method="POST"
+        )
+        print(result)
+    except Exception as e:
+        print(f"Apollo request failed: {e}", file=sys.stderr)
+        sys.exit(1)
     ```
   </TabItem>
 </Tabs>

--- a/src/components/templates/agent-connectors/_usage-apollo.mdx
+++ b/src/components/templates/agent-connectors/_usage-apollo.mdx
@@ -4,7 +4,7 @@ Connect a user's Apollo account and make API calls on their behalf — Scalekit 
 
 <Tabs syncKey="tech-stack">
   <TabItem label="Node.js">
-    ```typescript
+    ```typescript title="examples/apollo.ts"
     import { ScalekitClient } from '@scalekit-sdk/node';
     import 'dotenv/config';
 
@@ -19,28 +19,35 @@ Connect a user's Apollo account and make API calls on their behalf — Scalekit 
     );
     const actions = scalekit.actions;
 
-    try {
-      // Get authorization link and send it to your user
-      const { link } = await actions.getAuthorizationLink({
-        connectionName,
-        identifier,
-      });
-      console.log('Authorize Apollo:', link); // present this link to your user for authorization, or click it yourself for testing
-      process.stdout.write('Press Enter after authorizing...');
-      await new Promise(r => process.stdin.once('data', r));
+    async function main() {
+      try {
+        // Get authorization link and send it to your user
+        const { link } = await actions.getAuthorizationLink({
+          connectionName,
+          identifier,
+        });
+        console.log('Authorize Apollo:', link); // present this link to your user for authorization, or click it yourself for testing
+        process.stdout.write('Press Enter after authorizing...');
+        await new Promise(r => process.stdin.once('data', r));
 
-      // After the user authorizes, make API calls via Scalekit proxy
-      const result = await actions.request({
-        connectionName,
-        identifier,
-        path: '/api/v1/contacts/search',
-        method: 'POST',
-      });
-      console.log(result.data);
-    } catch (err) {
-      console.error('Apollo request failed:', err);
-      process.exit(1);
+        // After the user authorizes, make API calls via Scalekit proxy
+        const result = await actions.request({
+          connectionName,
+          identifier,
+          path: '/api/v1/contacts/search',
+          method: 'POST',
+        });
+        console.log(result.data);
+      } catch (err) {
+        console.error('Apollo request failed:', err);
+        process.exit(1);
+      }
     }
+
+    main().catch((err) => {
+      console.error('Unhandled error:', err);
+      process.exit(1);
+    });
     ```
   </TabItem>
   <TabItem label="Python">

--- a/src/components/templates/agent-connectors/_usage-asana.mdx
+++ b/src/components/templates/agent-connectors/_usage-asana.mdx
@@ -7,7 +7,6 @@ You can interact with Asana in two ways — via direct proxy API calls or via Sc
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with Asana in two ways — via direct proxy API calls or via Sc
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Asana:', link);
@@ -43,7 +42,6 @@ You can interact with Asana in two ways — via direct proxy API calls or via Sc
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-attention.mdx
+++ b/src/components/templates/agent-connectors/_usage-attention.mdx
@@ -7,7 +7,6 @@ You can interact with Attention in two ways — via direct proxy API calls or vi
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with Attention in two ways — via direct proxy API calls or vi
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Attention:', link);
@@ -43,7 +42,6 @@ You can interact with Attention in two ways — via direct proxy API calls or vi
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-attio.mdx
+++ b/src/components/templates/agent-connectors/_usage-attio.mdx
@@ -21,7 +21,9 @@ Connect a user's Attio workspace and make API calls on their behalf — Scalekit
 
     // Step 1: Send this URL to your user to authorize Attio access
     const { link } = await actions.getAuthorizationLink({ connectionName, identifier });
-    console.log('Authorize Attio:', link);
+    console.log('Authorize Attio:', link); // present this link to your user for authorization, or click it yourself for testing
+    process.stdout.write('Press Enter after authorizing...');
+    await new Promise(r => process.stdin.once('data', r));
 
     // Step 2: After the user authorizes, make API calls via Scalekit proxy
 

--- a/src/components/templates/agent-connectors/_usage-attio.mdx
+++ b/src/components/templates/agent-connectors/_usage-attio.mdx
@@ -264,6 +264,6 @@ Connect a user's Attio workspace and make API calls on their behalf — Scalekit
   </TabItem>
 </Tabs>
 
-<Aside type="tip">
-**Choosing the right filter syntax**: Attio uses attribute slugs for filtering. Use `attio_list_attributes` to discover available attributes and their slugs before querying. For example, `email_addresses` is a multi-value attribute — filter it as an array condition.
+<Aside type="tip" title="Choosing the right filter syntax">
+Attio uses attribute slugs for filtering. Use `attio_list_attributes` to discover available attributes and their slugs before querying. For example, `email_addresses` is a multi-value attribute — filter it as an array condition.
 </Aside>

--- a/src/components/templates/agent-connectors/_usage-attio.mdx
+++ b/src/components/templates/agent-connectors/_usage-attio.mdx
@@ -3,6 +3,126 @@ import { Tabs, TabItem, Aside } from '@astrojs/starlight/components'
 Connect a user's Attio workspace and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
 <Tabs syncKey="tech-stack">
+  <TabItem label="Node.js">
+    ```typescript
+    import { ScalekitClient } from '@scalekit-sdk/node';
+    import 'dotenv/config';
+
+    const connectionName = 'attio';  // connection name from Scalekit dashboard
+    const identifier = 'user_123';   // your unique user identifier
+
+    // Get credentials from app.scalekit.com → Developers → API Credentials
+    const scalekit = new ScalekitClient(
+      process.env.SCALEKIT_ENV_URL,
+      process.env.SCALEKIT_CLIENT_ID,
+      process.env.SCALEKIT_CLIENT_SECRET
+    );
+    const actions = scalekit.actions;
+
+    // Step 1: Send this URL to your user to authorize Attio access
+    const { link } = await actions.getAuthorizationLink({ connectionName, identifier });
+    console.log('Authorize Attio:', link);
+
+    // Step 2: After the user authorizes, make API calls via Scalekit proxy
+
+    // --- Query people records with a filter ---
+    const people = await actions.request({
+      connectionName,
+      identifier,
+      path: '/v2/objects/people/records/query',
+      method: 'POST',
+      body: {
+        filter: {
+          email_addresses: [{ email_address: { $eq: 'alice@example.com' } }],
+        },
+        limit: 10,
+      },
+    });
+    console.log('People:', people.data);
+
+    // --- Create a company record ---
+    const company = await actions.request({
+      connectionName,
+      identifier,
+      path: '/v2/objects/companies/records',
+      method: 'POST',
+      body: {
+        data: {
+          values: {
+            name: [{ value: 'Acme Corp' }],
+            domains: [{ domain: 'acme.com' }],
+          },
+        },
+      },
+    });
+    const companyId = company.data.data.id.record_id;
+    console.log('Created company:', companyId);
+
+    // --- Create a person record and associate with the company ---
+    const person = await actions.request({
+      connectionName,
+      identifier,
+      path: '/v2/objects/people/records',
+      method: 'POST',
+      body: {
+        data: {
+          values: {
+            name: [{ first_name: 'Alice', last_name: 'Smith' }],
+            email_addresses: [{ email_address: 'alice@acme.com', attribute_type: 'email' }],
+            company: [{ target_record_id: companyId }],
+          },
+        },
+      },
+    });
+    const personId = person.data.data.id.record_id;
+    console.log('Created person:', personId);
+
+    // --- Add a note to the person record ---
+    const note = await actions.request({
+      connectionName,
+      identifier,
+      path: '/v2/notes',
+      method: 'POST',
+      body: {
+        data: {
+          parent_object: 'people',
+          parent_record_id: personId,
+          title: 'Initial outreach',
+          content: 'Spoke with Alice about Q2 pricing. Follow up next week.',
+          format: 'plaintext',
+        },
+      },
+    });
+    console.log('Created note:', note.data.data.id.note_id);
+
+    // --- Create a task linked to the person ---
+    const task = await actions.request({
+      connectionName,
+      identifier,
+      path: '/v2/tasks',
+      method: 'POST',
+      body: {
+        data: {
+          content: 'Send Q2 pricing proposal to Alice',
+          deadline_at: '2026-03-20T17:00:00.000Z',
+          is_completed: false,
+          linked_records: [{ target_object: 'people', target_record_id: personId }],
+        },
+      },
+    });
+    console.log('Created task:', task.data.data.id.task_id);
+
+    // --- Verify current token and workspace ---
+    const tokenInfo = await actions.request({
+      connectionName,
+      identifier,
+      path: '/v2/self',
+      method: 'GET',
+    });
+    console.log('Connected to workspace:', tokenInfo.data.data.workspace.name);
+    console.log('Granted scopes:', tokenInfo.data.data.scopes.join(', '));
+    ```
+  </TabItem>
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-attio.mdx
+++ b/src/components/templates/agent-connectors/_usage-attio.mdx
@@ -19,116 +19,120 @@ Connect a user's Attio workspace and make API calls on their behalf — Scalekit
     );
     const actions = scalekit.actions;
 
-    try {
-      // Step 1: Send this URL to your user to authorize Attio access
-      const { link } = await actions.getAuthorizationLink({ connectionName, identifier });
-      console.log('Authorize Attio:', link); // present this link to your user for authorization, or click it yourself for testing
-      process.stdout.write('Press Enter after authorizing...');
-      await new Promise(r => process.stdin.once('data', r));
+    async function main() {
+      try {
+        // Step 1: Send this URL to your user to authorize Attio access
+        const { link } = await actions.getAuthorizationLink({ connectionName, identifier });
+        console.log('Authorize Attio:', link); // present this link to your user for authorization, or click it yourself for testing
+        process.stdout.write('Press Enter after authorizing...');
+        await new Promise(r => process.stdin.once('data', r));
 
-      // Step 2: After the user authorizes, make API calls via Scalekit proxy
+        // Step 2: After the user authorizes, make API calls via Scalekit proxy
 
-      // --- Query people records with a filter ---
-      const people = await actions.request({
-        connectionName,
-        identifier,
-        path: '/v2/objects/people/records/query',
-        method: 'POST',
-        body: {
-          filter: {
-            email_addresses: [{ email_address: { $eq: 'alice@example.com' } }],
+        // --- Query people records with a filter ---
+        const people = await actions.request({
+          connectionName,
+          identifier,
+          path: '/v2/objects/people/records/query',
+          method: 'POST',
+          body: {
+            filter: {
+              email_addresses: [{ email_address: { $eq: 'alice@example.com' } }],
+            },
+            limit: 10,
           },
-          limit: 10,
-        },
-      });
-      console.log('People:', people.data);
+        });
+        console.log('People:', people.data);
 
-      // --- Create a company record ---
-      const company = await actions.request({
-        connectionName,
-        identifier,
-        path: '/v2/objects/companies/records',
-        method: 'POST',
-        body: {
-          data: {
-            values: {
-              name: [{ value: 'Acme Corp' }],
-              domains: [{ domain: 'acme.com' }],
+        // --- Create a company record ---
+        const company = await actions.request({
+          connectionName,
+          identifier,
+          path: '/v2/objects/companies/records',
+          method: 'POST',
+          body: {
+            data: {
+              values: {
+                name: [{ value: 'Acme Corp' }],
+                domains: [{ domain: 'acme.com' }],
+              },
             },
           },
-        },
-      });
-      const companyId = company.data.data.id.record_id;
-      console.log('Created company:', companyId);
+        });
+        const companyId = company.data.data.id.record_id;
+        console.log('Created company:', companyId);
 
-      // --- Create a person record and associate with the company ---
-      const person = await actions.request({
-        connectionName,
-        identifier,
-        path: '/v2/objects/people/records',
-        method: 'POST',
-        body: {
-          data: {
-            values: {
-              name: [{ first_name: 'Alice', last_name: 'Smith' }],
-              email_addresses: [{ email_address: 'alice@acme.com', attribute_type: 'email' }],
-              company: [{ target_record_id: companyId }],
+        // --- Create a person record and associate with the company ---
+        const person = await actions.request({
+          connectionName,
+          identifier,
+          path: '/v2/objects/people/records',
+          method: 'POST',
+          body: {
+            data: {
+              values: {
+                name: [{ first_name: 'Alice', last_name: 'Smith' }],
+                email_addresses: [{ email_address: 'alice@acme.com', attribute_type: 'email' }],
+                company: [{ target_record_id: companyId }],
+              },
             },
           },
-        },
-      });
-      const personId = person.data.data.id.record_id;
-      console.log('Created person:', personId);
+        });
+        const personId = person.data.data.id.record_id;
+        console.log('Created person:', personId);
 
-      // --- Add a note to the person record ---
-      const note = await actions.request({
-        connectionName,
-        identifier,
-        path: '/v2/notes',
-        method: 'POST',
-        body: {
-          data: {
-            parent_object: 'people',
-            parent_record_id: personId,
-            title: 'Initial outreach',
-            content: 'Spoke with Alice about Q2 pricing. Follow up next week.',
-            format: 'plaintext',
+        // --- Add a note to the person record ---
+        const note = await actions.request({
+          connectionName,
+          identifier,
+          path: '/v2/notes',
+          method: 'POST',
+          body: {
+            data: {
+              parent_object: 'people',
+              parent_record_id: personId,
+              title: 'Initial outreach',
+              content: 'Spoke with Alice about Q2 pricing. Follow up next week.',
+              format: 'plaintext',
+            },
           },
-        },
-      });
-      console.log('Created note:', note.data.data.id.note_id);
+        });
+        console.log('Created note:', note.data.data.id.note_id);
 
-      // --- Create a task linked to the person ---
-      const deadlineAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(); // 7 days from now
-      const task = await actions.request({
-        connectionName,
-        identifier,
-        path: '/v2/tasks',
-        method: 'POST',
-        body: {
-          data: {
-            content: 'Send Q2 pricing proposal to Alice',
-            deadline_at: deadlineAt,
-            is_completed: false,
-            linked_records: [{ target_object: 'people', target_record_id: personId }],
+        // --- Create a task linked to the person ---
+        const deadlineAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(); // 7 days from now
+        const task = await actions.request({
+          connectionName,
+          identifier,
+          path: '/v2/tasks',
+          method: 'POST',
+          body: {
+            data: {
+              content: 'Send Q2 pricing proposal to Alice',
+              deadline_at: deadlineAt,
+              is_completed: false,
+              linked_records: [{ target_object: 'people', target_record_id: personId }],
+            },
           },
-        },
-      });
-      console.log('Created task:', task.data.data.id.task_id);
+        });
+        console.log('Created task:', task.data.data.id.task_id);
 
-      // --- Verify current token and workspace ---
-      const tokenInfo = await actions.request({
-        connectionName,
-        identifier,
-        path: '/v2/self',
-        method: 'GET',
-      });
-      console.log('Connected to workspace:', tokenInfo.data.data.workspace.name);
-      console.log('Granted scopes:', tokenInfo.data.data.scopes.join(', '));
-    } catch (err) {
-      console.error('Attio request failed:', err);
-      process.exit(1);
+        // --- Verify current token and workspace ---
+        const tokenInfo = await actions.request({
+          connectionName,
+          identifier,
+          path: '/v2/self',
+          method: 'GET',
+        });
+        console.log('Connected to workspace:', tokenInfo.data.data.workspace.name);
+        console.log('Granted scopes:', tokenInfo.data.data.scopes.join(', '));
+      } catch (err) {
+        console.error('Attio request failed:', err);
+        process.exit(1);
+      }
     }
+
+    main();
     ```
   </TabItem>
   <TabItem label="Python">

--- a/src/components/templates/agent-connectors/_usage-attio.mdx
+++ b/src/components/templates/agent-connectors/_usage-attio.mdx
@@ -4,7 +4,7 @@ Connect a user's Attio workspace and make API calls on their behalf — Scalekit
 
 <Tabs syncKey="tech-stack">
   <TabItem label="Node.js">
-    ```typescript
+    ```typescript title="examples/attio.ts"
     import { ScalekitClient } from '@scalekit-sdk/node';
     import 'dotenv/config';
 
@@ -19,110 +19,116 @@ Connect a user's Attio workspace and make API calls on their behalf — Scalekit
     );
     const actions = scalekit.actions;
 
-    // Step 1: Send this URL to your user to authorize Attio access
-    const { link } = await actions.getAuthorizationLink({ connectionName, identifier });
-    console.log('Authorize Attio:', link); // present this link to your user for authorization, or click it yourself for testing
-    process.stdout.write('Press Enter after authorizing...');
-    await new Promise(r => process.stdin.once('data', r));
+    try {
+      // Step 1: Send this URL to your user to authorize Attio access
+      const { link } = await actions.getAuthorizationLink({ connectionName, identifier });
+      console.log('Authorize Attio:', link); // present this link to your user for authorization, or click it yourself for testing
+      process.stdout.write('Press Enter after authorizing...');
+      await new Promise(r => process.stdin.once('data', r));
 
-    // Step 2: After the user authorizes, make API calls via Scalekit proxy
+      // Step 2: After the user authorizes, make API calls via Scalekit proxy
 
-    // --- Query people records with a filter ---
-    const people = await actions.request({
-      connectionName,
-      identifier,
-      path: '/v2/objects/people/records/query',
-      method: 'POST',
-      body: {
-        filter: {
-          email_addresses: [{ email_address: { $eq: 'alice@example.com' } }],
+      // --- Query people records with a filter ---
+      const people = await actions.request({
+        connectionName,
+        identifier,
+        path: '/v2/objects/people/records/query',
+        method: 'POST',
+        body: {
+          filter: {
+            email_addresses: [{ email_address: { $eq: 'alice@example.com' } }],
+          },
+          limit: 10,
         },
-        limit: 10,
-      },
-    });
-    console.log('People:', people.data);
+      });
+      console.log('People:', people.data);
 
-    // --- Create a company record ---
-    const company = await actions.request({
-      connectionName,
-      identifier,
-      path: '/v2/objects/companies/records',
-      method: 'POST',
-      body: {
-        data: {
-          values: {
-            name: [{ value: 'Acme Corp' }],
-            domains: [{ domain: 'acme.com' }],
+      // --- Create a company record ---
+      const company = await actions.request({
+        connectionName,
+        identifier,
+        path: '/v2/objects/companies/records',
+        method: 'POST',
+        body: {
+          data: {
+            values: {
+              name: [{ value: 'Acme Corp' }],
+              domains: [{ domain: 'acme.com' }],
+            },
           },
         },
-      },
-    });
-    const companyId = company.data.data.id.record_id;
-    console.log('Created company:', companyId);
+      });
+      const companyId = company.data.data.id.record_id;
+      console.log('Created company:', companyId);
 
-    // --- Create a person record and associate with the company ---
-    const person = await actions.request({
-      connectionName,
-      identifier,
-      path: '/v2/objects/people/records',
-      method: 'POST',
-      body: {
-        data: {
-          values: {
-            name: [{ first_name: 'Alice', last_name: 'Smith' }],
-            email_addresses: [{ email_address: 'alice@acme.com', attribute_type: 'email' }],
-            company: [{ target_record_id: companyId }],
+      // --- Create a person record and associate with the company ---
+      const person = await actions.request({
+        connectionName,
+        identifier,
+        path: '/v2/objects/people/records',
+        method: 'POST',
+        body: {
+          data: {
+            values: {
+              name: [{ first_name: 'Alice', last_name: 'Smith' }],
+              email_addresses: [{ email_address: 'alice@acme.com', attribute_type: 'email' }],
+              company: [{ target_record_id: companyId }],
+            },
           },
         },
-      },
-    });
-    const personId = person.data.data.id.record_id;
-    console.log('Created person:', personId);
+      });
+      const personId = person.data.data.id.record_id;
+      console.log('Created person:', personId);
 
-    // --- Add a note to the person record ---
-    const note = await actions.request({
-      connectionName,
-      identifier,
-      path: '/v2/notes',
-      method: 'POST',
-      body: {
-        data: {
-          parent_object: 'people',
-          parent_record_id: personId,
-          title: 'Initial outreach',
-          content: 'Spoke with Alice about Q2 pricing. Follow up next week.',
-          format: 'plaintext',
+      // --- Add a note to the person record ---
+      const note = await actions.request({
+        connectionName,
+        identifier,
+        path: '/v2/notes',
+        method: 'POST',
+        body: {
+          data: {
+            parent_object: 'people',
+            parent_record_id: personId,
+            title: 'Initial outreach',
+            content: 'Spoke with Alice about Q2 pricing. Follow up next week.',
+            format: 'plaintext',
+          },
         },
-      },
-    });
-    console.log('Created note:', note.data.data.id.note_id);
+      });
+      console.log('Created note:', note.data.data.id.note_id);
 
-    // --- Create a task linked to the person ---
-    const task = await actions.request({
-      connectionName,
-      identifier,
-      path: '/v2/tasks',
-      method: 'POST',
-      body: {
-        data: {
-          content: 'Send Q2 pricing proposal to Alice',
-          deadline_at: '2026-03-20T17:00:00.000Z',
-          is_completed: false,
-          linked_records: [{ target_object: 'people', target_record_id: personId }],
+      // --- Create a task linked to the person ---
+      const deadlineAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(); // 7 days from now
+      const task = await actions.request({
+        connectionName,
+        identifier,
+        path: '/v2/tasks',
+        method: 'POST',
+        body: {
+          data: {
+            content: 'Send Q2 pricing proposal to Alice',
+            deadline_at: deadlineAt,
+            is_completed: false,
+            linked_records: [{ target_object: 'people', target_record_id: personId }],
+          },
         },
-      },
-    });
-    console.log('Created task:', task.data.data.id.task_id);
+      });
+      console.log('Created task:', task.data.data.id.task_id);
 
-    // --- Verify current token and workspace ---
-    const tokenInfo = await actions.request({
-      connectionName,
-      identifier,
-      path: '/v2/self',
-      method: 'GET',
-    });
-    console.log('Connected to workspace:', tokenInfo.data.data.workspace.name);
-    console.log('Granted scopes:', tokenInfo.data.data.scopes.join(', '));
+      // --- Verify current token and workspace ---
+      const tokenInfo = await actions.request({
+        connectionName,
+        identifier,
+        path: '/v2/self',
+        method: 'GET',
+      });
+      console.log('Connected to workspace:', tokenInfo.data.data.workspace.name);
+      console.log('Granted scopes:', tokenInfo.data.data.scopes.join(', '));
+    } catch (err) {
+      console.error('Attio request failed:', err);
+      process.exit(1);
+    }
     ```
   </TabItem>
   <TabItem label="Python">

--- a/src/components/templates/agent-connectors/_usage-bigquery.mdx
+++ b/src/components/templates/agent-connectors/_usage-bigquery.mdx
@@ -7,7 +7,6 @@ You can interact with BigQuery in two ways — via direct proxy API calls or via
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with BigQuery in two ways — via direct proxy API calls or via
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize BigQuery:', link);
@@ -43,7 +42,6 @@ You can interact with BigQuery in two ways — via direct proxy API calls or via
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-chorus.mdx
+++ b/src/components/templates/agent-connectors/_usage-chorus.mdx
@@ -7,7 +7,6 @@ You can interact with Chorus in two ways — via direct proxy API calls or via S
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with Chorus in two ways — via direct proxy API calls or via S
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Chorus:', link);
@@ -43,7 +42,6 @@ You can interact with Chorus in two ways — via direct proxy API calls or via S
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-clari_copilot.mdx
+++ b/src/components/templates/agent-connectors/_usage-clari_copilot.mdx
@@ -7,7 +7,6 @@ You can interact with Clari Copilot in two ways — via direct proxy API calls o
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with Clari Copilot in two ways — via direct proxy API calls o
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Clari Copilot:', link);
@@ -43,7 +42,6 @@ You can interact with Clari Copilot in two ways — via direct proxy API calls o
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-clickup.mdx
+++ b/src/components/templates/agent-connectors/_usage-clickup.mdx
@@ -7,7 +7,6 @@ You can interact with ClickUp in two ways — via direct proxy API calls or via 
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with ClickUp in two ways — via direct proxy API calls or via 
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize ClickUp:', link);
@@ -43,7 +42,6 @@ You can interact with ClickUp in two ways — via direct proxy API calls or via 
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-confluence.mdx
+++ b/src/components/templates/agent-connectors/_usage-confluence.mdx
@@ -9,7 +9,6 @@ You can interact with Confluence in two ways — via direct proxy API calls or v
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -24,11 +23,11 @@ You can interact with Confluence in two ways — via direct proxy API calls or v
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Confluence:', link);
@@ -45,7 +44,6 @@ You can interact with Confluence in two ways — via direct proxy API calls or v
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-dropbox.mdx
+++ b/src/components/templates/agent-connectors/_usage-dropbox.mdx
@@ -7,7 +7,6 @@ You can interact with Dropbox in two ways — via direct proxy API calls or via 
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with Dropbox in two ways — via direct proxy API calls or via 
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Dropbox:', link);
@@ -43,7 +42,6 @@ You can interact with Dropbox in two ways — via direct proxy API calls or via 
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-exa.mdx
+++ b/src/components/templates/agent-connectors/_usage-exa.mdx
@@ -7,6 +7,33 @@ You can interact with Exa in two ways — via direct proxy API calls or via Scal
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
+  <TabItem label="Node.js">
+    ```typescript
+    import { ScalekitClient } from '@scalekit-sdk/node';
+    import 'dotenv/config';
+
+    const connectionName = 'exa';     // connection name from your Scalekit dashboard
+    const identifier = 'user_123';    // your user's unique identifier
+
+    // Get your credentials from app.scalekit.com → Developers → Settings → API Credentials
+    const scalekit = new ScalekitClient(
+      process.env.SCALEKIT_ENV_URL,
+      process.env.SCALEKIT_CLIENT_ID,
+      process.env.SCALEKIT_CLIENT_SECRET
+    );
+    const actions = scalekit.actions;
+
+    // Make a request via Scalekit proxy — no API key needed here
+    const result = await actions.request({
+      connectionName,
+      identifier,
+      path: '/search',
+      method: 'POST',
+      body: { query: 'LLM observability tools 2025', num_results: 5 },
+    });
+    console.log(result.data);
+    ```
+  </TabItem>
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-fathom.mdx
+++ b/src/components/templates/agent-connectors/_usage-fathom.mdx
@@ -7,7 +7,6 @@ You can interact with Fathom in two ways — via direct proxy API calls or via S
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with Fathom in two ways — via direct proxy API calls or via S
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Fathom:', link);
@@ -43,7 +42,6 @@ You can interact with Fathom in two ways — via direct proxy API calls or via S
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-freshdesk.mdx
+++ b/src/components/templates/agent-connectors/_usage-freshdesk.mdx
@@ -9,7 +9,6 @@ You can interact with Freshdesk in two ways — via direct proxy API calls or vi
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -24,11 +23,11 @@ You can interact with Freshdesk in two ways — via direct proxy API calls or vi
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Freshdesk:', link);
@@ -45,7 +44,6 @@ You can interact with Freshdesk in two ways — via direct proxy API calls or vi
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-github.mdx
+++ b/src/components/templates/agent-connectors/_usage-github.mdx
@@ -7,7 +7,6 @@ You can interact with GitHub in two ways — via direct proxy API calls or via S
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with GitHub in two ways — via direct proxy API calls or via S
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize GitHub:', link);
@@ -43,7 +42,6 @@ You can interact with GitHub in two ways — via direct proxy API calls or via S
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-gmail.mdx
+++ b/src/components/templates/agent-connectors/_usage-gmail.mdx
@@ -7,7 +7,6 @@ You can interact with Gmail in two ways — via direct proxy API calls or via Sc
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with Gmail in two ways — via direct proxy API calls or via Sc
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Gmail:', link); // present this link to your user for authorization, or click it yourself for testing
@@ -43,7 +42,6 @@ You can interact with Gmail in two ways — via direct proxy API calls or via Sc
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-gong.mdx
+++ b/src/components/templates/agent-connectors/_usage-gong.mdx
@@ -7,7 +7,6 @@ You can interact with Gong in two ways — via direct proxy API calls or via Sca
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with Gong in two ways — via direct proxy API calls or via Sca
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Gong:', link);
@@ -43,7 +42,6 @@ You can interact with Gong in two ways — via direct proxy API calls or via Sca
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-google_ads.mdx
+++ b/src/components/templates/agent-connectors/_usage-google_ads.mdx
@@ -7,7 +7,6 @@ You can interact with Google Ads in two ways — via direct proxy API calls or v
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with Google Ads in two ways — via direct proxy API calls or v
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Google Ads:', link); // present this link to your user for authorization, or click it yourself for testing
@@ -43,7 +42,6 @@ You can interact with Google Ads in two ways — via direct proxy API calls or v
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-googlecalendar.mdx
+++ b/src/components/templates/agent-connectors/_usage-googlecalendar.mdx
@@ -7,7 +7,6 @@ You can interact with Google Calendar in two ways — via direct proxy API calls
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with Google Calendar in two ways — via direct proxy API calls
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Google Calendar:', link); // present this link to your user for authorization, or click it yourself for testing
@@ -43,7 +42,6 @@ You can interact with Google Calendar in two ways — via direct proxy API calls
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-googledocs.mdx
+++ b/src/components/templates/agent-connectors/_usage-googledocs.mdx
@@ -7,7 +7,6 @@ You can interact with Google Docs in two ways — via direct proxy API calls or 
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with Google Docs in two ways — via direct proxy API calls or 
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Google Docs:', link); // present this link to your user for authorization, or click it yourself for testing
@@ -43,7 +42,6 @@ You can interact with Google Docs in two ways — via direct proxy API calls or 
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-googledrive.mdx
+++ b/src/components/templates/agent-connectors/_usage-googledrive.mdx
@@ -7,7 +7,6 @@ You can interact with Google Drive in two ways — via direct proxy API calls or
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with Google Drive in two ways — via direct proxy API calls or
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Google Drive:', link); // present this link to your user for authorization, or click it yourself for testing
@@ -43,7 +42,6 @@ You can interact with Google Drive in two ways — via direct proxy API calls or
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-googleforms.mdx
+++ b/src/components/templates/agent-connectors/_usage-googleforms.mdx
@@ -7,7 +7,6 @@ You can interact with Google Forms in two ways — via direct proxy API calls or
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with Google Forms in two ways — via direct proxy API calls or
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Google Forms:', link); // present this link to your user for authorization, or click it yourself for testing
@@ -43,7 +42,6 @@ You can interact with Google Forms in two ways — via direct proxy API calls or
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-googlemeet.mdx
+++ b/src/components/templates/agent-connectors/_usage-googlemeet.mdx
@@ -7,7 +7,6 @@ You can interact with Google Meet in two ways — via direct proxy API calls or 
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with Google Meet in two ways — via direct proxy API calls or 
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Google Meet:', link); // present this link to your user for authorization, or click it yourself for testing
@@ -43,7 +42,6 @@ You can interact with Google Meet in two ways — via direct proxy API calls or 
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-googlesheets.mdx
+++ b/src/components/templates/agent-connectors/_usage-googlesheets.mdx
@@ -7,7 +7,6 @@ You can interact with Google Sheets in two ways — via direct proxy API calls o
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with Google Sheets in two ways — via direct proxy API calls o
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Google Sheets:', link); // present this link to your user for authorization, or click it yourself for testing
@@ -43,7 +42,6 @@ You can interact with Google Sheets in two ways — via direct proxy API calls o
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-googleslides.mdx
+++ b/src/components/templates/agent-connectors/_usage-googleslides.mdx
@@ -7,7 +7,6 @@ You can interact with Google Slides in two ways — via direct proxy API calls o
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with Google Slides in two ways — via direct proxy API calls o
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Google Slides:', link); // present this link to your user for authorization, or click it yourself for testing
@@ -43,7 +42,6 @@ You can interact with Google Slides in two ways — via direct proxy API calls o
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-harvestapi.mdx
+++ b/src/components/templates/agent-connectors/_usage-harvestapi.mdx
@@ -7,6 +7,89 @@ You can interact with Harvest API in two ways — via direct proxy API calls or 
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
+  <TabItem label="Node.js">
+    ```typescript
+    import { ScalekitClient } from '@scalekit-sdk/node';
+    import 'dotenv/config';
+
+    const connectionName = 'harvestapi';  // connection name from Scalekit dashboard
+    const identifier = 'user_123';        // must match the identifier used when adding the connected account
+
+    // Get credentials from app.scalekit.com → Developers → API Credentials
+    const scalekit = new ScalekitClient(
+      process.env.SCALEKIT_ENV_URL,
+      process.env.SCALEKIT_CLIENT_ID,
+      process.env.SCALEKIT_CLIENT_SECRET
+    );
+    const actions = scalekit.actions;
+
+    // Scrape a LinkedIn profile by URL
+    const profile = await actions.request({
+      connectionName,
+      identifier,
+      path: '/linkedin/profile',
+      method: 'GET',
+      queryParams: { url: 'https://www.linkedin.com/in/satyanadella' },
+    });
+    console.log(profile.data);
+
+    // Search LinkedIn for people by title and location
+    const people = await actions.request({
+      connectionName,
+      identifier,
+      path: '/linkedin/lead-search',
+      method: 'GET',
+      queryParams: { title: 'VP of Engineering', location: 'San Francisco, CA' },
+    });
+    console.log(people.data);
+
+    // Scrape a LinkedIn company page
+    const company = await actions.request({
+      connectionName,
+      identifier,
+      path: '/linkedin/company',
+      method: 'GET',
+      queryParams: { url: 'https://www.linkedin.com/company/openai' },
+    });
+    console.log(company.data);
+
+    // Search LinkedIn job listings by keyword and location
+    const jobs = await actions.request({
+      connectionName,
+      identifier,
+      path: '/linkedin/job-search',
+      method: 'GET',
+      queryParams: { keywords: 'machine learning engineer', location: 'New York, NY' },
+    });
+    console.log(jobs.data);
+
+    // Scrape a single job listing by URL
+    const job = await actions.request({
+      connectionName,
+      identifier,
+      path: '/linkedin/job',
+      method: 'GET',
+      queryParams: { url: 'https://www.linkedin.com/jobs/view/1234567890' },
+    });
+    console.log(job.data);
+
+    // Bulk scrape multiple LinkedIn profiles in one request
+    const bulk = await actions.request({
+      connectionName,
+      identifier,
+      path: '/v2/acts/harvestapi~linkedin-profile-scraper/run-sync-get-dataset-items',
+      method: 'POST',
+      body: {
+        urls: [
+          'https://www.linkedin.com/in/satyanadella',
+          'https://www.linkedin.com/in/jeffweiner08',
+          'https://www.linkedin.com/in/reidhoffman',
+        ],
+      },
+    });
+    console.log(bulk.data);
+    ```
+  </TabItem>
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-hubspot.mdx
+++ b/src/components/templates/agent-connectors/_usage-hubspot.mdx
@@ -7,7 +7,6 @@ You can interact with HubSpot in two ways — via direct proxy API calls or via 
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with HubSpot in two ways — via direct proxy API calls or via 
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize HubSpot:', link);
@@ -43,7 +42,6 @@ You can interact with HubSpot in two ways — via direct proxy API calls or via 
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-intercom.mdx
+++ b/src/components/templates/agent-connectors/_usage-intercom.mdx
@@ -7,7 +7,6 @@ You can interact with Intercom in two ways — via direct proxy API calls or via
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with Intercom in two ways — via direct proxy API calls or via
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Intercom:', link);
@@ -43,7 +42,6 @@ You can interact with Intercom in two ways — via direct proxy API calls or via
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-jira.mdx
+++ b/src/components/templates/agent-connectors/_usage-jira.mdx
@@ -9,7 +9,6 @@ You can interact with Jira in two ways — via direct proxy API calls or via Sca
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -24,11 +23,11 @@ You can interact with Jira in two ways — via direct proxy API calls or via Sca
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Jira:', link);
@@ -45,7 +44,6 @@ You can interact with Jira in two ways — via direct proxy API calls or via Sca
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-linear.mdx
+++ b/src/components/templates/agent-connectors/_usage-linear.mdx
@@ -7,7 +7,6 @@ You can interact with Linear in two ways — via direct proxy API calls or via S
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with Linear in two ways — via direct proxy API calls or via S
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Linear:', link);
@@ -44,7 +43,6 @@ You can interact with Linear in two ways — via direct proxy API calls or via S
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os, json

--- a/src/components/templates/agent-connectors/_usage-microsoftexcel.mdx
+++ b/src/components/templates/agent-connectors/_usage-microsoftexcel.mdx
@@ -3,7 +3,6 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 Connect a user's Microsoft Excel account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -18,11 +17,11 @@ Connect a user's Microsoft Excel account and make API calls on their behalf — 
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Microsoft Excel:', link);
@@ -39,7 +38,6 @@ Connect a user's Microsoft Excel account and make API calls on their behalf — 
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-microsoftteams.mdx
+++ b/src/components/templates/agent-connectors/_usage-microsoftteams.mdx
@@ -3,7 +3,6 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 Connect a user's Microsoft Teams account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -18,11 +17,11 @@ Connect a user's Microsoft Teams account and make API calls on their behalf — 
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Microsoft Teams:', link);
@@ -39,7 +38,6 @@ Connect a user's Microsoft Teams account and make API calls on their behalf — 
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-microsoftword.mdx
+++ b/src/components/templates/agent-connectors/_usage-microsoftword.mdx
@@ -7,7 +7,6 @@ You can interact with Microsoft Word in two ways — via direct proxy API calls 
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with Microsoft Word in two ways — via direct proxy API calls 
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Microsoft Word:', link);
@@ -43,7 +42,6 @@ You can interact with Microsoft Word in two ways — via direct proxy API calls 
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-monday.mdx
+++ b/src/components/templates/agent-connectors/_usage-monday.mdx
@@ -7,7 +7,6 @@ You can interact with Monday in two ways — via direct proxy API calls or via S
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with Monday in two ways — via direct proxy API calls or via S
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Monday.com:', link);
@@ -43,7 +42,6 @@ You can interact with Monday in two ways — via direct proxy API calls or via S
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-notion.mdx
+++ b/src/components/templates/agent-connectors/_usage-notion.mdx
@@ -7,7 +7,6 @@ You can interact with Notion in two ways — via direct proxy API calls or via S
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with Notion in two ways — via direct proxy API calls or via S
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Notion:', link);
@@ -43,7 +42,6 @@ You can interact with Notion in two ways — via direct proxy API calls or via S
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-onedrive.mdx
+++ b/src/components/templates/agent-connectors/_usage-onedrive.mdx
@@ -3,7 +3,6 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 Connect a user's OneDrive account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -18,11 +17,11 @@ Connect a user's OneDrive account and make API calls on their behalf — Scaleki
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize OneDrive:', link);
@@ -39,7 +38,6 @@ Connect a user's OneDrive account and make API calls on their behalf — Scaleki
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-onenote.mdx
+++ b/src/components/templates/agent-connectors/_usage-onenote.mdx
@@ -3,7 +3,6 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 Connect a user's OneNote account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -18,11 +17,11 @@ Connect a user's OneNote account and make API calls on their behalf — Scalekit
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize OneNote:', link);
@@ -39,7 +38,6 @@ Connect a user's OneNote account and make API calls on their behalf — Scalekit
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-outlook.mdx
+++ b/src/components/templates/agent-connectors/_usage-outlook.mdx
@@ -7,7 +7,6 @@ You can interact with Outlook in two ways — via direct proxy API calls or via 
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with Outlook in two ways — via direct proxy API calls or via 
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Outlook:', link);
@@ -43,7 +42,6 @@ You can interact with Outlook in two ways — via direct proxy API calls or via 
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-salesforce.mdx
+++ b/src/components/templates/agent-connectors/_usage-salesforce.mdx
@@ -9,7 +9,6 @@ You can interact with Salesforce in two ways — via direct proxy API calls or v
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -24,11 +23,11 @@ You can interact with Salesforce in two ways — via direct proxy API calls or v
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Salesforce:', link);
@@ -45,7 +44,6 @@ You can interact with Salesforce in two ways — via direct proxy API calls or v
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-servicenow.mdx
+++ b/src/components/templates/agent-connectors/_usage-servicenow.mdx
@@ -9,7 +9,6 @@ You can interact with ServiceNow in two ways — via direct proxy API calls or v
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -24,11 +23,11 @@ You can interact with ServiceNow in two ways — via direct proxy API calls or v
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize ServiceNow:', link);
@@ -45,7 +44,6 @@ You can interact with ServiceNow in two ways — via direct proxy API calls or v
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-sharepoint.mdx
+++ b/src/components/templates/agent-connectors/_usage-sharepoint.mdx
@@ -7,7 +7,6 @@ You can interact with SharePoint in two ways — via direct proxy API calls or v
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with SharePoint in two ways — via direct proxy API calls or v
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize SharePoint:', link);
@@ -43,7 +42,6 @@ You can interact with SharePoint in two ways — via direct proxy API calls or v
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-slack.mdx
+++ b/src/components/templates/agent-connectors/_usage-slack.mdx
@@ -7,7 +7,6 @@ You can interact with Slack in two ways — via direct proxy API calls or via Sc
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with Slack in two ways — via direct proxy API calls or via Sc
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Slack:', link);
@@ -43,7 +42,6 @@ You can interact with Slack in two ways — via direct proxy API calls or via Sc
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-snowflake.mdx
+++ b/src/components/templates/agent-connectors/_usage-snowflake.mdx
@@ -9,7 +9,6 @@ You can interact with Snowflake in two ways — via direct proxy API calls or vi
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -24,11 +23,11 @@ You can interact with Snowflake in two ways — via direct proxy API calls or vi
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Snowflake:', link);
@@ -45,7 +44,6 @@ You can interact with Snowflake in two ways — via direct proxy API calls or vi
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-snowflakekeyauth.mdx
+++ b/src/components/templates/agent-connectors/_usage-snowflakekeyauth.mdx
@@ -9,7 +9,6 @@ You can interact with Snowflake in two ways — via direct proxy API calls or vi
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -24,11 +23,11 @@ You can interact with Snowflake in two ways — via direct proxy API calls or vi
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Snowflake:', link); // present this link to your user for authorization, or click it yourself for testing
@@ -46,7 +45,6 @@ You can interact with Snowflake in two ways — via direct proxy API calls or vi
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-trello.mdx
+++ b/src/components/templates/agent-connectors/_usage-trello.mdx
@@ -7,7 +7,6 @@ You can interact with Trello in two ways — via direct proxy API calls or via S
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with Trello in two ways — via direct proxy API calls or via S
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Trello:', link);
@@ -43,7 +42,6 @@ You can interact with Trello in two ways — via direct proxy API calls or via S
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-zendesk.mdx
+++ b/src/components/templates/agent-connectors/_usage-zendesk.mdx
@@ -9,7 +9,6 @@ You can interact with Zendesk in two ways — via direct proxy API calls or via 
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -24,11 +23,11 @@ You can interact with Zendesk in two ways — via direct proxy API calls or via 
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Zendesk:', link); // present this link to your user for authorization, or click it yourself for testing
@@ -45,7 +44,6 @@ You can interact with Zendesk in two ways — via direct proxy API calls or via 
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os

--- a/src/components/templates/agent-connectors/_usage-zoom.mdx
+++ b/src/components/templates/agent-connectors/_usage-zoom.mdx
@@ -7,7 +7,6 @@ You can interact with Zoom in two ways — via direct proxy API calls or via Sca
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
-{/* Node.js - commented out, uncomment when ready
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
@@ -22,11 +21,11 @@ You can interact with Zoom in two ways — via direct proxy API calls or via Sca
       process.env.SCALEKIT_CLIENT_ID,
       process.env.SCALEKIT_CLIENT_SECRET
     );
-    const { connectedAccounts, actions } = scalekit;
+    const actions = scalekit.actions;
 
     // Authenticate the user
-    const { link } = await connectedAccounts.getMagicLinkForConnectedAccount({
-      connector: connectionName,
+    const { link } = await actions.getAuthorizationLink({
+      connectionName,
       identifier,
     });
     console.log('🔗 Authorize Zoom:', link);
@@ -43,7 +42,6 @@ You can interact with Zoom in two ways — via direct proxy API calls or via Sca
     console.log(result);
     ```
   </TabItem>
-*/}
   <TabItem label="Python">
     ```python
     import scalekit.client, os


### PR DESCRIPTION
Re-enable and add Node.js examples across many agent connector MDX docs. Standardize usage to use scalekit.actions and actions.getAuthorizationLink(...) instead of the older connectedAccounts.getMagicLinkForConnectedAccount(...) pattern. Add new Node.js snippets (including expanded examples for Apollo, Attio, Exa, and HarvestAPI) and remove commented-out wrapper blocks so Node.js tabs are available and consistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Node.js connector examples to the new authorization + proxy pattern.
  * Enabled previously hidden Node.js examples so they now render as active tabs.
  * Added several end-to-end Node.js examples with auth link flow, user confirmation pauses, and improved error handling.
  * Standardized Node.js example patterns across connector docs for consistency and clearer guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->