### PR TITLE
docs: clarify connection_id vs resource_id and HTTP SDK alternative

### DIFF
--- a/src/content/docs/authenticate/mcp/custom-auth.mdx
+++ b/src/content/docs/authenticate/mcp/custom-auth.mdx
@@ -135,12 +135,14 @@ shape: sequence_diagram
 
    </details>
 
-   <Aside type="note">
+   <Aside type="note" title="Finding your connection_id">
      Replace the placeholder values:
-     - `<SCALEKIT_ENVIRONMENT_URL>` ? Your Scalekit environment URL
-     - `<connection_id>` ? Unique connection ID provided by Scalekit for your auth integration
-     - `<login_request_id>` ? The login request ID from step 1
-     - `<access_token>` ? Your Scalekit API access token
+     - `<SCALEKIT_ENVIRONMENT_URL>` — Your Scalekit environment URL
+     - `<connection_id>` — The connection ID for your BYOA integration. Find it in **Dashboard > MCP Servers > [your server] > Advanced Configurations > Connection ID**. It starts with `conn_`.
+     - `<login_request_id>` — The login request ID from step 1
+     - `<access_token>` — Your Scalekit API access token
+
+     **Do not use the MCP Server's resource ID here.** The resource ID (starts with `res_`) identifies the MCP server itself and is used for token audiences and client registration — it is a different value.
    </Aside>
 
 3. ## Redirect back to Scalekit

--- a/src/content/docs/authenticate/mcp/troubleshooting.mdx
+++ b/src/content/docs/authenticate/mcp/troubleshooting.mdx
@@ -25,6 +25,27 @@ Use this guide to troubleshoot setup problems, resolve CORS and network issues, 
 
 ## Configuration & Setup Issues
 
+### My POST to `/auth-requests/` returns a 404 or "invalid ID" error
+
+You may be passing the MCP server's resource ID instead of the connection ID in the URL path.
+
+These are two different identifiers with different purposes:
+
+| Identifier | Format | Purpose |
+|---|---|---|
+| `resource_id` | `res_xxx` | Identifies the MCP server; used in token audiences and client registration |
+| `connection_id` | `conn_xxx` | Identifies your BYOA auth connection; required in `/auth-requests/` endpoints |
+
+The correct endpoint uses `connection_id`:
+
+```txt frame="none"
+/api/v1/connections/<connection_id>/auth-requests/<login_request_id>/user
+```
+
+To find your `connection_id`: open **Dashboard > MCP Servers > [your server] > Advanced Configurations > Connection ID**.
+
+---
+
 ### I'm getting an access token but no refresh token
 
 Add the `offline_access` scope to your authorization request. Without it, Scalekit does not issue a refresh token alongside the access token.

--- a/src/content/docs/mcp/auth-methods/custom-auth.mdx
+++ b/src/content/docs/mcp/auth-methods/custom-auth.mdx
@@ -215,8 +215,9 @@ curl --location '{{env_url}}/api/v1/connections/{{connection_id}}/auth-requests/
 - Replace placeholders like `{{env_url}}`, `{{connection_id}}`, `{{login_request_id}}`, and `{{access_token}}` with actual values.
 - Only `sub` and `email` are required fields; all other properties are optional.
 
-You can get the `{{connection_id}}` from the User Info Post URL from Scalekit MCP server dashboard.
-If the user info post url is `https://yourapp.scalekit.com/api/v1/connections/conn_1234567890/auth-requests/{{login_request_id}}/user`, your connection_id is `conn_1234567890`.
+**Finding your `connection_id`:** Open **Dashboard > MCP Servers > [your server] > Advanced Configurations > Connection ID**. It starts with `conn_` and is distinct from the MCP server's resource ID (which starts with `res_`). Do not use the resource ID here.
+
+**Using raw HTTP instead of the SDK:** Making direct HTTP calls to this endpoint is a fully supported alternative to using an SDK. If the SDK introduces transitive dependency conflicts in your project, use the cURL tab above for the equivalent request.
 
 :::
 


### PR DESCRIPTION
## Summary

Clarifies two common sources of confusion when using Scalekit MCP authentication:

### 1. connection_id vs resource_id in BYOA custom auth
Updated documentation in three places to explicitly explain where to find the correct connection_id in the dashboard and warn developers against accidentally using the resource_id (res_xxx):
- `src/content/docs/authenticate/mcp/custom-auth.mdx` — Improved the connection_id Aside in Step 2 with dashboard navigation path
- `src/content/docs/authenticate/mcp/troubleshooting.mdx` — Added troubleshooting entry distinguishing connection_id vs resource_id for /auth-requests/ 404 errors
- `src/content/docs/mcp/auth-methods/custom-auth.mdx` — Enhanced connection_id note with dashboard path

### 2. HTTP as SDK fallback for transitive dependency conflicts
Added note that raw HTTP calls are a supported alternative to the SDK when developers encounter transitive dependency conflicts.

## Preview
https://deploy-preview-{PR_NUMBER}--scalekit-starlight.netlify.app/authenticate/mcp/custom-auth/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced authentication setup guidance with clearer instructions for locating connection identifiers in the Scalekit Dashboard.
  * Added new troubleshooting section addressing common POST request failures and resolution steps.
  * Clarified distinction between different identifier types to prevent configuration errors.
  * Documented support for raw HTTP requests as a valid alternative to using SDKs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->