### PR TITLE
Rename AgentKit examples title

### DIFF
--- a/scripts/sync-agent-connectors.js
+++ b/scripts/sync-agent-connectors.js
@@ -852,6 +852,14 @@ function generateAuthSection(authPattern, providerName) {
   return `This connector uses **${authPattern.display_name || type}** authentication.`
 }
 
+function generateConnectionSetupGuidance(providerName) {
+  return `Before calling this connector from your code, create the ${providerName} connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.`
+}
+
+function generateToolListGuidance() {
+  return `Use the exact tool names from the **Tool list** below when you call \`execute_tool\`. If you're not sure which name to use, list the tools available for the current user first.`
+}
+
 // ---------------------------------------------------------------------------
 // MDX generation
 // ---------------------------------------------------------------------------
@@ -938,6 +946,8 @@ function generateMdxContent(provider, tools) {
     lines.push('')
     lines.push(generateAuthSection(primaryAuth, providerName))
     lines.push('')
+    lines.push(generateConnectionSetupGuidance(providerName))
+    lines.push('')
   }
   appendSectionComponents(lines, SECTION_ENTRIES, providerSlug, 'after-authentication')
 
@@ -969,6 +979,8 @@ function generateMdxContent(provider, tools) {
   appendSectionComponents(lines, SECTION_ENTRIES, providerSlug, 'before-tool-list')
   if (tools.length > 0) {
     lines.push('## Tool list')
+    lines.push('')
+    lines.push(generateToolListGuidance())
     lines.push('')
     lines.push('<ToolList tools={tools} />')
     lines.push('')

--- a/src/components/templates/agent-connectors/_setup-googlecalendar.mdx
+++ b/src/components/templates/agent-connectors/_setup-googlecalendar.mdx
@@ -32,6 +32,7 @@ Register your Scalekit environment with the Google Calendar connector so Scaleki
 4. ### Add credentials in Scalekit
 
     - In [Scalekit dashboard](https://app.scalekit.com), go to **AgentKit** > **Connections** and open the connection you created.
+    - Copy the **Connection name** shown on that connection and use that exact value in your code as `connection_name` or `connectionName`. It may be something like `meeting-prep-agent-googlecalendar`, not `googlecalendar`.
     - Enter your credentials:
       - Client ID (from above)
       - Client Secret (from above)

--- a/src/components/templates/agent-connectors/_setup-hubspot.mdx
+++ b/src/components/templates/agent-connectors/_setup-hubspot.mdx
@@ -2,16 +2,6 @@ import { Steps } from '@astrojs/starlight/components'
 
 Register your Scalekit environment with the HubSpot connector so Scalekit handles the authentication flow and token lifecycle for you. The connection name you create will be used to identify and invoke the connection programmatically. Then complete the configuration in your application as follows:
 
-Use a HubSpot **Public App**, not a Private App. Private Apps use static API tokens and do not support OAuth redirect flows, so they do not show the Redirect URL field Scalekit needs.
-
-For a read-only CRM enrichment flow that looks up contacts, companies, and deals, configure the same scope strings in both your HubSpot Public App and the Scalekit connection:
-
-```text
-crm.objects.contacts.read
-crm.objects.companies.read
-crm.objects.deals.read
-```
-
 <Steps>
 1. ### Set up auth redirects
 
@@ -19,13 +9,19 @@ crm.objects.deals.read
 
       ![Copy redirect URI from Scalekit dashboard](@/assets/docs/agent-connectors/hubspot/use-own-credentials-redirect-uri.png)
 
-    - Log in to your [HubSpot developer dashboard](https://developers.hubspot.com/), click **Manage apps**, click **Create app**, and select **Public app**. If you already have a HubSpot Public App, open that app instead.
+    - Log in to your [HubSpot developer dashboard](https://developers.hubspot.com/), click **Manage apps**, click **Create app**, and select **Public app**. Do not select **Private app**; Private Apps use static API tokens and do not support OAuth redirect flows, so they do not show the Redirect URL field Scalekit needs. If you already have a HubSpot Public App, open that app instead.
 
     - Go to **Auth** > **Auth settings** > **Redirect URL**, paste the redirect URI from Scalekit, and click **Save**.
 
       ![Adding redirect URL to HubSpot](@/assets/docs/agent-connectors/hubspot/add-redirect-url.png)
 
-    - Under **Auth** > **Auth settings** > **Scopes**, select the required scopes for your application. The scopes you select here must match exactly what you configure in Scalekit.
+    - Under **Auth** > **Auth settings** > **Scopes**, select the required scopes for your application. The scopes you select here must match exactly what you configure in Scalekit. For a read-only CRM enrichment flow that looks up contacts, companies, and deals, use:
+
+      ```text
+      crm.objects.contacts.read
+      crm.objects.companies.read
+      crm.objects.deals.read
+      ```
 
 2. ### Get client credentials
 

--- a/src/components/templates/agent-connectors/_setup-hubspot.mdx
+++ b/src/components/templates/agent-connectors/_setup-hubspot.mdx
@@ -1,6 +1,16 @@
-import { Steps, Aside } from '@astrojs/starlight/components'
+import { Steps } from '@astrojs/starlight/components'
 
 Register your Scalekit environment with the HubSpot connector so Scalekit handles the authentication flow and token lifecycle for you. The connection name you create will be used to identify and invoke the connection programmatically. Then complete the configuration in your application as follows:
+
+Use a HubSpot **Public App**, not a Private App. Private Apps use static API tokens and do not support OAuth redirect flows, so they do not show the Redirect URL field Scalekit needs.
+
+For a read-only CRM enrichment flow that looks up contacts, companies, and deals, configure the same scope strings in both your HubSpot Public App and the Scalekit connection:
+
+```text
+crm.objects.contacts.read
+crm.objects.companies.read
+crm.objects.deals.read
+```
 
 <Steps>
 1. ### Set up auth redirects
@@ -9,7 +19,7 @@ Register your Scalekit environment with the HubSpot connector so Scalekit handle
 
       ![Copy redirect URI from Scalekit dashboard](@/assets/docs/agent-connectors/hubspot/use-own-credentials-redirect-uri.png)
 
-    - Log in to your [HubSpot developer dashboard](https://developers.hubspot.com/), click **Manage apps**, and open your app (or create one if you have not already).
+    - Log in to your [HubSpot developer dashboard](https://developers.hubspot.com/), click **Manage apps**, click **Create app**, and select **Public app**. If you already have a HubSpot Public App, open that app instead.
 
     - Go to **Auth** > **Auth settings** > **Redirect URL**, paste the redirect URI from Scalekit, and click **Save**.
 
@@ -30,11 +40,7 @@ Register your Scalekit environment with the HubSpot connector so Scalekit handle
     - Enter your credentials:
       - **Client ID** (from your HubSpot app)
       - **Client Secret** (from your HubSpot app)
-      - **Permissions** (OAuth scopes — see [HubSpot scopes reference](https://developers.hubspot.com/docs/api/overview))
-
-      <Aside type="caution" title="Scopes must match exactly">
-        The scopes selected in your HubSpot app must exactly match the scopes you enter in Scalekit. A mismatch breaks the OAuth flow.
-      </Aside>
+      - **Permissions** (OAuth scope strings such as `crm.objects.contacts.read`, entered exactly as configured in the HubSpot app)
 
       ![Add credentials in Scalekit dashboard](@/assets/docs/agent-connectors/hubspot/add-credentials.png)
 

--- a/src/components/templates/agent-connectors/_setup-slack.mdx
+++ b/src/components/templates/agent-connectors/_setup-slack.mdx
@@ -1,4 +1,4 @@
-import { Steps, Aside } from '@astrojs/starlight/components'
+import { Steps } from '@astrojs/starlight/components'
 
 Register your Scalekit environment with the Slack connector so Scalekit handles the authentication flow and token lifecycle for you. The connection name you create will be used to identify and invoke the connection programmatically. Then complete the configuration in your application as follows:
 
@@ -30,6 +30,8 @@ Register your Scalekit environment with the Slack connector so Scalekit handles 
 3. ### Add credentials in Scalekit
 
     - In [Scalekit dashboard](https://app.scalekit.com), go to **AgentKit** > **Connections** and open the connection you created.
+
+    Choose **Bot scope** for most agents, including agents that read channel history or send messages as your Slack app. Bot scope makes the agent act as the Slack app or bot; use **User scope** only when the agent must act as the authorizing Slack user.
 
     - Enter your credentials:
       - Client ID

--- a/src/components/templates/agent-connectors/_setup-slack.mdx
+++ b/src/components/templates/agent-connectors/_setup-slack.mdx
@@ -21,7 +21,13 @@ Register your Scalekit environment with the Slack connector so Scalekit handles 
 
 2. ### Enable distribution
 
-    - In your Slack app settings, go to **Manage Distribution** and enable it.
+    - In your Slack app settings, go to **Manage Distribution**.
+
+    - Under **Share Your App with Other Workspaces**, complete the checklist Slack shows for your app. This can include accepting Slack's distribution agreement, adding support and privacy URLs, and confirming that the redirect URL you added above is valid.
+
+    - Click **Activate Public Distribution**.
+
+      Slack app distribution must be active before users can authorize the app from external workspaces. If distribution is not active, OAuth can succeed in your development workspace but fail when a user tries to connect a second workspace.
 
       ![Enable Slack app distribution](@/assets/docs/agent-connectors/slack/enable-distribution.png)
 

--- a/src/components/templates/agent-connectors/_usage-brave-search.mdx
+++ b/src/components/templates/agent-connectors/_usage-brave-search.mdx
@@ -268,6 +268,7 @@ scalekit_client = ScalekitClient(
 tools = scalekit_client.actions.langchain.get_tools(
     providers=["BRAVE_SEARCH"],
     identifier="user_123",
+    page_size=100,  # avoid missing tools when a connector has more than the default page
 )
 
 llm = ChatAnthropic(

--- a/src/components/templates/agent-connectors/_usage-exa.mdx
+++ b/src/components/templates/agent-connectors/_usage-exa.mdx
@@ -311,7 +311,7 @@ actions.get_or_create_connected_account(
     identifier=identifier
 )
 
-# Load all Exa tools in LangChain format
+# Load all Exa tools in LangChain format. Use page_size=100 so connector tool lists are not truncated.
 tools = actions.langchain.get_tools(
     identifier=identifier,
     providers=["EXA"],

--- a/src/components/templates/agent-connectors/_usage-gmail.mdx
+++ b/src/components/templates/agent-connectors/_usage-gmail.mdx
@@ -2,6 +2,67 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Gmail account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+## Discover tool names
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for this Gmail connection first.
+
+<Tabs syncKey="tech-stack">
+  <TabItem label="Node.js">
+    ```typescript
+    import { ScalekitClient } from '@scalekit-sdk/node';
+    import 'dotenv/config';
+
+    const connectionName = 'your-gmail-connection'; // copy the exact Connection name from AgentKit > Connections
+    const identifier = 'user_123'; // your unique user identifier
+
+    const scalekit = new ScalekitClient(
+      process.env.SCALEKIT_ENV_URL,
+      process.env.SCALEKIT_CLIENT_ID,
+      process.env.SCALEKIT_CLIENT_SECRET
+    );
+
+    const { tools } = await scalekit.tools.listScopedTools(identifier, {
+      filter: { connectionNames: [connectionName] },
+      pageSize: 100,
+    });
+
+    for (const tool of tools) {
+      console.log('Available tool:', tool.tool.definition.name);
+    }
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    import os
+    import scalekit.client
+    from dotenv import load_dotenv
+    from google.protobuf.json_format import MessageToDict
+
+    load_dotenv()
+
+    connection_name = "your-gmail-connection"  # copy the exact Connection name from AgentKit > Connections
+    identifier = "user_123"  # your unique user identifier
+
+    scalekit_client = scalekit.client.ScalekitClient(
+        client_id=os.getenv("SCALEKIT_CLIENT_ID"),
+        client_secret=os.getenv("SCALEKIT_CLIENT_SECRET"),
+        env_url=os.getenv("SCALEKIT_ENV_URL"),
+    )
+    actions = scalekit_client.actions
+
+    scoped_response, _ = actions.tools.list_scoped_tools(
+        identifier=identifier,
+        filter={"connection_names": [connection_name]},
+        page_size=100,
+    )
+
+    for scoped_tool in scoped_response.tools:
+        definition = MessageToDict(scoped_tool.tool).get("definition", {})
+        print("Available tool:", definition.get("name"))
+    ```
+  </TabItem>
+</Tabs>
+
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
@@ -77,4 +138,3 @@ Connect a user's Gmail account and make API calls on their behalf — Scalekit h
     ```
   </TabItem>
 </Tabs>
-

--- a/src/components/templates/agent-connectors/_usage-gmail.mdx
+++ b/src/components/templates/agent-connectors/_usage-gmail.mdx
@@ -64,6 +64,66 @@ Use the exact tool names from the **Tool list** below when you call `execute_too
   </TabItem>
 </Tabs>
 
+## Use Gmail response fields as returned
+
+Response fields from Gmail tools use camelCase, such as `threadId`, `messageId`, and `internalDate`. Tool input parameters use the snake_case names shown in the Tool list, such as `thread_id` and `message_id`. Extract values with camelCase, then pass them with snake_case. The snippets below assume you already have an active connected account ID for the user.
+
+<Tabs syncKey="tech-stack">
+  <TabItem label="Node.js">
+    ```typescript
+    const fetchResponse = await actions.executeTool({
+      toolName: 'gmail_fetch_mails',
+      connectedAccountId,
+      toolInput: {
+        query: 'is:unread',
+        max_results: 5,
+      },
+    });
+
+    const messages = Array.isArray(fetchResponse.data?.messages)
+      ? fetchResponse.data.messages
+      : [];
+    const threadId = typeof messages[0]?.threadId === 'string' ? messages[0].threadId : '';
+
+    const threadResponse = await actions.executeTool({
+      toolName: 'gmail_get_thread_by_id',
+      connectedAccountId,
+      toolInput: {
+        thread_id: threadId,
+      },
+    });
+
+    console.log(threadResponse.data);
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    fetch_response = actions.execute_tool(
+        tool_name="gmail_fetch_mails",
+        connected_account_id=connected_account.id,
+        tool_input={
+            "query": "is:unread",
+            "max_results": 5,
+        },
+    )
+
+    data = fetch_response.data or {}
+    messages = data.get("messages", [])
+    thread_id = messages[0].get("threadId", "") if messages else ""
+
+    thread_response = actions.execute_tool(
+        tool_name="gmail_get_thread_by_id",
+        connected_account_id=connected_account.id,
+        tool_input={
+            "thread_id": thread_id,
+        },
+    )
+
+    print(thread_response.data)
+    ```
+  </TabItem>
+</Tabs>
+
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">

--- a/src/components/templates/agent-connectors/_usage-gmail.mdx
+++ b/src/components/templates/agent-connectors/_usage-gmail.mdx
@@ -37,6 +37,7 @@ Use the exact tool names from the **Tool list** below when you call `execute_too
     import scalekit.client
     from dotenv import load_dotenv
     from google.protobuf.json_format import MessageToDict
+    from scalekit.v1.tools.tools_pb2 import ScopedToolFilter
 
     load_dotenv()
 
@@ -52,7 +53,7 @@ Use the exact tool names from the **Tool list** below when you call `execute_too
 
     scoped_response, _ = actions.tools.list_scoped_tools(
         identifier=identifier,
-        filter={"connection_names": [connection_name]},
+        filter=ScopedToolFilter(connection_names=[connection_name]),
         page_size=100,
     )
 

--- a/src/components/templates/agent-connectors/_usage-gmail.mdx
+++ b/src/components/templates/agent-connectors/_usage-gmail.mdx
@@ -26,8 +26,8 @@ Use the exact tool names from the **Tool list** below when you call `execute_too
       pageSize: 100,
     });
 
-    for (const tool of tools) {
-      console.log('Available tool:', tool.tool.definition.name);
+    for (const scopedTool of tools) {
+      console.log('Available tool:', scopedTool.tool?.definition?.name);
     }
     ```
   </TabItem>

--- a/src/components/templates/agent-connectors/_usage-googlecalendar.mdx
+++ b/src/components/templates/agent-connectors/_usage-googlecalendar.mdx
@@ -2,16 +2,19 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 Connect a user's Google Calendar account and make API calls on their behalf — Scalekit handles OAuth and token management automatically.
 
+Before running this code, create the Google Calendar connection in **AgentKit** > **Connections** in the Scalekit dashboard and copy its exact **Connection name** into the `connection_name` or `connectionName` variable below.
+
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">
   <TabItem label="Node.js">
     ```typescript
     import { ScalekitClient } from '@scalekit-sdk/node';
+    import { ConnectorStatus } from '@scalekit-sdk/node/lib/pkg/grpc/scalekit/v1/connected_accounts/connected_accounts_pb';
     import 'dotenv/config';
 
-    const connectionName = 'googlecalendar'; // get your connection name from connection configurations
-    const identifier = 'user_123';           // your unique user identifier
+    const connectionName = 'meeting-prep-agent-googlecalendar'; // copy the exact Connection name from AgentKit > Connections
+    const identifier = 'user_123'; // your unique user identifier
 
     // Get your credentials from app.scalekit.com → Developers → Settings → API Credentials
     const scalekit = new ScalekitClient(
@@ -21,14 +24,22 @@ Connect a user's Google Calendar account and make API calls on their behalf — 
     );
     const actions = scalekit.actions;
 
-    // Authenticate the user
-    const { link } = await actions.getAuthorizationLink({
+    // Create or fetch the connected account first
+    const response = await actions.getOrCreateConnectedAccount({
       connectionName,
       identifier,
     });
-    console.log('🔗 Authorize Google Calendar:', link); // present this link to your user for authorization, or click it yourself for testing
-    process.stdout.write('Press Enter after authorizing...');
-    await new Promise(r => process.stdin.once('data', r));
+    const connectedAccount = response.connectedAccount;
+
+    if (connectedAccount?.status !== ConnectorStatus.ACTIVE) {
+      const { link } = await actions.getAuthorizationLink({
+        connectionName,
+        identifier,
+      });
+      console.log('🔗 Authorize Google Calendar:', link); // present this link to your user for authorization, or click it yourself for testing
+      process.stdout.write('Press Enter after authorizing...');
+      await new Promise(r => process.stdin.once('data', r));
+    }
 
     // Make a request via Scalekit proxy
     const result = await actions.request({
@@ -46,8 +57,8 @@ Connect a user's Google Calendar account and make API calls on their behalf — 
     from dotenv import load_dotenv
     load_dotenv()
 
-    connection_name = "googlecalendar"  # get your connection name from connection configurations
-    identifier = "user_123"             # your unique user identifier
+    connection_name = "meeting-prep-agent-googlecalendar"  # copy the exact Connection name from AgentKit > Connections
+    identifier = "user_123"  # your unique user identifier
 
     # Get your credentials from app.scalekit.com → Developers → Settings → API Credentials
     scalekit_client = scalekit.client.ScalekitClient(
@@ -57,14 +68,21 @@ Connect a user's Google Calendar account and make API calls on their behalf — 
     )
     actions = scalekit_client.actions
 
-    # Authenticate the user
-    link_response = actions.get_authorization_link(
+    # Create or fetch the connected account first
+    response = actions.get_or_create_connected_account(
         connection_name=connection_name,
         identifier=identifier
     )
-    # present this link to your user for authorization, or click it yourself for testing
-    print("🔗 Authorize Google Calendar:", link_response.link)
-    input("Press Enter after authorizing...")
+    connected_account = response.connected_account
+
+    if connected_account.status != "ACTIVE":
+        link_response = actions.get_authorization_link(
+            connection_name=connection_name,
+            identifier=identifier
+        )
+        # present this link to your user for authorization, or click it yourself for testing
+        print("🔗 Authorize Google Calendar:", link_response.link)
+        input("Press Enter after authorizing...")
 
     # Make a request via Scalekit proxy
     result = actions.request(
@@ -77,4 +95,3 @@ Connect a user's Google Calendar account and make API calls on their behalf — 
     ```
   </TabItem>
 </Tabs>
-

--- a/src/components/templates/agent-connectors/_usage-googlecalendar.mdx
+++ b/src/components/templates/agent-connectors/_usage-googlecalendar.mdx
@@ -66,6 +66,70 @@ Use the exact tool names from the **Tool list** below when you call `execute_too
   </TabItem>
 </Tabs>
 
+## Execute tools
+
+After the Google Calendar connected account is active, call the exact tool name and read the tool payload from `response.data`. For `googlecalendar_list_events`, the events array is inside `response.data["events"]`; the top-level response object is only the SDK wrapper.
+
+<Tabs syncKey="tech-stack">
+  <TabItem label="Node.js">
+    ```typescript
+    const accountResponse = await actions.getOrCreateConnectedAccount({
+      connectionName,
+      identifier,
+    });
+    const connectedAccountId = accountResponse.connectedAccount?.id;
+
+    if (!connectedAccountId) {
+      throw new Error('Authorize the Google Calendar connection before listing events.');
+    }
+
+    const response = await actions.executeTool({
+      toolName: 'googlecalendar_list_events',
+      connectedAccountId,
+      toolInput: {
+        calendar_id: 'primary',
+        max_results: 10,
+      },
+    });
+
+    const events = Array.isArray(response.data?.events) ? response.data.events : [];
+    const nextPageToken =
+      typeof response.data?.next_page_token === 'string' ? response.data.next_page_token : '';
+
+    console.log('Events returned:', events.length);
+    console.log('Next page token:', nextPageToken);
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    account_response = actions.get_or_create_connected_account(
+        connection_name=connection_name,
+        identifier=identifier,
+    )
+    connected_account = account_response.connected_account
+
+    if not connected_account.id:
+        raise RuntimeError("Authorize the Google Calendar connection before listing events.")
+
+    response = actions.execute_tool(
+        tool_name="googlecalendar_list_events",
+        connected_account_id=connected_account.id,
+        tool_input={
+            "calendar_id": "primary",
+            "max_results": 10,
+        },
+    )
+
+    data = response.data or {}
+    events = data.get("events", [])
+    next_page_token = data.get("next_page_token", "")
+
+    print("Events returned:", len(events))
+    print("Next page token:", next_page_token)
+    ```
+  </TabItem>
+</Tabs>
+
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">

--- a/src/components/templates/agent-connectors/_usage-googlecalendar.mdx
+++ b/src/components/templates/agent-connectors/_usage-googlecalendar.mdx
@@ -4,6 +4,67 @@ Connect a user's Google Calendar account and make API calls on their behalf — 
 
 Before running this code, create the Google Calendar connection in **AgentKit** > **Connections** in the Scalekit dashboard and copy its exact **Connection name** into the `connection_name` or `connectionName` variable below.
 
+## Discover tool names
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for this Google Calendar connection first.
+
+<Tabs syncKey="tech-stack">
+  <TabItem label="Node.js">
+    ```typescript
+    import { ScalekitClient } from '@scalekit-sdk/node';
+    import 'dotenv/config';
+
+    const connectionName = 'meeting-prep-agent-googlecalendar'; // copy the exact Connection name from AgentKit > Connections
+    const identifier = 'user_123'; // your unique user identifier
+
+    const scalekit = new ScalekitClient(
+      process.env.SCALEKIT_ENV_URL,
+      process.env.SCALEKIT_CLIENT_ID,
+      process.env.SCALEKIT_CLIENT_SECRET
+    );
+
+    const { tools } = await scalekit.tools.listScopedTools(identifier, {
+      filter: { connectionNames: [connectionName] },
+      pageSize: 100,
+    });
+
+    for (const tool of tools) {
+      console.log('Available tool:', tool.tool.definition.name);
+    }
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    import os
+    import scalekit.client
+    from dotenv import load_dotenv
+    from google.protobuf.json_format import MessageToDict
+
+    load_dotenv()
+
+    connection_name = "meeting-prep-agent-googlecalendar"  # copy the exact Connection name from AgentKit > Connections
+    identifier = "user_123"  # your unique user identifier
+
+    scalekit_client = scalekit.client.ScalekitClient(
+        client_id=os.getenv("SCALEKIT_CLIENT_ID"),
+        client_secret=os.getenv("SCALEKIT_CLIENT_SECRET"),
+        env_url=os.getenv("SCALEKIT_ENV_URL"),
+    )
+    actions = scalekit_client.actions
+
+    scoped_response, _ = actions.tools.list_scoped_tools(
+        identifier=identifier,
+        filter={"connection_names": [connection_name]},
+        page_size=100,
+    )
+
+    for scoped_tool in scoped_response.tools:
+        definition = MessageToDict(scoped_tool.tool).get("definition", {})
+        print("Available tool:", definition.get("name"))
+    ```
+  </TabItem>
+</Tabs>
+
 ## Proxy API Calls
 
 <Tabs syncKey="tech-stack">

--- a/src/components/templates/agent-connectors/_usage-googlecalendar.mdx
+++ b/src/components/templates/agent-connectors/_usage-googlecalendar.mdx
@@ -39,6 +39,7 @@ Use the exact tool names from the **Tool list** below when you call `execute_too
     import scalekit.client
     from dotenv import load_dotenv
     from google.protobuf.json_format import MessageToDict
+    from scalekit.v1.tools.tools_pb2 import ScopedToolFilter
 
     load_dotenv()
 
@@ -54,7 +55,7 @@ Use the exact tool names from the **Tool list** below when you call `execute_too
 
     scoped_response, _ = actions.tools.list_scoped_tools(
         identifier=identifier,
-        filter={"connection_names": [connection_name]},
+        filter=ScopedToolFilter(connection_names=[connection_name]),
         page_size=100,
     )
 

--- a/src/components/templates/agent-connectors/_usage-googlecalendar.mdx
+++ b/src/components/templates/agent-connectors/_usage-googlecalendar.mdx
@@ -28,8 +28,8 @@ Use the exact tool names from the **Tool list** below when you call `execute_too
       pageSize: 100,
     });
 
-    for (const tool of tools) {
-      console.log('Available tool:', tool.tool.definition.name);
+    for (const scopedTool of tools) {
+      console.log('Available tool:', scopedTool.tool?.definition?.name);
     }
     ```
   </TabItem>

--- a/src/components/templates/agent-connectors/_usage-heyreach.mdx
+++ b/src/components/templates/agent-connectors/_usage-heyreach.mdx
@@ -231,7 +231,7 @@ actions.get_or_create_connected_account(
     identifier=identifier
 )
 
-# Load all HeyReach tools in LangChain format
+# Load all HeyReach tools in LangChain format. Use page_size=100 so connector tool lists are not truncated.
 tools = actions.langchain.get_tools(
     identifier=identifier,
     providers=["HEYREACH"],

--- a/src/components/templates/agent-connectors/_usage-phantombuster.mdx
+++ b/src/components/templates/agent-connectors/_usage-phantombuster.mdx
@@ -270,7 +270,7 @@ actions.get_or_create_connected_account(
     identifier=identifier
 )
 
-# Load all PhantomBuster tools in LangChain format
+# Load all PhantomBuster tools in LangChain format. Use page_size=100 so connector tool lists are not truncated.
 tools = actions.langchain.get_tools(
     identifier=identifier,
     providers=["PHANTOMBUSTER"],

--- a/src/components/templates/agent-connectors/_usage-slack.mdx
+++ b/src/components/templates/agent-connectors/_usage-slack.mdx
@@ -38,6 +38,10 @@ Connect a user's Slack account and make API calls on their behalf — Scalekit h
       method: 'POST',
     });
     console.log(result);
+
+    // If you use slack_fetch_conversation_history, message text can contain
+    // Slack mention tokens like <@U09NZ1V7KPF>. Resolve the user ID with
+    // slack_get_user_info before showing messages to end users.
     ```
   </TabItem>
   <TabItem label="Python">
@@ -74,7 +78,10 @@ Connect a user's Slack account and make API calls on their behalf — Scalekit h
         method="POST"
     )
     print(result)
+
+    # If you use slack_fetch_conversation_history, message text can contain
+    # Slack mention tokens like <@U09NZ1V7KPF>. Resolve the user ID with
+    # slack_get_user_info before showing messages to end users.
     ```
   </TabItem>
 </Tabs>
-

--- a/src/configs/redirects.config.ts
+++ b/src/configs/redirects.config.ts
@@ -379,8 +379,12 @@ export const redirects = {
 
   // Legacy framework pages moved to /agentkit/examples/
   '/agentkit/frameworks': '/agentkit/examples/',
+  '/agentkit/frameworks/anthropic': '/agentkit/examples/anthropic/',
   '/agentkit/frameworks/langchain': '/agentkit/examples/langchain/',
   '/agentkit/frameworks/google-adk': '/agentkit/examples/google-adk/',
+  '/agentkit/frameworks/mastra': '/agentkit/examples/mastra/',
+  '/agentkit/frameworks/openai': '/agentkit/examples/openai/',
+  '/agentkit/frameworks/vercel-ai': '/agentkit/examples/vercel-ai/',
 
   // Agent connectors redirects
   '/reference/agent-connectors/[...slug]': '/agentkit/connectors/[...slug]',

--- a/src/configs/redirects.config.ts
+++ b/src/configs/redirects.config.ts
@@ -378,6 +378,7 @@ export const redirects = {
     '/agentkit/bring-your-own-connector/making-tool-calls/',
 
   // Legacy framework pages moved to /agentkit/examples/
+  '/agentkit/frameworks': '/agentkit/examples/',
   '/agentkit/frameworks/langchain': '/agentkit/examples/langchain/',
   '/agentkit/frameworks/google-adk': '/agentkit/examples/google-adk/',
 

--- a/src/configs/redirects.config.ts
+++ b/src/configs/redirects.config.ts
@@ -379,9 +379,7 @@ export const redirects = {
 
   // Legacy framework pages moved to /agentkit/examples/
   '/agentkit/frameworks/langchain': '/agentkit/examples/langchain/',
-  '/agentkit/frameworks/langchain/': '/agentkit/examples/langchain/',
   '/agentkit/frameworks/google-adk': '/agentkit/examples/google-adk/',
-  '/agentkit/frameworks/google-adk/': '/agentkit/examples/google-adk/',
 
   // Agent connectors redirects
   '/reference/agent-connectors/[...slug]': '/agentkit/connectors/[...slug]',

--- a/src/configs/redirects.config.ts
+++ b/src/configs/redirects.config.ts
@@ -377,6 +377,12 @@ export const redirects = {
   '/agentkit/bring-your-own-connector/using-tool-proxy':
     '/agentkit/bring-your-own-connector/making-tool-calls/',
 
+  // Legacy framework pages moved to /agentkit/examples/
+  '/agentkit/frameworks/langchain': '/agentkit/examples/langchain/',
+  '/agentkit/frameworks/langchain/': '/agentkit/examples/langchain/',
+  '/agentkit/frameworks/google-adk': '/agentkit/examples/google-adk/',
+  '/agentkit/frameworks/google-adk/': '/agentkit/examples/google-adk/',
+
   // Agent connectors redirects
   '/reference/agent-connectors/[...slug]': '/agentkit/connectors/[...slug]',
   '/reference/agent-connectors': '/agentkit/connectors/',

--- a/src/content/docs/agentkit/connected-accounts.mdx
+++ b/src/content/docs/agentkit/connected-accounts.mdx
@@ -31,10 +31,12 @@ A **connected account** is the per-user record that holds a user's credentials a
 
 ## Check account status
 
+Use `get_or_create_connected_account` as the safe default when a user may be connecting for the first time. Use `get_connected_account` only when you know the account already exists and you need to inspect or return its stored auth details.
+
 <Tabs syncKey="tech-stack">
   <TabItem label="Python">
 ```python
-response = actions.get_connected_account(
+response = actions.get_or_create_connected_account(
     connection_name="gmail",
     identifier="user_123"
 )
@@ -44,7 +46,7 @@ print(f"Status: {connected_account.status}")
   </TabItem>
   <TabItem label="Node.js">
 ```typescript
-const response = await actions.getConnectedAccount({
+const response = await actions.getOrCreateConnectedAccount({
   connectionName: 'gmail',
   identifier: 'user_123',
 });

--- a/src/content/docs/agentkit/connectors/affinity.mdx
+++ b/src/content/docs/agentkit/connectors/affinity.mdx
@@ -29,6 +29,10 @@ Connect this agent connector to let your agent:
 
 This connector uses **Bearer Token** authentication. Scalekit securely stores the token and injects it into API requests on behalf of your users. Your agent code never handles tokens directly — you only pass a `connectionName` and a user `identifier`.
 
+Before calling this connector from your code, create the Affinity connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/airtable.mdx
+++ b/src/content/docs/agentkit/connectors/airtable.mdx
@@ -23,6 +23,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Airtable **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Airtable connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 

--- a/src/content/docs/agentkit/connectors/apifymcp.mdx
+++ b/src/content/docs/agentkit/connectors/apifymcp.mdx
@@ -31,6 +31,8 @@ Connect this agent connector to let your agent:
 
 This connector uses **Bearer Token** authentication. Scalekit securely stores the token and injects it into API requests on behalf of your users. Your agent code never handles tokens directly — you only pass a `connectionName` and a user `identifier`.
 
+Before calling this connector from your code, create the Apify MCP connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -46,5 +48,7 @@ This connector uses **Bearer Token** authentication. Scalekit securely stores th
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/apollo.mdx
+++ b/src/content/docs/agentkit/connectors/apollo.mdx
@@ -34,6 +34,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Apollo **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Apollo connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -49,5 +51,7 @@ You supply your Apollo **Connected App** credentials (Client ID + Secret) once p
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/asana.mdx
+++ b/src/content/docs/agentkit/connectors/asana.mdx
@@ -23,6 +23,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Asana **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Asana connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 

--- a/src/content/docs/agentkit/connectors/attio.mdx
+++ b/src/content/docs/agentkit/connectors/attio.mdx
@@ -34,6 +34,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Attio **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Attio connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -49,5 +51,7 @@ You supply your Attio **Connected App** credentials (Client ID + Secret) once pe
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/bigquery.mdx
+++ b/src/content/docs/agentkit/connectors/bigquery.mdx
@@ -23,6 +23,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Google BigQuery **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Google BigQuery connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 

--- a/src/content/docs/agentkit/connectors/bigqueryserviceaccount.mdx
+++ b/src/content/docs/agentkit/connectors/bigqueryserviceaccount.mdx
@@ -31,6 +31,8 @@ Connect this agent connector to let your agent:
 
 This connector uses **Service Account** authentication.
 
+Before calling this connector from your code, create the BigQuery (Service Account) connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -46,5 +48,7 @@ This connector uses **Service Account** authentication.
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/bitbucket.mdx
+++ b/src/content/docs/agentkit/connectors/bitbucket.mdx
@@ -34,6 +34,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Bitbucket **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Bitbucket connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -49,5 +51,7 @@ You supply your Bitbucket **Connected App** credentials (Client ID + Secret) onc
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/box.mdx
+++ b/src/content/docs/agentkit/connectors/box.mdx
@@ -34,6 +34,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Box **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Box connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -49,5 +51,7 @@ You supply your Box **Connected App** credentials (Client ID + Secret) once per 
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/brave.mdx
+++ b/src/content/docs/agentkit/connectors/brave.mdx
@@ -30,6 +30,10 @@ Connect this agent connector to let your agent:
 
 This connector uses **API Key** authentication. Your users provide their Brave Search API key once, and Scalekit stores and manages it securely. Your agent code never handles keys directly — you only pass a `connectionName` and a user `identifier`.
 
+Before calling this connector from your code, create the Brave Search connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/calendly.mdx
+++ b/src/content/docs/agentkit/connectors/calendly.mdx
@@ -34,6 +34,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Calendly **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Calendly connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -49,5 +51,7 @@ You supply your Calendly **Connected App** credentials (Client ID + Secret) once
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/clickup.mdx
+++ b/src/content/docs/agentkit/connectors/clickup.mdx
@@ -23,6 +23,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your ClickUp **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the ClickUp connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 

--- a/src/content/docs/agentkit/connectors/close.mdx
+++ b/src/content/docs/agentkit/connectors/close.mdx
@@ -34,6 +34,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Close **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Close connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -49,5 +51,7 @@ You supply your Close **Connected App** credentials (Client ID + Secret) once pe
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/confluence.mdx
+++ b/src/content/docs/agentkit/connectors/confluence.mdx
@@ -23,6 +23,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Confluence **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Confluence connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 

--- a/src/content/docs/agentkit/connectors/databricksworkspace.mdx
+++ b/src/content/docs/agentkit/connectors/databricksworkspace.mdx
@@ -30,6 +30,10 @@ Connect this agent connector to let your agent:
 
 This connector uses **Service Principal (OAuth 2.0)** authentication.
 
+Before calling this connector from your code, create the Databricks Workspace connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/diarize.mdx
+++ b/src/content/docs/agentkit/connectors/diarize.mdx
@@ -29,6 +29,8 @@ Connect this agent connector to let your agent:
 
 This connector uses **Bearer Token** authentication. Scalekit securely stores the token and injects it into API requests on behalf of your users. Your agent code never handles tokens directly — you only pass a `connectionName` and a user `identifier`.
 
+Before calling this connector from your code, create the Diarize connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -44,5 +46,7 @@ This connector uses **Bearer Token** authentication. Scalekit securely stores th
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/discord.mdx
+++ b/src/content/docs/agentkit/connectors/discord.mdx
@@ -32,6 +32,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Discord **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Discord connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -47,5 +49,7 @@ You supply your Discord **Connected App** credentials (Client ID + Secret) once 
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/dropbox.mdx
+++ b/src/content/docs/agentkit/connectors/dropbox.mdx
@@ -23,6 +23,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Dropbox **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Dropbox connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 

--- a/src/content/docs/agentkit/connectors/dynamo.mdx
+++ b/src/content/docs/agentkit/connectors/dynamo.mdx
@@ -30,6 +30,10 @@ Connect this agent connector to let your agent:
 
 This connector uses **Bearer Token** authentication. Scalekit securely stores the token and injects it into API requests on behalf of your users. Your agent code never handles tokens directly — you only pass a `connectionName` and a user `identifier`.
 
+Before calling this connector from your code, create the Dynamo Software connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/evertrace.mdx
+++ b/src/content/docs/agentkit/connectors/evertrace.mdx
@@ -30,6 +30,10 @@ Connect this agent connector to let your agent:
 
 This connector uses **Bearer Token** authentication. Scalekit securely stores the token and injects it into API requests on behalf of your users. Your agent code never handles tokens directly — you only pass a `connectionName` and a user `identifier`.
 
+Before calling this connector from your code, create the Evertrace AI connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/exa.mdx
+++ b/src/content/docs/agentkit/connectors/exa.mdx
@@ -32,6 +32,8 @@ Connect this agent connector to let your agent:
 
 This connector uses **API Key** authentication. Your users provide their Exa API key once, and Scalekit stores and manages it securely. Your agent code never handles keys directly — you only pass a `connectionName` and a user `identifier`.
 
+Before calling this connector from your code, create the Exa connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -47,5 +49,7 @@ This connector uses **API Key** authentication. Your users provide their Exa API
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/figma.mdx
+++ b/src/content/docs/agentkit/connectors/figma.mdx
@@ -34,6 +34,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Figma **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Figma connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -49,5 +51,7 @@ You supply your Figma **Connected App** credentials (Client ID + Secret) once pe
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/freshdesk.mdx
+++ b/src/content/docs/agentkit/connectors/freshdesk.mdx
@@ -38,6 +38,10 @@ This connector uses **Basic Auth** authentication.
 
 </details>
 
+Before calling this connector from your code, create the Freshdesk connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/github.mdx
+++ b/src/content/docs/agentkit/connectors/github.mdx
@@ -33,6 +33,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Github **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Github connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -48,5 +50,7 @@ You supply your Github **Connected App** credentials (Client ID + Secret) once p
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/gitlab.mdx
+++ b/src/content/docs/agentkit/connectors/gitlab.mdx
@@ -33,6 +33,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your GitLab **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the GitLab connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -41,5 +43,7 @@ You supply your GitLab **Connected App** credentials (Client ID + Secret) once p
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/gmail.mdx
+++ b/src/content/docs/agentkit/connectors/gmail.mdx
@@ -33,6 +33,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Gmail **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Gmail connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -48,5 +50,7 @@ You supply your Gmail **Connected App** credentials (Client ID + Secret) once pe
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/gong.mdx
+++ b/src/content/docs/agentkit/connectors/gong.mdx
@@ -34,6 +34,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Gong **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Gong connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -49,5 +51,7 @@ You supply your Gong **Connected App** credentials (Client ID + Secret) once per
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/google_ads.mdx
+++ b/src/content/docs/agentkit/connectors/google_ads.mdx
@@ -23,6 +23,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Google Ads **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Google Ads connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 

--- a/src/content/docs/agentkit/connectors/googlecalendar.mdx
+++ b/src/content/docs/agentkit/connectors/googlecalendar.mdx
@@ -33,6 +33,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Google Calendar **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before running the code examples below, create the Google Calendar connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 

--- a/src/content/docs/agentkit/connectors/googlecalendar.mdx
+++ b/src/content/docs/agentkit/connectors/googlecalendar.mdx
@@ -33,7 +33,7 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Google Calendar **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
-Before running the code examples below, create the Google Calendar connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+Before calling this connector from your code, create the Google Calendar connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
 
 <details>
 <summary>Set up the connector</summary>
@@ -50,5 +50,7 @@ Before running the code examples below, create the Google Calendar connection in
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/googledocs.mdx
+++ b/src/content/docs/agentkit/connectors/googledocs.mdx
@@ -32,6 +32,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Google Docs **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Google Docs connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -47,5 +49,7 @@ You supply your Google Docs **Connected App** credentials (Client ID + Secret) o
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/googledrive.mdx
+++ b/src/content/docs/agentkit/connectors/googledrive.mdx
@@ -30,6 +30,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Google Drive **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Google Drive connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -45,5 +47,7 @@ You supply your Google Drive **Connected App** credentials (Client ID + Secret) 
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/googleforms.mdx
+++ b/src/content/docs/agentkit/connectors/googleforms.mdx
@@ -31,6 +31,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Google Forms **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Google Forms connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -46,5 +48,7 @@ You supply your Google Forms **Connected App** credentials (Client ID + Secret) 
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/googlemeet.mdx
+++ b/src/content/docs/agentkit/connectors/googlemeet.mdx
@@ -23,6 +23,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Google Meet **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Google Meet connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 

--- a/src/content/docs/agentkit/connectors/googlesheets.mdx
+++ b/src/content/docs/agentkit/connectors/googlesheets.mdx
@@ -33,6 +33,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Google Sheets **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Google Sheets connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -48,5 +50,7 @@ You supply your Google Sheets **Connected App** credentials (Client ID + Secret)
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/googleslides.mdx
+++ b/src/content/docs/agentkit/connectors/googleslides.mdx
@@ -30,6 +30,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Google Slides **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Google Slides connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -45,5 +47,7 @@ You supply your Google Slides **Connected App** credentials (Client ID + Secret)
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/granola.mdx
+++ b/src/content/docs/agentkit/connectors/granola.mdx
@@ -26,6 +26,10 @@ Connect this agent connector to let your agent:
 
 This connector uses **Bearer Token** authentication. Scalekit securely stores the token and injects it into API requests on behalf of your users. Your agent code never handles tokens directly — you only pass a `connectionName` and a user `identifier`.
 
+Before calling this connector from your code, create the Granola connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/granolamcp.mdx
+++ b/src/content/docs/agentkit/connectors/granolamcp.mdx
@@ -37,6 +37,10 @@ You supply your Granola MCP **Connected App** credentials (Client ID + Secret) o
 
 </details>
 
+Before calling this connector from your code, create the Granola MCP connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/harvestapi.mdx
+++ b/src/content/docs/agentkit/connectors/harvestapi.mdx
@@ -32,6 +32,8 @@ Connect this agent connector to let your agent:
 
 This connector uses **API Key** authentication. Your users provide their HarvestAPI API key once, and Scalekit stores and manages it securely. Your agent code never handles keys directly — you only pass a `connectionName` and a user `identifier`.
 
+Before calling this connector from your code, create the HarvestAPI connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -47,5 +49,7 @@ This connector uses **API Key** authentication. Your users provide their Harvest
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/heyreach.mdx
+++ b/src/content/docs/agentkit/connectors/heyreach.mdx
@@ -35,6 +35,8 @@ Connect this agent connector to let your agent:
 
 This connector uses **API Key** authentication. Your users provide their HeyReach API key once, and Scalekit stores and manages it securely. Your agent code never handles keys directly — you only pass a `connectionName` and a user `identifier`.
 
+Before calling this connector from your code, create the HeyReach connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -50,5 +52,7 @@ This connector uses **API Key** authentication. Your users provide their HeyReac
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/hubspot.mdx
+++ b/src/content/docs/agentkit/connectors/hubspot.mdx
@@ -40,6 +40,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your HubSpot **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the HubSpot connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -55,5 +57,7 @@ You supply your HubSpot **Connected App** credentials (Client ID + Secret) once 
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/intercom.mdx
+++ b/src/content/docs/agentkit/connectors/intercom.mdx
@@ -23,6 +23,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Intercom **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Intercom connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 

--- a/src/content/docs/agentkit/connectors/jiminny.mdx
+++ b/src/content/docs/agentkit/connectors/jiminny.mdx
@@ -31,6 +31,8 @@ Connect this agent connector to let your agent:
 
 This connector uses **Bearer Token** authentication. Scalekit securely stores the token and injects it into API requests on behalf of your users. Your agent code never handles tokens directly — you only pass a `connectionName` and a user `identifier`.
 
+Before calling this connector from your code, create the Jiminny connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -39,5 +41,7 @@ This connector uses **Bearer Token** authentication. Scalekit securely stores th
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/jira.mdx
+++ b/src/content/docs/agentkit/connectors/jira.mdx
@@ -32,6 +32,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Jira **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Jira connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -47,5 +49,7 @@ You supply your Jira **Connected App** credentials (Client ID + Secret) once per
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/linear.mdx
+++ b/src/content/docs/agentkit/connectors/linear.mdx
@@ -32,6 +32,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Linear **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Linear connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -47,5 +49,7 @@ You supply your Linear **Connected App** credentials (Client ID + Secret) once p
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/linkedin.mdx
+++ b/src/content/docs/agentkit/connectors/linkedin.mdx
@@ -32,6 +32,10 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your LinkedIn **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the LinkedIn connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/microsoftexcel.mdx
+++ b/src/content/docs/agentkit/connectors/microsoftexcel.mdx
@@ -23,6 +23,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Microsoft Excel **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Microsoft Excel connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 

--- a/src/content/docs/agentkit/connectors/microsoftteams.mdx
+++ b/src/content/docs/agentkit/connectors/microsoftteams.mdx
@@ -23,6 +23,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Teams **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Teams connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 

--- a/src/content/docs/agentkit/connectors/microsoftword.mdx
+++ b/src/content/docs/agentkit/connectors/microsoftword.mdx
@@ -23,6 +23,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Microsoft Word **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Microsoft Word connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 

--- a/src/content/docs/agentkit/connectors/miro.mdx
+++ b/src/content/docs/agentkit/connectors/miro.mdx
@@ -34,6 +34,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Miro **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Miro connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -49,5 +51,7 @@ You supply your Miro **Connected App** credentials (Client ID + Secret) once per
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/monday.mdx
+++ b/src/content/docs/agentkit/connectors/monday.mdx
@@ -23,6 +23,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Monday.com **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Monday.com connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 

--- a/src/content/docs/agentkit/connectors/notion.mdx
+++ b/src/content/docs/agentkit/connectors/notion.mdx
@@ -32,6 +32,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Notion **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Notion connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -47,5 +49,7 @@ You supply your Notion **Connected App** credentials (Client ID + Secret) once p
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/onedrive.mdx
+++ b/src/content/docs/agentkit/connectors/onedrive.mdx
@@ -23,6 +23,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your OneDrive **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the OneDrive connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 

--- a/src/content/docs/agentkit/connectors/onenote.mdx
+++ b/src/content/docs/agentkit/connectors/onenote.mdx
@@ -23,6 +23,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your OneNote **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the OneNote connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 

--- a/src/content/docs/agentkit/connectors/outlook.mdx
+++ b/src/content/docs/agentkit/connectors/outlook.mdx
@@ -34,6 +34,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Outlook **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Outlook connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -49,5 +51,7 @@ You supply your Outlook **Connected App** credentials (Client ID + Secret) once 
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/outreach.mdx
+++ b/src/content/docs/agentkit/connectors/outreach.mdx
@@ -32,6 +32,10 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Outreach **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Outreach connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/pagerduty.mdx
+++ b/src/content/docs/agentkit/connectors/pagerduty.mdx
@@ -32,6 +32,10 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your PagerDuty **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the PagerDuty connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/parallelaitaskmcp.mdx
+++ b/src/content/docs/agentkit/connectors/parallelaitaskmcp.mdx
@@ -28,6 +28,8 @@ Connect this agent connector to let your agent:
 
 This connector uses **Bearer Token** authentication. Scalekit securely stores the token and injects it into API requests on behalf of your users. Your agent code never handles tokens directly — you only pass a `connectionName` and a user `identifier`.
 
+Before calling this connector from your code, create the Parallel AI Task MCP connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -43,5 +45,7 @@ This connector uses **Bearer Token** authentication. Scalekit securely stores th
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/phantombuster.mdx
+++ b/src/content/docs/agentkit/connectors/phantombuster.mdx
@@ -32,6 +32,8 @@ Connect this agent connector to let your agent:
 
 This connector uses **API Key** authentication. Your users provide their PhantomBuster API key once, and Scalekit stores and manages it securely. Your agent code never handles keys directly — you only pass a `connectionName` and a user `identifier`.
 
+Before calling this connector from your code, create the PhantomBuster connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -47,5 +49,7 @@ This connector uses **API Key** authentication. Your users provide their Phantom
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/pipedrive.mdx
+++ b/src/content/docs/agentkit/connectors/pipedrive.mdx
@@ -33,6 +33,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Pipedrive **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Pipedrive connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -41,5 +43,7 @@ You supply your Pipedrive **Connected App** credentials (Client ID + Secret) onc
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/posthogmcp.mdx
+++ b/src/content/docs/agentkit/connectors/posthogmcp.mdx
@@ -45,6 +45,10 @@ This connector uses **OAuth 2.1/DCR with PKCE**. PostHog MCP is an MCP server th
 
 </details>
 
+Before calling this connector from your code, create the PostHog MCP connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/salesforce.mdx
+++ b/src/content/docs/agentkit/connectors/salesforce.mdx
@@ -35,6 +35,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Salesforce **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Salesforce connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -50,6 +52,8 @@ You supply your Salesforce **Connected App** credentials (Client ID + Secret) on
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />
 

--- a/src/content/docs/agentkit/connectors/servicenow.mdx
+++ b/src/content/docs/agentkit/connectors/servicenow.mdx
@@ -23,6 +23,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your ServiceNow **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the ServiceNow connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 

--- a/src/content/docs/agentkit/connectors/sharepoint.mdx
+++ b/src/content/docs/agentkit/connectors/sharepoint.mdx
@@ -23,6 +23,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your SharePoint **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the SharePoint connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 

--- a/src/content/docs/agentkit/connectors/slack.mdx
+++ b/src/content/docs/agentkit/connectors/slack.mdx
@@ -33,6 +33,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Slack **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Slack connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -48,5 +50,7 @@ You supply your Slack **Connected App** credentials (Client ID + Secret) once pe
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/snowflake.mdx
+++ b/src/content/docs/agentkit/connectors/snowflake.mdx
@@ -34,6 +34,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Snowflake **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Snowflake connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -49,5 +51,7 @@ You supply your Snowflake **Connected App** credentials (Client ID + Secret) onc
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/snowflakekeyauth.mdx
+++ b/src/content/docs/agentkit/connectors/snowflakekeyauth.mdx
@@ -38,6 +38,10 @@ This connector uses **Bearer Token** authentication. Scalekit securely stores th
 
 </details>
 
+Before calling this connector from your code, create the Snowflake Key Pair Auth connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/supadata.mdx
+++ b/src/content/docs/agentkit/connectors/supadata.mdx
@@ -31,6 +31,8 @@ Connect this agent connector to let your agent:
 
 This connector uses **API Key** authentication. Your users provide their Supadata API key once, and Scalekit stores and manages it securely. Your agent code never handles keys directly — you only pass a `connectionName` and a user `identifier`.
 
+Before calling this connector from your code, create the Supadata connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -46,5 +48,7 @@ This connector uses **API Key** authentication. Your users provide their Supadat
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/tableau.mdx
+++ b/src/content/docs/agentkit/connectors/tableau.mdx
@@ -42,6 +42,8 @@ Tableau uses **Personal Access Token (PAT)** authentication. You store your PAT 
 4. The fresh session token is injected as `X-Tableau-Auth` — your code does nothing
 5. After sign-in, the **site ID** (site LUID) is stored automatically in the connected account — you do not pass `site_id` to tool calls. Token lifetime is 120 minutes for Tableau Cloud and 240 minutes for Tableau Server.
 
+Before calling this connector from your code, create the Tableau connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -80,5 +82,7 @@ Most Tableau tools require one or more resource LUIDs. The **site ID is resolved
 ```
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/twitter.mdx
+++ b/src/content/docs/agentkit/connectors/twitter.mdx
@@ -32,6 +32,8 @@ Connect this agent connector to let your agent:
 
 This connector uses **Bearer Token** authentication. Scalekit securely stores the token and injects it into API requests on behalf of your users. Your agent code never handles tokens directly — you only pass a `connectionName` and a user `identifier`.
 
+Before calling this connector from your code, create the Twitter / X connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -47,5 +49,7 @@ This connector uses **Bearer Token** authentication. Scalekit securely stores th
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/vercel.mdx
+++ b/src/content/docs/agentkit/connectors/vercel.mdx
@@ -34,6 +34,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Vercel **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Vercel connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -49,5 +51,7 @@ You supply your Vercel **Connected App** credentials (Client ID + Secret) once p
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/vimeo.mdx
+++ b/src/content/docs/agentkit/connectors/vimeo.mdx
@@ -33,6 +33,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Vimeo **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Vimeo connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -41,5 +43,7 @@ You supply your Vimeo **Connected App** credentials (Client ID + Secret) once pe
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/youtube.mdx
+++ b/src/content/docs/agentkit/connectors/youtube.mdx
@@ -33,6 +33,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your YouTube **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the YouTube connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -41,5 +43,7 @@ You supply your YouTube **Connected App** credentials (Client ID + Secret) once 
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/zendesk.mdx
+++ b/src/content/docs/agentkit/connectors/zendesk.mdx
@@ -32,6 +32,8 @@ Connect this agent connector to let your agent:
 
 This connector uses **API KEY** authentication.
 
+Before calling this connector from your code, create the Zendesk connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 
@@ -47,5 +49,7 @@ This connector uses **API KEY** authentication.
 </details>
 
 ## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
 
 <ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/zoom.mdx
+++ b/src/content/docs/agentkit/connectors/zoom.mdx
@@ -23,6 +23,8 @@ This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirec
 
 You supply your Zoom **Connected App** credentials (Client ID + Secret) once per environment in the Scalekit dashboard.
 
+Before calling this connector from your code, create the Zoom connection in **AgentKit** > **Connections** and copy the exact **Connection name** from that connection into your code. The value in code must match the dashboard exactly.
+
 <details>
 <summary>Set up the connector</summary>
 

--- a/src/content/docs/agentkit/examples/anthropic.mdx
+++ b/src/content/docs/agentkit/examples/anthropic.mdx
@@ -110,6 +110,7 @@ Fetch tools scoped to this user, then run the full Claude tool-use loop:
 scoped_response, _ = actions.tools.list_scoped_tools(
     identifier="user_123",
     filter={"connection_names": ["gmail"]},
+    page_size=100,  # fetch beyond the default page so no connector tools are missed
 )
 llm_tools = [
     {
@@ -157,6 +158,7 @@ while True:
 // Fetch tools scoped to this user
 const { tools } = await scalekit.tools.listScopedTools('user_123', {
   filter: { connectionNames: ['gmail'] },
+  pageSize: 100, // fetch beyond the default page so no connector tools are missed
 });
 const llmTools = tools.map(t => ({
   name: t.tool.definition.name,

--- a/src/content/docs/agentkit/examples/google-adk.mdx
+++ b/src/content/docs/agentkit/examples/google-adk.mdx
@@ -70,6 +70,7 @@ from google.genai import types
 tools = actions.google.get_tools(
     identifier="user_123",
     connection_names=["gmail"],
+    page_size=100,  # avoid missing tools when a connector has more than the default page
 )
 
 agent = Agent(

--- a/src/content/docs/agentkit/examples/index.mdx
+++ b/src/content/docs/agentkit/examples/index.mdx
@@ -1,8 +1,8 @@
 ---
-title: Examples
+title: AgentKit code samples
 description: Full working examples showing how to integrate AgentKit with popular AI frameworks and agent platforms.
 sidebar:
-  label: Examples
+  label: AgentKit code samples
   order: 1
 tableOfContents: false
 ---

--- a/src/content/docs/agentkit/examples/langchain.mdx
+++ b/src/content/docs/agentkit/examples/langchain.mdx
@@ -67,6 +67,7 @@ from langchain_core.messages import HumanMessage, ToolMessage
 tools = actions.langchain.get_tools(
     identifier="user_123",
     connection_names=["gmail"],
+    page_size=100,  # avoid missing tools when a connector has more than the default page
 )
 tool_map = {t.name: t for t in tools}
 

--- a/src/content/docs/agentkit/examples/openai.mdx
+++ b/src/content/docs/agentkit/examples/openai.mdx
@@ -110,6 +110,7 @@ Fetch tools scoped to this user, convert to OpenAI's function format, then run t
 scoped_response, _ = actions.tools.list_scoped_tools(
     identifier="user_123",
     filter={"connection_names": ["gmail"]},
+    page_size=100,  # fetch beyond the default page so no connector tools are missed
 )
 llm_tools = [
     {
@@ -156,6 +157,7 @@ while True:
 // Fetch and convert tools to OpenAI format
 const { tools } = await scalekit.tools.listScopedTools('user_123', {
   filter: { connectionNames: ['gmail'] },
+  pageSize: 100, // fetch beyond the default page so no connector tools are missed
 });
 const llmTools: OpenAI.ChatCompletionTool[] = tools.map(t => ({
   type: 'function',

--- a/src/content/docs/agentkit/examples/vercel-ai.mdx
+++ b/src/content/docs/agentkit/examples/vercel-ai.mdx
@@ -58,6 +58,7 @@ import { openai } from '@ai-sdk/openai';
 
 const { tools: scopedTools } = await scalekit.tools.listScopedTools('user_123', {
   filter: { connectionNames: ['gmail'] },
+  pageSize: 100, // fetch beyond the default page so no connector tools are missed
 });
 
 const tools = Object.fromEntries(

--- a/src/content/docs/agentkit/quickstart.mdx
+++ b/src/content/docs/agentkit/quickstart.mdx
@@ -153,7 +153,7 @@ Complete these steps in the Scalekit dashboard before writing any code:
 
     ### 2. Create a connected account
 
-    Scalekit tracks each user's third-party connection as a connected account. This is the record that holds their OAuth tokens. Creating it tells Scalekit to start managing the user's Gmail access on your behalf. This step fails if the Gmail connection has not been created in **AgentKit** > **Connections** yet, or if `connection_name` does not match the dashboard exactly.
+    Scalekit tracks each user's third-party connection as a connected account. This is the record that holds their OAuth tokens. Creating it tells Scalekit to start managing the user's Gmail access on your behalf. This step fails if the Gmail connection has not been created in **AgentKit** > **Connections** yet, or if `connection_name` / `connectionName` does not match the dashboard exactly.
 
     <Tabs syncKey="tech-stack">
       <TabItem label="Python">

--- a/src/content/docs/agentkit/quickstart.mdx
+++ b/src/content/docs/agentkit/quickstart.mdx
@@ -30,12 +30,15 @@ Complete these steps in the Scalekit dashboard before writing any code:
 1. **Create a Scalekit account** at [app.scalekit.com](https://app.scalekit.com).
 2. **Configure a Gmail connector** at Dashboard → **AgentKit** > **Connections** > **Create Connection** → select **Gmail**.
 
+   Create the connection in the dashboard before running any code. Then copy the exact **Connection name** from that connection and use that value in your code. It must match the dashboard exactly, and it is not always the provider slug `gmail`.
+
    Gmail is enabled by default in new Scalekit environments. To connect to other services, create a connection for each app under **AgentKit** > **Connections** > **Create Connection**.
 
 3. **Copy your API credentials** at Dashboard → **Developers → Settings → API Credentials**. Save these three values as environment variables:
    - `SCALEKIT_CLIENT_ID`
    - `SCALEKIT_CLIENT_SECRET`
    - `SCALEKIT_ENV_URL`
+   - `GMAIL_CONNECTION_NAME` (copy the exact Connection name from **AgentKit** > **Connections**)
 
 ## Build your agent
 
@@ -127,6 +130,7 @@ Complete these steps in the Scalekit dashboard before writing any code:
             env_url=os.getenv("SCALEKIT_ENV_URL"),
         )
         actions = scalekit_client.actions
+        connection_name = os.getenv("GMAIL_CONNECTION_NAME")  # must match the Connection name in the dashboard exactly
         ```
       </TabItem>
       <TabItem label="Node.js">
@@ -142,20 +146,21 @@ Complete these steps in the Scalekit dashboard before writing any code:
         );
 
         const actions = scalekit.actions;
+        const connectionName = process.env.GMAIL_CONNECTION_NAME!; // must match the Connection name in the dashboard exactly
         ```
       </TabItem>
     </Tabs>
 
     ### 2. Create a connected account
 
-    Scalekit tracks each user's third-party connection as a connected account. This is the record that holds their OAuth tokens. Creating it tells Scalekit to start managing the user's Gmail access on your behalf.
+    Scalekit tracks each user's third-party connection as a connected account. This is the record that holds their OAuth tokens. Creating it tells Scalekit to start managing the user's Gmail access on your behalf. This step fails if the Gmail connection has not been created in **AgentKit** > **Connections** yet, or if `connection_name` does not match the dashboard exactly.
 
     <Tabs syncKey="tech-stack">
       <TabItem label="Python">
         ```python wrap {2} showLineNumbers=false frame="none"
         # Create or retrieve the user's connected Gmail account
         response = actions.get_or_create_connected_account(
-            connection_name="gmail",
+            connection_name=connection_name,
             identifier="user_123"  # Replace with your system's unique user ID
         )
         connected_account = response.connected_account
@@ -166,7 +171,7 @@ Complete these steps in the Scalekit dashboard before writing any code:
         ```typescript showLineNumbers=false frame="none"
         // Create or retrieve the user's connected Gmail account
         const response = await actions.getOrCreateConnectedAccount({
-          connectionName: 'gmail',
+          connectionName,
           identifier: 'user_123',  // Replace with your system's unique user ID
         });
 
@@ -187,7 +192,7 @@ Complete these steps in the Scalekit dashboard before writing any code:
         if(connected_account.status != "ACTIVE"):
               print(f"Gmail is not connected: {connected_account.status}")
               link_response = actions.get_authorization_link(
-                  connection_name="gmail",
+                  connection_name=connection_name,
                   identifier="user_123"
               )
               print(f"🔗 click on the link to authorize Gmail", link_response.link)
@@ -202,7 +207,7 @@ Complete these steps in the Scalekit dashboard before writing any code:
         if (connectedAccount?.status !== ConnectorStatus.ACTIVE) {
           console.log('gmail is not connected:', connectedAccount?.status);
           const linkResponse = await actions.getAuthorizationLink({
-            connectionName: 'gmail',
+            connectionName,
             identifier: 'user_123',
           });
           console.log('🔗 click on the link to authorize gmail', linkResponse.link);

--- a/src/content/docs/agentkit/sdks/node/index.mdx
+++ b/src/content/docs/agentkit/sdks/node/index.mdx
@@ -300,12 +300,12 @@ Lists all tools available in your workspace.
 
 #### listScopedTools
 
-Lists tools scoped to a specific user. Use this to fetch per-user tool schemas to pass to an LLM API.
+Lists tools scoped to a specific user. Use this for tool discovery because it returns pagination metadata such as `nextPageToken` and `totalSize`.
 
 <MethodParams label="Input schema" params={[
   { name: 'identifier', type: 'string', required: true, description: "User's connected account identifier" },
   { name: 'filter', type: 'ScopedToolFilter', required: false, description: 'Filter by providers, tool names, or connection names' },
-  { name: 'pageSize', type: 'number', required: false, description: 'Maximum tools per page (server default if omitted)' },
+  { name: 'pageSize', type: 'number', required: false, description: 'Maximum tools per page. Use 100 for discovery so connectors with more than the default page are not truncated.' },
   { name: 'pageToken', type: 'string', required: false, description: 'Opaque cursor from a previous list response' },
 ]} />
 
@@ -320,6 +320,7 @@ Lists tools scoped to a specific user. Use this to fetch per-user tool schemas t
 ```ts title="Example"
 const { tools } = await scalekit.tools.listScopedTools('user@example.com', {
   filter: { connectionNames: ['gmail'] },
+  pageSize: 100,
 });
 // Pass tools to your LLM's tool call API
 ```

--- a/src/content/docs/agentkit/sdks/python/index.mdx
+++ b/src/content/docs/agentkit/sdks/python/index.mdx
@@ -464,7 +464,7 @@ pip install langchain
   { name: 'providers', type: 'list', required: false, description: 'Filter by provider (e.g. ["google"])' },
   { name: 'tool_names', type: 'list', required: false, description: 'Filter by tool name' },
   { name: 'connection_names', type: 'list', required: false, description: 'Filter by connection name' },
-  { name: 'page_size', type: 'int', required: false, description: 'Maximum tools per page (server default if omitted)' },
+  { name: 'page_size', type: 'int', required: false, description: 'Maximum tools per page. Use 100 for discovery so connectors with more than the default page are not truncated.' },
   { name: 'page_token', type: 'str', required: false, description: 'Opaque cursor from a previous list response' },
 ]} />
 
@@ -477,7 +477,10 @@ pip install langchain
 ```python title="Example"
 from langchain.agents import create_react_agent
 
-tools = actions.langchain.get_tools(identifier="user@example.com")
+tools = actions.langchain.get_tools(
+    identifier="user@example.com",
+    page_size=100,  # avoid missing tools when a connector has more than the default page
+)
 agent = create_react_agent(llm=llm, tools=tools, prompt=prompt)
 ```
 
@@ -494,7 +497,10 @@ Same parameters as `actions.langchain.get_tools`.
 Returns `List[ScalekitGoogleAdkTool]`. Pass it directly to a Google ADK agent.
 
 ```python title="Example"
-tools = actions.google.get_tools(identifier="user@example.com")
+tools = actions.google.get_tools(
+    identifier="user@example.com",
+    page_size=100,  # avoid missing tools when a connector has more than the default page
+)
 ```
 
 ---
@@ -507,7 +513,7 @@ tools = actions.google.get_tools(identifier="user@example.com")
 
 <MethodParams label="Input schema" params={[
   { name: 'filter', type: 'Filter', required: false, description: 'Filter by provider, identifier, or tool name' },
-  { name: 'page_size', type: 'int', required: false, description: 'Maximum tools per page (server default if omitted)' },
+  { name: 'page_size', type: 'int', required: false, description: 'Maximum tools per page. Use 100 for discovery so connectors with more than the default page are not truncated.' },
   { name: 'page_token', type: 'str', required: false, description: 'Opaque cursor from a previous list response' },
 ]} />
 
@@ -518,12 +524,12 @@ tools = actions.google.get_tools(identifier="user@example.com")
 
 #### actions.tools.list_scoped_tools
 
-Lists tools scoped to a specific user. This is what framework adapters use internally to fetch per-user tool schemas.
+Lists tools scoped to a specific user. Use this method for tool discovery because it returns pagination metadata such as `next_page_token` and `total_size`; framework `get_tools()` helpers return framework-ready tool objects and do not expose that metadata.
 
 <MethodParams label="Input schema" params={[
   { name: 'identifier', type: 'str', required: true, description: 'User connected account identifier' },
   { name: 'filter', type: 'ScopedToolFilter', required: false, description: 'Filter by providers, tool names, or connection names' },
-  { name: 'page_size', type: 'int', required: false, description: 'Maximum tools per page (server default if omitted)' },
+  { name: 'page_size', type: 'int', required: false, description: 'Maximum tools per page. Use 100 for discovery so connectors with more than the default page are not truncated.' },
   { name: 'page_token', type: 'str', required: false, description: 'Opaque cursor from a previous list response' },
 ]} />
 
@@ -538,6 +544,7 @@ Lists tools scoped to a specific user. This is what framework adapters use inter
 ```python title="Example"
 tools_response = scalekit_client.actions.tools.list_scoped_tools(
     identifier="user@example.com",
+    page_size=100,
 )
 # Pass tools_response.tools to your LLM's tool call API
 ```

--- a/src/content/docs/agentkit/sdks/python/index.mdx
+++ b/src/content/docs/agentkit/sdks/python/index.mdx
@@ -129,6 +129,8 @@ print(account.connected_account.id)
 
 Fetches auth details for a connected account. Returns sensitive credentials. Protect access to this method.
 
+Use this when you know the connected account already exists and you need its credential payload. For first-time setup or general application flows, prefer `get_or_create_connected_account` so new users do not hit a not-found error.
+
 Requires `connected_account_id` **or** `connection_name` + `identifier`.
 
 <MethodParams label="Input schema" params={[

--- a/src/content/docs/agentkit/tools/agent-tools-quickstart.mdx
+++ b/src/content/docs/agentkit/tools/agent-tools-quickstart.mdx
@@ -48,12 +48,12 @@ To list every connector for the user, remove the `filter=` argument entirely.
 const connectionName = 'your-connection-name'; // copy the exact Connection name from AgentKit > Connections
 
 const { tools } = await scalekit.tools.listScopedTools('user_123', {
-  filter: { connectionNames: [connectionName] }, // omit filter to list every connector
+  filter: { connectionNames: [connectionName] }, // use filter: {} to list every connector
   pageSize: 100,
 });
 
-for (const tool of tools) {
-  console.log('Available tool:', tool.tool.definition.name);
+for (const scopedTool of tools) {
+  console.log('Available tool:', scopedTool.tool?.definition?.name);
 }
 ```
 

--- a/src/content/docs/agentkit/tools/agent-tools-quickstart.mdx
+++ b/src/content/docs/agentkit/tools/agent-tools-quickstart.mdx
@@ -31,7 +31,7 @@ connection_name = "your-connection-name"  # copy the exact Connection name from 
 scoped_response, _ = actions.tools.list_scoped_tools(
     identifier="user_123",
     filter=ScopedToolFilter(connection_names=[connection_name]),
-    page_size=100,
+    page_size=100,  # fetch beyond the default page so no connector tools are missed
 )
 
 for scoped_tool in scoped_response.tools:
@@ -49,7 +49,7 @@ const connectionName = 'your-connection-name'; // copy the exact Connection name
 
 const { tools } = await scalekit.tools.listScopedTools('user_123', {
   filter: { connectionNames: [connectionName] }, // use filter: {} to list every connector
-  pageSize: 100,
+  pageSize: 100, // fetch beyond the default page so no connector tools are missed
 });
 
 for (const scopedTool of tools) {
@@ -264,7 +264,7 @@ Let an LLM determine which tool to call and with what parameters based on user i
    tools =  actions.langchain.get_tools(
        identifier=identifier,
         providers = ["GMAIL"], # all tools for connector used by default
-        page_size=100
+        page_size=100  # avoid missing tools when a connector has more than the default page
    )
 
    prompt = ChatPromptTemplate.from_messages([

--- a/src/content/docs/agentkit/tools/agent-tools-quickstart.mdx
+++ b/src/content/docs/agentkit/tools/agent-tools-quickstart.mdx
@@ -70,6 +70,8 @@ Using Scalekit SDK, you can execute any action on behalf of a user using the fol
 - `tool_name`
 - `tool_input_parameters`
 
+`execute_tool` / `executeTool` returns a response wrapper. The tool output lives in `response.data`, and the keys inside `data` depend on the tool you called. When integrating a new tool, print `response.data` first, then extract the specific fields you need.
+
 <Tabs syncKey="tech-stack">
 <TabItem label="Python">
 
@@ -87,7 +89,7 @@ tool_response = actions.execute_tool(
     connected_account_id=connected_account.id,
 )
 
-print(f'Recent emails: {tool_response.result}')
+print(f'Recent emails: {tool_response.data}')
 ```
 
 </TabItem>
@@ -107,7 +109,7 @@ const toolResponse = await actions.executeTool({
   },
 });
 
-console.log('Recent emails:', toolResponse.result);
+console.log('Recent emails:', toolResponse.data);
 ```
 
 </TabItem>

--- a/src/content/docs/agentkit/tools/agent-tools-quickstart.mdx
+++ b/src/content/docs/agentkit/tools/agent-tools-quickstart.mdx
@@ -13,6 +13,52 @@ import { LinkCard, CardGrid, Aside, Steps, Tabs, TabItem } from '@astrojs/starli
 
 Agent Auth supports three approaches to tool calling: execute tools directly with explicit parameters, customize tool behavior with pre- and post-modifiers, or let an LLM select and invoke tools automatically based on user input.
 
+## Find a tool name
+
+Tool names are exact identifiers such as `gmail_fetch_mails` and `googlecalendar_list_events`. Don't guess them from the connector label. Use the connector page's **Tool list**, or list the tools available for the current user before calling `execute_tool`.
+
+After you initialize `scalekit` or `actions`, run:
+
+<Tabs syncKey="tech-stack">
+<TabItem label="Python">
+
+```python
+from google.protobuf.json_format import MessageToDict
+
+connection_name = "your-connection-name"  # copy the exact Connection name from AgentKit > Connections
+
+scoped_response, _ = actions.tools.list_scoped_tools(
+    identifier="user_123",
+    filter={"connection_names": [connection_name]},  # omit filter to list every connector
+    page_size=100,
+)
+
+for scoped_tool in scoped_response.tools:
+    definition = MessageToDict(scoped_tool.tool).get("definition", {})
+    print("Available tool:", definition.get("name"))
+```
+
+</TabItem>
+<TabItem label="Node.js">
+
+```typescript
+const connectionName = 'your-connection-name'; // copy the exact Connection name from AgentKit > Connections
+
+const { tools } = await scalekit.tools.listScopedTools('user_123', {
+  filter: { connectionNames: [connectionName] }, // omit filter to list every connector
+  pageSize: 100,
+});
+
+for (const tool of tools) {
+  console.log('Available tool:', tool.tool.definition.name);
+}
+```
+
+</TabItem>
+</Tabs>
+
+Once you have the exact tool name, pass it to `execute_tool` / `executeTool`.
+
 ## Direct tool execution
 
 Using Scalekit SDK, you can execute any action on behalf of a user using the following parameters:

--- a/src/content/docs/agentkit/tools/agent-tools-quickstart.mdx
+++ b/src/content/docs/agentkit/tools/agent-tools-quickstart.mdx
@@ -24,12 +24,13 @@ After you initialize `scalekit` or `actions`, run:
 
 ```python
 from google.protobuf.json_format import MessageToDict
+from scalekit.v1.tools.tools_pb2 import ScopedToolFilter
 
 connection_name = "your-connection-name"  # copy the exact Connection name from AgentKit > Connections
 
 scoped_response, _ = actions.tools.list_scoped_tools(
     identifier="user_123",
-    filter={"connection_names": [connection_name]},  # omit filter to list every connector
+    filter=ScopedToolFilter(connection_names=[connection_name]),
     page_size=100,
 )
 
@@ -37,6 +38,8 @@ for scoped_tool in scoped_response.tools:
     definition = MessageToDict(scoped_tool.tool).get("definition", {})
     print("Available tool:", definition.get("name"))
 ```
+
+To list every connector for the user, remove the `filter=` argument entirely.
 
 </TabItem>
 <TabItem label="Node.js">

--- a/src/content/docs/agentkit/tools/agent-tools-quickstart.mdx
+++ b/src/content/docs/agentkit/tools/agent-tools-quickstart.mdx
@@ -237,10 +237,10 @@ Let an LLM determine which tool to call and with what parameters based on user i
 For more detailed framework-specific implementations, explore the AI framework guides:
 
 <CardGrid>
-  <LinkCard title="LangChain Framework" icon="star" href="/agentkit/frameworks/langchain">
+  <LinkCard title="LangChain Framework" icon="star" href="/agentkit/examples/langchain/">
     Build agents using LangChain with advanced tool calling and workflow capabilities.
   </LinkCard>
-  <LinkCard title="Google ADK Framework" icon="star" href="/agentkit/frameworks/google-adk">
+  <LinkCard title="Google ADK Framework" icon="star" href="/agentkit/examples/google-adk/">
     Create agents using Google ADK with Gemini models and native Google integration.
   </LinkCard>
   <LinkCard title="OpenClaw" icon="star" href="/agentkit/openclaw">

--- a/src/content/docs/agentkit/tools/scalekit-optimized-tools.mdx
+++ b/src/content/docs/agentkit/tools/scalekit-optimized-tools.mdx
@@ -32,6 +32,7 @@ from google.protobuf.json_format import MessageToDict
 scoped_response, _ = actions.tools.list_scoped_tools(
     identifier="user_123",
     filter={"connection_names": ["gmail"]},   # optional; omit for all connectors
+    page_size=100,                            # fetch beyond the default page
 )
 for scoped_tool in scoped_response.tools:
     definition = MessageToDict(scoped_tool.tool).get("definition", {})
@@ -42,7 +43,8 @@ for scoped_tool in scoped_response.tools:
   <TabItem label="Node.js">
 ```typescript
 const { tools } = await scalekit.tools.listScopedTools('user_123', {
-  filter: { connectionNames: ['gmail'] },     // optional; omit for all connectors
+  filter: { connectionNames: ['gmail'] },     // use filter: {} to list every connector
+  pageSize: 100,                              // fetch beyond the default page
 });
 for (const tool of tools) {
   const { name, input_schema } = tool.tool.definition;
@@ -119,6 +121,7 @@ client = anthropic.Anthropic()
 scoped_response, _ = actions.tools.list_scoped_tools(
     identifier="user_123",
     filter={"connection_names": ["gmail"]},
+    page_size=100,  # fetch beyond the default page so no connector tools are missed
 )
 llm_tools = [
     {
@@ -162,6 +165,7 @@ const anthropic = new Anthropic();
 // 1. Fetch tools scoped to this user
 const { tools } = await scalekit.tools.listScopedTools('user_123', {
   filter: { connectionNames: ['gmail'] },
+  pageSize: 100, // fetch beyond the default page so no connector tools are missed
 });
 const llmTools = tools.map((t) => ({
   name: t.tool.definition.name,
@@ -212,7 +216,7 @@ from langchain.agents import create_agent
 tools = actions.langchain.get_tools(
     identifier="user_123",
     connection_names=["gmail"],
-    page_size=100,
+    page_size=100,  # avoid missing tools when a connector has more than the default page
 )
 llm = ChatOpenAI(model="claude-sonnet-4-6")
 agent = create_agent(model=llm, tools=tools, system_prompt="You are a helpful assistant.")
@@ -227,7 +231,7 @@ from google.adk.models.lite_llm import LiteLlm
 gmail_tools = actions.google.get_tools(
     identifier="user_123",
     connection_names=["gmail"],
-    page_size=100,
+    page_size=100,  # avoid missing tools when a connector has more than the default page
 )
 agent = Agent(
     name="gmail_assistant",
@@ -242,6 +246,7 @@ import { generateText, jsonSchema, tool } from 'ai';
 
 const { tools: scopedTools } = await scalekit.tools.listScopedTools('user_123', {
   filter: { connectionNames: ['gmail'] },
+  pageSize: 100, // fetch beyond the default page so no connector tools are missed
 });
 const tools = Object.fromEntries(
   scopedTools.map((t) => [

--- a/src/content/docs/authenticate/set-up-scalekit.mdx
+++ b/src/content/docs/authenticate/set-up-scalekit.mdx
@@ -304,7 +304,7 @@ Use the most common client configs below. For the full list of supported MCP hos
 
 Run this command in your terminal:
 
-```bash
+```bash title="Terminal"
 claude mcp add --transport http scalekit https://mcp.scalekit.com/
 ```
 
@@ -314,7 +314,7 @@ claude mcp add --transport http scalekit https://mcp.scalekit.com/
 
 Edit `~/.cursor/mcp.json`, or open **Cursor Settings → MCP → Add New Global MCP Server** and paste the config:
 
-```json
+```json title="~/.cursor/mcp.json" showLineNumbers=false
 {
   "mcpServers": {
     "scalekit": {
@@ -330,7 +330,7 @@ Edit `~/.cursor/mcp.json`, or open **Cursor Settings → MCP → Add New Global 
 
 Run this command in your terminal:
 
-```bash
+```bash title="Terminal"
 codex mcp add scalekit --url https://mcp.scalekit.com/
 ```
 
@@ -340,7 +340,7 @@ codex mcp add scalekit --url https://mcp.scalekit.com/
 
 Edit `opencode.json` in your project root:
 
-```json
+```json title="opencode.json" showLineNumbers=false
 {
   "mcp": {
     "scalekit": {

--- a/src/content/docs/authenticate/set-up-scalekit.mdx
+++ b/src/content/docs/authenticate/set-up-scalekit.mdx
@@ -287,7 +287,7 @@ Before you begin, create a Scalekit account if you haven't already. After creati
 
 ## Set up Scalekit MCP Server <Badge text="Optional" />
 
-Scalekit's Model Context Protocol (MCP) server connects your AI coding assistants to Scalekit. Manage environments, organizations, users, and authentication through natural language queries in Claude, Cursor, Windsurf, and other MCP-compatible tools.
+Scalekit's Model Context Protocol (MCP) server connects your AI coding assistants to Scalekit. Manage environments, organizations, users, and authentication through natural language queries in your MCP client.
 
 The MCP server provides AI assistants with tools for environment management, organization and user management, authentication connection setup, role administration, and admin portal access. It uses OAuth 2.1 authentication to securely connect your AI tools to your Scalekit workspace.
 
@@ -297,44 +297,28 @@ If you're building your own MCP server and need to add OAuth-based authorization
 
 ### Configure your MCP client
 
-Based on your MCP client, follow the configuration instructions below:
+Use the most common client configs below. For the full list of supported MCP hosts and editor setups, see the [Scalekit MCP server guide](/dev-kit/ai-assisted-development/scalekit-mcp-server/).
 
 <Tabs>
-<TabItem value="claude" label="Claude Desktop">
+<TabItem value="claude-code" label="Claude Code">
 
-1. Open the Claude Desktop app, go to Settings, then Developer
-2. Click Edit Config
-3. Open the `claude_desktop_config.json` file
-4. Copy and paste the server config to your existing file, then save
-5. Restart Claude
+Run this command in your terminal:
 
-```json
-{
-  "mcpServers": {
-    "scalekit": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.scalekit.com/"]
-    }
-  }
-}
+```bash
+claude mcp add --transport http scalekit https://mcp.scalekit.com/
 ```
 
 </TabItem>
 
 <TabItem value="cursor" label="Cursor">
 
-1. Open Cursor, go to Settings, then Cursor Settings
-2. Select MCP on the left
-3. Click Add "New Global MCP Server" at the top right
-4. Copy and paste the server config to your existing file, then save
-5. Restart Cursor
+Edit `~/.cursor/mcp.json`, or open **Cursor Settings → MCP → Add New Global MCP Server** and paste the config:
 
 ```json
 {
   "mcpServers": {
     "scalekit": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.scalekit.com/"]
+      "url": "https://mcp.scalekit.com/"
     }
   }
 }
@@ -342,36 +326,25 @@ Based on your MCP client, follow the configuration instructions below:
 
 </TabItem>
 
-<TabItem value="windsurf" label="Windsurf">
+<TabItem value="codex" label="Codex">
 
-1. Open Windsurf, go to Settings, then Developer
-2. Click Edit Config
-3. Open the `windsurf_config.json` file
-4. Copy and paste the server config to your existing file, then save
-5. Restart Windsurf
+Run this command in your terminal:
 
-```json
-{
-  "mcpServers": {
-    "scalekit": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.scalekit.com/"]
-    }
-  }
-}
+```bash
+codex mcp add scalekit --url https://mcp.scalekit.com/
 ```
 
 </TabItem>
 
-<TabItem value="vscode" label="VS Code (1.101+)">
+<TabItem value="opencode" label="OpenCode">
 
-VS Code version 1.101 or greater supports OAuth natively. Configure the MCP server directly without the `mcp-remote` proxy:
+Edit `opencode.json` in your project root:
 
 ```json
 {
-  "servers": {
+  "mcp": {
     "scalekit": {
-      "type": "http",
+      "type": "remote",
       "url": "https://mcp.scalekit.com/"
     }
   }
@@ -384,7 +357,7 @@ VS Code version 1.101 or greater supports OAuth natively. Configure the MCP serv
 After configuration, your MCP client will initiate an OAuth authorization workflow to securely connect to Scalekit's MCP server.
 
 <Aside type="note">
-The Scalekit MCP server source code is available on [GitHub](https://github.com/scalekit-inc/mcp). Feel free to explore the code, raise issues, or contribute new tools.
+For Claude Desktop, VS Code, Windsurf, Gemini CLI, Kiro, Warp, Zed, and other hosts, use the full [Scalekit MCP server guide](/dev-kit/ai-assisted-development/scalekit-mcp-server/).
 </Aside>
 
 ## Configure code editors for Scalekit documentation

--- a/src/content/docs/cookbooks/daily-briefing-agent.mdx
+++ b/src/content/docs/cookbooks/daily-briefing-agent.mdx
@@ -274,13 +274,19 @@ For Google Calendar, retrieve a valid access token from Scalekit and call the Go
 
     ```python
     def get_access_token(connector: str) -> str:
-        # get_connected_account always returns a fresh token —
-        # Scalekit refreshes expired tokens before returning.
-        response = actions.get_connected_account(
+        # Use get_or_create_connected_account as the safe default so
+        # first-time users do not hit RESOURCE_NOT_FOUND.
+        response = actions.get_or_create_connected_account(
             connection_name=connector,
             identifier=USER_ID,
         )
-        tokens = response.connected_account.authorization_details["oauth_token"]
+        connected_account = response.connected_account
+        if connected_account.status != "ACTIVE":
+            raise RuntimeError(
+                f"{connector} is not active yet. Complete authorization first."
+            )
+
+        tokens = connected_account.authorization_details["oauth_token"]
         return tokens["access_token"]
 
     def fetch_calendar_events(access_token: str, max_results: int = 5) -> list:


### PR DESCRIPTION
Update the AgentKit examples page title and sidebar label from "Examples" to "AgentKit code samples".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed "Examples" to "AgentKit code samples" and updated next-step links.
  * Clarified connected-account flows: use get-or-create, validate status; updated token examples.
  * Require exact dashboard Connection names and exact tool names across many connectors; added guidance to list tools first when unsure.
  * Increased tool-list pagination in examples and snippets (recommend page_size/pageSize = 100).
* **Chores**
  * Added redirects from legacy framework doc paths to new example routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->