### PR TITLE
docs: clarify directory enabled webhook timing

### DIFF
--- a/src/content/docs/reference/webhooks/directory-events.mdx
+++ b/src/content/docs/reference/webhooks/directory-events.mdx
@@ -28,7 +28,7 @@ head:
 
 This webhook is triggered when a directory sync is enabled. The event type is `organization.directory_enabled`
 
-For most SCIM providers, `organization.directory_enabled` is emitted as soon as an admin selects the identity provider in the Scalekit admin panel. Scalekit can begin listening for directory events immediately, so customers often see `organization.directory_created` and `organization.directory_enabled` before the admin finishes configuration on the provider side.
+For most SCIM providers, `organization.directory_enabled` is emitted as soon as an admin selects the identity provider in the Scalekit admin portal. Scalekit can begin listening for directory events immediately, so customers often see `organization.directory_created` and `organization.directory_enabled` before the admin finishes configuration on the provider side.
 
 Google SCIM is the main exception. Because it requires an additional OAuth authorization step, `organization.directory_enabled` is emitted only after that authorization is completed.
 

--- a/src/content/docs/reference/webhooks/directory-events.mdx
+++ b/src/content/docs/reference/webhooks/directory-events.mdx
@@ -28,6 +28,12 @@ head:
 
 This webhook is triggered when a directory sync is enabled. The event type is `organization.directory_enabled`
 
+For most SCIM providers, `organization.directory_enabled` is emitted as soon as an admin selects the identity provider in the Scalekit admin panel. Scalekit can begin listening for directory events immediately, so customers often see `organization.directory_created` and `organization.directory_enabled` before the admin finishes configuration on the provider side.
+
+Google SCIM is the main exception. Because it requires an additional OAuth authorization step, `organization.directory_enabled` is emitted only after that authorization is completed.
+
+This differs from [`organization.sso_enabled`](/reference/webhooks/sso-events/#organizationsso_enabled), which is emitted only after the admin finishes the full SSO configuration.
+
 ```json title="organization.directory_enabled"
 {
   "environment_id": "env_27758032200925221",


### PR DESCRIPTION
## Summary
- clarify when  is emitted for most SCIM providers
- note the Google SCIM exception where OAuth authorization must finish first
- contrast this timing with  so webhook consumers can design automation correctly

## Testing
- not run (docs copy change only)

Closes #584

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified timing for the `organization.directory_enabled` webhook: most SCIM providers emit it immediately when an identity provider is selected in the admin UI, while Google SCIM waits until OAuth authorization completes. Added a cross-reference noting this differs from `organization.sso_enabled`, which emits only after full SSO configuration is finished.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->