### PR TITLE
Add roles and custom claims support to MCP BYOA

### DIFF
--- a/src/content/docs/mcp/auth-methods/custom-auth.mdx
+++ b/src/content/docs/mcp/auth-methods/custom-auth.mdx
@@ -204,7 +204,12 @@ curl --location '{{env_url}}/api/v1/connections/{{connection_id}}/auth-requests/
   --header 'Authorization: Bearer {{access_token}}' \
   --data-raw '{
     "sub": "1234567890",
-    "email": "alice@example.com"
+    "email": "alice@example.com",
+    "roles": ["support", "developer"],
+    "custom_attributes": {
+      "access_level": 101,
+      "subscription_type": "PREMIUM"
+    }
   }'
 ```
 

--- a/src/content/docs/reference/agent-connectors/granolamcp.mdx
+++ b/src/content/docs/reference/agent-connectors/granolamcp.mdx
@@ -87,7 +87,7 @@ Use get_meetings to retrieve detailed meeting content after identifying relevant
 
 ## `granolamcp_query_granola_meetings`
 
-Query Granola about the user's meetings using natural language. Returns a tailored response with inline citation links in mark  (e.g. [\[0\]](url)) that reference source meeting notes.
+Query Granola about the user's meetings using natural language. Returns a tailored response with inline citation links in mark that reference source meeting notes.
 
 IMPORTANT: The response includes numbered citation links to specific Granola meeting notes. These citations MUST be preserved in your response to the user — they provide transparency and allow the user to verify information by clicking through to the original notes.
 

--- a/src/content/docs/reference/agent-connectors/granolamcp.mdx
+++ b/src/content/docs/reference/agent-connectors/granolamcp.mdx
@@ -87,7 +87,7 @@ Use get_meetings to retrieve detailed meeting content after identifying relevant
 
 ## `granolamcp_query_granola_meetings`
 
-Query Granola about the user's meetings using natural language. Returns a tailored response with inline citation links in mark that reference source meeting notes.
+Query Granola about the user's meetings using natural language. Returns a tailored response with inline citation that reference source meeting notes.
 
 IMPORTANT: The response includes numbered citation links to specific Granola meeting notes. These citations MUST be preserved in your response to the user — they provide transparency and allow the user to verify information by clicking through to the original notes.
 

--- a/src/content/docs/reference/agent-connectors/granolamcp.mdx
+++ b/src/content/docs/reference/agent-connectors/granolamcp.mdx
@@ -87,7 +87,7 @@ Use get_meetings to retrieve detailed meeting content after identifying relevant
 
 ## `granolamcp_query_granola_meetings`
 
-Query Granola about the user's meetings using natural language. Returns a tailored response with inline citation that reference source meeting notes.
+Query Granola about the user's meetings using natural language. Returns a tailored response with inline citations that reference source meeting notes.
 
 IMPORTANT: The response includes numbered citation links to specific Granola meeting notes. These citations MUST be preserved in your response to the user — they provide transparency and allow the user to verify information by clicking through to the original notes.
 


### PR DESCRIPTION
## Summary

This PR adds support for roles and custom claims in the MCP BYOA (Bring Your Own Authentication) connector implementation.

## Changes

- Added roles and custom attributes documentation in MCP BYOA reference
- Fixed broken relative link in granolamcp connector page

## Test plan

- [ ] Preview link displays correctly
- [ ] All internal links resolve properly
- [ ] Content renders without formatting issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated authentication docs: cURL example now shows optional user claims — added a roles array and custom_attributes fields to illustrate extra attributes in the request payload.
  * Improved agent connector docs: corrected formatting/wording for inline citations to enhance clarity while preserving the documented behavior and required-field guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->