### PR TITLE
Fix tools list  and quick start

### DIFF
--- a/src/components/templates/agent-connectors/_usage-airtable.mdx
+++ b/src/components/templates/agent-connectors/_usage-airtable.mdx
@@ -83,5 +83,3 @@ You can interact with Airtable in two ways — via direct proxy API calls or via
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-asana.mdx
+++ b/src/components/templates/agent-connectors/_usage-asana.mdx
@@ -83,5 +83,3 @@ You can interact with Asana in two ways — via direct proxy API calls or via Sc
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-attention.mdx
+++ b/src/components/templates/agent-connectors/_usage-attention.mdx
@@ -83,5 +83,3 @@ You can interact with Attention in two ways — via direct proxy API calls or vi
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-bigquery.mdx
+++ b/src/components/templates/agent-connectors/_usage-bigquery.mdx
@@ -83,5 +83,3 @@ You can interact with BigQuery in two ways — via direct proxy API calls or via
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-chorus.mdx
+++ b/src/components/templates/agent-connectors/_usage-chorus.mdx
@@ -83,5 +83,3 @@ You can interact with Chorus in two ways — via direct proxy API calls or via S
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-clari_copilot.mdx
+++ b/src/components/templates/agent-connectors/_usage-clari_copilot.mdx
@@ -83,5 +83,3 @@ You can interact with Clari Copilot in two ways — via direct proxy API calls o
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-clickup.mdx
+++ b/src/components/templates/agent-connectors/_usage-clickup.mdx
@@ -83,5 +83,3 @@ You can interact with ClickUp in two ways — via direct proxy API calls or via 
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-confluence.mdx
+++ b/src/components/templates/agent-connectors/_usage-confluence.mdx
@@ -85,5 +85,3 @@ You can interact with Confluence in two ways — via direct proxy API calls or v
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-dropbox.mdx
+++ b/src/components/templates/agent-connectors/_usage-dropbox.mdx
@@ -83,5 +83,3 @@ You can interact with Dropbox in two ways — via direct proxy API calls or via 
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-exa.mdx
+++ b/src/components/templates/agent-connectors/_usage-exa.mdx
@@ -42,5 +42,3 @@ Exa uses API key auth — unlike OAuth connectors, there is no authorization lin
 </Aside>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-fathom.mdx
