### PR TITLE
Add missing SSO error codes to error reference

### DIFF
--- a/src/content/docs/sso/reference/sso-integration-errors.mdx
+++ b/src/content/docs/sso/reference/sso-integration-errors.mdx
@@ -36,6 +36,11 @@ Ideally, you would want to catch these errors in the development environments. T
 | <pre>invalid_connection_id</pre> | Invalid connection ID | Verify and use a valid connection ID |
 | <pre>domain_not_found</pre> | No domain specified for the SSO connection(s) | Check domain configuration in Scalekit dashboard |
 | <pre>invalid_user_domain</pre> | User's domain not allowed for this SSO connection | Ensure user domain is part of the allowed domains list |
+| <pre>invalid_client</pre> | The client application is not recognized or not configured correctly | Verify the `client_id` value in your authorization URL |
+| <pre>application_not_active</pre> | The application is inactive | Enable the application in the Scalekit dashboard |
+| <pre>invalid_request</pre> | The authorization request contains invalid or missing parameters | Review the authorization URL parameters |
+| <pre>unauthorized</pre> | The request is unauthorized | Verify that valid credentials are being used |
+| <pre>user_not_active</pre> | The user account is inactive | Activate the user account or contact the IT admin |
 | <pre>server_error</pre> | _actual error description from the server_ | This must be a rare occurrence. Please reach out to us via your private slack channel or <a href="mailto:support@scalekit.com" target="_blank" rel="noopener">via email</a> |
 
 ## SSO configuration related errors
@@ -56,9 +61,14 @@ Once your customer configures the SSO settings properly, tests the configuration
 | <pre>user_info_retrieve_failed</pre> | User info retrieval failed, possibly due to an incorrect `client_secret` or other issues | Update the `client_secret` with the correct value. If unsuccessful, investigate further. Please reach out to us via your private slack channel or <a href="mailto:support@scalekit.com" target="_blank" rel="noopener">via email</a> |
 | <pre>invalid_saml_metadata</pre> | Incorrect SAML metadata configuration | Update SAML metadata URL with the correct value |
 | <pre>invalid_saml_response</pre> | Invalid SAML response | Review and fix SAML configuration settings |
+| <pre>invalid_saml_request</pre> | The SAML request is invalid | Check the SAML configuration in both Scalekit and the identity provider |
+| <pre>invalid_saml_form_params</pre> | The SAML form parameters are invalid or malformed | Review the SAML response format from the identity provider |
 | <pre>signature_validation_failed</pre> | Failed signature validation | Review and update the ACS URL in the identity provider's settings |
 | <pre>invalid_acs_url</pre> | Invalid ACS URL | Review and update the ACS URL in the identity provider's settings |
+| <pre>invalid_assertion_url</pre> | The assertion URL in the SAML request is invalid | Verify and update the ACS URL in the identity provider's settings |
 | <pre>invalid_status</pre> | Invalid status | Review and update the SAML configuration settings in the identity provider |
 | <pre>malformed_saml_response</pre> | Marshalling error | Ensure SAML response is properly formatted |
 | <pre>assertion_expired</pre> | Expired SAML assertion | We received an expired SAML assertion. This could be because of clock skew between the identity provider's server and our servers. Please reach out to us via your private slack channel or <a href="mailto:support@scalekit.com" target="_blank" rel="noopener">via email</a> |
 | <pre>response_expired</pre> | Expired SAML response | We received an expired SAML response. This could be because of clock skew between the identity provider's server and our servers. Please reach out to us via your private slack channel or <a href="mailto:support@scalekit.com" target="_blank" rel="noopener">via email</a> |
+| <pre>authentication_not_completed</pre> | The authentication flow was not completed | Ensure the user completes the login process in the identity provider |
+| <pre>user_login_required</pre> | User login is required to continue | Redirect the user to the login page to complete authentication |


### PR DESCRIPTION
Add 10 missing error codes to the SSO error reference page that were not previously documented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added expanded SSO integration error reference documentation with new error codes covering client authentication failures, application status validation, SAML processing, and user authentication workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->