### PR TITLE
docs: order Scalar API reference operations

### DIFF
--- a/src/pages/apis.astro
+++ b/src/pages/apis.astro
@@ -161,7 +161,6 @@ const frontmatter = {
   <ScalarComponent
     configuration={{
       url: '/api/scalekit.scalar.yaml',
-      cdn: 'https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.44.26',
       theme: 'default',
       layout: 'modern',
       pageTitle: 'Scalekit API',
@@ -173,6 +172,48 @@ const frontmatter = {
       darkMode: false,
       proxyUrl: 'https://proxy.scalar.com',
       defaultOpenAllTags: false,
+      tagsSorter: (a, b) => {
+        const tagOrder = [
+          'Organizations',
+          'Permissions',
+          'Users',
+          'Connections',
+          'Directory',
+          'Roles',
+          'Sessions',
+          'Domains',
+          'API Auth',
+          'Magic link & OTP',
+          'Passkeys',
+          'Connected Accounts',
+        ]
+        const getTagRank = (name) => {
+          const rank = tagOrder.indexOf(name ?? '')
+          return rank === -1 ? Number.POSITIVE_INFINITY : rank
+        }
+        const rankA = getTagRank(a?.name)
+        const rankB = getTagRank(b?.name)
+
+        if (rankA !== rankB) {
+          return rankA - rankB
+        }
+
+        return (a?.name ?? '').localeCompare(b?.name ?? '')
+      },
+      operationsSorter: (a, b) => {
+        const methodOrder = ['get', 'post', 'put', 'patch', 'delete']
+        const getMethodRank = (method) => {
+          const rank = methodOrder.indexOf((method ?? '').toLowerCase())
+          return rank === -1 ? Number.POSITIVE_INFINITY : rank
+        }
+        const methodComparison = getMethodRank(a?.method) - getMethodRank(b?.method)
+
+        if (methodComparison !== 0) {
+          return methodComparison
+        }
+
+        return (a?.path ?? '').localeCompare(b?.path ?? '')
+      },
       servers: [
         {
           url: 'https://{SCALEKIT_ENVIRONMENT_URL}',


### PR DESCRIPTION
## Summary
- add Scalar tag and operation sorting to the API reference page
- remove the old pinned Scalar CDN so the page uses the current default loader
- keep the ordering logic self-contained so the runtime sorter functions execute correctly

## Verification
- verified the /apis/ page locally after fixing the runtime sorter error
- git push pre-push checks passed, including node scripts/search-index-apis.js and astro build

## Preview
- Branch preview: https://preview-scalar-numbering--scalekit-starlight.netlify.app/apis/
- Deploy preview: https://deploy-preview-572--scalekit-starlight.netlify.app/apis/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * API reference tags are now sorted using a prioritized list, with consistent ordering for improved discoverability.
  * API operations are now automatically sorted by HTTP method (GET, POST, PUT, PATCH, DELETE) followed by path for better navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->