### PR TITLE
Add Monday tools docs

### DIFF
--- a/src/components/templates/agent-connectors/_section-before-tool-list-monday-resource-ids.mdx
+++ b/src/components/templates/agent-connectors/_section-before-tool-list-monday-resource-ids.mdx
@@ -1,0 +1,24 @@
+import { Aside } from '@astrojs/starlight/components'
+
+export const sectionTitle = 'Getting resource IDs'
+
+Most Monday.com tools require one or more resource IDs. Run list/read tools first to discover real IDs — never guess them.
+
+| Resource | Tool to get ID | Field in response |
+|----------|---------------|-------------------|
+| Board ID | `monday_boards_list` | `data.boards[].id` |
+| Item ID | `monday_items_list` (requires `board_id`) | `data.boards[].items_page.items[].id` |
+| Group ID | `monday_items_list` | `data.boards[].items_page.items[].group.id` |
+| Column ID | `monday_items_list` | `data.boards[].items_page.items[].column_values[].id` |
+| User ID | `monday_users_list` or `monday_me_get` | `data.users[].id` / `data.me.id` |
+| Workspace ID | `monday_workspaces_list` | `data.workspaces[].id` |
+| Update ID | `monday_updates_list` | `data.updates[].id` |
+| Tag ID | `monday_tags_list` | `data.tags[].id` |
+| Team ID | `monday_teams_list` | `data.teams[].id` |
+| Webhook ID | `monday_webhooks_list` (requires `board_id`) | `data.webhooks[].id` |
+| Doc ID | `monday_docs_list` | `data.docs[].id` |
+| Subitem ID | `monday_subitem_create` response | `data.create_subitem.id` |
+
+<Aside type="tip" title="Find column IDs for value updates">
+  When calling `monday_item_column_value_change` or `monday_item_column_values_change`, you need the column's `id` (not its title). Run `monday_items_list` and read `column_values[].id` from any item on the board. Common built-in column IDs are `name`, `status`, `person`, `date`, and `files` — custom columns have generated IDs like `color_abc123`.
+</Aside>

--- a/src/components/templates/agent-connectors/index.ts
+++ b/src/components/templates/agent-connectors/index.ts
@@ -143,6 +143,7 @@ export { default as SectionAfterSetupZoomCommonWorkflows } from './_section-afte
 export { default as SectionAfterToolListSalesforceMetadataApiSoap } from './_section-after-tool-list-salesforce-metadata-api-soap.mdx'
 export { default as SectionBeforeToolListDatadogResourceIds } from './_section-before-tool-list-datadog-resource-ids.mdx'
 export { default as SectionBeforeToolListHubspotResourceIds } from './_section-before-tool-list-hubspot-resource-ids.mdx'
+export { default as SectionBeforeToolListMondayResourceIds } from './_section-before-tool-list-monday-resource-ids.mdx'
 export { default as SectionBeforeToolListTableauResourceIds } from './_section-before-tool-list-tableau-resource-ids.mdx'
 export { default as SectionBeforeToolListXeroCommonPatterns } from './_section-before-tool-list-xero-common-patterns.mdx'
 export { default as QuickstartGenericApikeySection } from './_quickstart-generic-apikey.astro'

