### PR TITLE
fix: warn on missing setup/usage templates in sync-agent-connectors

### DIFF
--- a/scripts/sync-agent-connectors.js
+++ b/scripts/sync-agent-connectors.js
@@ -425,6 +425,26 @@ function getSetupComponent(stemMap, providerSlug) {
   )
 }
 
+// Warns when a provider that has tools is missing a setup or usage template.
+// Catches slug-matching failures silently dropped by getSetupComponent/getUsageComponent.
+function warnMissingTemplates(providers, toolsByProvider, setupMap, usageMap) {
+  for (const provider of providers) {
+    const slug = toSafeIdentifier(provider.identifier || '')
+    const providerTools = toolsByProvider.get(provider.identifier || '') || []
+    if (providerTools.length === 0) continue // skip stubs with no tools yet
+    if (!getSetupComponent(setupMap, slug)) {
+      console.warn(
+        `  ⚠ No setup template for "${provider.identifier}" (slug: ${slug}) — _setup-${slug}.mdx missing`,
+      )
+    }
+    if (!getUsageComponent(usageMap, slug)) {
+      console.warn(
+        `  ⚠ No usage template for "${provider.identifier}" (slug: ${slug}) — _usage-${slug}.mdx missing`,
+      )
+    }
+  }
+}
+
 const SETUP_STEM_MAP = buildSetupStemMap()
 
 // ---------------------------------------------------------------------------
@@ -678,6 +698,9 @@ async function main() {
   console.log(`✓ Fetched ${tools.length} tools`)
 
   const toolsByProvider = groupToolsByProvider(tools)
+
+  // Warn about providers with tools but no matching setup/usage template
+  warnMissingTemplates(providers, toolsByProvider, SETUP_STEM_MAP, USAGE_STEM_MAP)
 
   // Build the set of file names this run will produce
   const expectedFiles = new Set(providers.map((p) => toSafeIdentifier(p.identifier || '') + '.mdx'))


### PR DESCRIPTION
## Summary
- Adds `warnMissingTemplates()` to `scripts/sync-agent-connectors.js`
- For every provider that has tools, checks whether a matching `_setup-*` and `_usage-*` template file can be resolved via the slug-matching strategies
- Logs a `⚠` warning with the provider identifier, computed slug, and expected filename if either template is missing
- Prevents silent omission of setup/usage sections that would ship connector pages without setup instructions

## Why
Root-cause investigation of scalekit-inc/developer-docs#570 found that when `getSetupComponent()` / `getUsageComponent()` can't match a provider slug to a template file, the section is silently dropped — no error, no log. This fix makes the gap visible at sync time.

## Test plan
- [ ] Run `node scripts/sync-agent-connectors.js` (requires env vars) — providers with tools but no template should print warnings
- [ ] Providers with both templates generate pages as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added validation to verify setup and usage templates exist for all agent connectors with tools, with warnings logged for any missing documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->