### PR TITLE
docs(bigquery): add dry run and cancel job tools for BigQuery Service Account

### DIFF
--- a/src/content/docs/agentkit/connectors/bigqueryserviceaccount.mdx
+++ b/src/content/docs/agentkit/connectors/bigqueryserviceaccount.mdx
@@ -21,7 +21,9 @@ import { UsageBigqueryserviceaccountSection } from '@components/templates'
 
 Connect this agent connector to let your agent:
 
-- **Run run** — Execute a SQL query synchronously against BigQuery and return results immediately
+- **Query insert** — Submit an asynchronous BigQuery query job
+- **Job cancel** — Request cancellation of a running BigQuery job
+- **Run dry, run** — Validate a SQL query and estimate its cost without executing it
 - **List list** — List all tables and views in a BigQuery dataset
 - **Get get** — Retrieve metadata and schema for a specific BigQuery table or view, including column names, types, descriptions, and table properties
 

--- a/src/data/agent-connectors/bigqueryserviceaccount.ts
+++ b/src/data/agent-connectors/bigqueryserviceaccount.ts
@@ -2,6 +2,48 @@ import type { Tool } from '../../types/agent-connectors'
 
 export const tools: Tool[] = [
   {
+    name: 'bigqueryserviceaccount_cancel_job',
+    description: `Request cancellation of a running BigQuery job. Returns the final job resource. Cancellation is best-effort and the job may complete before it can be cancelled.`,
+    params: [
+      {
+        name: 'job_id',
+        type: 'string',
+        required: true,
+        description: `The ID of the job to cancel`,
+      },
+      {
+        name: 'location',
+        type: 'string',
+        required: false,
+        description: `Geographic location where the job was created, e.g. US or EU`,
+      },
+    ],
+  },
+  {
+    name: 'bigqueryserviceaccount_dry_run_query',
+    description: `Validate a SQL query and estimate its cost without executing it. Returns statistics.totalBytesProcessed so you can check byte usage before running the real job.`,
+    params: [
+      {
+        name: 'query',
+        type: 'string',
+        required: true,
+        description: `SQL query to validate and estimate`,
+      },
+      {
+        name: 'location',
+        type: 'string',
+        required: false,
+        description: `Geographic location where the job should run, e.g. US or EU`,
+      },
+      {
+        name: 'use_legacy_sql',
+        type: 'boolean',
+        required: false,
+        description: `Use BigQuery legacy SQL syntax instead of standard SQL`,
+      },
+    ],
+  },
+  {
     name: 'bigqueryserviceaccount_get_dataset',
     description: `Retrieve metadata for a specific BigQuery dataset, including location, description, labels, access controls, and creation/modification times.`,
     params: [
@@ -118,6 +160,61 @@ export const tools: Tool[] = [
         type: 'string',
         required: true,
         description: `The ID of the table or view to retrieve`,
+      },
+    ],
+  },
+  {
+    name: 'bigqueryserviceaccount_insert_query_job',
+    description: `Submit an asynchronous BigQuery query job. Returns a job ID that can be used with Get Job or Get Query Results to poll for completion and retrieve results.`,
+    params: [
+      { name: 'query', type: 'string', required: true, description: `SQL query to execute` },
+      {
+        name: 'create_disposition',
+        type: 'string',
+        required: false,
+        description: `Specifies whether the destination table is created if it does not exist`,
+      },
+      {
+        name: 'destination_dataset_id',
+        type: 'string',
+        required: false,
+        description: `Dataset ID to write query results into`,
+      },
+      {
+        name: 'destination_table_id',
+        type: 'string',
+        required: false,
+        description: `Table ID to write query results into`,
+      },
+      {
+        name: 'location',
+        type: 'string',
+        required: false,
+        description: `Geographic location where the job should run, e.g. US or EU`,
+      },
+      {
+        name: 'maximum_bytes_billed',
+        type: 'string',
+        required: false,
+        description: `Maximum bytes that can be billed for this query; query fails if limit is exceeded`,
+      },
+      {
+        name: 'priority',
+        type: 'string',
+        required: false,
+        description: `Job priority: INTERACTIVE (default) or BATCH`,
+      },
+      {
+        name: 'use_legacy_sql',
+        type: 'boolean',
+        required: false,
+        description: `Use BigQuery legacy SQL syntax instead of standard SQL`,
+      },
+      {
+        name: 'write_disposition',
+        type: 'string',
+        required: false,
+        description: `Specifies the action when the destination table already exists`,
       },
     ],
   },


### PR DESCRIPTION
## Summary

- Adds `bigqueryserviceaccount_dry_run_query` tool to the BigQuery Service Account connector docs
- Adds `bigqueryserviceaccount_cancel_job` tool to the BigQuery Service Account connector docs
- Restores `ConnectedAccountBigqueryserviceaccountSection` export in `index.ts` (was dropped by sync script)
- Syncs `bigqueryserviceaccount.ts` data file with latest tool definitions from staging (16 tools total)

## Test plan

- [ ] Verify BigQuery Service Account connector page shows 16 tools
- [ ] Verify Dry Run Query and Cancel Job tools appear in the tool list
- [ ] Verify "Create a Connected Account" section renders correctly on the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * BigQuery connector now includes three new asynchronous capabilities: Submit query jobs to run in the background, cancel running jobs on demand, and run dry-run queries to validate SQL syntax and estimate costs before full execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->