### PR TITLE
docs: add Codex tab to home page agent tabs

### DIFF
--- a/src/content/docs/cookbooks/daily-briefing-agent.mdx
+++ b/src/content/docs/cookbooks/daily-briefing-agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Build a daily briefing agent with Vercel AI SDK and Scalekit Agent Auth'
-description: 'Connect a TypeScript or Python agent to Google Calendar and Gmail via Scalekit Agent Auth to summarize your day using two integration patterns.'
+description: 'Connect a TypeScript or Python agent via Vercel AI SDK and Scalekit Agent Auth to Google Calendar and Gmail using two integration patterns.'
 date: 2026-03-27
 tags: ['Agent auth']
 sidebar:

--- a/src/content/docs/cookbooks/daily-briefing-agent.mdx
+++ b/src/content/docs/cookbooks/daily-briefing-agent.mdx
@@ -3,6 +3,8 @@ title: 'Build a daily briefing agent with Vercel AI SDK and Scalekit Agent Auth'
 description: 'Connect a TypeScript or Python agent to Google Calendar and Gmail via Scalekit Agent Auth to summarize your day — using two different integration patterns.'
 date: 2026-03-27
 tags: ['Agent auth']
+sidebar:
+  label: 'Daily briefing agent'
 excerpt: >
   Connecting an agent to two external APIs means handling two separate OAuth tokens, two authorization flows, and two different error surfaces. This recipe shows how Scalekit manages the OAuth lifecycle for both connectors, then demonstrates two patterns for calling those APIs: fetching a token and calling the REST API directly, versus letting Scalekit execute the call through a built-in action.
 featured: false

--- a/src/content/docs/cookbooks/daily-briefing-agent.mdx
+++ b/src/content/docs/cookbooks/daily-briefing-agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Build a daily briefing agent with Vercel AI SDK and Scalekit Agent Auth'
-description: 'Connect a TypeScript or Python agent to Google Calendar and Gmail via Scalekit Agent Auth to summarize your day — using two different integration patterns.'
+description: 'Connect a TypeScript or Python agent to Google Calendar and Gmail via Scalekit Agent Auth to summarize your day using two integration patterns.'
 date: 2026-03-27
 tags: ['Agent auth']
 sidebar:

--- a/src/content/docs/dev-kit/build-with-ai/index.mdx
+++ b/src/content/docs/dev-kit/build-with-ai/index.mdx
@@ -22,39 +22,29 @@ Pick the auth feature you need below. Each page gives you a ready-to-paste promp
     iconKey="fsa"
     href="/dev-kit/build-with-ai/full-stack-auth/"
     clickable={true}
-  >
-    Prompt your coding agent to add login, sessions, user management, and role-based access to your app end-to-end
-  </FoldCard>
+  />
   <FoldCard
     title="Agent Auth"
     iconKey="bot"
     href="/dev-kit/build-with-ai/agent-auth/"
     clickable={true}
-  >
-    Let coding agents wire in OAuth token storage and automatic refresh so your AI app can call Gmail, Slack, Notion, and more on behalf of users
-  </FoldCard>
+  />
   <FoldCard
     title="MCP Auth"
     iconKey="mcp"
     href="/dev-kit/build-with-ai/mcp-auth/"
     clickable={true}
-  >
-    Prompt Claude Code or Cursor to secure your remote MCP server with OAuth 2.1, Dynamic Client Registration, and short-lived tokens
-  </FoldCard>
+  />
   <FoldCard
     title="Modular SSO"
     iconKey="sso"
     href="/dev-kit/build-with-ai/sso/"
     clickable={true}
-  >
-    Have coding agents add SAML or OIDC SSO with enterprise identity providers — Okta, Microsoft Entra, Google, and more
-  </FoldCard>
+  />
   <FoldCard
     title="Modular SCIM"
     iconKey="scim"
     href="/dev-kit/build-with-ai/scim/"
     clickable={true}
-  >
-    Let coding agents automate user provisioning and directory sync from Okta, Azure AD, and other enterprise directories
-  </FoldCard>
+  />
 </ResponsiveCardGrid>

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -220,6 +220,13 @@ import complianceImage from '@/content/docs/compliance.svg'
 
     [View full guide →](/dev-kit/build-with-ai/)
   </TabItem>
+  <TabItem label="Codex">
+    ```bash title="Terminal" frame="terminal" showLineNumbers=false
+    curl -fsSL https://raw.githubusercontent.com/scalekit-inc/codex-authstack/main/install.sh | bash
+    ```
+
+    [View full guide →](/dev-kit/build-with-ai/)
+  </TabItem>
   <TabItem label="GitHub Copilot CLI">
     ```bash title="Register Scalekit Auth Stack for GitHub Copilot" frame="terminal" showLineNumbers=false
     copilot plugin marketplace add scalekit-inc/github-copilot-authstack


### PR DESCRIPTION
## Summary

Adds a Codex tab to the home page agent tabs section, positioned between Claude Code and GitHub Copilot CLI. Users can now quickly access Codex installation instructions alongside other AI coding agents.

## Test Plan

- [x] Verify Codex tab appears in the correct position on the home page
- [x] Preview link: https://deploy-preview-{PR_NUMBER}--scalekit-starlight.netlify.app/

## What Changed

- Added Codex tab to the agent tabs component at `src/content/docs/index.mdx`
- Tab includes installation command and link to the full guide

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Codex" tab with a one-line install command and a link to the full "Build with AI" guide alongside existing coding-agent tabs.
  * Simplified several guide cards by removing descriptive child text, leaving titles, icons, and links for a cleaner layout.
  * Updated the daily-briefing guide frontmatter: revised description and added a sidebar label for improved navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->