### PR TITLE
fix(scripts): install-d2 uses macos asset name for darwin

### DIFF
--- a/scripts/install-d2.sh
+++ b/scripts/install-d2.sh
@@ -29,10 +29,10 @@ case "$ARCH" in
     ;;
 esac
 
-# Map OS names
+# Map OS names (upstream uses "macos" for Darwin starting in v0.7.x)
 case "$OS" in
   Darwin)
-    OS="darwin"
+    OS="macos"
     ;;
   Linux)
     OS="linux"


### PR DESCRIPTION
## Summary

- Fixes 404 errors when running `pnpm install:d2` on macOS
- Updates OS mapping in `install-d2.sh` to use "macos" instead of "darwin" for GitHub release asset names, matching d2 v0.7.x upstream release naming

## Test plan

- [ ] Run `pnpm install:d2` on macOS arm64 and confirm it downloads and installs successfully
- [ ] Verify the installed d2 binary works correctly

## Preview

N/A — build script change only, no doc pages affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved macOS installer compatibility by ensuring the correct binary is downloaded during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->