### PR TITLE
docs: add native MCP setup instructions for all 13 AI coding tools

### DIFF
--- a/src/content/docs/dev-kit/ai-assisted-development/scalekit-mcp-server.mdx
+++ b/src/content/docs/dev-kit/ai-assisted-development/scalekit-mcp-server.mdx
@@ -54,11 +54,34 @@ This MCP server enables AI assistants to interact with Scalekit's identity and a
 
 ## Configuration
 
-The Scalekit MCP server can be configured to support OAuth for compatible clients.
+Connect the Scalekit MCP server to your AI coding tool. Find your tool below, paste the config, and restart the client — it will prompt you to sign in via OAuth on first use.
 
-If your MCP Client doesn't support OAuth based authorization for MCP Servers, you can still use the Scalekit MCP server with the mcp-remote acting as a local proxy to add OAuth support.
+### Claude Code
 
-### Using OAuth (VS Code version 1.101 or greater)
+Run this command in your terminal:
+
+```bash
+claude mcp add --transport http scalekit https://mcp.scalekit.com/
+```
+
+### Claude Desktop
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows), then restart Claude Desktop:
+
+```json
+{
+  "mcpServers": {
+    "scalekit": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://mcp.scalekit.com/"]
+    }
+  }
+}
+```
+
+### VS Code
+
+Edit `.vscode/mcp.json` in your project (requires VS Code 1.101 or later):
 
 ```json
 {
@@ -71,58 +94,15 @@ If your MCP Client doesn't support OAuth based authorization for MCP Servers, yo
 }
 ```
 
-### Using mcp-remote proxy
-
-```json
-{
-  "mcpServers": {
-    "scalekit": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.scalekit.com/"]
-    }
-  }
-}
-```
-
-Based on your MCP Host, configuration instructions to add Scalekit as an MCP Server can be found below:
-
-### Claude Desktop
-
-Configure the Claude app to use the MCP server:
-
-1. Open the Claude Desktop app, go to Settings, then Developer
-2. Click Edit Config
-3. Open the claude_desktop_config.json file
-4. Copy and paste the server config to your existing file, then save
-5. Restart Claude
-
-```json
-{
-  "mcpServers": {
-    "scalekit": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.scalekit.com/"]
-    }
-  }
-}
-```
-
 ### Cursor
 
-Configure Cursor to use the MCP server:
-
-1. Open Cursor, go to Settings, then Cursor Settings
-2. Select MCP on the left
-3. Click Add "New Global MCP Server" at the top right
-4. Copy and paste the server config to your existing file, then save
-5. Restart Cursor
+Edit `~/.cursor/mcp.json`, or open **Cursor Settings → MCP → Add New Global MCP Server** and paste the config:
 
 ```json
 {
   "mcpServers": {
     "scalekit": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.scalekit.com/"]
+      "url": "https://mcp.scalekit.com/"
     }
   }
 }
@@ -130,13 +110,110 @@ Configure Cursor to use the MCP server:
 
 ### Windsurf
 
-Configure Windsurf to use the MCP server:
+Edit `~/.codeium/windsurf/mcp_config.json`:
 
-1. Open Windsurf, go to Settings, then Developer
-2. Click Edit Config
-3. Open the windsurf_config.json file
-4. Copy and paste the server config to your existing file, then save
-5. Restart Windsurf
+```json
+{
+  "mcpServers": {
+    "scalekit": {
+      "serverUrl": "https://mcp.scalekit.com/"
+    }
+  }
+}
+```
+
+### Gemini CLI
+
+Edit `~/.gemini/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "scalekit": {
+      "httpUrl": "https://mcp.scalekit.com/"
+    }
+  }
+}
+```
+
+### Codex
+
+Run this command in your terminal:
+
+```bash
+codex mcp add scalekit --url https://mcp.scalekit.com/
+```
+
+### OpenCode
+
+Edit `opencode.json` in your project root:
+
+```json
+{
+  "mcp": {
+    "scalekit": {
+      "type": "remote",
+      "url": "https://mcp.scalekit.com/",
+      "enabled": true
+    }
+  }
+}
+```
+
+### Roo Code
+
+Add to your MCP configuration:
+
+```json
+{
+  "mcpServers": {
+    "scalekit": {
+      "type": "streamable-http",
+      "url": "https://mcp.scalekit.com/"
+    }
+  }
+}
+```
+
+### Zed
+
+Add to your Zed `settings.json`:
+
+```json
+{
+  "context_servers": {
+    "scalekit": {
+      "url": "https://mcp.scalekit.com/"
+    }
+  }
+}
+```
+
+### Kiro
+
+Edit `~/.kiro/settings/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "scalekit": {
+      "url": "https://mcp.scalekit.com/"
+    }
+  }
+}
+```
+
+### Warp
+
+Go to **Settings → MCP Servers → Add MCP Server** and enter `https://mcp.scalekit.com/`.
+
+### v0 by Vercel
+
+Go to **Prompt Tools → Add MCP** and enter `https://mcp.scalekit.com/`.
+
+### If the native config doesn't work
+
+The Scalekit MCP server requires OAuth 2.1 authentication. If your client does not complete the OAuth flow with the native config above, use `mcp-remote` as a local proxy — it handles the OAuth handshake for any client. Replace your platform's native config with this:
 
 ```json
 {
@@ -148,6 +225,8 @@ Configure Windsurf to use the MCP server:
   }
 }
 ```
