### PR TITLE
[POC] Managed Scalar instance to overcome UX overhead.

### DIFF
--- a/src/configs/secondary-nav.config.ts
+++ b/src/configs/secondary-nav.config.ts
@@ -229,7 +229,7 @@ export const secondaryNavItems: NavItem[] = [
       },
       {
         id: 'rest-apis',
-        href: '/apis/#description/overview',
+        href: 'https://saif-at-scalekit-scalekit-api.apidocumentation.com/',
         label: 'REST APIs',
         iconComponent: IconApi,
         description: 'Programmatic control to manage users, orgs, sessions etc.',

--- a/src/pages/apis.astro
+++ b/src/pages/apis.astro
@@ -225,7 +225,16 @@ const frontmatter = {
       baseServerURL: 'https://scalekit.com',
       documentDownloadType: 'json',
       // hides an unnecessary button that says "Authorize" + intro card
-      customCss: `#scalar-client-0 { margin-top: 8rem; } .introduction-card-item.scalar-reference-intro-clients { display: none; } }`,
+      // Collapse double rule: Developer Tools header uses border-b; SectionContainer also adds
+      // border-top — together they read as two lines. Keep a single separator.
+      customCss: `
+        #scalar-client-0 { margin-top: 8rem; }
+        .introduction-card-item.scalar-reference-intro-clients { display: none; }
+        /* Developer Tools uses border-b; the intro SectionContainer adds border-t — stack as one line */
+        .scalar-app .narrow-references-container > header.api-reference-toolbar + * > .section-container:first-child {
+          border-top: none !important;
+        }
+      `,
       // Custom slug generation for webhooks to prevent "undefined" in URLs
       generateWebhookSlug: (webhook) => {
         // For OpenAPI webhooks, the key is typically not included in the parsed object


### PR DESCRIPTION
- Update secondary nav REST APIs href to external apidocumentation.com URL
- Fix double border/rule rendering in Scalar API reference page by removing redundant border-top on the first SectionContainer after the toolbar header