### PR TITLE
fix: correct Auth.js basePath claim and invalid Spring Security timeout properties

### DIFF
--- a/src/content/docs/cookbooks/add-enterprise-sso-nextjs-authjs.mdx
+++ b/src/content/docs/cookbooks/add-enterprise-sso-nextjs-authjs.mdx
@@ -57,7 +57,7 @@ Create an environment in the [Scalekit dashboard](https://app.scalekit.com/):
 1. Copy your **Issuer URL** (e.g. `https://yourenv.scalekit.dev`), **Client ID** (`skc_...`), and **Client Secret** from **API Keys**.
 2. Register your redirect URI: `http://localhost:3000/auth/callback/scalekit`
 
-   > Auth.js v5 defaults to `/auth` as its base path — not `/api/auth`. The callback URL must match exactly or the OAuth flow will fail.
+   > This guide sets `basePath: "/auth"` in `auth.ts` — a custom override. The Auth.js v5 default is `/api/auth`. Register your redirect URI to match whatever `basePath` you configure or the OAuth flow will fail.
 
 3. Create an **Organization** and add an **SSO Connection** for your test IdP.
 4. Copy the **Connection ID** (`conn_...`) — you'll use it to route sign-in attempts during development.
@@ -272,7 +272,7 @@ AUTH_DEBUG=true pnpm dev
 
 ## Common mistakes
 
-1. **Wrong redirect URI** — registering `/api/auth/callback/scalekit` instead of `/auth/callback/scalekit`. Auth.js v5 changed the default `basePath` from `/api/auth` to `/auth`. The URI in Scalekit's dashboard must match the callback path Auth.js actually uses.
+1. **Wrong redirect URI** — registering `/api/auth/callback/scalekit` instead of `/auth/callback/scalekit`. This guide sets `basePath: "/auth"` (a custom override, not the v5 default — the default remains `/api/auth`). The URI in Scalekit's dashboard must match the callback path Auth.js actually uses.
 
 2. **Missing `AUTH_SECRET`** — sign-in appears to start but fails on the callback with no visible error. Always set `AUTH_SECRET`. Generate one with `npx auth secret`.
 

--- a/src/content/docs/cookbooks/java-spring-boot-jwt-timeout.mdx
+++ b/src/content/docs/cookbooks/java-spring-boot-jwt-timeout.mdx
@@ -12,7 +12,6 @@ authors:
     picture: '/images/blog/authors/hashirr-lukmahn.jpg'
 ---
 
-import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 If you're using Spring Boot 4.0.0 or later and experiencing connection timeout errors when validating JWT tokens from Scalekit, you'll need to explicitly configure timeout values. This is a known issue affecting Spring Security's OAuth2 resource server configuration.
 
@@ -68,46 +67,7 @@ You **don't** need this if:
 
 ## The solution
 
-Configure explicit timeout values for the OAuth2 resource server's HTTP client. Spring Security provides configuration properties specifically for this:
-
-<Tabs>
-  <TabItem value="yaml" label="application.yml">
-    ```yaml
-    spring:
-      security:
-        oauth2:
-          resourceserver:
-            jwt:
-              issuer-uri: https://auth.scalekit.com
-              # Configure timeouts for JWKS and discovery endpoints
-              client:
-                registration:
-                  connect-timeout: 10000  # 10 seconds for connection
-                  read-timeout: 10000     # 10 seconds for reading response
-    ```
-  </TabItem>
-  <TabItem value="properties" label="application.properties">
-    ```properties
-    spring.security.oauth2.resourceserver.jwt.issuer-uri=https://auth.scalekit.com
-    # Configure timeouts for JWKS and discovery endpoints
-    spring.security.oauth2.resourceserver.jwt.client.registration.connect-timeout=10000
-    spring.security.oauth2.resourceserver.jwt.client.registration.read-timeout=10000
-    ```
-  </TabItem>
-</Tabs>
-
-### Timeout values explained
-
-- **connect-timeout**: Maximum time (in milliseconds) to establish a connection to Scalekit's servers
-- **read-timeout**: Maximum time (in milliseconds) to wait for a response after connection is established
-
-**Recommended values**:
-- **Development**: 5000ms (5 seconds) for faster feedback
-- **Production**: 10000-15000ms (10-15 seconds) to handle network variability
-
-## Alternative: Programmatic configuration
-
-If you need more control or want to configure this per-environment, use Java configuration:
+Spring Security has no properties for configuring HTTP client timeouts on JWT validation. The only supported approach is a custom `JwtDecoder` bean with a `RestTemplate` that sets explicit timeouts:
 
 ```java
 import org.springframework.context.annotation.Bean;
@@ -138,10 +98,10 @@ public class SecurityConfig {
 }
 ```
 
-This approach gives you:
+This gives you:
 - Full control over HTTP client configuration
 - Ability to add custom headers or interceptors
-- Environment-specific timeout tuning
+- Environment-specific timeout tuning (development: 5000ms, production: 10000–15000ms)
 
 ## Verifying the fix
 
@@ -171,5 +131,5 @@ This cookbook addresses a specific Spring Boot 4.0+ timeout issue. For general J
 ## Related resources
 
 - [Spring Security OAuth2 Resource Server - JWT Timeouts](https://docs.spring.io/spring-security/reference/servlet/oauth2/resource-server/jwt.html#oauth2resourceserver-jwt-timeouts)
-- [Scalekit Java SDK Documentation](https://docs.scalekit.com/apis/#tag/authentication)
+- [Scalekit API reference](/apis/#tag/authentication)
 - [Spring Boot 4.0 Release Notes](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Release-Notes)

--- a/src/content/docs/cookbooks/java-spring-boot-jwt-timeout.mdx
+++ b/src/content/docs/cookbooks/java-spring-boot-jwt-timeout.mdx
@@ -67,7 +67,7 @@ You **don't** need this if:
 
 ## The solution
 
-Spring Security has no properties for configuring HTTP client timeouts on JWT validation. The only supported approach is a custom `JwtDecoder` bean with a `RestTemplate` that sets explicit timeouts:
+For Spring Security servlet resource servers, there are no properties to configure JWT discovery/JWKS HTTP timeouts. Use a custom `JwtDecoder` bean with `RestOperations` (for example, `RestTemplate`) and explicit timeout values:
 
 ```java
 import org.springframework.context.annotation.Bean;


### PR DESCRIPTION
## Summary

- **#499** — Fixes two incorrect claims in the Auth.js v5 Next.js cookbook: `/auth` is a custom `basePath` override configured in this guide, not the v5 default (which remains `/api/auth`)
- **#500** — Removes invalid `spring.security.oauth2.resourceserver.jwt.client.registration.connect-timeout` / `read-timeout` properties that don't exist in Spring Security and silently have no effect; promotes the programmatic `JwtDecoder` + `RestTemplate` approach as the only supported solution; fixes hardcoded absolute URL to relative path

Closes #499
Closes #500

## Preview

https://deploy-preview-{PR_NUMBER}--scalekit-starlight.netlify.app/cookbooks/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified redirect URI guidance for Enterprise SSO: explains how a configured callback base path differs from Auth.js v5 defaults and how the dashboard redirect must match the effective callback path.
  * Updated Java Spring Boot JWT guidance: removed outdated UI/format instructions, now recommends creating a custom JWT decoder with HTTP-timeout-configured HTTP client, includes environment-specific timeout suggestions and an internal API reference link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->