+++ b/src/components/templates/agent-connectors/_usage-fathom.mdx
@@ -83,5 +83,3 @@ You can interact with Fathom in two ways — via direct proxy API calls or via S
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-freshdesk.mdx
+++ b/src/components/templates/agent-connectors/_usage-freshdesk.mdx
@@ -85,5 +85,3 @@ You can interact with Freshdesk in two ways — via direct proxy API calls or vi
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-github.mdx
+++ b/src/components/templates/agent-connectors/_usage-github.mdx
@@ -83,5 +83,3 @@ You can interact with GitHub in two ways — via direct proxy API calls or via S
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-gmail.mdx
+++ b/src/components/templates/agent-connectors/_usage-gmail.mdx
@@ -83,5 +83,3 @@ You can interact with Gmail in two ways — via direct proxy API calls or via Sc
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-gong.mdx
+++ b/src/components/templates/agent-connectors/_usage-gong.mdx
@@ -83,5 +83,3 @@ You can interact with Gong in two ways — via direct proxy API calls or via Sca
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-google_ads.mdx
+++ b/src/components/templates/agent-connectors/_usage-google_ads.mdx
@@ -83,5 +83,3 @@ You can interact with Google Ads in two ways — via direct proxy API calls or v
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-googlecalendar.mdx
+++ b/src/components/templates/agent-connectors/_usage-googlecalendar.mdx
@@ -83,5 +83,3 @@ You can interact with Google Calendar in two ways — via direct proxy API calls
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-googleforms.mdx
+++ b/src/components/templates/agent-connectors/_usage-googleforms.mdx
@@ -83,5 +83,3 @@ You can interact with Google Forms in two ways — via direct proxy API calls or
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-googlemeet.mdx
+++ b/src/components/templates/agent-connectors/_usage-googlemeet.mdx
@@ -83,5 +83,3 @@ You can interact with Google Meet in two ways — via direct proxy API calls or 
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-googleslides.mdx
+++ b/src/components/templates/agent-connectors/_usage-googleslides.mdx
@@ -83,5 +83,3 @@ You can interact with Google Slides in two ways — via direct proxy API calls o
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-harvestapi.mdx
+++ b/src/components/templates/agent-connectors/_usage-harvestapi.mdx
@@ -93,5 +93,3 @@ You can interact with Harvest API in two ways — via direct proxy API calls or 
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-hubspot.mdx
+++ b/src/components/templates/agent-connectors/_usage-hubspot.mdx
@@ -83,5 +83,3 @@ You can interact with HubSpot in two ways — via direct proxy API calls or via 
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-intercom.mdx
+++ b/src/components/templates/agent-connectors/_usage-intercom.mdx
@@ -83,5 +83,3 @@ You can interact with Intercom in two ways — via direct proxy API calls or via
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-jira.mdx
+++ b/src/components/templates/agent-connectors/_usage-jira.mdx
@@ -85,5 +85,3 @@ You can interact with Jira in two ways — via direct proxy API calls or via Sca
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-linear.mdx
+++ b/src/components/templates/agent-connectors/_usage-linear.mdx
@@ -85,5 +85,3 @@ You can interact with Linear in two ways — via direct proxy API calls or via S
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-microsoftword.mdx
+++ b/src/components/templates/agent-connectors/_usage-microsoftword.mdx
@@ -83,5 +83,3 @@ You can interact with Microsoft Word in two ways — via direct proxy API calls 
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-monday.mdx
+++ b/src/components/templates/agent-connectors/_usage-monday.mdx
@@ -83,5 +83,3 @@ You can interact with Monday in two ways — via direct proxy API calls or via S
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-notion.mdx
+++ b/src/components/templates/agent-connectors/_usage-notion.mdx
@@ -83,5 +83,3 @@ You can interact with Notion in two ways — via direct proxy API calls or via S
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-outlook.mdx
+++ b/src/components/templates/agent-connectors/_usage-outlook.mdx
@@ -83,5 +83,3 @@ You can interact with Outlook in two ways — via direct proxy API calls or via 
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-salesforce.mdx
+++ b/src/components/templates/agent-connectors/_usage-salesforce.mdx
@@ -85,5 +85,3 @@ You can interact with Salesforce in two ways — via direct proxy API calls or v
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-servicenow.mdx
+++ b/src/components/templates/agent-connectors/_usage-servicenow.mdx
@@ -85,5 +85,3 @@ You can interact with ServiceNow in two ways — via direct proxy API calls or v
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-slack.mdx
+++ b/src/components/templates/agent-connectors/_usage-slack.mdx
@@ -83,5 +83,3 @@ You can interact with Slack in two ways — via direct proxy API calls or via Sc
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-snowflake.mdx
+++ b/src/components/templates/agent-connectors/_usage-snowflake.mdx
@@ -85,5 +85,3 @@ You can interact with Snowflake in two ways — via direct proxy API calls or vi
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-snowflakekeyauth.mdx
+++ b/src/components/templates/agent-connectors/_usage-snowflakekeyauth.mdx
@@ -87,5 +87,3 @@ You can interact with Snowflake in two ways — via direct proxy API calls or vi
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-trello.mdx
+++ b/src/components/templates/agent-connectors/_usage-trello.mdx
@@ -83,5 +83,3 @@ You can interact with Trello in two ways — via direct proxy API calls or via S
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-zendesk.mdx
+++ b/src/components/templates/agent-connectors/_usage-zendesk.mdx
@@ -85,5 +85,3 @@ You can interact with Zendesk in two ways — via direct proxy API calls or via 
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/components/templates/agent-connectors/_usage-zoom.mdx
+++ b/src/components/templates/agent-connectors/_usage-zoom.mdx
@@ -83,5 +83,3 @@ You can interact with Zoom in two ways — via direct proxy API calls or via Sca
 </Tabs>
 
 ## Scalekit Tools
-
-No Scalekit optimized tools are available for this provider yet.

