### PR TITLE
docs: remove default credentials note from github agent connector setup

### DIFF
--- a/src/components/templates/agent-connectors/_setup-github.mdx
+++ b/src/components/templates/agent-connectors/_setup-github.mdx
@@ -7,10 +7,6 @@ Register your Scalekit environment with the GitHub connector so Scalekit handles
 
     - In [Scalekit dashboard](https://app.scalekit.com), go to **Agent Auth** → **Create Connection**. Find **GitHub** and click **Create**.
 
-      <Aside>
-        By default, a connection using Scalekit's credentials will be created. If you are testing, go directly to the Usage section. Before going to production, update your connection by following the steps below.
-      </Aside>
-
     - Click **Use your own credentials** and copy the redirect URI. It looks like `https://<SCALEKIT_ENVIRONMENT_URL>/sso/v1/oauth/<CONNECTION_ID>/callback`.
 
       ![Copy redirect URI from Scalekit dashboard](@/assets/docs/agent-connectors/github/use-own-credentials-redirect-uri.png)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed informational content from GitHub authentication setup documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->