### PR TITLE
Slow down homepage hover transition by 30%

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -122,10 +122,10 @@ head:
         text-decoration: none;
         color: inherit;
         transition:
-          flex 0.52s cubic-bezier(0.4, 0, 0.2, 1),
-          opacity 0.325s ease,
-          background 0.26s ease,
-          box-shadow 0.26s ease;
+          flex 0.6s cubic-bezier(0.4, 0, 0.2, 1),
+          opacity 0.374s ease,
+          background 0.3s ease,
+          box-shadow 0.3s ease;
         position: relative;
         overflow: hidden;
       }

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -130,6 +130,12 @@ head:
         overflow: hidden;
       }
 
+      @media (prefers-reduced-motion: reduce) {
+        .panel {
+          transition: none;
+        }
+      }
+
       .panel-agents {
         background: linear-gradient(180deg, #ffffff 0%, #ECFDF5 100%);
       }

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -122,10 +122,10 @@ head:
         text-decoration: none;
         color: inherit;
         transition:
-          flex 0.4s cubic-bezier(0.4, 0, 0.2, 1),
-          opacity 0.25s ease,
-          background 0.2s ease,
-          box-shadow 0.2s ease;
+          flex 0.52s cubic-bezier(0.4, 0, 0.2, 1),
+          opacity 0.325s ease,
+          background 0.26s ease,
+          box-shadow 0.26s ease;
         position: relative;
         overflow: hidden;
       }


### PR DESCRIPTION
Increases the panel hover transition durations on the homepage gateway by 30% for a smoother feel.

**Changes (src/content/docs/index.mdx)**

| Property | Before | After |
|---|---|---|
| flex | 0.4s | 0.52s |
| opacity | 0.25s | 0.325s |
| background | 0.2s | 0.26s |
| box-shadow | 0.2s | 0.26s |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Tuned panel hover and collapse animations for smoother, slightly slower motion and longer opacity/background/box-shadow fades.
  * Added respect for users' "reduced motion" preference to disable panel transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->