--- a/src/content/docs/agent-auth/quickstart.mdx
+++ b/src/content/docs/agent-auth/quickstart.mdx
@@ -228,7 +228,7 @@ In this quickstart, you'll build a simple tool-calling program that:
     <Tabs syncKey="tech-stack">
       <TabItem label="Python">
         ```python showLineNumbers=false frame="none" wrap
-        response = scalekit_client.connect.execute_tool(
+        response = actions.execute_tool(
             tool_name="gmail_fetch_mails",
             identifier="user_123",
             tool_input={

--- a/src/content/docs/agent-auth/quickstart.mdx
+++ b/src/content/docs/agent-auth/quickstart.mdx
@@ -147,6 +147,8 @@ In this quickstart, you'll build a simple tool-calling program that:
     </Tabs>
     <Aside title="Set up a connection">
       The Gmail connector is enabled by default for quick getting started purposes. In case your app wants to connect to different third-party apps, you can setup a connection for each app in the Scalekit dashboard > Agent Auth > _+ Create Connection_
+
+      To set up your app's credentials for a provider, check the **Providers** section in the sidebar.
     </Aside>
 3. ## Authenticate the user
 
@@ -186,138 +188,68 @@ In this quickstart, you'll build a simple tool-calling program that:
       </TabItem>
     </Tabs>
 
-4. ## Fetch OAuth tokens for the user
+4. ## Call the Gmail API to fetch last 5 unread emails
 
-     Now that the user has successfully authorized the Gmail connection, you can fetch the latest access token and refresh token for the user's connected account anytime you want.
-    Scalekit will keep the token refreshed periodically so that you always have the latest valid access token to make API calls on behalf of the user.
+     Now that the user is authenticated, use Scalekit's proxy to call the Gmail API directly — no need to manage access tokens yourself.
 
     <Tabs syncKey="tech-stack">
       <TabItem label="Python">
         ```python showLineNumbers=false frame="none" wrap
