### PR TITLE
Override .md with rendered .agent.md at build time

### DIFF
--- a/src/integrations/inject-agent-header.ts
+++ b/src/integrations/inject-agent-header.ts
@@ -1,6 +1,6 @@
 import { AGENT_PLUGIN_VISIBLE_MD, AGENT_DOCS_FOOTER } from '../configs/agent-instructions'
 import type { AstroIntegration } from 'astro'
-import { readdir, readFile, writeFile } from 'node:fs/promises'
+import { access, readdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -38,12 +38,14 @@ export function injectAgentHeader(): AstroIntegration {
         for await (const agentFile of walkAgentMdFiles(distPath)) {
           const mdFile = agentFile.replace(/\.agent\.md$/, '.md')
           try {
-            const content = await readFile(agentFile, 'utf-8')
-            await writeFile(mdFile, content)
-            overrides++
-          } catch {
-            // .md sibling may not exist for pages page-actions skipped — fine to ignore
+            await access(mdFile)
+          } catch (err) {
+            if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue
+            throw err
           }
+          const content = await readFile(agentFile, 'utf-8')
+          await writeFile(mdFile, content)
+          overrides++
         }
         logger.info(`Overrode ${overrides} .md files with rendered .agent.md content`)
 

--- a/src/integrations/inject-agent-header.ts
+++ b/src/integrations/inject-agent-header.ts
@@ -13,12 +13,41 @@ async function* walkMdFiles(dir: string): AsyncGenerator<string> {
   }
 }
 
+async function* walkAgentMdFiles(dir: string): AsyncGenerator<string> {
+  const entries = await readdir(dir, { withFileTypes: true })
+  for (const entry of entries) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) yield* walkAgentMdFiles(full)
+    else if (entry.name.endsWith('.agent.md')) yield full
+  }
+}
+
 export function injectAgentHeader(): AstroIntegration {
   return {
     name: 'inject-agent-header',
     hooks: {
       'astro:build:done': async ({ dir, logger }) => {
         const distPath = fileURLToPath(dir)
+
+        // Override .md with .agent.md where both exist.
+        // starlight-page-actions copies raw .mdx source as .md but can't render custom
+        // components like <ProviderCatalog /> or <ToolList />. The agent-markdown system
+        // produces fully rendered .agent.md counterparts — copy those over the raw .md so
+        // the public .md URL returns the same high-quality content.
+        let overrides = 0
+        for await (const agentFile of walkAgentMdFiles(distPath)) {
+          const mdFile = agentFile.replace(/\.agent\.md$/, '.md')
+          try {
+            const content = await readFile(agentFile, 'utf-8')
+            await writeFile(mdFile, content)
+            overrides++
+          } catch {
+            // .md sibling may not exist for pages page-actions skipped — fine to ignore
+          }
+        }
+        logger.info(`Overrode ${overrides} .md files with rendered .agent.md content`)
+
+        // Inject the agent plugin discovery header into every .md file that doesn't have it yet.
         let count = 0
         for await (const file of walkMdFiles(distPath)) {
           const content = await readFile(file, 'utf-8')


### PR DESCRIPTION
## Summary

Pages with custom components (e.g. `<ProviderCatalog />`, `<ToolList />`) produced a `.md` URL (via `starlight-page-actions`) that showed raw JSX tags instead of rendered content. The `agent-markdown` system already generates a `.agent.md` counterpart with fully rendered output, but the public `.md` URL was still the page-actions raw copy.

## Changes

Extended `injectAgentHeader` integration (`src/integrations/inject-agent-header.ts`) to copy each `.agent.md` file over its matching `.md` before the existing header-inject pass. This is purely a build-time step with no runtime cost or edge-function changes.

## Test Plan

- [x] Verify build completes without errors
- [x] Check that `.md` URLs now show rendered content instead of raw JSX tags
- [x] Confirm `.agent.md` files are still generated and preserved
- [x] Test preview deployment link: https://deploy-preview-{PR_NUMBER}--scalekit-starlight.netlify.app/agentkit/connectors.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build now merges agent-rendered markdown into standard markdown before processing, ensuring generated content replaces originals where present.
  * Continues to add the visible agent header to markdown files, skipping files that already include it.
  * Logs counts for both overrides and header injections to aid build transparency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->