### PR TITLE
docs: correct offline_access scope note in Modular SSO

### DIFF
--- a/src/content/docs/authenticate/sso/add-modular-sso.mdx
+++ b/src/content/docs/authenticate/sso/add-modular-sso.mdx
@@ -310,7 +310,7 @@ Choose Modular SSO when you:
      response_type=code&                        # OAuth2 authorization code flow
      client_id=<SCALEKIT_CLIENT_ID>&            # Your Scalekit client ID
      redirect_uri=<REDIRECT_URI>&               # URL-encoded callback URL
-     scope=openid profile email&                # "offline_access" is required to receive a refresh token
+     scope=openid profile email&                # Note: "offline_access" scope is not supported in Modular SSO
      organization_id=org_15421144869927830&     # (Optional) Route by organization
      connection_id=conn_15696105471768821&      # (Optional) Specific SSO connection
      login_hint=user@example.com                # (Optional) Extract domain from email


### PR DESCRIPTION
## Summary

- Corrected misleading documentation about offline_access scope in Modular SSO authentication URL example
- Changed comment from: "offline_access" is required to receive a refresh token
- To: Note: "offline_access" scope is not supported in Modular SSO

## Why this matters

Modular SSO does NOT support offline_access scope. This is by design — users manage their own sessions in Modular SSO. The previous documentation caused customer confusion (Pylon #608). Support confirmed that offline_access is not supported across multiple customer conversations.

## Preview

https://deploy-preview-{PR_NUMBER}--scalekit-starlight.netlify.app/authenticate/sso/add-modular-sso/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OAuth2 authorization documentation to clarify that `offline_access` is not supported in Modular SSO.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->