-        # Retrieve the connected account to extract OAuth tokens
-        response = actions.get_connected_account(
-                connection_name="gmail",
-                identifier="user_123"
+        # Fetch 5 unread emails via Scalekit proxy
+        result = actions.request(
+            connection_name="gmail",
+            identifier="user_123",
+            path="/gmail/v1/users/me/messages",
+            method="GET",
+            params={"q": "is:unread", "maxResults": 5}
         )
-
-        connected_account = response.connected_account
-
-        # Extract OAuth tokens from authorization details
-        tokens = connected_account.authorization_details["oauth_token"]
-        access_token = tokens["access_token"]
-        refresh_token = tokens["refresh_token"]
-
-        # Security Warning: Never log OAuth tokens in production. Token exposure in logs
-        # or aggregators creates credential leakage risks. Use safe redaction,
-        # conditional debug-only logging, or secure secret storage instead.
-        if os.getenv("DEBUG"):
-            print("access token:", access_token)
-            print("refresh token:", refresh_token)
+        print(result)
         ```
       </TabItem>
       <TabItem label="Node.js">
         ```typescript showLineNumbers=false frame="none" wrap
-        const accountResponse = await actions.getConnectedAccount({
+        // Fetch 5 unread emails via Scalekit proxy
+        const result = await actions.request({
           connectionName: 'gmail',
           identifier: 'user_123',
+          path: '/gmail/v1/users/me/messages',
+          method: 'GET',
+          params: { q: 'is:unread', maxResults: '5' },
         });
-
-        // Extract OAuth tokens from authorization details
-        const authDetails = accountResponse?.connectedAccount?.authorizationDetails;
-        const accessToken = (authDetails && authDetails.details?.case === 'oauthToken')
-          ? authDetails.details.value?.accessToken
-          : undefined;
-        const refreshToken = (authDetails && authDetails.details?.case === 'oauthToken')
-          ? authDetails.details.value?.refreshToken
-          : undefined;
-
-        // Security Warning: Never log OAuth tokens in production. Token exposure in logs
-        // or aggregators creates credential leakage risks. Use safe redaction,
-        // conditional debug-only logging, or secure secret storage instead.
-        if (process.env.NODE_ENV === 'development') {
-          console.log('accessToken:', accessToken);
-          console.log('refreshToken:', refreshToken);
-        }
+        console.log(result);
         ```
       </TabItem>
     </Tabs>
-    Refer to the respective connector's API documentation for more details on how to use these tokens and consume their API. Scalekit provides tools for most of the connectors, so you can use them to call the API directly.
 
-5. ## Call the Gmail API to fetch last 5 unread emails
+5. ## Use Scalekit optimized tools
 
-     Now that the user is authenticated and you have the access token, you can execute the Gmail API to fetch the last 5 unread emails from the user's inbox.
-     The example below directly calls the Gmail API. You can use the Gmail SDK or any other HTTP client of your choice to make the API calls.
+     In addition to the proxy, Scalekit provides optimized tools built specifically for AI agents. These tools abstract away API complexity — no need to know the exact endpoint, parameters, or response shape. Under the hood, they orchestrate multiple API calls and return the response in a structured, AI-friendly format that's easy for your agent to reason over.
 
     <Tabs syncKey="tech-stack">
       <TabItem label="Python">
-         ```python showLineNumbers=false frame="none" wrap
-         # Fetch 5 unread emails using Gmail API
-         headers = {
-             "Authorization": f"Bearer {access_token}",  # Use the OAuth access token
-         }
-
-         list_url = "https://gmail.googleapis.com/gmail/v1/users/me/messages"
-         params = {
-             "q": "is:unread",
-             "maxResults": 5,
-         }
-
-         list_response = requests.get(list_url, headers=headers, params=params)
-         messages = list_response.json().get("messages", [])
-
-         print(f"\nFound {len(messages)} unread emails:\n")
-
-         # Fetch and display details for each email
-         for msg in messages:
-            msg_url = f"{list_url}/{msg['id']}"
-            msg_response = requests.get(msg_url, headers=headers, params={"format": "metadata", "metadataHeaders": ["From", "Subject", "Date"]})
-            msg_data = msg_response.json()
-
-            headers_list = msg_data.get("payload", {}).get("headers", [])
-            subject = next((h["value"] for h in headers_list if h["name"] == "Subject"), "No Subject")
-            sender = next((h["value"] for h in headers_list if h["name"] == "From"), "Unknown")
-            date = next((h["value"] for h in headers_list if h["name"] == "Date"), "Unknown")
-
-            print(f"From: {sender}")
-            print(f"Subject: {subject}")
-            print(f"Date: {date}")
-            print(f"Snippet: {msg_data.get('snippet', '')}")
-            print("-" * 50)
+        ```python showLineNumbers=false frame="none" wrap
+        response = scalekit_client.connect.execute_tool(
+            tool_name="gmail_fetch_mails",
+            identifier="user_123",
+            tool_input={
+                "query": "is:unread",
+                "max_results": 5,
+            },
+        )
+        print(response)
         ```
       </TabItem>
       <TabItem label="Node.js">
-         ```typescript showLineNumbers=false frame="none" wrap
-         // Fetch 5 unread emails using Gmail API
-         const listUrl = 'https://gmail.googleapis.com/gmail/v1/users/me/messages';
-         const params = new URLSearchParams({ q: 'is:unread', maxResults: '5' });
-
-         const listResponse = await fetch(`${listUrl}?${params}`, {
-           headers: { Authorization: `Bearer ${accessToken}` },  // Use the OAuth access token
-         });
-         const listData = await listResponse.json();
-         const messages = listData.messages ?? [];
-
-         console.log(`\nFound ${messages.length} unread emails:\n`);
-
-         // Fetch and display details for each email
-         for (const msg of messages) {
-          const msgResponse = await fetch(
-            `${listUrl}/${msg.id}?format=metadata&metadataHeaders=From&metadataHeaders=Subject&metadataHeaders=Date`,
-            { headers: { Authorization: `Bearer ${accessToken}` } }
-          );
-          const msgData = await msgResponse.json();
-
-          const headersList = msgData.payload?.headers ?? [];
-          const subject = headersList.find((h) => h.name === 'Subject')?.value ?? 'No Subject';
-          const sender = headersList.find((h) => h.name === 'From')?.value ?? 'Unknown';
-          const date = headersList.find((h) => h.name === 'Date')?.value ?? 'Unknown';
-
-          console.log(`From: ${sender}`);
-          console.log(`Subject: ${subject}`);
-          console.log(`Date: ${date}`);
-          console.log(`Snippet: ${msgData.snippet ?? ''}`);
-          console.log('-'.repeat(50));
-        }
+        ```typescript showLineNumbers=false frame="none" wrap
+        const toolResponse = await actions.executeTool({
+          toolName: 'gmail_fetch_mails',
+          connectedAccountId: connectedAccount?.id,
+          toolInput: {
+            query: 'is:unread',
+            max_results: 5,
+          },
+        });
+        console.log('Recent emails:', toolResponse.result);
         ```
       </TabItem>
     </Tabs>


### PR DESCRIPTION
Fix tools list  and udpate quick start to bring tool calling along with tool execution framework as optimised tools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed placeholder “no tools available” messages from many provider usage pages to declutter provider docs.
  * Quickstart: added guidance to check the Providers sidebar when configuring credentials.
  * Quickstart examples: replaced manual Gmail API/token examples with demonstrations of invoking Scalekit-optimized tools and displaying their results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->