### PR TITLE
chore: replace Netlify build hook with git push to production branch

### DIFF
--- a/.github/workflows/scheduled-deploy.yml
+++ b/.github/workflows/scheduled-deploy.yml
@@ -3,7 +3,10 @@ name: Scheduled Netlify Deploy
 on:
   schedule:
     - cron: '30 10 * * *' # 4:00 PM IST (UTC+5:30) daily
-  workflow_dispatch: # allows manual trigger for testing
+  workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   check_and_deploy:
@@ -11,6 +14,12 @@ jobs:
     name: Deploy if new commits on main
 
     steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 1
+
       - name: Get last deployed commit on Netlify
         id: netlify
         env:
@@ -20,35 +29,27 @@ jobs:
           set -euo pipefail
           LAST_DEPLOYED=$(curl -fsS \
             -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN" \
-            "https://api.netlify.com/api/v1/sites/$NETLIFY_SITE_ID/deploys?branch=main&per_page=10" \
+            "https://api.netlify.com/api/v1/sites/$NETLIFY_SITE_ID/deploys?branch=production&per_page=10" \
             | jq -r '[.[] | select(.state == "ready")][0].commit_ref')
-          if [ -z "${LAST_DEPLOYED:-}" ] || [ "$LAST_DEPLOYED" = "null" ]; then
-            echo "::error::Unable to resolve last deployed commit from Netlify."
-            exit 1
+          if [ "$LAST_DEPLOYED" = "null" ] || [ -z "${LAST_DEPLOYED:-}" ]; then
+            echo "No prior production deploy found. Will deploy."
+            LAST_DEPLOYED=""
           fi
-          echo "Last deployed SHA: $LAST_DEPLOYED"
+          echo "Last deployed SHA: ${LAST_DEPLOYED:-<none>}"
           echo "last_deployed=$LAST_DEPLOYED" >> "$GITHUB_OUTPUT"
 
       - name: Get current HEAD of main
         id: github
         run: |
-          set -euo pipefail
-          CURRENT_HEAD=$(curl -fsS \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/${{ github.repository }}/git/ref/heads/main" \
-            | jq -r '.object.sha')
-          if [ -z "${CURRENT_HEAD:-}" ] || [ "$CURRENT_HEAD" = "null" ]; then
-            echo "::error::Unable to resolve GitHub main HEAD SHA."
-            exit 1
-          fi
+          CURRENT_HEAD=$(git rev-parse HEAD)
           echo "Current HEAD SHA: $CURRENT_HEAD"
           echo "current_head=$CURRENT_HEAD" >> "$GITHUB_OUTPUT"
 
-      - name: Trigger Netlify deploy
+      - name: Push main to production branch
         if: steps.netlify.outputs.last_deployed != steps.github.outputs.current_head
         run: |
-          curl -fsS -X POST -d '{}' "${{ secrets.NETLIFY_BUILD_HOOK }}"
-          echo "Deploy triggered — new commits detected."
+          git push origin HEAD:production --force
+          echo "Deploy triggered — pushed main to production branch."
 
       - name: Skip deploy
         if: steps.netlify.outputs.last_deployed == steps.github.outputs.current_head


### PR DESCRIPTION
## Summary

- Netlify production branch changed to `production` (done in Netlify UI)
- Replaces `curl` build hook trigger with `git push origin HEAD:production --force`
- Handles first-run case gracefully (no prior production deploy → deploys instead of erroring)
- Removes `NETLIFY_BUILD_HOOK` secret dependency from the workflow

## How it works

At 4 PM IST (or on manual trigger), the workflow:
1. Checks last deployed SHA on Netlify's `production` branch
2. Compares to current `main` HEAD
3. If different → force-pushes `main` to `production` → Netlify detects the push and builds
4. If same → skips

Pushes to `main` no longer auto-deploy to production. PR preview URLs continue to work (PRs target `main`, which is a branch deploy branch).

## Test Plan

- [ ] Trigger via `workflow_dispatch` — verify Netlify shows a new deploy from `production` branch
- [ ] Trigger again immediately — verify workflow logs "Already up to date. Skipping deploy."
- [ ] Merge a PR to `main` — verify Netlify shows a branch deploy (not production) and live site is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored scheduled deployment workflow for improved reliability and efficiency. Enhanced deployment detection logic to better handle edge cases, streamlined checkout process for faster builds, and optimized deployment triggering mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->