### PR TITLE
docs(sso): advanced SAML tip and support contact

### DIFF
--- a/src/content/docs/sso/guides/sso-basics.mdx
+++ b/src/content/docs/sso/guides/sso-basics.mdx
@@ -86,7 +86,11 @@ Since the user login workflow starts from the Identity Provider portal (and not 
 IdP initiated SSO is susceptible to common security attacks like Man In the Middle attack, Stolen Assertion attack or Assertion Replay attack etc. Read the [IdP initiated SSO](/sso/guides/idp-init-sso) guide to understand these risks and how to mitigate them.
 
 <Aside type="tip" title="Advanced SAML options">
-  Some organizations require **encrypted SAML assertions** (the IdP encrypts the assertion so only the service provider can decrypt it) or **signed authentication requests** (the service provider signs the `AuthnRequest` sent to the IdP). Scalekit supports both on SAML connections. For help enabling them and aligning identity provider settings (for example Okta or Microsoft Entra ID), contact [support@scalekit.com](mailto:support@scalekit.com).
+  Some organizations require **encrypted SAML assertions**, where the IdP encrypts the assertion so only the service provider can decrypt it.
+
+  Others require **signed authentication requests**—the service provider signs the `AuthnRequest` sent to the IdP.
+
+  Scalekit supports both on SAML connections; contact [support@scalekit.com](mailto:support@scalekit.com) for help aligning IdP settings (e.g., Okta or Microsoft Entra ID).
 </Aside>
 
 ## Understanding OIDC protocol

--- a/src/content/docs/sso/guides/sso-basics.mdx
+++ b/src/content/docs/sso/guides/sso-basics.mdx
@@ -19,6 +19,7 @@ next:
   label: 'Implementing SSO login UX'
 ---
 
+import { Aside } from '@astrojs/starlight/components';
 
 Single Sign-On (SSO) streamlines user access by enabling a single authentication event to grant access to multiple applications with the same credentials. For example, logging into one Google service, such as Gmail, automatically authenticates you to YouTube, Google Drive, and other Google platforms.
 
@@ -83,6 +84,10 @@ Since the user login workflow starts from the Identity Provider portal (and not 
 #### Mitigate security risks
 
 IdP initiated SSO is susceptible to common security attacks like Man In the Middle attack, Stolen Assertion attack or Assertion Replay attack etc. Read the [IdP initiated SSO](/sso/guides/idp-init-sso) guide to understand these risks and how to mitigate them.
+
+<Aside type="tip" title="Advanced SAML options">
+  Some organizations require **encrypted SAML assertions** (the IdP encrypts the assertion so only the service provider can decrypt it) or **signed authentication requests** (the service provider signs the `AuthnRequest` sent to the IdP). Scalekit supports both on SAML connections. For help enabling them and aligning identity provider settings (for example Okta or Microsoft Entra ID), contact [support@scalekit.com](mailto:support@scalekit.com).
+</Aside>
 
 ## Understanding OIDC protocol
 


### PR DESCRIPTION
## Summary

Adds a short tip on [Introduction to Single Sign-on](/sso/guides/sso-basics/) covering **encrypted SAML assertions** and **signed authentication requests (AuthnRequest)**, and directs customers to [support@scalekit.com](mailto:support@scalekit.com) for help enabling them and aligning IdP configuration.

## Context

- Addresses https://github.com/scalekit-inc/developer-docs/issues/27 (guides for advanced SAML; this PR documents product support and the support path; full IdP-by-IdP runbooks can follow separately).

## Change

- `src/content/docs/sso/guides/sso-basics.mdx`: import `Aside`, add tip after IdP-initiated security subsection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an "Advanced SAML options" tip to the SSO basics guide explaining encrypted SAML assertions and signed AuthnRequest support, plus contact information for users needing help with advanced SAML configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->