--- a/src/data/agent-connectors/capabilities.json
+++ b/src/data/agent-connectors/capabilities.json
@@ -1,80 +1,78 @@
 {
   "_comment": "Hand-curated 'What you can do' bullets per connector. Key = provider slug (matches src/data/agent-connectors/<slug>.ts). The sync script uses these instead of auto-generating from tool names. Add up to 6 bullets per connector. Omit a connector to fall back to auto-generation.",
-
   "salesforce": [
-    "**Read CRM records** — retrieve accounts, contacts, leads, opportunities, and cases by ID or search query",
-    "**Create and update records** — open leads, close opportunities, update deal stages, and edit contacts",
-    "**Log activities** — create tasks and events linked to any CRM record",
-    "**Run SOQL queries** — execute arbitrary Salesforce Object Query Language queries for custom data retrieval",
-    "**Search across objects** — find records by name, email, phone, or any field value",
-    "**Call the Metadata API** — use [SOAP proxy calls](#call-the-metadata-api-through-soap-proxy) to inspect and modify Salesforce org metadata"
+    "**Read CRM records** \u2014 retrieve accounts, contacts, leads, opportunities, and cases by ID or search query",
+    "**Create and update records** \u2014 open leads, close opportunities, update deal stages, and edit contacts",
+    "**Log activities** \u2014 create tasks and events linked to any CRM record",
+    "**Run SOQL queries** \u2014 execute arbitrary Salesforce Object Query Language queries for custom data retrieval",
+    "**Search across objects** \u2014 find records by name, email, phone, or any field value",
+    "**Call the Metadata API** \u2014 use [SOAP proxy calls](#call-the-metadata-api-through-soap-proxy) to inspect and modify Salesforce org metadata"
   ],
-
   "gmail": [
-    "**Read emails** — fetch messages, threads, and attachments from any label or inbox",
-    "**Send and reply** — compose new emails and reply to existing threads on behalf of your users",
-    "**Search messages** — query Gmail with full search syntax to find emails by sender, subject, or content",
-    "**Manage labels** — apply, remove, and list labels to organize messages",
-    "**Access contacts** — look up contacts and people from the user's address book"
+    "**Read emails** \u2014 fetch messages, threads, and attachments from any label or inbox",
+    "**Send and reply** \u2014 compose new emails and reply to existing threads on behalf of your users",
+    "**Search messages** \u2014 query Gmail with full search syntax to find emails by sender, subject, or content",
+    "**Manage labels** \u2014 apply, remove, and list labels to organize messages",
+    "**Access contacts** \u2014 look up contacts and people from the user's address book"
   ],
-
   "google_calendar": [
-    "**Read events** — list and retrieve calendar events across any of the user's calendars",
-    "**Create and update events** — schedule meetings, set attendees, and modify existing events",
-    "**Delete events** — cancel and remove events from the user's calendar",
-    "**List calendars** — enumerate all calendars the user has access to"
+    "**Read events** \u2014 list and retrieve calendar events across any of the user's calendars",
+    "**Create and update events** \u2014 schedule meetings, set attendees, and modify existing events",
+    "**Delete events** \u2014 cancel and remove events from the user's calendar",
+    "**List calendars** \u2014 enumerate all calendars the user has access to"
   ],
-
   "slack": [
-    "**Send messages** — post to channels, DMs, and threads on behalf of your users",
-    "**Read conversations** — retrieve channel history, thread replies, and direct messages",
-    "**Manage channels** — create channels, invite members, and update channel settings",
-    "**Look up users** — search for team members by name, email, or username",
-    "**Upload files** — share files and attachments into any conversation"
+    "**Send messages** \u2014 post to channels, DMs, and threads on behalf of your users",
+    "**Read conversations** \u2014 retrieve channel history, thread replies, and direct messages",
+    "**Manage channels** \u2014 create channels, invite members, and update channel settings",
+    "**Look up users** \u2014 search for team members by name, email, or username",
+    "**Upload files** \u2014 share files and attachments into any conversation"
   ],
-
   "github": [
-    "**Read repositories** — fetch repo metadata, files, commits, branches, and tags",
-    "**Manage issues** — create, update, close, and comment on issues",
-    "**Work with pull requests** — open PRs, post reviews, and merge changes",
-    "**Search code** — search across repositories by keyword, language, or file path",
-    "**Trigger workflows** — dispatch GitHub Actions workflow runs"
+    "**Read repositories** \u2014 fetch repo metadata, files, commits, branches, and tags",
+    "**Manage issues** \u2014 create, update, close, and comment on issues",
+    "**Work with pull requests** \u2014 open PRs, post reviews, and merge changes",
+    "**Search code** \u2014 search across repositories by keyword, language, or file path",
+    "**Trigger workflows** \u2014 dispatch GitHub Actions workflow runs"
   ],
-
   "linear": [
-    "**Read issues** — fetch issues, projects, cycles, and team details",
-    "**Create and update issues** — file new issues, update status, set priority, and assign teammates",
-    "**Manage projects** — create and update project metadata and milestones",
-    "**Search** — find issues by keyword, assignee, label, or state"
+    "**Read issues** \u2014 fetch issues, projects, cycles, and team details",
+    "**Create and update issues** \u2014 file new issues, update status, set priority, and assign teammates",
+    "**Manage projects** \u2014 create and update project metadata and milestones",
+    "**Search** \u2014 find issues by keyword, assignee, label, or state"
   ],
-
   "notion": [
-    "**Read pages and databases** — retrieve page content and query database entries",
-    "**Create pages** — add new pages and database rows with full content",
-    "**Update content** — edit existing page blocks, properties, and database fields",
-    "**Search** — find pages and databases across the user's Notion workspace"
+    "**Read pages and databases** \u2014 retrieve page content and query database entries",
+    "**Create pages** \u2014 add new pages and database rows with full content",
+    "**Update content** \u2014 edit existing page blocks, properties, and database fields",
+    "**Search** \u2014 find pages and databases across the user's Notion workspace"
   ],
-
   "hubspot": [
-    "**Manage contacts** — create, update, search, and list contacts; batch create, update, upsert, read, and archive",
-    "**Manage companies and deals** — create and update company records and deals; batch create, update, upsert, read, and archive",
-    "**Manage tickets and tasks** — create and update support tickets; create tasks with due dates and priorities",
-    "**Batch operations with inline associations** — create contacts, companies, deals, or tickets and link them to related records in a single call",
-    "**Log engagements** — record calls, meetings, notes, and emails against any CRM record",
-    "**Search, associate, and extend** — full-text search across all CRM objects, batch-manage associations, list owners, discover properties, and work with custom objects"
+    "**Manage contacts** \u2014 create, update, search, and list contacts; batch create, update, upsert, read, and archive",
+    "**Manage companies and deals** \u2014 create and update company records and deals; batch create, update, upsert, read, and archive",
+    "**Manage tickets and tasks** \u2014 create and update support tickets; create tasks with due dates and priorities",
+    "**Batch operations with inline associations** \u2014 create contacts, companies, deals, or tickets and link them to related records in a single call",
+    "**Log engagements** \u2014 record calls, meetings, notes, and emails against any CRM record",
+    "**Search, associate, and extend** \u2014 full-text search across all CRM objects, batch-manage associations, list owners, discover properties, and work with custom objects"
   ],
-
   "jira": [
-    "**Read issues** — fetch issue details, comments, attachments, and linked items",
-    "**Create and update issues** — file bugs, stories, and tasks; update status and assignees",
-    "**Manage projects** — list projects, sprints, and boards",
-    "**Search with JQL** — execute Jira Query Language searches for advanced filtering"
+    "**Read issues** \u2014 fetch issue details, comments, attachments, and linked items",
+    "**Create and update issues** \u2014 file bugs, stories, and tasks; update status and assignees",
+    "**Manage projects** \u2014 list projects, sprints, and boards",
+    "**Search with JQL** \u2014 execute Jira Query Language searches for advanced filtering"
   ],
-
   "google_drive": [
-    "**Browse files** — list and search files and folders across the user's Drive",
-    "**Read file content** — download and extract text from documents, spreadsheets, and PDFs",
-    "**Create and upload** — create new documents and upload files to Drive",
-    "**Manage permissions** — share files and update access settings"
+    "**Browse files** \u2014 list and search files and folders across the user's Drive",
+    "**Read file content** \u2014 download and extract text from documents, spreadsheets, and PDFs",
+    "**Create and upload** \u2014 create new documents and upload files to Drive",
+    "**Manage permissions** \u2014 share files and update access settings"
+  ],
+  "monday": [
+    "**Manage boards** \u2014 create, update, archive, duplicate, and delete boards across workspaces",
+    "**Manage items** \u2014 create, update, move, duplicate, archive, and delete items (rows) on any board",
+    "**Update column values** \u2014 set single or multiple column values including status, date, people, and custom types",
+    "**Manage groups** \u2014 create, rename, reorder, duplicate, archive, and delete groups within a board",
+    "**Post updates** \u2014 add, edit, and delete comments and activity updates on items",
+    "**Manage structure** \u2014 create and delete columns, manage subitems, webhooks, workspaces, teams, and tags"
   ]
 }


### PR DESCRIPTION
## Monday.com connector docs

- Generates `monday.ts` with all 44 tools
- Adds `monday` capabilities entry to `capabilities.json`
- Creates `_section-before-tool-list-monday-resource-ids.mdx` with resource ID lookup table
- Exports the section template from `index.ts`
- Updates `monday.mdx` to inject resource IDs section and render tool list

Preview: https://deploy-preview-663--scalekit-starlight.netlify.app/agentkit/connectors/monday/