### PR TITLE
Add missing Salesforce tools to agent connector docs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,7 +170,7 @@ importers:
         version: 0.2.5(astro@5.18.1(@netlify/blobs@10.7.4)(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3))
       '@tailwindcss/vite':
         specifier: ^4.2.2
-        version: 4.2.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.2.2(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -233,10 +233,10 @@ importers:
         version: 0.12.0(@astrojs/starlight@0.37.7(astro@5.18.1(@netlify/blobs@10.7.4)(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3)))
       starlight-page-actions:
         specifier: ^0.5.0
-        version: 0.5.0(@astrojs/starlight@0.37.7(astro@5.18.1(@netlify/blobs@10.7.4)(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3)))(astro@5.18.1(@netlify/blobs@10.7.4)(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
+        version: 0.5.0(@astrojs/starlight@0.37.7(astro@5.18.1(@netlify/blobs@10.7.4)(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3)))(astro@5.18.1(@netlify/blobs@10.7.4)(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3))(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
       starlight-plugin-icons:
         specifier: ^1.1.6
-        version: 1.1.6(@astrojs/starlight@0.37.7(astro@5.18.1(@netlify/blobs@10.7.4)(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3)))(astro@5.18.1(@netlify/blobs@10.7.4)(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3))(typescript@5.9.3)(unocss@66.4.2(postcss@8.5.8)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)))(zod@4.3.6)
+        version: 1.1.6(@astrojs/starlight@0.37.7(astro@5.18.1(@netlify/blobs@10.7.4)(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3)))(astro@5.18.1(@netlify/blobs@10.7.4)(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3))(typescript@5.9.3)(unocss@66.4.2(postcss@8.5.8)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)))(zod@3.25.76)
       starlight-showcases:
         specifier: ^0.3.2
         version: 0.3.2(@astrojs/starlight@0.37.7(astro@5.18.1(@netlify/blobs@10.7.4)(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3)))
@@ -267,7 +267,7 @@ importers:
         version: 0.4.14(typescript@5.9.3)
       '@vitejs/plugin-vue':
         specifier: ^6.0.5
-        version: 6.0.5(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.31(typescript@5.9.3))
+        version: 6.0.5(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.31(typescript@5.9.3))
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
@@ -1395,105 +1395,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -2029,42 +2013,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-wasm@2.5.6':
     resolution: {integrity: sha512-byAiBZ1t3tXQvc8dMD/eoyE7lTXYorhn+6uVW5AC+JGI1KtJC/LvDche5cfUE+qiefH+Ybq0bUCJU0aB1cSHUA==}
@@ -2205,79 +2183,66 @@ packages:
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
@@ -2524,28 +2489,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -4798,28 +4759,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -9859,12 +9816,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
 
-  '@tailwindcss/vite@4.2.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))':
+  '@tailwindcss/vite@4.2.2(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
 
   '@tanstack/virtual-core@3.13.23': {}
 
@@ -10028,13 +9985,13 @@ snapshots:
       unhead: 2.1.12
       vue: 3.5.31(typescript@5.9.3)
 
-  '@unocss/astro@66.4.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))':
+  '@unocss/astro@66.4.2(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))':
     dependencies:
       '@unocss/core': 66.4.2
       '@unocss/reset': 66.4.2
-      '@unocss/vite': 66.4.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
+      '@unocss/vite': 66.4.2(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
 
   '@unocss/cli@66.4.2':
     dependencies:
@@ -10163,7 +10120,7 @@ snapshots:
     dependencies:
       '@unocss/core': 66.4.2
 
-  '@unocss/vite@66.4.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))':
+  '@unocss/vite@66.4.2(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@unocss/config': 66.4.2
@@ -10174,7 +10131,7 @@ snapshots:
       pathe: 2.0.3
       tinyglobby: 0.2.15
       unplugin-utils: 0.2.5
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
 
   '@usesapient/agent-tracker@0.1.1': {}
 
@@ -10246,10 +10203,10 @@ snapshots:
       vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
       vue: 3.5.31(typescript@5.9.3)
 
-  '@vitejs/plugin-vue@6.0.5(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.31(typescript@5.9.3))':
+  '@vitejs/plugin-vue@6.0.5(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.2
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
       vue: 3.5.31(typescript@5.9.3)
 
   '@vue/babel-helper-vue-transform-on@1.5.0': {}
@@ -14344,16 +14301,16 @@ snapshots:
     dependencies:
       '@astrojs/starlight': 0.37.7(astro@5.18.1(@netlify/blobs@10.7.4)(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3))
 
-  starlight-page-actions@0.5.0(@astrojs/starlight@0.37.7(astro@5.18.1(@netlify/blobs@10.7.4)(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3)))(astro@5.18.1(@netlify/blobs@10.7.4)(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)):
+  starlight-page-actions@0.5.0(@astrojs/starlight@0.37.7(astro@5.18.1(@netlify/blobs@10.7.4)(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3)))(astro@5.18.1(@netlify/blobs@10.7.4)(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3))(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)):
     dependencies:
       '@astrojs/starlight': 0.37.7(astro@5.18.1(@netlify/blobs@10.7.4)(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3))
       astro: 5.18.1(@netlify/blobs@10.7.4)(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3)
-      vite-plugin-static-copy: 3.4.0(patch_hash=af70d2811d381cdea319ad374155ad8bf276cf04bf80834dd64bc0800a7cd4a3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
-      vite-plugin-virtual: 0.5.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
+      vite-plugin-static-copy: 3.4.0(patch_hash=af70d2811d381cdea319ad374155ad8bf276cf04bf80834dd64bc0800a7cd4a3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
+      vite-plugin-virtual: 0.5.0(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
     transitivePeerDependencies:
       - vite
 
-  starlight-plugin-icons@1.1.6(@astrojs/starlight@0.37.7(astro@5.18.1(@netlify/blobs@10.7.4)(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3)))(astro@5.18.1(@netlify/blobs@10.7.4)(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3))(typescript@5.9.3)(unocss@66.4.2(postcss@8.5.8)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)))(zod@4.3.6):
+  starlight-plugin-icons@1.1.6(@astrojs/starlight@0.37.7(astro@5.18.1(@netlify/blobs@10.7.4)(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3)))(astro@5.18.1(@netlify/blobs@10.7.4)(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3))(typescript@5.9.3)(unocss@66.4.2(postcss@8.5.8)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)))(zod@3.25.76):
     dependencies:
       '@astrojs/starlight': 0.37.7(astro@5.18.1(@netlify/blobs@10.7.4)(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3))
       astro: 5.18.1(@netlify/blobs@10.7.4)(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3)
@@ -14364,8 +14321,8 @@ snapshots:
       rehype: 13.0.2
       typescript: 5.9.3
       unist-util-visit: 5.1.0
-      unocss: 66.4.2(postcss@8.5.8)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
-      zod: 4.3.6
+      unocss: 66.4.2(postcss@8.5.8)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
+      zod: 3.25.76
 
   starlight-showcases@0.3.2(@astrojs/starlight@0.37.7(astro@5.18.1(@netlify/blobs@10.7.4)(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.0)(terser@5.46.1)(typescript@5.9.3)(yaml@2.8.3))):
     dependencies:
@@ -14841,9 +14798,9 @@ snapshots:
     dependencies:
       normalize-path: 2.1.1
 
