### PR TITLE
fix: correct Go method call syntax for Organization().DeleteOrganization()

### DIFF
--- a/src/content/docs/authenticate/manage-users-orgs/delete-users-and-organizations.mdx
+++ b/src/content/docs/authenticate/manage-users-orgs/delete-users-and-organizations.mdx
@@ -101,7 +101,7 @@ Before permanent deletion, confirm this is the intended action. If you only need
 
    ```go title="Delete an organization permanently" wrap
    // Use case: Company closure, account restructuring, or removing test organizations
-   err := scalekitClient.Organization.DeleteOrganization(
+   err := scalekitClient.Organization().DeleteOrganization(
      ctx,
      organizationId
    )


### PR DESCRIPTION
## Summary
Fixes the final broken code example (D5) in the developer documentation.

- Line 104 in delete-users-and-organizations.mdx had missing parentheses on Organization method call
- Changed from: `scalekitClient.Organization.DeleteOrganization()`
- Changed to: `scalekitClient.Organization().DeleteOrganization()`

## Notes
- D1-D4 were already fixed in commit e9c7f58c (membership → user client fixes)
- This PR completes the D1-D5 critical doc fixes from the 2026-03-29 audit
- Build passed with no errors

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the Go code example for deleting organizations to demonstrate the proper method invocation pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->