+
+Restart your client after updating the config. See [how mcp-remote works](https://exa.ai/docs/reference/exa-mcp#web-search-mcp) for more context on when this fallback applies.
 
 ## Authentication for MCP Server
 

--- a/src/content/docs/dev-kit/ai-assisted-development/scalekit-mcp-server.mdx
+++ b/src/content/docs/dev-kit/ai-assisted-development/scalekit-mcp-server.mdx
@@ -69,7 +69,7 @@ claude mcp add --transport http scalekit https://mcp.scalekit.com/
 1. Open Claude Desktop
 2. Go to **Settings → Connectors**
 3. Click **Add custom connector**
-4. Enter `https://mcp.scalekit.com`
+4. Enter `Scalekit` as the name and `https://mcp.scalekit.com` as the URL
 5. Click **Connect** to authenticate
 
 ### VS Code

--- a/src/content/docs/dev-kit/ai-assisted-development/scalekit-mcp-server.mdx
+++ b/src/content/docs/dev-kit/ai-assisted-development/scalekit-mcp-server.mdx
@@ -213,7 +213,7 @@ Go to **Settings → MCP Servers → Add MCP Server** and enter `https://mcp.sca
 Go to **Prompt Tools → Add MCP** and enter `https://mcp.scalekit.com/`.
 
 :::tip
-Building your own MCP server? Add OAuth-protected access using [Auth for MCP Servers](https://docs.scalekit.com/authenticate/mcp/quickstart).
+Building your own MCP server? Add OAuth-protected access using [Auth for MCP Servers](/authenticate/mcp/quickstart/).
 :::
 
 ## GitHub

--- a/src/content/docs/dev-kit/ai-assisted-development/scalekit-mcp-server.mdx
+++ b/src/content/docs/dev-kit/ai-assisted-development/scalekit-mcp-server.mdx
@@ -212,23 +212,6 @@ Go to **Settings → MCP Servers → Add MCP Server** and enter `https://mcp.sca
 
 Go to **Prompt Tools → Add MCP** and enter `https://mcp.scalekit.com/`.
 
-### Via npm package
-
-The Scalekit MCP server requires OAuth 2.1 authentication. If your client does not complete the OAuth flow, use `mcp-remote` as a local proxy — it handles the OAuth handshake for any client. Replace your platform's native config with:
-
-```json
-{
-  "mcpServers": {
-    "scalekit": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.scalekit.com/"]
-    }
-  }
-}
-```
-
-For Claude Code, add this to `.mcp.json` in your project root. For all other tools, replace the native config block and restart the client.
-
 :::tip
 Building your own MCP server? Add OAuth-protected access using [Auth for MCP Servers](https://docs.scalekit.com/authenticate/mcp/quickstart).
 :::

--- a/src/content/docs/dev-kit/ai-assisted-development/scalekit-mcp-server.mdx
+++ b/src/content/docs/dev-kit/ai-assisted-development/scalekit-mcp-server.mdx
@@ -213,9 +213,7 @@ Go to **Prompt Tools → Add MCP** and enter `https://mcp.scalekit.com/`.
 
 ### If the native config doesn't work
 
-The Scalekit MCP server requires OAuth 2.1 authentication. If your client does not complete the OAuth flow with the steps above, use `mcp-remote` as a local proxy — it handles the OAuth handshake for any client.
-
-For file-based config (Cursor, Windsurf, VS Code, Roo Code, Zed, Kiro, OpenCode), replace the native JSON block with:
+The Scalekit MCP server requires OAuth 2.1 authentication. If your client does not complete the OAuth flow, use `mcp-remote` as a local proxy — it handles the OAuth handshake for any client. Replace your platform's native config with:
 
 ```json
 {
@@ -228,15 +226,7 @@ For file-based config (Cursor, Windsurf, VS Code, Roo Code, Zed, Kiro, OpenCode)
 }
 ```
 
-For Claude Desktop, this is already the default config shown above.
-
-For Claude Code, run:
-
-```bash
-claude mcp add scalekit npx -- -y mcp-remote https://mcp.scalekit.com/
-```
-
-Restart your client after making changes.
+For Claude Desktop, this is already the config shown above. For Claude Code, add this to `.mcp.json` in your project root. For all other tools, replace the native config block and restart the client.
 
 :::tip
 Building your own MCP server? Add OAuth-protected access using [Auth for MCP Servers](https://docs.scalekit.com/authenticate/mcp/quickstart).

--- a/src/content/docs/dev-kit/ai-assisted-development/scalekit-mcp-server.mdx
+++ b/src/content/docs/dev-kit/ai-assisted-development/scalekit-mcp-server.mdx
@@ -219,7 +219,7 @@ Go to **Settings → MCP Servers → Add MCP Server** and enter `https://mcp.sca
 
 Go to **Prompt Tools → Add MCP** and enter `https://mcp.scalekit.com/`.
 
-### If the native config doesn't work
+### Via npm package
 
 The Scalekit MCP server requires OAuth 2.1 authentication. If your client does not complete the OAuth flow, use `mcp-remote` as a local proxy — it handles the OAuth handshake for any client. Replace your platform's native config with:
 

--- a/src/content/docs/dev-kit/ai-assisted-development/scalekit-mcp-server.mdx
+++ b/src/content/docs/dev-kit/ai-assisted-development/scalekit-mcp-server.mdx
@@ -205,7 +205,15 @@ Edit `~/.kiro/settings/mcp.json`:
 
 ### Warp
 
-Go to **Settings → MCP Servers → Add MCP Server** and enter `https://mcp.scalekit.com/`.
+Go to **Settings → MCP Servers → Add MCP Server** and enter `https://mcp.scalekit.com/`, or add to your Warp MCP config:
+
+```json
+{
+  "scalekit": {
+    "serverUrl": "https://mcp.scalekit.com/"
+  }
+}
+```
 
 ### v0 by Vercel
 

--- a/src/content/docs/dev-kit/ai-assisted-development/scalekit-mcp-server.mdx
+++ b/src/content/docs/dev-kit/ai-assisted-development/scalekit-mcp-server.mdx
@@ -54,7 +54,7 @@ This MCP server enables AI assistants to interact with Scalekit's identity and a
 
 ## Configuration
 
-Connect the Scalekit MCP server to your AI coding tool. Find your tool below, paste the config, and restart the client — it will prompt you to sign in via OAuth on first use.
+Connect the Scalekit MCP server to your AI coding tool. Find your tool below and follow the steps — your client will prompt you to sign in via OAuth on first use.
 
 ### Claude Code
 
@@ -213,7 +213,9 @@ Go to **Prompt Tools → Add MCP** and enter `https://mcp.scalekit.com/`.
 
 ### If the native config doesn't work
 
-The Scalekit MCP server requires OAuth 2.1 authentication. If your client does not complete the OAuth flow with the native config above, use `mcp-remote` as a local proxy — it handles the OAuth handshake for any client. Replace your platform's native config with this:
+The Scalekit MCP server requires OAuth 2.1 authentication. If your client does not complete the OAuth flow with the steps above, use `mcp-remote` as a local proxy — it handles the OAuth handshake for any client.
+
+For file-based config (Cursor, Windsurf, VS Code, Roo Code, Zed, Kiro, OpenCode), replace the native JSON block with:
 
 ```json
 {
@@ -226,19 +228,23 @@ The Scalekit MCP server requires OAuth 2.1 authentication. If your client does n
 }
 ```
 
-Restart your client after updating the config.
+For Claude Desktop, this is already the default config shown above.
 
-## Authentication for MCP Server
+For Claude Code, run:
 
-Scalekit MCP server uses OAuth2.1 based authentication. As soon as you register Scalekit MCP Server in your MCP Host, your MCP Host will initiate an OAuth authorization workflow so that the MCP Client can get appropriate tokens to securely communicate with Scalekit's MCP Server.
+```bash
+claude mcp add scalekit --transport sse https://mcp.scalekit.com/
+```
+
+Restart your client after making changes.
 
 :::tip
-If you are building your own MCP Server and would like to add OAuth based authorization, you can refer to our solution [Auth for MCP Servers](https://docs.scalekit.com/authenticate/mcp/quickstart).
+Building your own MCP server? Add OAuth-protected access using [Auth for MCP Servers](https://docs.scalekit.com/authenticate/mcp/quickstart).
 :::
 
-## Github
+## GitHub
 
-We have made the source code for the Scalekit MCP server available on [Github](https://github.com/scalekit-inc/mcp). You can also find all available tools and descriptions in our Github repo.
+The source code for the Scalekit MCP server is available on [GitHub](https://github.com/scalekit-inc/mcp), including a full list of available tools and their descriptions.
 
-- Feel free to go through the code and raise an issue if you find any bugs or have any questions.
-- If you have suggestions for new tools, please raise a PR or open an issue.
+- Open an issue if you find a bug or have a question.
+- Submit a PR or open an issue to suggest new tools.

--- a/src/content/docs/dev-kit/ai-assisted-development/scalekit-mcp-server.mdx
+++ b/src/content/docs/dev-kit/ai-assisted-development/scalekit-mcp-server.mdx
@@ -226,7 +226,7 @@ The Scalekit MCP server requires OAuth 2.1 authentication. If your client does n
 }
 ```
 
-Restart your client after updating the config. See [how mcp-remote works](https://exa.ai/docs/reference/exa-mcp#web-search-mcp) for more context on when this fallback applies.
+Restart your client after updating the config.
 
 ## Authentication for MCP Server
 

--- a/src/content/docs/dev-kit/ai-assisted-development/scalekit-mcp-server.mdx
+++ b/src/content/docs/dev-kit/ai-assisted-development/scalekit-mcp-server.mdx
@@ -66,18 +66,11 @@ claude mcp add --transport http scalekit https://mcp.scalekit.com/
 
 ### Claude Desktop
 
-Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows), then restart Claude Desktop:
-
-```json
-{
-  "mcpServers": {
-    "scalekit": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.scalekit.com/"]
-    }
-  }
-}
-```
+1. Open Claude Desktop
+2. Go to **Settings → Connectors**
+3. Click **Add custom connector**
+4. Enter `https://mcp.scalekit.com`
+5. Click **Connect** to authenticate
 
 ### VS Code
 
@@ -234,7 +227,7 @@ The Scalekit MCP server requires OAuth 2.1 authentication. If your client does n
 }
 ```
 
-For Claude Desktop, this is already the config shown above. For Claude Code, add this to `.mcp.json` in your project root. For all other tools, replace the native config block and restart the client.
+For Claude Code, add this to `.mcp.json` in your project root. For all other tools, replace the native config block and restart the client.
 
 :::tip
 Building your own MCP server? Add OAuth-protected access using [Auth for MCP Servers](https://docs.scalekit.com/authenticate/mcp/quickstart).

--- a/src/content/docs/dev-kit/ai-assisted-development/scalekit-mcp-server.mdx
+++ b/src/content/docs/dev-kit/ai-assisted-development/scalekit-mcp-server.mdx
@@ -233,7 +233,7 @@ For Claude Desktop, this is already the default config shown above.
 For Claude Code, run:
 
 ```bash
-claude mcp add scalekit --transport sse https://mcp.scalekit.com/
+claude mcp add scalekit npx -- -y mcp-remote https://mcp.scalekit.com/
 ```
 
 Restart your client after making changes.


### PR DESCRIPTION
## Summary

- Expands the Scalekit MCP server setup page from 3 platforms to all 13 AI coding tools that support MCP
- Each platform gets its own native config (direct URL, CLI command, or tool-specific JSON schema)
- Adds a fallback section explaining how to use \`mcp-remote\` if the native OAuth flow doesn't complete

**Platforms added:** Claude Code, Gemini CLI, Codex, OpenCode, Roo Code, Zed, Kiro, Warp, v0 by Vercel
**Platforms updated:** Cursor and Windsurf now use native URL configs instead of mcp-remote

## Test plan

- [ ] Verify build passes (Netlify preview)
- [ ] Check that all JSON code blocks render correctly
- [ ] Confirm mcp-remote fallback section is clear and actionable

Preview: https://deploy-preview-{PR_NUMBER}--scalekit-starlight.netlify.app/dev-kit/ai-assisted-development/scalekit-mcp-server/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked configuration into a tool-by-tool "connect your AI coding tool" setup with client-specific sections (Claude Code, Claude Desktop, Cursor, Windsurf, Gemini CLI, Codex, OpenCode, Roo Code, Zed, Kiro, Warp, v0).
  * Updated examples to prefer native remote fields (url/httpUrl/serverUrl/type) and retain a package-based fallback when OAuth can't complete.
  * Removed the standalone authentication section, added a pointer to the "Auth for MCP Servers" quickstart, and renamed/streamlined GitHub contribution guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->