-  unocss@66.4.2(postcss@8.5.8)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)):
+  unocss@66.4.2(postcss@8.5.8)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)):
     dependencies:
-      '@unocss/astro': 66.4.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
+      '@unocss/astro': 66.4.2(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
       '@unocss/cli': 66.4.2
       '@unocss/core': 66.4.2
       '@unocss/postcss': 66.4.2(postcss@8.5.8)
@@ -14861,9 +14818,9 @@ snapshots:
       '@unocss/transformer-compile-class': 66.4.2
       '@unocss/transformer-directives': 66.4.2
       '@unocss/transformer-variant-group': 66.4.2
-      '@unocss/vite': 66.4.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
+      '@unocss/vite': 66.4.2(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - postcss
       - supports-color
@@ -14973,17 +14930,17 @@ snapshots:
     dependencies:
       monaco-editor: 0.54.0
 
-  vite-plugin-static-copy@3.4.0(patch_hash=af70d2811d381cdea319ad374155ad8bf276cf04bf80834dd64bc0800a7cd4a3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)):
+  vite-plugin-static-copy@3.4.0(patch_hash=af70d2811d381cdea319ad374155ad8bf276cf04bf80834dd64bc0800a7cd4a3)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)):
     dependencies:
       chokidar: 3.6.0
       p-map: 7.0.4
       picocolors: 1.1.1
       tinyglobby: 0.2.15
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
 
-  vite-plugin-virtual@0.5.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)):
+  vite-plugin-virtual@0.5.0(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)):
     dependencies:
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
+      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
 
   vite-plugin-vue-devtools@7.7.9(rollup@4.60.0)(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.31(typescript@5.9.3)):
     dependencies:

--- a/src/content/docs/reference/agent-connectors/attio.mdx
+++ b/src/content/docs/reference/agent-connectors/attio.mdx
@@ -358,6 +358,52 @@ Permanently delete a note by its `note_id`. This operation is irreversible.
 | --- | --- | --- | --- |
 | `note_id` | string | Yes | UUID of the note to delete |
 
+## `attio_create_select_option`
+
+Adds a new select option to a `select` or `multiselect` attribute on an Attio object or list.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `attribute` | string | Yes | Attribute slug or UUID of the select/multiselect attribute |
+| `object` | string | Yes | Object slug or UUID (e.g. `people`, `companies`, `deals`) |
+| `title` | string | Yes | Display title for the new select option |
+
+## `attio_create_status`
+
+Adds a new status to a status attribute on an Attio object or list. Company and person objects do not support status attributes.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `attribute` | string | Yes | Attribute slug or UUID of the status attribute |
+| `object` | string | Yes | Object slug or UUID (e.g. `deals`) |
+| `title` | string | Yes | Display title for the new status |
+
+## `attio_create_user_record`
+
+Creates a new user record in Attio. Requires `primary_email_address`, `user_id`, and `workspace_id` in the values field. Optionally link to an existing person record.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `values` | object | Yes | Attribute values for the new user record |
+
+## `attio_create_webhook`
+
+Creates a webhook and subscribes to events in Attio. Returns the webhook configuration including a one-time signing secret for verifying event authenticity.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `target_url` | string | Yes | HTTPS URL that will receive webhook event payloads |
+| `subscriptions` | array | Yes | Array of event subscription objects (each needs `event_type` and `filter` fields) |
+| `secret` | string | No | Optional signing secret for verifying webhook payloads |
+
+## `attio_create_workspace_record`
+
+Creates a new workspace record in Attio. The `workspace_id` field is required and must be unique. Throws an error on conflicts of unique attributes.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `values` | object | Yes | Attribute values for the new workspace record |
+
 ## `attio_create_comment`
 
 Create a comment on a CRM record or list entry. To comment on a record, provide `record_object` and `record_id`. To comment on a list entry, provide `list_id` and `entry_id`. To reply to an existing thread, include `thread_id`. Content is always plaintext.
@@ -473,6 +519,64 @@ Optionally set list-level attribute values (e.g., pipeline stage) on the entry u
 | `record_id` | string | Yes | UUID of the record to add |
 | `entry_values` | object | No | Attribute values to set on the list entry itself (not the underlying record). Keys are list attribute slugs |
 
+## `attio_assert_company`
+
+Creates or updates a company record in Attio using a unique attribute. If a company with the same matching attribute value exists, it is updated; otherwise a new one is created.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `matching_attribute` | string | Yes | The attribute slug to match on for upsert (e.g. `domains`) |
+| `values` | object | Yes | Attribute values for the company record |
+
+## `attio_assert_list_entry`
+
+Creates or updates a list entry for a given parent record in Attio. If an entry with the specified parent record exists, it is updated. Otherwise a new entry is created.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `list_id` | string | Yes | The unique identifier or slug of the list |
+| `matching_attribute` | string | Yes | Attribute slug to match on for upsert |
+| `parent_object` | string | Yes | Object slug of the parent record (e.g. `people`, `companies`) |
+| `parent_record_id` | string | Yes | The unique identifier of the parent record |
+| `entry_values` | object | No | Optional attribute values for the list entry |
+
+## `attio_assert_person`
+
+Creates or updates a person record in Attio using a unique attribute. If a person with the same matching attribute value exists, it is updated; otherwise a new one is created.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `matching_attribute` | string | Yes | The attribute slug to match on for upsert (e.g. `email_addresses`) |
+| `values` | object | Yes | Attribute values for the person record |
+
+## `attio_assert_record`
+
+Trigger an Attio automation workflow for a specific record by upserting the record, which fires any automations configured on record create or update events. Matches on a unique attribute to avoid duplicates.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `matching_attribute` | string | Yes | The attribute slug to use as the unique match key (e.g. `email_addresses` for people, `domains` for companies) |
+| `object` | string | Yes | The slug or UUID of the object type to upsert into (e.g. `people`, `companies`, `deals`) |
+| `values` | object | Yes | Attribute values for the record |
+
+## `attio_assert_user_record`
+
+Creates or updates a user record in Attio using a unique attribute. If a user with the same matching attribute exists, it is updated; otherwise a new one is created.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `matching_attribute` | string | Yes | The attribute slug to match on for upsert (e.g. `primary_email_address`) |
+| `values` | object | Yes | Attribute values for the user record |
+
+## `attio_assert_workspace`
+
+Creates or updates a workspace record in Attio using a unique attribute. If a workspace with the same matching attribute value exists, it is updated; otherwise a new one is created.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `matching_attribute` | string | Yes | The attribute slug to match on for upsert (e.g. `workspace_id`) |
+| `values` | object | Yes | Attribute values for the workspace record |
+
 ## `attio_remove_from_list`
 
 Remove a specific entry from an Attio list by its `entry_id`. Deletes the list entry but does not delete the underlying record. Use the `entry_id` returned by `attio_add_to_list` or `attio_list_record_entries`.
@@ -490,6 +594,38 @@ List all list memberships for a specific record across all lists. Returns the li
 | --- | --- | --- | --- |
 | `object` | string | Yes | Object type slug or UUID |
 | `record_id` | string | Yes | UUID of the record |
