### PR TITLE
docs: clarify what users see on consent screen with DCR

### DIFF
--- a/src/content/docs/authenticate/mcp/managing-mcp-clients.mdx
+++ b/src/content/docs/authenticate/mcp/managing-mcp-clients.mdx
@@ -35,6 +35,8 @@ There are three main categories of MCP Clients that can interact with your MCP S
 
 These are MCP Clients that automatically register themselves as OAuth clients. Most modern MCP clients, such as Claude Desktop, OpenAI, VS Code, and Cursor, support Dynamic Client Registration (DCR). They initiate the registration process and start the OAuth Authorization flow with the Scalekit server to obtain an access token without requiring manual configuration.
 
+During the consent flow, users see your **environment domain** as the requesting identifier — not "Scalekit" and not your application name. This is by design: the domain identifies the authorization server handling the request, similar to how Google OAuth shows the requesting domain. To display a custom branded domain, configure a [custom domain](/agent-auth/advanced/custom-domain) for your Scalekit environment.
+
 ## 2. Manual client pre-registration
 
 These are MCP Clients that you manually register in the Scalekit Dashboard. This is useful when you want to restrict access to specific, pre-approved clients or when you are building a custom client that requires fixed credentials. You can create OAuth clients that can either act as themselves or on behalf of the user.


### PR DESCRIPTION
## Summary

- Adds two sentences to the "Automatic registration with DCR" section in the Managing MCP Clients page
- Explains that the OAuth consent screen shows the **environment domain** (not "Scalekit" or the app name) when DCR clients like Claude or Cursor initiate the auth flow
- Notes this is by design, with a link to the custom domain guide for teams wanting branded branding

Fixes scalekit-inc/developer-docs#587

## Preview

https://deploy-preview-{PR_NUMBER}--scalekit-starlight.netlify.app/authenticate/mcp/managing-mcp-clients/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification on how the MCP environment domain appears in consent flows and information about custom domain configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->