### PR TITLE
Add scheduled Netlify deploy workflow

### DIFF
--- a/.github/workflows/scheduled-deploy.yml
+++ b/.github/workflows/scheduled-deploy.yml
@@ -1,0 +1,45 @@
+name: Scheduled Netlify Deploy
+
+on:
+  schedule:
+    - cron: '30 10 * * *' # 4:00 PM IST (UTC+5:30) daily
+  workflow_dispatch: # allows manual trigger for testing
+
+jobs:
+  check_and_deploy:
+    runs-on: ubuntu-latest
+    name: Deploy if new commits on main
+
+    steps:
+      - name: Get last deployed commit on Netlify
+        id: netlify
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        run: |
+          LAST_DEPLOYED=$(curl -s \
+            -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN" \
+            "https://api.netlify.com/api/v1/sites/$NETLIFY_SITE_ID/deploys?branch=main&per_page=1" \
+            | jq -r '[.[] | select(.state == "ready")][0].commit_ref')
+          echo "Last deployed SHA: $LAST_DEPLOYED"
+          echo "last_deployed=$LAST_DEPLOYED" >> $GITHUB_OUTPUT
+
+      - name: Get current HEAD of main
+        id: github
+        run: |
+          CURRENT_HEAD=$(curl -s \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/git/ref/heads/main" \
+            | jq -r '.object.sha')
+          echo "Current HEAD SHA: $CURRENT_HEAD"
+          echo "current_head=$CURRENT_HEAD" >> $GITHUB_OUTPUT
+
+      - name: Trigger Netlify deploy
+        if: steps.netlify.outputs.last_deployed != steps.github.outputs.current_head
+        run: |
+          curl -s -X POST -d '{}' "${{ secrets.NETLIFY_BUILD_HOOK }}"
+          echo "Deploy triggered — new commits detected."
+
+      - name: Skip deploy
+        if: steps.netlify.outputs.last_deployed == steps.github.outputs.current_head
+        run: echo "Already up to date. Skipping deploy."

--- a/.github/workflows/scheduled-deploy.yml
+++ b/.github/workflows/scheduled-deploy.yml
@@ -17,27 +17,37 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
         run: |
-          LAST_DEPLOYED=$(curl -s \
+          set -euo pipefail
+          LAST_DEPLOYED=$(curl -fsS \
             -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN" \
             "https://api.netlify.com/api/v1/sites/$NETLIFY_SITE_ID/deploys?branch=main&per_page=10" \
             | jq -r '[.[] | select(.state == "ready")][0].commit_ref')
+          if [ -z "${LAST_DEPLOYED:-}" ] || [ "$LAST_DEPLOYED" = "null" ]; then
+            echo "::error::Unable to resolve last deployed commit from Netlify."
+            exit 1
+          fi
           echo "Last deployed SHA: $LAST_DEPLOYED"
-          echo "last_deployed=$LAST_DEPLOYED" >> $GITHUB_OUTPUT
+          echo "last_deployed=$LAST_DEPLOYED" >> "$GITHUB_OUTPUT"
 
       - name: Get current HEAD of main
         id: github
         run: |
-          CURRENT_HEAD=$(curl -s \
+          set -euo pipefail
+          CURRENT_HEAD=$(curl -fsS \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/${{ github.repository }}/git/ref/heads/main" \
             | jq -r '.object.sha')
+          if [ -z "${CURRENT_HEAD:-}" ] || [ "$CURRENT_HEAD" = "null" ]; then
+            echo "::error::Unable to resolve GitHub main HEAD SHA."
+            exit 1
+          fi
           echo "Current HEAD SHA: $CURRENT_HEAD"
-          echo "current_head=$CURRENT_HEAD" >> $GITHUB_OUTPUT
+          echo "current_head=$CURRENT_HEAD" >> "$GITHUB_OUTPUT"
 
       - name: Trigger Netlify deploy
         if: steps.netlify.outputs.last_deployed != steps.github.outputs.current_head
         run: |
-          curl -s -X POST -d '{}' "${{ secrets.NETLIFY_BUILD_HOOK }}"
+          curl -fsS -X POST -d '{}' "${{ secrets.NETLIFY_BUILD_HOOK }}"
           echo "Deploy triggered — new commits detected."
 
       - name: Skip deploy

--- a/.github/workflows/scheduled-deploy.yml
+++ b/.github/workflows/scheduled-deploy.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           LAST_DEPLOYED=$(curl -s \
             -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN" \
-            "https://api.netlify.com/api/v1/sites/$NETLIFY_SITE_ID/deploys?branch=main&per_page=1" \
+            "https://api.netlify.com/api/v1/sites/$NETLIFY_SITE_ID/deploys?branch=main&per_page=10" \
             | jq -r '[.[] | select(.state == "ready")][0].commit_ref')
           echo "Last deployed SHA: $LAST_DEPLOYED"
           echo "last_deployed=$LAST_DEPLOYED" >> $GITHUB_OUTPUT

--- a/project-docs/SCHEDULED_DEPLOY.md
+++ b/project-docs/SCHEDULED_DEPLOY.md
@@ -1,0 +1,55 @@
+# Scheduled Netlify Deploy
+
+This project uses a GitHub Actions workflow to automatically deploy the Netlify site when `main` has undeployed commits. The workflow avoids unnecessary builds by comparing SHAs before triggering.
+
+---
+
+## How it works
+
+**File:** `.github/workflows/scheduled-deploy.yml`
+
+The workflow runs daily at 4:00 PM IST (cron `30 10 * * *` UTC) and can also be triggered manually via `workflow_dispatch`.
+
+1. **Fetch last deployed commit** — Queries the Netlify API for the most recent `ready` deploy on the `main` branch and extracts its `commit_ref`.
+2. **Fetch current HEAD** — Queries the GitHub API for the current SHA of `refs/heads/main`.
+3. **Compare** — If the SHAs differ, POSTs to the Netlify build hook to trigger a deploy. If they match, the job logs "up to date" and exits.
+
+```
+Netlify API (last ready deploy SHA)  ─┐
+                                      ├─ differ? → POST build hook → deploy
+GitHub API  (current main HEAD SHA)  ─┘
+                                      └─ match?  → skip
+```
+
+## Required secrets
+
+These must be configured in the repository's **Settings → Secrets and variables → Actions**:
+
+| Secret | Purpose |
+|--------|---------|
+| `NETLIFY_BUILD_HOOK` | Netlify build hook URL (Settings → Build hooks) |
+| `NETLIFY_AUTH_TOKEN` | Netlify personal access token (User settings → Applications) |
+| `NETLIFY_SITE_ID` | Netlify site ID (Site settings → General → Site ID) |
+
+`GITHUB_TOKEN` is provided automatically by GitHub Actions.
+
+## Error handling
+
+The workflow uses `curl -fsS` and `set -euo pipefail` so that:
+
+- HTTP errors from Netlify or GitHub APIs fail the step immediately instead of silently returning garbage.
+- If `jq` extracts an empty or `"null"` SHA (e.g., no ready deploys exist yet), the step errors with a clear `::error::` annotation and exits non-zero.
+
+This prevents false deploy/skip decisions from silent API failures.
+
+## Debugging
+
+**Workflow never runs?** Check that the cron schedule is correct. GitHub Actions cron uses UTC — `30 10 * * *` is 10:30 UTC (4:00 PM IST). Note that GitHub may delay scheduled workflows by minutes during high-load periods.
+
+**Step fails with "Unable to resolve last deployed commit"?** The Netlify API returned no `ready` deploys for the `main` branch. This can happen on a brand-new site or if all recent deploys failed. Verify in the Netlify dashboard that at least one successful deploy exists for `main`.
+
+**Step fails with "Unable to resolve GitHub main HEAD SHA"?** The `GITHUB_TOKEN` may lack read permissions, or the repository reference is wrong. Check the Actions permissions in repo settings.
+
+**Deploys trigger but the site doesn't update?** The build hook URL may be stale. Regenerate it in Netlify (Site settings → Build hooks) and update the `NETLIFY_BUILD_HOOK` secret.
+
+**Manual trigger:** Use `workflow_dispatch` from the Actions tab to test without waiting for the cron schedule.


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that triggers a Netlify deploy daily at 4 PM IST
- Uses the Netlify API to compare the last deployed commit SHA against current \`main\` HEAD — only fires the build hook if there are undeployed commits
- No unnecessary builds if \`main\` hasn't changed

## Secrets required
Add these three repository secrets before the workflow runs:
- \`NETLIFY_BUILD_HOOK\` — Netlify build hook URL
- \`NETLIFY_AUTH_TOKEN\` — Netlify personal access token
- \`NETLIFY_SITE_ID\` — Netlify site ID

## Preview
https://deploy-preview-626--scalekit-starlight.netlify.app/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a scheduled (daily) and manual deployment check that compares the live site's last deployed commit with the repository HEAD, triggers a deploy if they differ, skips otherwise, and includes error handling and reporting.
* **Documentation**
  * Added documentation describing the workflow steps, required secrets, error handling, and debugging/manual trigger guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->