+
+## `attio_patch_record`
+
+Updates a record by its `record_id` using PATCH for any object type. For multiselect attributes, values are prepended to existing values. Use `attio_put_record` to overwrite or remove multiselect values.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `object` | string | Yes | Object slug or UUID (e.g. `people`, `companies`, `deals`) |
+| `record_id` | string | Yes | The unique identifier of the record to update |
+| `values` | object | Yes | Attribute values to update on the record |
+
+## `attio_put_record`
+
+Updates a record by its `record_id` using PUT for any object type. For multiselect attributes, values overwrite existing values. Use `attio_patch_record` to append without removing.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `object` | string | Yes | Object slug or UUID (e.g. `people`, `companies`, `deals`) |
+| `record_id` | string | Yes | The unique identifier of the record to update |
+| `values` | object | Yes | Attribute values to set on the record (overwrites existing multiselect values) |
+
+## `attio_query_records`
+
+Queries records for a specific Attio object using server-side filtering operators and sorting. Use for complex filter criteria rather than simple listing.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `object` | string | Yes | Object slug or UUID to query records for (e.g. `companies`, `people`, `deals`) |
+| `filter` | object | No | Filter criteria for the query |
+| `sorts` | array | No | Sorting criteria for the results |
+| `limit` | number | No | Maximum number of records to return |
+| `offset` | number | No | Number of records to skip for pagination |
 
 ## `attio_list_objects`
 
@@ -702,3 +838,147 @@ This tool takes no input parameters. It returns:
 - After a user completes OAuth — confirm the connection succeeded and identify which workspace they authorized.
 - Before a write operation — verify the required scope is in `scopes` to give a clear error rather than a cryptic API rejection.
 - When debugging — check `active` is `true` and that expected scopes are present.
+
+## `attio_update_attribute`
+
+Updates an existing attribute on an Attio object or list by its slug or ID. Can modify title, description, or archive the attribute. Cannot modify system attributes.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `attribute` | string | Yes | Attribute slug or UUID to update |
+| `object` | string | Yes | Object slug or UUID (e.g. `people`, `companies`, `deals`) |
+| `title` | string | No | New display title for the attribute |
+| `is_archived` | boolean | No | Whether to archive the attribute |
+
+## `attio_update_company`
+
+Updates a company record in Attio by its `record_id` using PATCH. Only the provided attributes are updated. For multiselect attributes, values are prepended. Note: `logo_url` cannot be updated via API.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `record_id` | string | Yes | The unique identifier of the company record to update |
+| `values` | object | Yes | Attribute values to update on the company record |
+
+## `attio_update_deal`
+
+Updates a deal record in Attio by its `record_id` using PATCH. Only the provided fields are updated, leaving other fields unchanged.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `record_id` | string | Yes | The unique identifier of the deal record to update |
+| `values` | object | Yes | Attribute values to update on the deal record |
+
+## `attio_update_list`
+
+Updates an existing list in Attio. Can modify name, api_slug, or permissions. Changing the parent object of a list is not possible through the API.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `list_id` | string | Yes | The unique identifier or slug of the list to update |
+| `name` | string | No | New display name for the list |
+| `api_slug` | string | No | New snake_case identifier for the list |
+| `workspace_access` | string | No | New access level for workspace members |
+
+## `attio_update_list_entry`
+
+Updates a list entry by its `entry_id` in Attio using PATCH. For multiselect attributes, values are prepended to existing values. Use PUT to overwrite multiselect values.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `list_id` | string | Yes | The unique identifier or slug of the list |
+| `entry_id` | string | Yes | The unique identifier of the list entry to update |
+| `entry_values` | object | Yes | Attribute values to update on the list entry |
+
+## `attio_update_object`
+
+Updates a single object's configuration in Attio. Can modify the object's API slug, singular noun, or plural noun.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `object` | string | Yes | Object slug or UUID to update |
+| `singular_noun` | string | No | New singular noun for the object type |
+| `plural_noun` | string | No | New plural noun for the object type |
+| `api_slug` | string | No | New snake_case identifier for the object |
+
+## `attio_update_person`
+
+Updates a person record in Attio by its `record_id` using PATCH. Only the provided attributes are updated. For multiselect attributes, values are prepended. Note: `avatar_url` cannot be updated via API.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `record_id` | string | Yes | The unique identifier of the person record to update |
+| `values` | object | Yes | Attribute values to update on the person record |
+
+## `attio_update_record`
+
+Update an existing record's attributes in Attio. For multiselect attributes, the supplied values will overwrite (replace) the existing list. Supports people, companies, deals, and custom objects.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `object` | string | Yes | The slug or UUID of the object type (e.g. `people`, `companies`, `deals`) |
+| `record_id` | string | Yes | The UUID of the record to update |
+| `values` | object | Yes | Attribute values to update (multiselect values replace all existing) |
+
+## `attio_update_select_option`
+
+Updates an existing select option for a `select` or `multiselect` attribute in Attio. Can rename or archive an option. Archived options are hidden from selection but preserve historical data.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `attribute` | string | Yes | Attribute slug or UUID of the select/multiselect attribute |
+| `object` | string | Yes | Object slug or UUID (e.g. `people`, `companies`, `deals`) |
+| `option_id` | string | Yes | The unique identifier of the select option to update |
+| `title` | string | No | New display title for the select option |
+| `is_archived` | boolean | No | Whether to archive the select option |
+
+## `attio_update_status`
+
+Updates a status on a status attribute in Attio. Can modify title or archive the status. Company and person objects do not support status attributes.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `attribute` | string | Yes | Attribute slug or UUID of the status attribute |
+| `object` | string | Yes | Object slug or UUID (e.g. `deals`) |
+| `status_id` | string | Yes | The unique identifier of the status to update |
+| `title` | string | No | New display title for the status |
+| `is_archived` | boolean | No | Whether to archive the status |
+
+## `attio_update_task`
+
+Updates an existing task in Attio by its `task_id`. Only deadline, is_completed, linked_records, and assignees can be updated via this endpoint.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `task_id` | string | Yes | The unique identifier of the task to update |
+| `deadline_at` | string | No | ISO 8601 datetime string for the task deadline |
+| `is_completed` | boolean | No | Whether the task is completed |
+| `linked_records` | array | No | Records linked to this task |
+| `assignees` | array | No | Workspace members assigned to this task |
+
+## `attio_update_user_record`
+
+Updates a user record in Attio by its `record_id` using PATCH. Only the provided attributes are updated; other fields remain unchanged.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `record_id` | string | Yes | The unique identifier of the user record to update |
+| `values` | object | Yes | Attribute values to update on the user record |
+
+## `attio_update_webhook`
+
+Updates a webhook's target URL and/or event subscriptions in Attio. Each subscription must be an object with an `event_type` field.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `webhook_id` | string | Yes | The unique identifier of the webhook to update |
+| `target_url` | string | No | New HTTPS URL that will receive webhook events |
+| `subscriptions` | array | No | New array of event subscription objects to replace current subscriptions |
+
+## `attio_update_workspace_record`
+
+Updates a workspace record in Attio by its `record_id` using PATCH. Only the provided attributes are updated.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `record_id` | string | Yes | The unique identifier of the workspace record to update |
+| `values` | object | Yes | Attribute values to update on the workspace record |

--- a/src/content/docs/reference/agent-connectors/evertrace.mdx
+++ b/src/content/docs/reference/agent-connectors/evertrace.mdx
@@ -23,7 +23,7 @@ import { Accordion, AccordionItem } from 'accessible-astro-components'
   Connect to evertrace.ai to search and manage talent signals, saved searches, and lists. Access rich professional profiles with scoring, experiences, and education data to power your recruiting and sourcing workflows.
  </div>
  <div class="flex justify-center">
