### PR TITLE
docs: external ID constraints, multi-region pattern, and org deletion behavior

### DIFF
--- a/src/content/docs/guides/external-ids-and-metadata.mdx
+++ b/src/content/docs/guides/external-ids-and-metadata.mdx
@@ -121,7 +121,7 @@ This pattern keeps the region and account identifier in a single field and stays
 
 ### Organization deletion and SCIM
 
-When you delete an organization in Scalekit, all associated connections and SCIM configurations are deleted automatically. No charges apply to the deleted organization after deletion.
+When you delete an organization in Scalekit, Scalekit automatically deletes all associated connections and SCIM configurations. No charges apply to the deleted organization after deletion.
 
 However, if your customer's identity provider has SCIM provisioning enabled, the IdP will continue attempting to send SCIM events after the organization is gone. Because there is no active SCIM endpoint to receive those events, the IdP will log errors for each attempt.
 

--- a/src/content/docs/guides/external-ids-and-metadata.mdx
+++ b/src/content/docs/guides/external-ids-and-metadata.mdx
@@ -99,3 +99,32 @@ curl 'https://<SCALEKIT_ENVIRONMENT_URL>/api/v1/organizations/{id}' \
 ### View external IDs and metadata
 
 All organization endpoints that return organization details will include the external ID and metadata in their responses. This makes it easy to access your custom data when working with organizations.
+
+### External ID constraints
+
+External IDs have the following constraints:
+
+- **Unique per environment**: Each external ID must be unique across all organizations in the same Scalekit environment, regardless of region.
+- **Maximum length**: 255 characters.
+- **Searchable by external ID**: You can look up organizations by external ID using the list organizations endpoint. You cannot search organizations by a metadata field.
+
+#### Multi-region external ID pattern
+
+If your application operates across multiple regions and your internal account IDs are unique only within a region, prefix each external ID with the region name to ensure uniqueness across your Scalekit environment:
+
+```text
+us-east-CUST-12345   # US East account
+eu-west-CUST-12345   # EU West account with the same internal ID
+```
+
+This pattern keeps the region and account identifier in a single field and stays within the 255-character limit.
+
+### Organization deletion and SCIM
+
+When you delete an organization in Scalekit, all associated connections and SCIM configurations are deleted automatically. No charges apply to the deleted organization after deletion.
+
+However, if your customer's identity provider has SCIM provisioning enabled, the IdP will continue attempting to send SCIM events after the organization is gone. Because there is no active SCIM endpoint to receive those events, the IdP will log errors for each attempt.
+
+<Aside type="tip" title="Disable SCIM before deleting">
+  Before deleting an organization, ask your customer to disable SCIM provisioning in their identity provider. This prevents error logs on their side after the organization is removed.
+</Aside>

--- a/src/content/docs/guides/external-ids-and-metadata.mdx
+++ b/src/content/docs/guides/external-ids-and-metadata.mdx
@@ -106,7 +106,7 @@ External IDs have the following constraints:
 
 - **Unique per environment**: Each external ID must be unique across all organizations in the same Scalekit environment, regardless of region.
 - **Maximum length**: 255 characters.
-- **Searchable by external ID**: You can look up organizations by external ID using the list organizations endpoint. You cannot search organizations by a metadata field.
+- **Searchable by `external_id`**: You can look up organizations by `external_id` using the `list organizations` endpoint. You cannot search organizations by a metadata field.
 
 #### Multi-region external ID pattern
 

--- a/src/content/docs/guides/external-ids-and-metadata.mdx
+++ b/src/content/docs/guides/external-ids-and-metadata.mdx
@@ -121,9 +121,9 @@ This pattern keeps the region and account identifier in a single field and stays
 
 ### Organization deletion and SCIM
 
-When you delete an organization in Scalekit, Scalekit automatically deletes all associated connections and SCIM configurations. No charges apply to the deleted organization after deletion.
+When you delete an organization in Scalekit, Scalekit automatically deletes all associated connections and SCIM configurations. No charges apply after deletion.
 
-However, if your customer's identity provider has SCIM provisioning enabled, the IdP will continue attempting to send SCIM events after the organization is gone. Because there is no active SCIM endpoint to receive those events, the IdP will log errors for each attempt.
+However, if your customer's identity provider has SCIM provisioning enabled, the IdP will continue attempting to send SCIM events after the organization is deleted. Because there is no active SCIM endpoint to receive those events, the IdP will log errors for each attempt.
 
 <Aside type="tip" title="Disable SCIM before deleting">
   Before deleting an organization, ask your customer to disable SCIM provisioning in their identity provider. This prevents error logs on their side after the organization is removed.


### PR DESCRIPTION
## Summary

Two recurring support questions revealed gaps in the organization identifiers guide (`guides/external-ids-and-metadata.mdx`):

- **External ID uniqueness is per environment, not per region** (Pylon #798 — Rocketlane). Customers with multi-region deployments try to reuse account IDs across regions and hit uniqueness violations. Added: constraint table, recommended `region-accountid` prefix pattern, and 255-char length limit.
- **Org deletion cascades to connections and SCIM — but the IdP keeps sending events** (Pylon #803 — Hiver). Deleting an org incurs no further charges, but the customer's IdP will log errors for every SCIM event it sends to the now-gone endpoint. Added: explanation of cascade behavior and a tip to disable SCIM on the IdP side before deletion.

## Changes

- `src/content/docs/guides/external-ids-and-metadata.mdx`
  - New section: **External ID constraints** (uniqueness, 255-char limit, metadata not searchable)
  - New subsection: **Multi-region external ID pattern** with code example
  - New section: **Organization deletion and SCIM** with cascade explanation and an `Aside` tip

## Test plan

- [ ] Confirm the page renders without build errors
- [ ] Verify the `<Aside>` component displays correctly
- [ ] Check that the code block renders as plain text (not a language block)
- [ ] Preview link: `https://deploy-preview-{PR_NUMBER}--scalekit-starlight.netlify.app/guides/external-ids-and-metadata/`

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeQSQChf9A67n8p3C3Qsu8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified external ID rules: must be unique across the environment (including other regions), max 255 characters, and only external IDs are searchable (metadata fields are not).
  * Added multi-region guidance recommending region-prefixed external IDs to avoid collisions while staying within length limits.
  * Explained SCIM deletion behavior: removes SCIM configs and connections, may cause IdP-side errors, and advises disabling SCIM provisioning before deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->