### PR TITLE
Add tool docs for Google Docs, Sheets, and Forms

### DIFF
--- a/src/content/docs/reference/agent-connectors/googledocs.mdx
+++ b/src/content/docs/reference/agent-connectors/googledocs.mdx
@@ -67,3 +67,14 @@ Update the content of an existing Google Doc using batch update requests. Suppor
 | `schema_version` | string | No | Optional schema version to use for tool execution |
 | `tool_version` | string | No | Optional tool version to use for execution |
 | `write_control` | `object` | No | Optional write control for revision management |
+
+## `googledocs_list_documents`
+
+List all Google Docs documents in the user's Drive. Optionally search by document name. Returns document IDs, names, and metadata with pagination support.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `query` | string | No | Drive search query to filter documents. Default lists all docs. To search by name, use: `mimeType = 'application/vnd.google-apps.document' and trashed = false and name contains 'report'` |
+| `page_size` | integer | No | Number of documents to return per page (max 1000, default 100) |
+| `page_token` | string | No | Token for retrieving the next page of results. Use the nextPageToken from a previous response. |
+| `order_by` | string | No | Sort order for results. Examples: modifiedTime desc, name asc, createdTime desc |

--- a/src/content/docs/reference/agent-connectors/googleforms.mdx
+++ b/src/content/docs/reference/agent-connectors/googleforms.mdx
@@ -32,3 +32,42 @@ Supports authentication: <Badge text="OAuth 2.0" />
 ## Usage
 
 <UsageGoogleformsSection />
+
+## Tool list
+
+## `googleforms_create_form`
+
+Create a new Google Form with a title and optional document title. Returns the new form's ID and metadata.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `title` | string | Yes | The title of the form shown to respondents |
+| `document_title` | string | No | The title of the document shown in Google Drive (defaults to the form title if not provided) |
+
+## `googleforms_get_form`
+
+Get the structure and metadata of a Google Form including its title, description, and all questions.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `form_id` | string | Yes | The ID of the Google Form to retrieve |
+
+## `googleforms_list_responses`
+
+List all responses submitted to a Google Form. Returns response IDs, submission timestamps, and answer values for each respondent.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `form_id` | string | Yes | The ID of the Google Form to list responses for |
+| `page_size` | integer | No | Maximum number of responses to return (max 5000) |
+| `page_token` | string | No | Token for retrieving the next page of results |
+| `filter` | string | No | Filter responses by submission time. Format: timestamp > 2026-01-01T00:00:00Z |
+
+## `googleforms_get_response`
+
+Get a single response submitted to a Google Form by its response ID. Returns the respondent's answers for all questions.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `form_id` | string | Yes | The ID of the Google Form |
+| `response_id` | string | Yes | The ID of the specific response to retrieve |

--- a/src/content/docs/reference/agent-connectors/googlesheets.mdx
+++ b/src/content/docs/reference/agent-connectors/googlesheets.mdx
@@ -86,3 +86,24 @@ Update cell values in a specific range of a Google Sheet. Supports writing singl
 | `tool_version` | string | No | Optional tool version to use for execution |
 | `value_input_option` | string | No | How input values should be interpreted |
 | `values` | `array<array>` | Yes | 2D array of values to write to the range |
+
+## `googlesheets_append_values`
+
+Append rows of data to a Google Sheets spreadsheet. Data is added after the last row with existing content in the specified range.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `spreadsheet_id` | string | Yes | The ID of the spreadsheet to append data to |
+| `range` | string | Yes | The A1 notation range to append data to (e.g. Sheet1!A1) |
+| `values` | `array<array>` | Yes | 2D array of values to append. Each inner array is a row. |
+| `value_input_option` | string | No | How input data should be interpreted. Options: RAW, USER_ENTERED. Default: USER_ENTERED |
+| `insert_data_option` | string | No | How the input data should be inserted. Options: INSERT_ROWS, OVERWRITE. Default: OVERWRITE |
+
+## `googlesheets_clear_values`
+
+Clear all values in a specified range of a Google Sheets spreadsheet. Formatting is preserved; only the cell values are cleared.
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `spreadsheet_id` | string | Yes | The ID of the spreadsheet to clear values in |
+| `range` | string | Yes | The A1 notation range to clear (e.g. Sheet1!A1:D10) |


### PR DESCRIPTION
## Summary
- **Google Docs**: Added `googledocs_list_documents` tool documentation
- **Google Sheets**: Added `googlesheets_append_values` and `googlesheets_clear_values` tool documentation
- **Google Forms**: Added all 4 new tools — `googleforms_create_form`, `googleforms_get_form`, `googleforms_list_responses`, `googleforms_get_response`

## Test plan
- [ ] Verify MDX renders correctly on docs site
- [ ] Confirm tool parameter tables match tool definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Google Docs: Added reference documentation for listing documents with optional search and sorting capabilities.
  * Google Forms: Added reference documentation for four new tools to create, retrieve, and list form responses.
  * Google Sheets: Added reference documentation for appending values and clearing cell ranges with configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->