-  <img src="https://cdn.scalekit.cloud/sk-connect/assets/provider-icons/evertrace.svg" width="64" height="64" alt="evertrace.ai logo" />
+  <img src="https://cdn.scalekit.com/sk-connect/assets/provider-icons/evertrace.png" width="64" height="64" alt="evertrace.ai logo" />
  </div>
 </div>
 

--- a/src/content/docs/reference/agent-connectors/evertrace.mdx
+++ b/src/content/docs/reference/agent-connectors/evertrace.mdx
@@ -1,0 +1,465 @@
+---
+title: evertrace.ai
+description: Connect to evertrace.ai to search and manage talent signals, saved searches, and lists
+tableOfContents: true
+sidebar:
+  label: evertrace.ai
+head:
+  - tag: style
+    content: |
+      .sl-markdown-content h2 {
+        font-size: var(--sl-text-xl);
+      }
+      table td:first-child, table th:first-child {
+        white-space: nowrap;
+      }
+---
+
+import { Card, CardGrid, Tabs, TabItem, Badge, Steps, Aside, Code } from '@astrojs/starlight/components'
+import { Accordion, AccordionItem } from 'accessible-astro-components'
+
+<div class="grid grid-cols-5 gap-4 items-center">
+ <div class="col-span-4">
+  Connect to evertrace.ai to search and manage talent signals, saved searches, and lists. Access rich professional profiles with scoring, experiences, and education data to power your recruiting and sourcing workflows.
+ </div>
+ <div class="flex justify-center">
+  <img src="https://cdn.scalekit.cloud/sk-connect/assets/provider-icons/evertrace.svg" width="64" height="64" alt="evertrace.ai logo" />
+ </div>
+</div>
+
+Supports authentication: <Badge text="API Key" />
+
+## Set up the agent connector
+
+Register your evertrace.ai API key with Scalekit so it can authenticate and proxy requests on behalf of your users.
+
+<Steps>
+1. ### Generate an evertrace.ai API key
+
+   - Sign in to evertrace.ai. Go to **Settings** → **API Keys**.
+
+   - Create a new API key and copy it. Store it somewhere safe — you will not be able to view it again.
+
+2. ### Create a connection in Scalekit
+
+   - In [Scalekit dashboard](https://app.scalekit.com), go to **Agent Auth** → **Create Connection**. Find **evertrace.ai** and click **Create**.
+
+   - Note the **Connection name** — you will use this as `connection_name` in your code (e.g., `evertrace`).
+
+3. ### Add a connected account
+
+   Connected accounts link a specific user identifier in your system to an evertrace.ai API key. Add accounts via the dashboard for testing, or via the Scalekit API in production.
+
+   **Via dashboard (for testing)**
+
+   - Open the connection you created and click the **Connected Accounts** tab → **Add account**.
+
+   - Fill in:
+     - **Your User's ID** — a unique identifier for this user in your system (e.g., `user_123`)
+     - **API Key** — the evertrace.ai API key you copied in step 1
+
+   - Click **Save**.
+
+   **Via API (for production)**
+
+   <Tabs syncKey="tech-stack">
+     <TabItem label="Node.js">
+       ```typescript
+       await scalekit.actions.upsertConnectedAccount({
+         connectionName: 'evertrace',
+         identifier: 'user_123',
+         credentials: { api_key: 'your-evertrace-api-key' },
+       });
+       ```
+     </TabItem>
+     <TabItem label="Python">
+       ```python
+       scalekit_client.actions.upsert_connected_account(
+           connection_name="evertrace",
+           identifier="user_123",
+           credentials={"api_key": "your-evertrace-api-key"}
+       )
+       ```
+     </TabItem>
+   </Tabs>
+</Steps>
+
+## Usage
+
+Once a connected account is set up, make API calls through the Scalekit proxy. Scalekit injects the evertrace.ai API key automatically.
+
+<Tabs syncKey="tech-stack">
+  <TabItem label="Node.js">
+    ```typescript
+    import { ScalekitClient } from '@scalekit-sdk/node';
+    import 'dotenv/config';
+
+    const connectionName = 'evertrace';
+    const identifier = 'user_123';
+
+    const scalekit = new ScalekitClient(
+      process.env.SCALEKIT_ENV_URL,
+      process.env.SCALEKIT_CLIENT_ID,
+      process.env.SCALEKIT_CLIENT_SECRET
+    );
+    const actions = scalekit.actions;
+
+    const result = await actions.request({
+      connectionName,
+      identifier,
+      path: '/signals',
+      method: 'GET',
+    });
+    console.log(result.data);
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    import scalekit.client, os
+    from dotenv import load_dotenv
+    load_dotenv()
+
+    connection_name = "evertrace"
+    identifier = "user_123"
+
+    scalekit_client = scalekit.client.ScalekitClient(
+        client_id=os.getenv("SCALEKIT_CLIENT_ID"),
+        client_secret=os.getenv("SCALEKIT_CLIENT_SECRET"),
+        env_url=os.getenv("SCALEKIT_ENV_URL"),
+    )
+    actions = scalekit_client.actions
+
+    result = actions.request(
+        connection_name=connection_name,
+        identifier=identifier,
+        path="/signals",
+        method="GET",
+    )
+    print(result)
+    ```
+  </TabItem>
+</Tabs>
+
+## Tool list
+
+## `evertrace_cities_list`
+
+Search available cities by name. Returns city name strings sorted by signal count. Use these values in signal filters for the city field.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `search` | string | No | Case-insensitive partial match on city name (e.g. "san fran") |
+| `page` | string | No | Page number for pagination |
+| `limit` | string | No | Number of results per page |
+
+## `evertrace_companies_list`
+
+Search companies by name or look up by specific IDs. Returns company entity IDs (exe_* format) needed for signal filtering by past_companies.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `search` | string | No | Case-insensitive partial match on company name (e.g. "google") |
+| `ids` | array | No | Look up specific companies by entity ID (exe_* format) |
+| `page` | string | No | Page number for pagination |
+| `limit` | string | No | Number of results per page |
+
+## `evertrace_educations_list`
+
+Search education institutions by name or look up by specific IDs. Returns institution entity IDs (ede_* format) needed for signal filtering by past_education.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `search` | string | No | Case-insensitive partial match on institution name (e.g. "stanford") |
+| `ids` | array | No | Look up specific institutions by entity ID (ede_* format) |
+| `page` | string | No | Page number for pagination |
+| `limit` | string | No | Number of results per page |
+
+## `evertrace_list_entries_create`
+
+Add a signal to a list.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `list_id` | string | Yes | The list ID to add the signal to |
+| `signal_id` | string | Yes | The signal ID to add |
+
+## `evertrace_list_entries_delete`
+
+Remove an entry from a list.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `list_id` | string | Yes | The list ID |
+| `entry_id` | string | Yes | The entry ID to remove |
+
+## `evertrace_list_entries_download`
+
+Export list entries as a CSV file. Maximum 250 entries per export.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `list_id` | string | Yes | The list ID to export entries from |
+
+## `evertrace_list_entries_get`
+
+Get a single list entry with its full signal profile.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `list_id` | string | Yes | The list ID |
+| `entry_id` | string | Yes | The entry ID |
+
+## `evertrace_list_entries_list`
+
+List entries in a list with pagination, sorting, and filtering by screening/viewed status.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `list_id` | string | Yes | The list ID |
+| `page` | string | No | Page number for pagination |
+| `limit` | string | No | Number of results per page |
+| `sort_by` | string | No | Sort field: "entry_created_at" (when added to list) or "signal_discovered_at" (when signal was discovered) |
+| `sort_order` | string | No | Sort direction: "asc" (oldest first) or "desc" (newest first) |
+| `screened_by` | array | No | Filter by screening status. Prefix with "-" to exclude (e.g. ["-me", "-others"]) |
+| `viewed_by` | array | No | Filter by viewed status. Prefix with "-" to exclude (e.g. ["-me"]) |
+
+## `evertrace_list_entries_list_by_linkedin_id`
+
+Get all signals representing the same person as a list entry, matched by LinkedIn ID.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `list_id` | string | Yes | The list ID |
+| `entry_id` | string | Yes | The entry ID |
+
+## `evertrace_lists_create`
+
+Create a new list. Provide user IDs in accesses to share the list with teammates. The creator is automatically granted access.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | string | Yes | Name of the new list |
+| `accesses` | array | No | Array of user IDs to share this list with. Pass an empty array for private list |
+
+## `evertrace_lists_delete`
+
+Permanently delete a list and all its entries.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string | Yes | The list ID to delete |
+
+## `evertrace_lists_get`
+
+Get a list by ID with its entries, accesses, and creator information.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string | Yes | The list ID |
+
+## `evertrace_lists_list`
+
+List all lists the current user has access to in evertrace.ai.
+
+## `evertrace_lists_update`
+
+Rename a list.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string | Yes | The list ID to update |
+| `name` | string | Yes | New name for the list |
+
+## `evertrace_screenings_count`
+
+Count how many signals the current user has screened.
+
+## `evertrace_searches_create`
+
+Create a new saved search with filters. Each filter requires a key, operator, and value. Provide sharee user IDs to share the search with teammates.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `title` | string | Yes | Title of the saved search (max 50 characters) |
+| `visited_at` | number | Yes | Epoch timestamp in milliseconds for when the search was last visited |
+| `filters` | array | Yes | Array of filter objects. Each filter has: key (e.g. "country", "industry", "score"), operator (e.g. "in"), and value |
+| `sharees` | array | Yes | Array of user IDs to share this search with |
+| `emoji` | string | No | Optional emoji for the saved search |
+
+## `evertrace_searches_delete`
+
+Permanently delete a saved search.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string | Yes | The saved search ID to delete |
+
+## `evertrace_searches_duplicate`
+
+Duplicate a saved search, creating a copy with the same filters and settings.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string | Yes | The saved search ID to duplicate |
+
+## `evertrace_searches_get`
+
+Get a saved search by ID with its filters and sharees.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string | Yes | The saved search ID |
+
+## `evertrace_searches_list`
+
+List all saved searches accessible to the current user in evertrace.ai.
+
+## `evertrace_searches_notifications_get`
+
+Count new signals matching a saved search since it was last visited. Use the optional max parameter to cap the count for performance.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string | Yes | The saved search ID |
+| `max` | string | No | Optional cap on the count for performance (e.g. "99") |
+
+## `evertrace_searches_signals_list`
+
+List signals matching a saved search's filters with pagination.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string | Yes | The saved search ID |
+| `page` | string | No | Page number for pagination |
+| `limit` | string | No | Number of results per page |
+
+## `evertrace_searches_update`
+
+Update a saved search. All fields are optional — only provided fields are changed. If filters are provided, they replace all existing filters. If sharees are provided, they replace the full access list.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string | Yes | The saved search ID to update |
+| `title` | string | No | New title for the saved search (max 50 characters) |
+| `emoji` | string | No | New emoji for the saved search |
+| `visited_at` | number | No | Epoch timestamp in milliseconds for when the search was last visited |
+| `filters` | array | No | Replaces all existing filters. Each filter has: key, operator, value |
+| `sharees` | array | No | Replaces the full sharee list with these user IDs |
+
+## `evertrace_signal_mark_viewed`
+
+Mark a signal as viewed by the current user.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `signal_id` | string | Yes | The ID of the signal to mark as viewed |
+
+## `evertrace_signal_screen`
+
+Screen a signal, marking it as reviewed by the current user. Screened signals are hidden from default views.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `signal_id` | string | Yes | The ID of the signal to screen |
+
+## `evertrace_signal_unscreen`
+
+Unscreen a signal, making it visible again in default views.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `signal_id` | string | Yes | The ID of the signal to unscreen |
+
+## `evertrace_signals_count`
+
+Count signals matching the given filters without returning the data. Accepts the same filters as the list endpoint.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `time_range` | array | No | Absolute date range as [from, to] in YYYY-MM-DD format. Mutually exclusive with time_relative |
+| `time_relative` | string | No | Relative time window in days from today (e.g. "30"). Mutually exclusive with time_range |
+| `created_after` | string | No | Epoch timestamp in milliseconds. Only counts signals discovered after this point |
+| `score` | string | No | Minimum score threshold (1-10) |
+| `fullname` | string | No | Free-text search on person name |
+| `type` | array | No | Filter by signal type. Valid values: "New Company", "Stealth Position", "Left Position", "New Position", "Promoted", etc. |
+| `country` | array | No | Filter by country. Prefix with "!" to exclude |
+| `industry` | array | No | Filter by industry vertical. Prefix with "!" to exclude |
+| `origin` | array | No | Filter by nationality/origin country |
+| `region` | array | No | Filter by geographic region or US state |
+| `past_companies` | array | No | Filter by past employer using company entity IDs (exe_* format) |
+| `past_education` | array | No | Filter by past education institution using IDs (ede_* format) |
+| `screened_by` | array | No | Filter by screening status. Use "me", "others", or user IDs. Prefix with "-" to exclude |
+
+## `evertrace_signals_download`
+
+Export signals matching the given filters as a CSV file. Maximum 250 signals per export.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `time_range` | array | No | Absolute date range as [from, to] in YYYY-MM-DD format. Mutually exclusive with time_relative |
+| `time_relative` | string | No | Relative time window in days from today (e.g. "30"). Mutually exclusive with time_range |
+| `score` | string | No | Minimum score threshold (1-10) |
+| `type` | array | No | Filter by signal type |
+| `country` | array | No | Filter by country. Prefix with "!" to exclude |
+| `industry` | array | No | Filter by industry vertical |
+| `origin` | array | No | Filter by nationality/origin country |
+| `past_education` | array | No | Filter by past education institution using IDs (ede_* format) |
+| `page` | string | No | Page number for pagination |
+| `limit` | string | No | Number of results per page (max 250) |
+
+## `evertrace_signals_entries`
+
+Get all list entries for a signal. Shows which lists this signal has been added to.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string | Yes | The signal ID |
+
+## `evertrace_signals_get`
+
+Get a single talent signal by ID with full profile details including experiences, educations, taggings, views, and screenings.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string | Yes | The signal ID to retrieve |
+
+## `evertrace_signals_list`
+
+Search and filter talent signals with pagination. Returns full signal profiles including experiences, educations, taggings, views, and screenings.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `time_range` | array | No | Absolute date range as [from, to] in YYYY-MM-DD format (e.g. ["2026-01-01", "2026-03-01"]). Mutually exclusive with time_relative |
+| `time_relative` | string | No | Relative time window in days from today (e.g. "30", "60", "90"). Mutually exclusive with time_range |
+| `created_after` | string | No | Epoch timestamp in milliseconds. Only returns signals discovered after this point |
+| `score` | string | No | Minimum score threshold (1-10). Acts as a >= filter |
+| `fullname` | string | No | Free-text search on person name (case-insensitive partial match) |
+| `profile_tags` | array | No | Filter by profile background tags. Valid values: "Serial Founder", "VC Backed Founder", "VC Backed Operator", "VC Investor", "YC Alumni", "Big Tech experience", "Big 4 experience", "Banking experience", "Consulting experience" |
+| `type` | array | No | Filter by signal type. Valid values: "New Company", "Stealth Position", "Left Position", "Investor Position", "Board Position", "New Position", "Promoted", "New Patent", "New Grant" |
+| `country` | array | No | Filter by country name (e.g. ["United States"]). Prefix with "!" to exclude |
+| `gender` | array | No | Filter by gender. Valid values: "man", "woman" |
+| `age` | array | No | Filter by age range buckets. Valid values: "Below 25", "25 to 29", "30 to 34", "35 to 39", "40 to 44", "45 to 49", "Above 49" |
+| `past_companies` | array | No | Filter by past employer using company entity IDs in exe_* format. Use evertrace_companies_list to look up IDs |
+| `past_education` | array | No | Filter by past education institution using IDs in ede_* format. Use evertrace_educations_list to look up IDs |
+| `education_level` | array | No | Filter by highest education level. Valid values: "Bachelor", "Master", "PhD or Above", "MBA", "No university degree" |
+| `customer_focus` | array | No | Filter by target market. Valid values: "B2B", "B2C" |
+| `industry` | array | No | Filter by industry vertical (e.g. ["Technology", "Healthcare"]). Prefix with "!" to exclude |
+| `origin` | array | No | Filter by nationality/origin country (e.g. ["India"]). Prefix with "!" to exclude |
+| `region` | array | No | Filter by geographic region or US state (e.g. ["Europe", "California"]). Prefix with "!" to exclude |
+| `city` | array | No | Filter by city name (e.g. ["San Francisco"]). Use evertrace_cities_list to search available cities. Prefix with "!" to exclude |
+| `source` | array | No | Filter by data source name. Values are dynamic per workspace |
+| `screened_by` | array | No | Filter by screening status. Use "me", "others", or user IDs. Prefix with "-" to exclude |
+| `page` | string | No | Page number for pagination |
+| `limit` | string | No | Number of results per page |
+
+## `evertrace_signals_list_by_linkedin_id`
+
+Get all signals representing the same person, matched by LinkedIn ID. Useful for finding duplicate or historical signals for the same individual.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string | Yes | The signal ID to match LinkedIn ID from |
+
+## `evertrace_views_count`
+
+Count how many signals the current user has viewed.

--- a/src/content/docs/reference/agent-connectors/notion.mdx
+++ b/src/content/docs/reference/agent-connectors/notion.mdx
@@ -109,6 +109,38 @@ Fetch data from Notion using the workspace search API (/search). Supports pagina
 | `start_cursor` | string | No | Cursor for pagination; pass the previous response's next_cursor |
 | `tool_version` | string | No | Optional tool version to use for execution |
 
+## `notion_data_source_fetch`
+
+Retrieve a Notion database's schema, title, and properties using the Notion 2025-09-03 API. Unlike notion_database_fetch, this returns a data_sources array — each entry contains a data_source_id required by notion_data_source_query and notion_data_source_insert_row. Use this as the first step when working with merged, synced, or multi-source databases.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `database_id` | string | Yes | The target database ID in UUID format with hyphens |
+
+## `notion_data_source_insert_row`
+
+Create a new row (page) in a Notion data source using the 2025-09-03 API. Required for merged, synced, or multi-source databases — these require parent.data_source_id instead of parent.database_id which the older notion_database_insert_row uses.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `data_source_id` | string | Yes | The ID of the data source to insert a row into. Retrieve from notion_data_source_fetch response under data_sources[].id |
+| `properties` | `object` | Yes | Object mapping column names (or property ids) to property values |
+| `child_blocks` | `array<unknown>` | No | Optional array of Notion blocks to append as page content |
+| `cover` | `object` | No | Optional page cover object (external/file) |
+| `icon` | `object` | No | Optional page icon object (emoji/external/file) |
+
+## `notion_data_source_query`
+
+Query rows (pages) from a Notion data source using the 2025-09-03 API. Required for merged, synced, or multi-source databases — these cannot be queried via notion_database_query as that tool uses the older /databases/{id}/query endpoint which does not support multiple data sources.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `data_source_id` | string | Yes | The ID of the data source to query. Retrieve from notion_data_source_fetch response under data_sources[].id |
+| `filter` | `object` | No | Notion filter object to narrow results. Supports compound filters with 'and'/'or' arrays |
+| `page_size` | integer | No | Maximum number of rows to return (1-100). Default: 10 |
+| `sorts` | `array<object>` | No | Order the results. Each item must include either `property` or `timestamp`, plus `direction` |
+| `start_cursor` | string | No | Cursor to fetch the next page of results |
+
 ## `notion_database_create`
 
 Create a new database in Notion under a parent page. Provide a parent object with page_id, a database title (rich_text array), and a properties object that defines the database schema (columns).
@@ -250,6 +282,18 @@ Retrieve a Notion page by its ID. Returns the page properties, metadata, and par
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
 | `page_id` | string | Yes | The ID of the Notion page to retrieve |
+
+## `notion_page_search`
+
+Search Notion pages by text query. Returns matching pages with their titles, IDs, and metadata. Optionally sort by last_edited_time or created_time, and paginate with start_cursor.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `query` | string | No | Text to search for across Notion pages |
+| `page_size` | integer | No | Maximum number of pages to return (1-100). Default: 10 |
+| `sort_direction` | string | No | Direction to sort results: ascending or descending. Default: descending |
+| `sort_timestamp` | string | No | Timestamp field to sort by: last_edited_time or created_time. Default: last_edited_time |
+| `start_cursor` | string | No | Cursor to fetch the next page of results |
 
 ## `notion_page_update`
 

--- a/src/content/docs/reference/agent-connectors/notion.mdx
+++ b/src/content/docs/reference/agent-connectors/notion.mdx
@@ -131,7 +131,7 @@ Create a new row (page) in a Notion data source using the 2025-09-03 API. Requir
 
 ## `notion_data_source_query`
 
-Query rows (pages) from a Notion data source using the 2025-09-03 API. Required for merged, synced, or multi-source databases — these cannot be queried via notion_database_query as that tool uses the older /databases/{id}/query endpoint which does not support multiple data sources.
+Query rows (pages) from a Notion data source using the 2025-09-03 API. Required for merged, synced, or multi-source databases — these cannot be queried via notion_database_query as that tool uses the older `/databases/&#123;id&#125;/query` endpoint which does not support multiple data sources.
 
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |

--- a/src/content/docs/reference/agent-connectors/outlook.mdx
+++ b/src/content/docs/reference/agent-connectors/outlook.mdx
@@ -75,6 +75,20 @@ Create a new calendar event in the user's Outlook calendar. Supports attendees, 
 | `start_timezone` | string | Yes | No description |
 | `subject` | string | Yes | No description |
 
+## `outlook_create_contact`
+
+Create a new contact in the user's mailbox with name, email addresses, and phone numbers.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `givenName` | string | Yes | First name of the contact |
+| `surname` | string | Yes | Last name of the contact |
+| `emailAddresses` | array | No | Array of email address objects with 'address' and optional 'name' fields |
+| `businessPhones` | array | No | Array of business phone numbers |
+| `mobilePhone` | string | No | Mobile phone number |
+| `jobTitle` | string | No | Job title |
+| `companyName` | string | No | Company name |
+
 ## `outlook_delete_calendar_event`
 
 Delete a calendar event by ID.
@@ -83,6 +97,15 @@ Delete a calendar event by ID.
 | --- | --- | --- | --- |
 | `event_id` | string | Yes | No description |
 
+## `outlook_get_attachment`
+
+Download a specific attachment from an Outlook email message by attachment ID. Returns the full attachment including base64-encoded file content in the contentBytes field.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `message_id` | string | Yes | The ID of the message containing the attachment |
+| `attachment_id` | string | Yes | The ID of the attachment to download |
+
 ## `outlook_get_calendar_event`
 
 Retrieve an existing calendar event by ID from the user's Outlook calendar.
@@ -90,6 +113,22 @@ Retrieve an existing calendar event by ID from the user's Outlook calendar.
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
 | `event_id` | string | Yes | No description |
+
+## `outlook_get_message`
+
+Retrieve a specific email message by ID from the user's Outlook mailbox, including full body content, sender, recipients, attachments info, and metadata.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `message_id` | string | Yes | The ID of the message to retrieve |
+
+## `outlook_list_attachments`
+
+List all attachments on a specific Outlook email message. Returns attachment metadata including ID, name, size, and content type.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `message_id` | string | Yes | The ID of the message to list attachments for |
 
 ## `outlook_list_calendar_events`
 
@@ -139,3 +178,179 @@ Update an existing Outlook calendar event. Only provided fields will be updated.
 | `start_datetime` | string | No | Event start time in RFC3339 format |
 | `start_timezone` | string | No | Timezone for start time |
 | `subject` | string | No | Event title/summary |
+
+## `outlook_list_contacts`
+
+List all contacts in the user's mailbox with support for filtering, pagination, and field selection.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `$filter` | string | No | Filter expression to narrow results (OData) |
+| `$orderby` | string | No | Property to sort by (e.g., "displayName") |
+| `$select` | string | No | Comma-separated list of properties to return |
+| `$skip` | integer | No | Number of contacts to skip for pagination |
+| `$top` | integer | No | Number of contacts to return (default: 10) |
+
+## `outlook_list_messages`
+
+List all messages in the user's mailbox with support for filtering, pagination, and field selection. Returns 10 messages by default.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `$filter` | string | No | Filter expression to narrow results (OData) |
+| `$orderby` | string | No | Property to sort by (e.g., "receivedDateTime desc") |
+| `$select` | string | No | Comma-separated list of properties to return |
+| `$skip` | integer | No | Number of messages to skip for pagination |
+| `$top` | integer | No | Number of messages to return (1-1000, default: 10) |
+
+## `outlook_mailbox_settings_get`
+
+Retrieve the mailbox settings for the signed-in user. Returns automatic replies (out-of-office) configuration, language, timezone, working hours, date/time format, and delegate meeting message delivery preferences.
+
+## `outlook_mailbox_settings_update`
+
+Update mailbox settings for the signed-in user. Supports configuring automatic replies (out-of-office), language, timezone, working hours, date/time format, and delegate meeting message delivery preferences. Only fields provided will be updated.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `automaticRepliesSetting` | `object` | No | Configuration for automatic replies (out-of-office). Includes status, internalReplyMessage, externalReplyMessage, externalAudience, scheduledStartDateTime, scheduledEndDateTime |
+| `dateFormat` | string | No | Preferred date format string (e.g., 'MM/dd/yyyy') |
+| `delegateMeetingMessageDeliveryOptions` | string | No | Controls how meeting messages are delivered when a delegate is configured |
+| `language` | `object` | No | Language and locale. Properties: locale (string), displayName (string) |
+| `timeFormat` | string | No | Preferred time format string (e.g., 'hh:mm tt' or 'HH:mm') |
+| `timeZone` | string | No | Preferred time zone (e.g., 'UTC', 'Pacific Standard Time') |
+| `workingHours` | `object` | No | Working hours config. Properties: daysOfWeek (array), startTime, endTime, timeZone |
+
+## `outlook_reply_to_message`
+
+Reply to an existing email message. The reply is automatically sent to the original sender and saved in the Sent Items folder.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `messageId` | string | Yes | The unique identifier of the message to reply to |
+| `comment` | string | Yes | Reply message content |
+
+## `outlook_search_messages`
+
+Search messages by keywords across subject, body, sender, and other fields. Returns matching messages with support for pagination.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `query` | string | Yes | Search query string (searches across subject, body, from, to) |
+| `$select` | string | No | Comma-separated list of properties to return |
+| `$skip` | integer | No | Number of messages to skip for pagination |
+| `$top` | integer | No | Number of messages to return (1-1000, default: 10) |
+
+## `outlook_send_message`
+
+Send an email message using Microsoft Graph API. The message is saved in the Sent Items folder by default.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `subject` | string | Yes | Subject line of the email |
+| `body` | string | Yes | Body content of the email |
+| `toRecipients` | `array<string>` | Yes | Array of email addresses to send to |
+| `bodyType` | string | No | Content type of the body (Text or HTML) |
+| `ccRecipients` | array | No | Array of email addresses to CC |
+| `bccRecipients` | array | No | Array of email addresses to BCC |
+| `saveToSentItems` | boolean | No | Save the message in Sent Items folder (default: true) |
+
+## `outlook_todo_lists_create`
+
+Create a new Microsoft To Do task list.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `display_name` | string | Yes | The name of the task list |
+
+## `outlook_todo_lists_delete`
+
+Permanently delete a Microsoft To Do task list and all its tasks.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `list_id` | string | Yes | The ID of the task list to delete |
+
+## `outlook_todo_lists_get`
+
+Get a specific Microsoft To Do task list by ID.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `list_id` | string | Yes | The ID of the task list |
+
+## `outlook_todo_lists_list`
+
+List all Microsoft To Do task lists for the current user.
+
+## `outlook_todo_lists_update`
+
+Rename a Microsoft To Do task list.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `list_id` | string | Yes | The ID of the task list to update |
+| `display_name` | string | Yes | The new name for the task list |
+
+## `outlook_todo_tasks_create`
+
+Create a new task in a Microsoft To Do task list with optional body, due date, importance, and reminder.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `list_id` | string | Yes | The ID of the task list to add the task to |
+| `title` | string | Yes | The title of the task |
+| `body` | string | No | The body/notes of the task (plain text) |
+| `importance` | string | No | The importance of the task: low, normal, or high |
+| `status` | string | No | The status: notStarted, inProgress, completed, waitingOnOthers, or deferred |
+| `due_date` | string | No | Due date in YYYY-MM-DD format |
+| `due_time_zone` | string | No | Time zone for the due date (defaults to UTC) |
+| `reminder_date_time` | string | No | Reminder date and time in ISO 8601 format |
+| `reminder_time_zone` | string | No | Time zone for the reminder (defaults to UTC) |
+| `categories` | array | No | Array of category names to assign to the task |
+
+## `outlook_todo_tasks_delete`
+
+Permanently delete a task from a Microsoft To Do task list.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `list_id` | string | Yes | The ID of the task list |
+| `task_id` | string | Yes | The ID of the task to delete |
+
+## `outlook_todo_tasks_get`
+
+Get a specific task from a Microsoft To Do task list.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `list_id` | string | Yes | The ID of the task list |
+| `task_id` | string | Yes | The ID of the task |
+
+## `outlook_todo_tasks_list`
+
+List all tasks in a Microsoft To Do task list with optional filtering and pagination.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `list_id` | string | Yes | The ID of the task list |
+| `$top` | integer | No | Number of tasks to return (default: 10) |
+| `$skip` | integer | No | Number of tasks to skip for pagination |
+| `$filter` | string | No | OData filter expression (e.g., "status eq 'notStarted'") |
+| `$orderby` | string | No | Property to sort by (e.g., "createdDateTime desc") |
+
+## `outlook_todo_tasks_update`
+
+Update a task in a Microsoft To Do task list. Only provided fields are changed.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `list_id` | string | Yes | The ID of the task list |
+| `task_id` | string | Yes | The ID of the task to update |
+| `title` | string | No | New title for the task |
+| `body` | string | No | New body/notes for the task (plain text) |
+| `importance` | string | No | The importance: low, normal, or high |
+| `status` | string | No | The status: notStarted, inProgress, completed, waitingOnOthers, or deferred |
+| `due_date` | string | No | Due date in YYYY-MM-DD format |
+| `due_time_zone` | string | No | Time zone for the due date (defaults to UTC) |
+| `categories` | array | No | Array of category names to assign |

--- a/src/content/docs/reference/agent-connectors/salesforce.mdx
+++ b/src/content/docs/reference/agent-connectors/salesforce.mdx
@@ -139,6 +139,81 @@ Retrieve a list of accounts from Salesforce using a pre-built SOQL query. Return
 | --- | --- | --- | --- |
 | `limit` | number | Yes | Number of results to return per page |
 
+## `salesforce_chatter_comment_create`
+
+Add a comment to a Salesforce Chatter post (feed element).
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `feed_element_id` | string | Yes | The ID of the Chatter post to comment on |
+| `text` | string | Yes | The text body of the comment |
+
+## `salesforce_chatter_comment_delete`
+
+Delete a comment from a Salesforce Chatter post.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `comment_id` | string | Yes | The ID of the Chatter comment to delete |
+
+## `salesforce_chatter_comments_list`
+
+List all comments on a Salesforce Chatter post (feed element).
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `feed_element_id` | string | Yes | The ID of the Chatter post to list comments for |
+| `page` | string | No | Page token for retrieving the next page of results |
+| `page_size` | number | No | Number of comments to return per page (default: 25, max: 100) |
+
+## `salesforce_chatter_post_create`
+
+Create a new post (feed element) on a Salesforce Chatter feed. Use 'me' as subject_id to post to the current user's feed.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `text` | string | Yes | The text body of the Chatter post |
+| `is_rich_text` | boolean | No | If true, the text body will be treated as HTML rich text |
+| `message_segments` | array | No | Advanced: raw Salesforce message segments array for full rich text control (bold, italic, links, mentions, etc.) |
+| `subject_id` | string | No | The ID of the subject (user, record, or group) to post to. Use 'me' for the current user's feed |
+
+## `salesforce_chatter_post_delete`
+
+Delete a Salesforce Chatter post (feed element) by its ID.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `feed_element_id` | string | Yes | The ID of the Chatter post to delete |
+
+## `salesforce_chatter_post_get`
+
+Retrieve a specific Salesforce Chatter post (feed element) by its ID.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `feed_element_id` | string | Yes | The ID of the Chatter feed element (post) to retrieve |
+
+## `salesforce_chatter_posts_search`
+
+Search Salesforce Chatter posts (feed elements) by keyword across all feeds.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `q` | string | Yes | Search query string to find matching Chatter posts |
+| `page` | string | No | Page token for retrieving the next page of results |
+| `page_size` | number | No | Number of results to return per page (default: 25, max: 100) |
+
+## `salesforce_chatter_user_feed_list`
+
+Retrieve feed elements (posts) from a Salesforce user's Chatter news feed. Use 'me' as the user ID to get the current user's feed.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `user_id` | string | Yes | The ID of the user whose Chatter feed to retrieve. Use 'me' for the current user |
+| `page` | string | No | Page token for retrieving the next page of results |
+| `page_size` | number | No | Number of feed elements to return per page (default: 25, max: 100) |
+| `sort_param` | string | No | Sort order for feed elements. Options: LastModifiedDateDesc (default), CreatedDateDesc, MostRecentActivity |
+
 ## `salesforce_composite`
 
 Execute multiple Salesforce REST API requests in a single call using the Composite API. Allows for efficient batch operations and related data retrieval.
@@ -302,6 +377,14 @@ Execute SOQL queries against Salesforce data. Supports complex queries with join
 | --- | --- | --- | --- |
 | `query` | string | Yes | SOQL query string to execute |
 
+## `salesforce_query_next_page`
+
+Fetch the next page of results from a previous SOQL query. Use the nextRecordsUrl returned when a query response has `done=false`.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `cursor` | string | Yes | The record cursor from a previous SOQL query response. Extract the cursor ID from the nextRecordsUrl (e.g. `01gxx0000002GJm-2000` from `/services/data/v66.0/query/01gxx0000002GJm-2000`) |
+
 ## `salesforce_report_create`
 
 Create a new report in Salesforce using the Analytics API. Minimal verified version with only confirmed working fields.
@@ -327,6 +410,14 @@ Delete an existing report from Salesforce by report ID. This is a destructive op
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
 | `report_id` | string | Yes | ID of the report to delete |
+
+## `salesforce_report_get`
+
+Retrieve report definition and metadata from Salesforce by report ID. Returns the full report configuration including columns, filters, groupings, and chart settings.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `report_id` | string | Yes | ID of the report to retrieve |
 
 ## `salesforce_report_metadata_get`
 


### PR DESCRIPTION
## Summary

- Adds 10 missing Salesforce tools to the agent connector reference docs (`salesforce.mdx`)
- 8 Chatter tools: `salesforce_chatter_comment_create`, `salesforce_chatter_comment_delete`, `salesforce_chatter_comments_list`, `salesforce_chatter_post_create`, `salesforce_chatter_post_delete`, `salesforce_chatter_post_get`, `salesforce_chatter_posts_search`, `salesforce_chatter_user_feed_list`
- Pagination tool: `salesforce_query_next_page`
- Report tool: `salesforce_report_get`

## Test plan

- [ ] Verify all 10 new tool entries render correctly in the docs
- [ ] Check alphabetical ordering is maintained in the tool list
- [ ] Confirm parameter tables (name, type, required, description) are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Salesforce Chatter: create/delete/search posts and comments, list user feeds with pagination/sorting; SOQL/reporting: fetch next query page and retrieve report metadata
  * Attio: extensive create/upsert/query/update tools for records, lists, workspaces, webhooks, tasks, select options and statuses
  * Notion: data-source fetch/insert/query and page search with pagination/sorting
  * Outlook: contacts, message/attachment retrieval, search/send/reply, mailbox settings, and full To Do lists/tasks support

* **Documentation**
  * Added comprehensive evertrace.ai connector docs with setup, usage examples, and full tool reference
<!-- end of auto-generated comment: release notes by coderabbit.ai -->