### PR TITLE
Add extensible agent markdown exports

### DIFF
--- a/netlify/edge-functions/serve-markdown.ts
+++ b/netlify/edge-functions/serve-markdown.ts
@@ -3,18 +3,20 @@ import type { Config, Context } from '@netlify/edge-functions'
 export default async function handler(request: Request, context: Context) {
   const accept = request.headers.get('accept') ?? ''
 
-  // Serve pre-generated .md file for agents that send Accept: text/markdown
+  // Serve the richer agent export when available, then fall back to .md.
   if (accept.includes('text/markdown')) {
     const url = new URL(request.url)
-    const mdPath = url.pathname.replace(/\/$/, '') + '.md'
-    const mdUrl = new URL(mdPath, url.origin).toString()
+    const basePath = url.pathname.replace(/\/$/, '')
+    const markdownPaths = [`${basePath}.agent.md`, `${basePath}.md`]
 
-    const response = await fetch(mdUrl)
-    if (response.ok) {
-      const headers = new Headers(response.headers)
-      headers.set('content-type', 'text/markdown; charset=utf-8')
-      headers.set('link', '</llms.txt>; rel="llms-txt"')
-      return new Response(response.body, { status: 200, headers })
+    for (const path of markdownPaths) {
+      const response = await fetch(new URL(path, url.origin).toString())
+      if (response.ok) {
+        const headers = new Headers(response.headers)
+        headers.set('content-type', 'text/markdown; charset=utf-8')
+        headers.set('link', '</llms.txt>; rel="llms-txt"')
+        return new Response(response.body, { status: 200, headers })
+      }
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "netlify dev --skip-wait-port",
     "start": "cross-env NETLIFY_DEV=1 astro dev",
-    "build": "astro build && node scripts/generate-llms-index.js",
+    "build": "astro build && node scripts/generate-llms-index.js && node scripts/agent-markdown-audit.js",
+    "agent-markdown:audit": "node scripts/agent-markdown-audit.js",
     "preview": "astro preview",
     "astro": "astro",
     "upgrade": "pnpm dlx @astrojs/upgrade",

--- a/scripts/agent-markdown-audit.js
+++ b/scripts/agent-markdown-audit.js
@@ -1,0 +1,192 @@
+import { readdir, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const DOCS_ROOT = new URL('../src/content/docs', import.meta.url)
+const STRICT = process.argv.includes('--strict')
+
+const supportedSources = new Set([
+  '/src/components/MethodParams.astro',
+  '/src/components/MethodReturns.astro',
+  '/src/components/ProviderCatalog.astro',
+  '/src/components/ToolList.astro',
+  '/src/components/ui/CheckItem.astro',
+  '/src/components/ui/FoldCard.astro',
+  '/src/components/ui/Subtitle.astro',
+  '/src/components/ui/Tabs.astro',
+])
+
+function normalizeLines(value) {
+  return value.replace(/\r\n/g, '\n')
+}
+
+function splitFrontmatter(raw) {
+  const match = normalizeLines(raw).match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/)
+  if (!match) return { frontmatter: '', body: normalizeLines(raw) }
+  return { frontmatter: match[1], body: match[2] }
+}
+
+function readFrontmatterValue(frontmatter, key) {
+  const match = frontmatter.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'))
+  return match?.[1]?.trim().replace(/^['"]|['"]$/g, '') ?? ''
+}
+
+function deriveRoute(filePath, frontmatter) {
+  const slug = readFrontmatterValue(frontmatter, 'slug')
+  if (slug) return slug.replace(/^\/|\/$/g, '')
+
+  return filePath
+    .replace(/\\/g, '/')
+    .replace(/^.*\/src\/content\/docs\//, '')
+    .replace(/\.mdx$/u, '')
+    .replace(/\/index$/u, '')
+}
+
+function resolveImportSource(source, importerPath) {
+  if (source.startsWith('@/')) return `/src/${source.slice(2)}`
+  if (source.startsWith('@components/'))
+    return `/src/components/${source.slice('@components/'.length)}`
+  if (source.startsWith('./') || source.startsWith('../')) {
+    const importerSegments = importerPath.replace(/\\/g, '/').split('/').slice(0, -1)
+    for (const segment of source.split('/')) {
+      if (!segment || segment === '.') continue
+      if (segment === '..') importerSegments.pop()
+      else importerSegments.push(segment)
+    }
+    return importerSegments.join('/')
+  }
+  return source
+}
+
+function parseImports(body, filePath) {
+  const imports = []
+  const matches = normalizeLines(body).matchAll(/^import\s+([\s\S]+?)\s+from\s+['"](.+?)['"];?$/gm)
+
+  for (const match of matches) {
+    const bindings = match[1].trim()
+    const source = match[2]
+    const resolvedSource = resolveImportSource(source, filePath)
+
+    if (bindings.startsWith('{') && bindings.endsWith('}')) {
+      for (const entry of bindings.slice(1, -1).split(',')) {
+        const trimmed = entry.trim()
+        if (!trimmed) continue
+        const [importedName, alias] = trimmed.split(/\s+as\s+/)
+        imports.push({
+          localName: (alias ?? importedName).trim(),
+          source,
+          resolvedSource,
+        })
+      }
+      continue
+    }
+
+    const defaultAndNamed = bindings.match(/^([A-Za-z0-9_]+)\s*,\s*\{([\s\S]+)\}$/)
+    if (defaultAndNamed) {
+      imports.push({
+        localName: defaultAndNamed[1],
+        source,
+        resolvedSource,
+      })
+
+      for (const entry of defaultAndNamed[2].split(',')) {
+        const trimmed = entry.trim()
+        if (!trimmed) continue
+        const [importedName, alias] = trimmed.split(/\s+as\s+/)
+        imports.push({
+          localName: (alias ?? importedName).trim(),
+          source,
+          resolvedSource,
+        })
+      }
+      continue
+    }
+
+    imports.push({
+      localName: bindings,
+      source,
+      resolvedSource,
+    })
+  }
+
+  return imports
+}
+
+function getComponentNames(body) {
+  return new Set(
+    [...normalizeLines(body).matchAll(/<([A-Z][A-Za-z0-9_]*)\b/g)].map((match) => match[1]),
+  )
+}
+
+function isTrackedComponentImport(binding) {
+  return (
+    binding.resolvedSource.startsWith('/src/components') ||
+    binding.resolvedSource.startsWith('/src/components/templates')
+  )
+}
+
+function isSupported(binding) {
+  return (
+    supportedSources.has(binding.resolvedSource) ||
+    binding.resolvedSource.startsWith('/src/components/templates')
+  )
+}
+
+async function* walk(dir) {
+  const entries = await readdir(dir, { withFileTypes: true })
+  for (const entry of entries) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      yield* walk(full)
+    } else if (entry.name.endsWith('.mdx')) {
+      yield full
+    }
+  }
+}
+
+const rows = []
+
+for await (const filePath of walk(DOCS_ROOT.pathname)) {
+  const source = await readFile(filePath, 'utf8')
+  const { frontmatter, body } = splitFrontmatter(source)
+  const route = deriveRoute(filePath, frontmatter)
+  const componentNames = getComponentNames(body)
+  const componentImports = parseImports(body, filePath)
+    .filter(isTrackedComponentImport)
+    .filter((binding) => componentNames.has(binding.localName))
+
+  if (componentImports.length === 0) continue
+
+  const unsupportedComponents = componentImports
+    .filter((binding) => !isSupported(binding))
+    .map((binding) => `${binding.localName} -> ${binding.resolvedSource}`)
+
+  rows.push({
+    route,
+    status: unsupportedComponents.length === 0 ? 'supported' : 'lossy-risk',
+    unsupportedComponents,
+  })
+}
+
+rows.sort((left, right) => left.route.localeCompare(right.route))
+
+for (const row of rows) {
+  console.log(`${row.status}\t${row.route}`)
+  for (const component of row.unsupportedComponents) {
+    console.log(`  - ${component}`)
+  }
+}
+
+const lossyCount = rows.filter((row) => row.status === 'lossy-risk').length
+console.log(`\nScanned ${rows.length} component-heavy docs pages.`)
+console.log(`Lossy-risk pages: ${lossyCount}`)
+
+if (lossyCount > 0) {
+  console.warn('\n[agent-markdown] Warning: some docs pages still fall back to raw .md output.')
+  console.warn(
+    '[agent-markdown] Add a renderer for the unsupported component family to make those pages agent-safe.',
+  )
+}
+
+if (STRICT && lossyCount > 0) {
+  process.exit(1)
+}

--- a/src/components/overrides/PageTitle.astro
+++ b/src/components/overrides/PageTitle.astro
@@ -196,7 +196,8 @@ const isConnectorPage = Boolean(connectorIcon)
         copyBtn.disabled = true
         let cls = 'copied'
         try {
-          const res = await fetch(`${copyBtn.dataset.path}.md`)
+          const agentRes = await fetch(`${copyBtn.dataset.path}.agent.md`)
+          const res = agentRes.ok ? agentRes : await fetch(`${copyBtn.dataset.path}.md`)
           if (!res.ok) throw new Error(`Failed to fetch markdown: ${res.status}`)
           const md = await res.text()
           await navigator.clipboard.writeText(agentPluginHeader + md)

--- a/src/lib/agent-markdown/markdown.ts
+++ b/src/lib/agent-markdown/markdown.ts
@@ -1,0 +1,97 @@
+export function normalizeLines(value: string): string {
+  return value.replace(/\r\n/g, '\n')
+}
+
+export function collapseBlankLines(value: string): string {
+  return normalizeLines(value)
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+}
+
+export function dedent(value: string): string {
+  const lines = normalizeLines(value).split('\n')
+  const indents = lines
+    .filter((line) => line.trim().length > 0)
+    .map((line) => line.match(/^ */)?.[0].length ?? 0)
+
+  if (indents.length === 0) return value.trim()
+
+  const minIndent = Math.min(...indents)
+  return lines
+    .map((line) => line.slice(minIndent))
+    .join('\n')
+    .trim()
+}
+
+function renderParagraphs(markdown: string): string {
+  return markdown.replace(/<p>([\s\S]*?)<\/p>/g, (_match, body) => `${dedent(body)}\n`)
+}
+
+function renderHtmlLinks(markdown: string): string {
+  return markdown.replace(
+    /<a\s+[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/g,
+    (_match, href, label) => {
+      const text = dedent(label).replace(/\s+/g, ' ').trim()
+      return `[${text}](${href})`
+    },
+  )
+}
+
+function renderImagesAsNotes(markdown: string): string {
+  return markdown.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_match, alt) => {
+    const label = alt?.trim() || 'Screenshot'
+    return `> Image: ${label}`
+  })
+}
+
+function renderAsides(markdown: string): string {
+  return markdown.replace(/<Aside\b([^>]*)>([\s\S]*?)<\/Aside>/g, (_match, attrs, body) => {
+    const title = attrs.match(/title="([^"]+)"/)?.[1]
+    const type = attrs.match(/type="([^"]+)"/)?.[1]
+    const heading = [type, title].filter(Boolean).join(': ')
+    const content = dedent(body)
+      .split('\n')
+      .map((line) => (line.trim().length > 0 ? `> ${line}` : '>'))
+      .join('\n')
+
+    return heading ? `> ${heading}\n>\n${content}` : content
+  })
+}
+
+function renderDetails(markdown: string): string {
+  return markdown.replace(
+    /<details>\s*<summary>([\s\S]*?)<\/summary>\s*([\s\S]*?)<\/details>/g,
+    (_match, summary, body) =>
+      `## ${dedent(summary).replace(/\s+/g, ' ').trim()}\n\n${dedent(body)}\n`,
+  )
+}
+
+function renderTabs(markdown: string): string {
+  const withTabItems = markdown.replace(
+    /<TabItem\b([^>]*)label="([^"]+)"[^>]*>([\s\S]*?)<\/TabItem>/g,
+    (_match, _attrs, label, body) => `### ${label}\n\n${dedent(body)}\n`,
+  )
+
+  return withTabItems.replace(/<\/?Tabs[^>]*>/g, '')
+}
+
+function stripWrapperTags(markdown: string): string {
+  return markdown
+    .replace(/<\/?(Steps|CardGrid|Card)\b[^>]*>/g, '')
+    .replace(/<\/?[A-Z][A-Za-z0-9_]*\b[^>]*\/>/g, '')
+    .replace(/<\/?[A-Z][A-Za-z0-9_]*\b[^>]*>/g, '')
+}
+
+export function cleanMarkdownFragment(markdown: string): string {
+  const cleaned = stripWrapperTags(
+    renderImagesAsNotes(
+      renderAsides(
+        renderTabs(
+          renderDetails(renderHtmlLinks(renderParagraphs(markdown.replace(/^import\s.+$/gm, '')))),
+        ),
+      ),
+    ),
+  )
+
+  return collapseBlankLines(cleaned)
+}

--- a/src/lib/agent-markdown/page-parser.ts
+++ b/src/lib/agent-markdown/page-parser.ts
@@ -1,0 +1,257 @@
+import { getDocSourceEntries, resolveImportSource } from './source-loader'
+import type { ComponentUsage, ImportBinding, ParsedMdxFile } from './types'
+
+function normalizeLines(value: string): string {
+  return value.replace(/\r\n/g, '\n')
+}
+
+export function splitFrontmatter(raw: string): { frontmatter: string; body: string } {
+  const match = normalizeLines(raw).match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/)
+  if (!match) {
+    return { frontmatter: '', body: normalizeLines(raw) }
+  }
+
+  return {
+    frontmatter: match[1],
+    body: match[2],
+  }
+}
+
+export function readFrontmatterValue(frontmatter: string, key: string): string {
+  const match = frontmatter.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'))
+  return match?.[1]?.trim().replace(/^['"]|['"]$/g, '') ?? ''
+}
+
+function deriveRoute(filePath: string, frontmatter: string): string {
+  const explicitSlug = readFrontmatterValue(frontmatter, 'slug')
+  if (explicitSlug) return explicitSlug.replace(/^\/|\/$/g, '')
+
+  const relativePath = filePath.replace(/^\/src\/content\/docs\//, '').replace(/\.mdx$/u, '')
+  return relativePath.replace(/\/index$/u, '')
+}
+
+export function parseImports(body: string, filePath: string): ImportBinding[] {
+  const imports: ImportBinding[] = []
+  const importStatements = normalizeLines(body).matchAll(
+    /^import\s+([\s\S]+?)\s+from\s+['"](.+?)['"];?$/gm,
+  )
+
+  for (const match of importStatements) {
+    const bindings = match[1].trim()
+    const source = match[2]
+    const resolvedSource = resolveImportSource(source, filePath)
+
+    const defaultAndNamed = bindings.match(/^([A-Za-z0-9_]+)\s*,\s*\{([\s\S]+)\}$/)
+    if (defaultAndNamed) {
+      imports.push({
+        localName: defaultAndNamed[1],
+        importedName: 'default',
+        source,
+        resolvedSource,
+        isDefault: true,
+      })
+
+      for (const entry of defaultAndNamed[2].split(',')) {
+        const trimmed = entry.trim()
+        if (!trimmed) continue
+        const [importedName, alias] = trimmed.split(/\s+as\s+/)
+        imports.push({
+          localName: (alias ?? importedName).trim(),
+          importedName: importedName.trim(),
+          source,
+          resolvedSource,
+          isDefault: false,
+        })
+      }
+      continue
+    }
+
+    if (bindings.startsWith('{') && bindings.endsWith('}')) {
+      for (const entry of bindings.slice(1, -1).split(',')) {
+        const trimmed = entry.trim()
+        if (!trimmed) continue
+        const [importedName, alias] = trimmed.split(/\s+as\s+/)
+        imports.push({
+          localName: (alias ?? importedName).trim(),
+          importedName: importedName.trim(),
+          source,
+          resolvedSource,
+          isDefault: false,
+        })
+      }
+      continue
+    }
+
+    imports.push({
+      localName: bindings,
+      importedName: 'default',
+      source,
+      resolvedSource,
+      isDefault: true,
+    })
+  }
+
+  return imports
+}
+
+export function getComponentNames(body: string): string[] {
+  return Array.from(
+    new Set(
+      [...normalizeLines(body).matchAll(/<([A-Z][A-Za-z0-9_]*)\b/g)].map((match) => match[1]),
+    ),
+  )
+}
+
+function parseAttributes(
+  attrs: string,
+): Record<string, { kind: 'string' | 'expression' | 'boolean'; value: string | boolean }> {
+  const result: Record<
+    string,
+    { kind: 'string' | 'expression' | 'boolean'; value: string | boolean }
+  > = {}
+  let index = 0
+
+  while (index < attrs.length) {
+    while (index < attrs.length && /\s/.test(attrs[index])) index++
+    if (index >= attrs.length) break
+
+    const nameStart = index
+    while (index < attrs.length && /[A-Za-z0-9_:-]/.test(attrs[index])) index++
+    const name = attrs.slice(nameStart, index)
+    if (!name) break
+
+    while (index < attrs.length && /\s/.test(attrs[index])) index++
+
+    if (attrs[index] !== '=') {
+      result[name] = { kind: 'boolean', value: true }
+      continue
+    }
+
+    index++
+    while (index < attrs.length && /\s/.test(attrs[index])) index++
+
+    if (attrs[index] === '"' || attrs[index] === "'") {
+      const quote = attrs[index]
+      index++
+      const valueStart = index
+      while (index < attrs.length && attrs[index] !== quote) index++
+      result[name] = { kind: 'string', value: attrs.slice(valueStart, index) }
+      index++
+      continue
+    }
+
+    if (attrs[index] === '{') {
+      let depth = 0
+      const exprStart = index + 1
+      let inString: string | null = null
+      index++
+      while (index < attrs.length) {
+        const char = attrs[index]
+        if (inString) {
+          if (char === '\\') {
+            index += 2
+            continue
+          }
+          if (char === inString) inString = null
+          index++
+          continue
+        }
+        if (char === '"' || char === "'" || char === '`') {
+          inString = char
+          index++
+          continue
+        }
+        if (char === '{') depth++
+        if (char === '}') {
+          if (depth === 0) break
+          depth--
+        }
+        index++
+      }
+      result[name] = { kind: 'expression', value: attrs.slice(exprStart, index) }
+      index++
+      continue
+    }
+
+    const valueStart = index
+    while (index < attrs.length && !/\s/.test(attrs[index])) index++
+    result[name] = { kind: 'string', value: attrs.slice(valueStart, index) }
+  }
+
+  return result
+}
+
+export function evaluateExpression(expression: string, scope: Record<string, unknown>): unknown {
+  const keys = Object.keys(scope)
+  const values = Object.values(scope)
+  return Function(...keys, `return (${expression})`)(...values)
+}
+
+export function resolveProps(
+  attrs: string,
+  scope: Record<string, unknown>,
+): Record<string, unknown> {
+  const parsed = parseAttributes(attrs)
+  const result: Record<string, unknown> = {}
+
+  for (const [key, descriptor] of Object.entries(parsed)) {
+    if (descriptor.kind === 'boolean') {
+      result[key] = descriptor.value
+      continue
+    }
+
+    if (descriptor.kind === 'string') {
+      result[key] = descriptor.value
+      continue
+    }
+
+    result[key] = evaluateExpression(String(descriptor.value), scope)
+  }
+
+  return result
+}
+
+export function buildComponentUsage(
+  componentName: string,
+  attrs: string,
+  slot?: string,
+): ComponentUsage {
+  return {
+    componentName,
+    attrs,
+    slot,
+    selfClosing: slot === undefined,
+  }
+}
+
+export function parseMdxSource(filePath: string, source: string): ParsedMdxFile {
+  const { frontmatter, body } = splitFrontmatter(source)
+  const title = readFrontmatterValue(frontmatter, 'title')
+  const description = readFrontmatterValue(frontmatter, 'description')
+
+  return {
+    filePath,
+    route: deriveRoute(filePath, frontmatter),
+    frontmatter,
+    body,
+    title,
+    description,
+    imports: parseImports(body, filePath),
+    componentNames: getComponentNames(body),
+  }
+}
+
+const parsedDocs = new Map<string, ParsedMdxFile>(
+  getDocSourceEntries().map(([filePath, source]) => {
+    const parsed = parseMdxSource(filePath, source)
+    return [parsed.route, parsed]
+  }),
+)
+
+export function getParsedDoc(route: string): ParsedMdxFile | undefined {
+  return parsedDocs.get(route)
+}
+
+export function getParsedDocs(): ParsedMdxFile[] {
+  return Array.from(parsedDocs.values())
+}

--- a/src/lib/agent-markdown/registry.ts
+++ b/src/lib/agent-markdown/registry.ts
@@ -1,0 +1,347 @@
+import { cleanMarkdownFragment, collapseBlankLines } from './markdown'
+import { getParsedDoc, getParsedDocs, parseMdxSource, readFrontmatterValue } from './page-parser'
+import {
+  getDataModule,
+  getDataTools,
+  getTemplateSource,
+  resolveTemplateExport,
+} from './source-loader'
+import { getConnectorCatalogItems } from './renderers/connectors'
+import {
+  checkItemRenderer,
+  foldCardRenderer,
+  methodParamsRenderer,
+  methodReturnsRenderer,
+  subtitleRenderer,
+} from './renderers/common'
+import { providerCatalogRenderer, toolListRenderer } from './renderers/connectors'
+import { templateComponentRenderer } from './renderers/templates'
+import type {
+  ComponentRenderer,
+  ComponentUsage,
+  ImportBinding,
+  PageSupportResult,
+  ParsedMdxFile,
+  RenderContext,
+  RenderScope,
+} from './types'
+
+const componentRenderers: ComponentRenderer[] = [
+  templateComponentRenderer,
+  providerCatalogRenderer,
+  toolListRenderer,
+  checkItemRenderer,
+  foldCardRenderer,
+  subtitleRenderer,
+  methodParamsRenderer,
+  methodReturnsRenderer,
+]
+
+const cleanupHandledSources = new Set(['/src/components/ui/Tabs.astro'])
+
+function readFrontmatterList(frontmatter: string, key: string): string[] {
+  const raw = readFrontmatterValue(frontmatter, key)
+  if (!raw.startsWith('[') || !raw.endsWith(']')) return []
+
+  return raw
+    .slice(1, -1)
+    .split(',')
+    .map((item) => item.trim().replace(/^['"]|['"]$/g, ''))
+    .filter(Boolean)
+}
+
+function normalizeBinding(binding: ImportBinding): ImportBinding {
+  const isTemplateNamespace = binding.resolvedSource.startsWith('/src/components/templates')
+  if (!isTemplateNamespace || binding.resolvedSource.endsWith('.mdx')) return binding
+
+  const templateSource = resolveTemplateExport(
+    binding.isDefault ? binding.localName : binding.importedName,
+  )
+  if (!templateSource) return binding
+
+  return {
+    ...binding,
+    resolvedSource: templateSource,
+  }
+}
+
+function getCustomComponentBindings(file: ParsedMdxFile): ImportBinding[] {
+  return file.imports.map(normalizeBinding).filter((binding) => {
+    const source = binding.resolvedSource
+    return source.startsWith('/src/components') || source.startsWith('/src/components/templates')
+  })
+}
+
+function isSupportedBinding(binding: ImportBinding): boolean {
+  if (cleanupHandledSources.has(binding.resolvedSource)) return true
+
+  const selfClosingUsage: ComponentUsage = {
+    componentName: binding.localName,
+    importBinding: binding,
+    attrs: '',
+    selfClosing: true,
+  }
+  const blockUsage: ComponentUsage = {
+    componentName: binding.localName,
+    importBinding: binding,
+    attrs: '',
+    slot: '',
+    selfClosing: false,
+  }
+
+  return componentRenderers.some(
+    (renderer) => renderer.supports(selfClosingUsage) || renderer.supports(blockUsage),
+  )
+}
+
+function getPageSupport(file: ParsedMdxFile): PageSupportResult {
+  const unsupportedComponents = getCustomComponentBindings(file)
+    .filter((binding) => file.componentNames.includes(binding.localName))
+    .filter((binding) => !isSupportedBinding(binding))
+    .map((binding) => `${binding.localName} -> ${binding.resolvedSource}`)
+
+  return {
+    supported: unsupportedComponents.length === 0,
+    unsupportedComponents,
+  }
+}
+
+function buildRenderScope(file: ParsedMdxFile): RenderScope {
+  const values: Record<string, unknown> = {}
+
+  for (const binding of file.imports.map(normalizeBinding)) {
+    const source = binding.resolvedSource
+    if (!source.startsWith('/src/data/')) continue
+
+    const module = getDataModule(source)
+    if (!module) continue
+
+    values[binding.localName] = binding.isDefault
+      ? (module.default ?? module)
+      : module[binding.importedName]
+  }
+
+  return { values }
+}
+
+function findTagEnd(markdown: string, startIndex: number): number {
+  let depth = 0
+  let quote: string | null = null
+
+  for (let index = startIndex; index < markdown.length; index++) {
+    const char = markdown[index]
+
+    if (quote) {
+      if (char === '\\') {
+        index++
+        continue
+      }
+      if (char === quote) quote = null
+      continue
+    }
+
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char
+      continue
+    }
+
+    if (char === '{') {
+      depth++
+      continue
+    }
+
+    if (char === '}') {
+      depth = Math.max(0, depth - 1)
+      continue
+    }
+
+    if (char === '>' && depth === 0) {
+      return index
+    }
+  }
+
+  return -1
+}
+
+function replaceComponentInstances(
+  markdown: string,
+  componentName: string,
+  replacer: (usage: ComponentUsage) => string,
+): string {
+  let result = ''
+  let cursor = 0
+
+  while (cursor < markdown.length) {
+    const start = markdown.indexOf(`<${componentName}`, cursor)
+    if (start === -1) {
+      result += markdown.slice(cursor)
+      break
+    }
+
+    const nextChar = markdown[start + componentName.length + 1] ?? ''
+    if (/[A-Za-z0-9_]/.test(nextChar)) {
+      result += markdown.slice(cursor, start + 1)
+      cursor = start + 1
+      continue
+    }
+
+    result += markdown.slice(cursor, start)
+    const tagEnd = findTagEnd(markdown, start + componentName.length + 1)
+    if (tagEnd === -1) {
+      result += markdown.slice(start)
+      break
+    }
+
+    const openTag = markdown.slice(start, tagEnd + 1)
+    const attrs = openTag
+      .replace(new RegExp(`^<${componentName}`), '')
+      .replace(/\/?>$/, '')
+      .trim()
+    const selfClosing = /\/>$/.test(openTag)
+
+    if (selfClosing) {
+      result += replacer({
+        componentName,
+        attrs,
+        selfClosing: true,
+      })
+      cursor = tagEnd + 1
+      continue
+    }
+
+    const closeTag = `</${componentName}>`
+    const closeIndex = markdown.indexOf(closeTag, tagEnd + 1)
+    if (closeIndex === -1) {
+      result += markdown.slice(start)
+      break
+    }
+
+    const slot = markdown.slice(tagEnd + 1, closeIndex)
+    result += replacer({
+      componentName,
+      attrs,
+      slot,
+      selfClosing: false,
+    })
+    cursor = closeIndex + closeTag.length
+  }
+
+  return result
+}
+
+function renderFragment(
+  markdown: string,
+  filePath: string,
+  parentScope: RenderScope = { values: {} },
+): string {
+  const parsed = parseMdxSource(filePath, markdown)
+  const fileScope = buildRenderScope(parsed)
+  const scope: RenderScope = {
+    values: {
+      ...parentScope.values,
+      ...fileScope.values,
+    },
+  }
+
+  let rendered = parsed.body
+
+  for (const binding of getCustomComponentBindings(parsed)) {
+    if (!parsed.componentNames.includes(binding.localName)) continue
+    if (cleanupHandledSources.has(binding.resolvedSource)) continue
+
+    rendered = replaceComponentInstances(rendered, binding.localName, (usage) => {
+      const effectiveUsage: ComponentUsage = {
+        ...usage,
+        importBinding: binding,
+      }
+
+      const renderer = componentRenderers.find((candidate) => candidate.supports(effectiveUsage))
+      if (!renderer) return ''
+
+      const context: RenderContext = {
+        file: parsed,
+        scope,
+        renderFragment,
+        getTemplateSource,
+        getConnectorCatalogItems: () =>
+          getConnectorCatalogItems(
+            getParsedDocs().map((doc) => ({
+              route: doc.route,
+              title: doc.title,
+              description: doc.description,
+            })),
+          ),
+        getToolsForSlug: (slug) => getDataTools(`/src/data/agent-connectors/${slug}.ts`),
+      }
+
+      return renderer.render(effectiveUsage, context).markdown
+    })
+  }
+
+  return cleanMarkdownFragment(rendered)
+}
+
+function renderPageHeader(file: ParsedMdxFile): string {
+  const lines = [`# ${file.title || file.route}`, '']
+
+  if (file.description) {
+    lines.push(file.description, '')
+  }
+
+  const connectorAuthType = readFrontmatterValue(file.frontmatter, 'connectorAuthType')
+  const connectorCategories = readFrontmatterList(file.frontmatter, 'connectorCategories')
+
+  if (connectorAuthType) lines.push(`**Authentication:** ${connectorAuthType}`)
+  if (connectorCategories.length > 0) {
+    const labels = connectorCategories
+      .map((category) => category.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase()))
+      .join(', ')
+    lines.push(`**Categories:** ${labels}`)
+  }
+  if (connectorAuthType || connectorCategories.length > 0) lines.push('')
+
+  return lines.join('\n')
+}
+
+export function getAgentMarkdownRoutes(): string[] {
+  return getParsedDocs()
+    .filter((file) => getPageSupport(file).supported)
+    .map((file) => file.route)
+}
+
+export function getAgentMarkdownSupport(route: string): PageSupportResult | null {
+  const file = getParsedDoc(route)
+  return file ? getPageSupport(file) : null
+}
+
+export function renderAgentMarkdown(route: string): string | null {
+  const file = getParsedDoc(route)
+  if (!file) return null
+
+  const support = getPageSupport(file)
+  if (!support.supported) return null
+
+  const body = renderFragment(file.body, file.filePath, buildRenderScope(file))
+  return collapseBlankLines(`${renderPageHeader(file)}${body}`) + '\n'
+}
+
+export function getAgentMarkdownAuditRows(): Array<{
+  route: string
+  status: 'supported' | 'fallback' | 'lossy-risk'
+  unsupportedComponents: string[]
+}> {
+  return getParsedDocs()
+    .filter((file) =>
+      getCustomComponentBindings(file).some((binding) =>
+        file.componentNames.includes(binding.localName),
+      ),
+    )
+    .map((file) => {
+      const support = getPageSupport(file)
+      return {
+        route: file.route,
+        status: support.supported ? 'supported' : 'lossy-risk',
+        unsupportedComponents: support.unsupportedComponents,
+      }
+    })
+}

--- a/src/lib/agent-markdown/renderers/common.ts
+++ b/src/lib/agent-markdown/renderers/common.ts
@@ -1,0 +1,111 @@
+import { cleanMarkdownFragment, collapseBlankLines } from '../markdown'
+import { resolveProps } from '../page-parser'
+import type { ComponentRenderer } from '../types'
+
+function renderCheckItemMarkdown(props: Record<string, unknown>, slot: string): string {
+  const text = cleanMarkdownFragment(slot)
+  const href = typeof props.href === 'string' ? props.href : ''
+  return href ? `- [${text}](${href})` : `- ${text}`
+}
+
+function renderFoldCardMarkdown(props: Record<string, unknown>, slot: string): string {
+  const title = typeof props.title === 'string' ? props.title : 'Card'
+  const href = typeof props.href === 'string' ? props.href : ''
+  const badgeText =
+    props.badge && typeof props.badge === 'object' && props.badge && 'text' in props.badge
+      ? String((props.badge as { text?: string }).text ?? '')
+      : ''
+  const body = cleanMarkdownFragment(slot)
+  const heading = href ? `### [${title}](${href})` : `### ${title}`
+  const lines = [heading]
+
+  if (badgeText) lines.push('', `Badge: ${badgeText}`)
+  if (body) lines.push('', body)
+
+  return collapseBlankLines(lines.join('\n'))
+}
+
+function renderMethodParamsMarkdown(props: Record<string, unknown>): string {
+  const label = typeof props.label === 'string' ? props.label : 'Parameters'
+  const params = Array.isArray(props.params) ? props.params : []
+  const lines = [`### ${label}`, '']
+
+  for (const param of params) {
+    if (!param || typeof param !== 'object') continue
+    const name = String((param as { name?: string }).name ?? '')
+    const type = String((param as { type?: string }).type ?? '')
+    const required = (param as { required?: boolean }).required ? 'required' : 'optional'
+    const description = String((param as { description?: string }).description ?? '')
+    lines.push(`- \`${name}\` (\`${type}\`, ${required}): ${description}`)
+  }
+
+  return collapseBlankLines(lines.join('\n'))
+}
+
+function renderMethodReturnsMarkdown(props: Record<string, unknown>): string {
+  const responseType = typeof props.type === 'string' ? props.type : 'Response'
+  const fields = Array.isArray(props.fields) ? props.fields : []
+  const lines = ['### Response schema', '', `Type: \`${responseType}\``, '']
+
+  for (const field of fields) {
+    if (!field || typeof field !== 'object') continue
+    const name = String((field as { name?: string }).name ?? '')
+    const type = String((field as { type?: string }).type ?? '')
+    const description = String((field as { description?: string }).description ?? '')
+    lines.push(`- \`${name}\` (\`${type}\`): ${description}`)
+  }
+
+  return collapseBlankLines(lines.join('\n'))
+}
+
+export const checkItemRenderer: ComponentRenderer = {
+  supports: (usage) =>
+    usage.importBinding?.resolvedSource === '/src/components/ui/CheckItem.astro' &&
+    !usage.selfClosing,
+  render: (usage, context) => {
+    const props = resolveProps(usage.attrs, context.scope.values)
+    return { markdown: renderCheckItemMarkdown(props, usage.slot ?? '') }
+  },
+}
+
+export const foldCardRenderer: ComponentRenderer = {
+  supports: (usage) =>
+    usage.importBinding?.resolvedSource === '/src/components/ui/FoldCard.astro' &&
+    !usage.selfClosing,
+  render: (usage, context) => {
+    const props = resolveProps(usage.attrs, context.scope.values)
+    const slot = context.renderFragment(usage.slot ?? '', context.file.filePath, context.scope)
+    return { markdown: renderFoldCardMarkdown(props, slot) }
+  },
+}
+
+export const subtitleRenderer: ComponentRenderer = {
+  supports: (usage) =>
+    usage.importBinding?.resolvedSource === '/src/components/ui/Subtitle.astro' &&
+    !usage.selfClosing,
+  render: (usage, context) => ({
+    markdown: cleanMarkdownFragment(
+      context.renderFragment(usage.slot ?? '', context.file.filePath, context.scope),
+    ),
+  }),
+}
+
+export const methodParamsRenderer: ComponentRenderer = {
+  supports: (usage) =>
+    usage.importBinding?.resolvedSource === '/src/components/MethodParams.astro' &&
+    usage.selfClosing,
+  render: (usage, context) => {
+    const props = resolveProps(usage.attrs, context.scope.values)
+    return { markdown: renderMethodParamsMarkdown(props) }
+  },
+}
+
+export const methodReturnsRenderer: ComponentRenderer = {
+  supports: (usage) =>
+    usage.importBinding?.resolvedSource === '/src/components/MethodReturns.astro' &&
+    usage.selfClosing,
+  render: (usage, context) => {
+    const props = resolveProps(usage.attrs, context.scope.values)
+    return { markdown: renderMethodReturnsMarkdown(props) }
+  },
+}

--- a/src/lib/agent-markdown/renderers/connectors.ts
+++ b/src/lib/agent-markdown/renderers/connectors.ts
@@ -1,0 +1,143 @@
+import { catalog } from '@/data/agent-connectors/catalog'
+import type { Tool } from '@/types/agent-connectors'
+import { collapseBlankLines } from '../markdown'
+import { resolveProps } from '../page-parser'
+import type { ComponentRenderer, ConnectorCatalogItem } from '../types'
+
+const CATEGORY_LABELS: Record<string, string> = {
+  ai: 'AI',
+  analytics: 'Analytics',
+  automation: 'Automation',
+  calendar: 'Calendar',
+  communication: 'Communication',
+  crm: 'CRM',
+  customer_support: 'Customer Support',
+  data: 'Data',
+  developer_tools: 'Developer Tools',
+  documents: 'Documents',
+  files: 'Files',
+  productivity: 'Productivity',
+  project_management: 'Project Management',
+  sales: 'Sales',
+  scheduling: 'Scheduling',
+}
+
+function categoryLabel(slug: string): string {
+  const normalized = slug.replace(/-/g, '_')
+  return (
+    CATEGORY_LABELS[normalized] ??
+    normalized.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase())
+  )
+}
+
+function renderProviderCatalogMarkdown(items: ConnectorCatalogItem[]): string {
+  const categoryOrder = Array.from(new Set(items.flatMap((item) => item.categories))).sort(
+    (left, right) => {
+      if (left === 'other') return 1
+      if (right === 'other') return -1
+      return categoryLabel(left).localeCompare(categoryLabel(right))
+    },
+  )
+
+  const lines = ['## Connector catalog', '']
+
+  for (const category of categoryOrder) {
+    lines.push(`### ${categoryLabel(category)}`, '')
+    for (const item of items.filter((entry) => entry.categories.includes(category))) {
+      const summary = item.description
+        ? ` - ${item.authType}. ${item.description}`
+        : ` - ${item.authType}`
+      lines.push(`- [${item.title}](${item.href})${summary}`)
+    }
+    lines.push('')
+  }
+
+  return collapseBlankLines(lines.join('\n'))
+}
+
+function renderToolListMarkdown(
+  props: Record<string, unknown>,
+  getToolsForSlug: (slug: string) => Tool[],
+): string {
+  const directTools = Array.isArray(props.tools) ? props.tools : null
+  const slug = typeof props.connectorSlug === 'string' ? props.connectorSlug : ''
+  const tools = directTools ?? (slug ? getToolsForSlug(slug) : [])
+
+  if (!Array.isArray(tools) || tools.length === 0) {
+    return '## Tool list\n\nNo tools are documented yet.'
+  }
+
+  const lines = ['## Tool list', '']
+
+  for (const tool of tools) {
+    if (!tool || typeof tool !== 'object') continue
+    const name = String((tool as { name?: string }).name ?? '')
+    const description = String((tool as { description?: string }).description ?? '')
+    const params = Array.isArray((tool as { params?: unknown[] }).params)
+      ? (tool as { params: unknown[] }).params
+      : []
+
+    lines.push(`### \`${name}\``, '', description, '')
+
+    if (params.length > 0) {
+      lines.push('Parameters:', '')
+      for (const param of params) {
+        if (!param || typeof param !== 'object') continue
+        const paramName = String((param as { name?: string }).name ?? '')
+        const type = String((param as { type?: string }).type ?? '')
+        const required = (param as { required?: boolean }).required ? 'required' : 'optional'
+        const paramDescription = String((param as { description?: string }).description ?? '')
+        lines.push(`- \`${paramName}\` (\`${type}\`, ${required}): ${paramDescription}`)
+      }
+      lines.push('')
+    }
+  }
+
+  return collapseBlankLines(lines.join('\n'))
+}
+
+export function getConnectorCatalogItems(
+  docs: Array<{ route: string; title: string; description: string }>,
+): ConnectorCatalogItem[] {
+  return docs
+    .filter(
+      (doc) => doc.route.startsWith('agentkit/connectors') && doc.route !== 'agentkit/connectors',
+    )
+    .map((doc) => {
+      const slug = doc.route.replace(/^agentkit\/connectors\//, '')
+      const meta = catalog[slug]
+
+      return {
+        slug,
+        title: doc.title || slug,
+        description: doc.description,
+        href: `/${doc.route}/`,
+        categories: meta?.categories?.length
+          ? meta.categories.map((category) => category.replace(/-/g, '_'))
+          : ['other'],
+        authType: meta?.authType ?? 'OAuth 2.0',
+      }
+    })
+    .sort((left, right) => left.title.localeCompare(right.title))
+}
+
+export const providerCatalogRenderer: ComponentRenderer = {
+  supports: (usage) =>
+    usage.importBinding?.resolvedSource === '/src/components/ProviderCatalog.astro' &&
+    usage.selfClosing,
+  render: (_usage, context) => ({
+    markdown: renderProviderCatalogMarkdown(context.getConnectorCatalogItems()),
+  }),
+}
+
+export const toolListRenderer: ComponentRenderer = {
+  supports: (usage) =>
+    usage.importBinding?.resolvedSource === '/src/components/ToolList.astro' && usage.selfClosing,
+  render: (usage, context) => {
+    const props = {
+      ...resolveProps(usage.attrs, context.scope.values),
+      connectorSlug: context.file.route.replace(/^agentkit\/connectors\//, ''),
+    }
+    return { markdown: renderToolListMarkdown(props, context.getToolsForSlug) }
+  },
+}

--- a/src/lib/agent-markdown/renderers/templates.ts
+++ b/src/lib/agent-markdown/renderers/templates.ts
@@ -1,0 +1,19 @@
+import { cleanMarkdownFragment } from '../markdown'
+import type { ComponentRenderer } from '../types'
+
+export const templateComponentRenderer: ComponentRenderer = {
+  supports: (usage) => {
+    const source = usage.importBinding?.resolvedSource ?? ''
+    return source.startsWith('/src/components/templates/') && source.endsWith('.mdx')
+  },
+  render: (usage, context) => {
+    const source = usage.importBinding?.resolvedSource
+    const template = source ? context.getTemplateSource(source) : undefined
+    if (!template) {
+      return { markdown: '' }
+    }
+
+    const rendered = context.renderFragment(template, source, { values: context.scope.values })
+    return { markdown: cleanMarkdownFragment(rendered) }
+  },
+}

--- a/src/lib/agent-markdown/source-loader.ts
+++ b/src/lib/agent-markdown/source-loader.ts
@@ -1,0 +1,114 @@
+import type { Tool } from '@/types/agent-connectors'
+
+const docsSourceModules = import.meta.glob('/src/content/docs/**/*.mdx', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>
+
+const templateSourceModules = import.meta.glob('/src/components/templates/**/*.mdx', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>
+
+const templateIndexModules = import.meta.glob('/src/components/templates/**/index.ts', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>
+
+const dataModules = import.meta.glob('/src/data/**/*.ts', {
+  eager: true,
+}) as Record<string, Record<string, unknown>>
+
+export function getDocSourceEntries(): Array<[string, string]> {
+  return Object.entries(docsSourceModules)
+}
+
+export function getDocSource(path: string): string | undefined {
+  return docsSourceModules[path]
+}
+
+export function getTemplateSourceEntries(): Array<[string, string]> {
+  return Object.entries(templateSourceModules)
+}
+
+export function getTemplateSource(path: string): string | undefined {
+  return templateSourceModules[path]
+}
+
+export function getDataModule(path: string): Record<string, unknown> | undefined {
+  return dataModules[path]
+}
+
+export function getDataTools(path: string): Tool[] {
+  const module = dataModules[path] as { tools?: Tool[] } | undefined
+  return module?.tools ?? []
+}
+
+function normalizeRelativePath(basePath: string, relativePath: string): string {
+  const baseSegments = basePath.split('/').slice(0, -1)
+  const nextSegments = relativePath.split('/')
+
+  for (const segment of nextSegments) {
+    if (!segment || segment === '.') continue
+    if (segment === '..') {
+      baseSegments.pop()
+      continue
+    }
+    baseSegments.push(segment)
+  }
+
+  return baseSegments.join('/')
+}
+
+function finalizeResolvedSource(candidate: string): string {
+  if (candidate.endsWith('.mdx') || candidate.endsWith('.ts') || candidate.endsWith('.astro')) {
+    return candidate
+  }
+  if (templateSourceModules[`${candidate}.mdx`]) return `${candidate}.mdx`
+  if (dataModules[`${candidate}.ts`]) return `${candidate}.ts`
+  if (templateIndexModules[`${candidate}/index.ts`]) return `${candidate}/index.ts`
+  return candidate
+}
+
+export function resolveImportSource(source: string, importerPath: string): string {
+  if (source.startsWith('@/')) return finalizeResolvedSource(`/src/${source.slice(2)}`)
+  if (source.startsWith('@components/'))
+    return finalizeResolvedSource(`/src/components/${source.slice('@components/'.length)}`)
+  if (source.startsWith('./') || source.startsWith('../'))
+    return finalizeResolvedSource(normalizeRelativePath(importerPath, source))
+  return source
+}
+
+function resolveReExportPath(indexPath: string, exportedPath: string): string {
+  const normalized = resolveImportSource(exportedPath, indexPath)
+  if (normalized.endsWith('.mdx') || normalized.endsWith('.ts')) return normalized
+  if (getTemplateSource(`${normalized}.mdx`)) return `${normalized}.mdx`
+  if (templateIndexModules[`${normalized}/index.ts`]) return `${normalized}/index.ts`
+  return normalized
+}
+
+function buildTemplateExportMap(): Map<string, string> {
+  const exportMap = new Map<string, string>()
+
+  for (const [indexPath, source] of Object.entries(templateIndexModules)) {
+    const normalized = source.replace(/\r\n/g, '\n')
+    const namedExports = normalized.matchAll(
+      /export\s*\{\s*default\s+as\s+([A-Za-z0-9_]+)\s*\}\s*from\s*['"](.+?)['"]/g,
+    )
+
+    for (const match of namedExports) {
+      exportMap.set(match[1], resolveReExportPath(indexPath, match[2]))
+    }
+  }
+
+  return exportMap
+}
+
+const templateExportMap = buildTemplateExportMap()
+
+export function resolveTemplateExport(symbolName: string): string | undefined {
+  return templateExportMap.get(symbolName)
+}

--- a/src/lib/agent-markdown/types.ts
+++ b/src/lib/agent-markdown/types.ts
@@ -1,0 +1,64 @@
+import type { Tool } from '@/types/agent-connectors'
+
+export interface ImportBinding {
+  localName: string
+  importedName: string
+  source: string
+  resolvedSource: string
+  isDefault: boolean
+}
+
+export interface ComponentUsage {
+  componentName: string
+  importBinding?: ImportBinding
+  attrs: string
+  slot?: string
+  selfClosing: boolean
+}
+
+export interface ParsedMdxFile {
+  filePath: string
+  route: string
+  frontmatter: string
+  body: string
+  title: string
+  description: string
+  imports: ImportBinding[]
+  componentNames: string[]
+}
+
+export interface RenderScope {
+  values: Record<string, unknown>
+}
+
+export interface RenderContext {
+  file: ParsedMdxFile
+  scope: RenderScope
+  renderFragment: (markdown: string, filePath: string, parentScope?: RenderScope) => string
+  getTemplateSource: (resolvedSource: string) => string | undefined
+  getConnectorCatalogItems: () => ConnectorCatalogItem[]
+  getToolsForSlug: (slug: string) => Tool[]
+}
+
+export interface RenderResult {
+  markdown: string
+}
+
+export interface ComponentRenderer {
+  supports: (usage: ComponentUsage) => boolean
+  render: (usage: ComponentUsage, context: RenderContext) => RenderResult
+}
+
+export interface ConnectorCatalogItem {
+  slug: string
+  title: string
+  description: string
+  href: string
+  categories: string[]
+  authType: string
+}
+
+export interface PageSupportResult {
+  supported: boolean
+  unsupportedComponents: string[]
+}

--- a/src/pages/[...slug].agent.md.ts
+++ b/src/pages/[...slug].agent.md.ts
@@ -1,0 +1,28 @@
+import type { APIRoute } from 'astro'
+import { getAgentMarkdownRoutes, renderAgentMarkdown } from '@/lib/agent-markdown/registry'
+
+export const prerender = true
+
+export function getStaticPaths() {
+  return getAgentMarkdownRoutes().map((route) => ({
+    params: { slug: route },
+  }))
+}
+
+export const GET: APIRoute = async ({ params }) => {
+  const route = params.slug
+  if (!route) {
+    return new Response('Not found', { status: 404 })
+  }
+
+  const markdown = renderAgentMarkdown(route)
+  if (!markdown) {
+    return new Response('Not found', { status: 404 })
+  }
+
+  return new Response(markdown, {
+    headers: {
+      'content-type': 'text/markdown; charset=utf-8',
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- add a shared agent-markdown pipeline that generates `*.agent.md` pages for supported component-heavy docs
- expand connector docs, template imports, and common UI/data components into semantic markdown for Copy Markdown and `text/markdown`
- add an audit script and build warning so unsupported component families are reported without failing builds

## Test plan
- [x] Run `pnpm build`
- [x] Run `pnpm agent-markdown:audit`
- [x] Spot-check generated `*.agent.md` output for connector pages and code-sample pages