### PR TITLE
docs: clarify localhost redirect URI support for MCP server in staging

### DIFF
--- a/src/content/docs/agentkit/connections.mdx
+++ b/src/content/docs/agentkit/connections.mdx
@@ -47,6 +47,10 @@ OAuth connections require you to create an OAuth app with the provider and link 
 
    This URI is where the provider sends the user after they complete the OAuth consent screen. Scalekit handles the callback automatically.
 
+   <Aside type="tip" title="Localhost redirect URIs work in staging">
+     For development and staging, you can run your MCP server on `localhost`. Register a localhost URL (for example, `http://localhost:3000/callback`) as the redirect URI in the provider's console. The MCP client must be able to reach the server — typically both run on the same machine during local testing.
+   </Aside>
+
 3. ### Register your OAuth app with the provider
 
    In the provider's developer console (GitHub, Salesforce, Google, etc.), create an OAuth app and add Scalekit's Redirect URI to the list of authorized redirect URIs.
@@ -103,4 +107,3 @@ You can create more than one connection for the same connector. This is useful w
 - You're integrating with multiple instances of the same service (for example, two different Salesforce orgs)
 
 Each connection has its own name, which you use to identify it in API calls and in the dashboard.
-


### PR DESCRIPTION
## Summary

A developer testing AgentKit in a staging environment asked whether their MCP server could run on `localhost` for redirects to work (Pylon #765). The answer is yes — localhost redirect URIs are supported — but this wasn't documented anywhere. Developers unfamiliar with OAuth testing patterns may assume localhost is blocked.

## Changes

- `src/content/docs/agentkit/connections.mdx`
  - Added an `<Aside type="tip">` inside step 2 ("Copy the redirect URI") clarifying that localhost redirect URIs work in staging and that the MCP server can run on localhost as long as the MCP client can reach it

## Test plan

- [ ] Confirm the page renders without build errors
- [ ] Verify the `<Aside>` inside the `<Steps>` block renders correctly (no broken `<ol>`)
- [ ] Preview link: `https://deploy-preview-{PR_NUMBER}--scalekit-starlight.netlify.app/agentkit/connections/`

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeQSQChf9A67n8p3C3Qsu8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced OAuth redirect URI setup documentation with clearer guidance for localhost configuration in development and staging environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->