### PR TITLE
All SSO integration guides: add prerequisites, explicit attributes, and next steps

### DIFF
--- a/src/content/docs/guides/integrations/sso-integrations/azure-ad-saml.mdx
+++ b/src/content/docs/guides/integrations/sso-integrations/azure-ad-saml.mdx
@@ -18,6 +18,12 @@ import { Steps, Aside, Badge } from "@astrojs/starlight/components"
 
 This guide walks you through configuring Microsoft Entra ID as your SAML identity provider for the application you are onboarding, enabling secure Single Sign-On for your users. You'll learn how to set up an enterprise application, configure SAML settings, map user attributes, and assign users to the application. By following these steps, your users will be able to seamlessly authenticate using their Microsoft Entra ID credentials.
 
+<Aside type="tip" title="Before you begin">
+Make sure you have [registered a redirect URL](/guides/dashboard/redirects/) for your application in the Scalekit Dashboard. SSO login will fail with a "No redirect uris found" error if this step is skipped.
+
+If you haven't started integrating SSO into your app yet, follow [Add modular SSO](/authenticate/sso/add-modular-sso/) first.
+</Aside>
+
 ## Download metadata XML
 
 <Steps>
@@ -69,7 +75,13 @@ This guide walks you through configuring Microsoft Entra ID as your SAML identit
 
    ![Click on Edit](@/assets/docs/guides/sso-integrations/azure-ad-saml/6.png)
 
-2. Check the **Attribute Mapping** section in the **SSO Configuration Portal**, and carefully map the same attributes on your **Entra ID** app
+2. The following user profile attributes must be mapped in Entra ID so that Scalekit receives user details during SSO login:
+
+   - **Email Address** of the user
+   - **First Name** of the user
+   - **Last Name** of the user
+
+   Check the **Attribute Mapping** section in the **SSO Configuration Portal** for the exact attribute names and values to use, then map the same attributes on your **Entra ID** app.
 
    ![SSO Configuration Portal](@/assets/docs/guides/sso-integrations/azure-ad-saml/7.png)
    ![Microsoft Entra ID](@/assets/docs/guides/sso-integrations/azure-ad-saml/8.png)
@@ -118,3 +130,8 @@ Click on **Enable Connection**. This will let all your selected users login to t
 ![Enable SSO on Entra ID](@/assets/docs/guides/sso-integrations/azure-ad-saml/13.png)
 
 With this, we are done configuring your Microsoft Entra ID application for an SSO login setup.
+
+## Next steps
+
+- [Map custom user attributes](/sso/guides/sso-user-attributes/) to pass additional profile details from your IdP to your application.
+- [Test your SSO integration](/sso/guides/test-sso/) end to end to verify the full login flow.

--- a/src/content/docs/guides/integrations/sso-integrations/generic-oidc.mdx
+++ b/src/content/docs/guides/integrations/sso-integrations/generic-oidc.mdx
@@ -12,9 +12,15 @@ sidebar:
     text: OIDC
 ---
 
-import { Steps } from "@astrojs/starlight/components";
+import { Steps, Aside } from "@astrojs/starlight/components";
 
 This guide walks you through configuring a generic OIDC identity provider for your application, enabling secure single sign-on for your users. You'll learn how to set up OIDC integration, configure client credentials, and test the connection.
+
+<Aside type="tip" title="Before you begin">
+Make sure you have [registered a redirect URL](/guides/dashboard/redirects/) for your application in the Scalekit Dashboard. SSO login will fail with a "No redirect uris found" error if this step is skipped.
+
+If you haven't started integrating SSO into your app yet, follow [Add modular SSO](/authenticate/sso/add-modular-sso/) first.
+</Aside>
 
 <Steps>
 1. ### Configure OIDC
@@ -89,3 +95,8 @@ This guide walks you through configuring a generic OIDC identity provider for yo
 
    With this, we are done configuring your application for an OIDC login setup.
 </Steps>
+
+## Next steps
+
+- [Map custom user attributes](/sso/guides/sso-user-attributes/) to pass additional profile details from your IdP to your application.
+- [Test your SSO integration](/sso/guides/test-sso/) end to end to verify the full login flow.

--- a/src/content/docs/guides/integrations/sso-integrations/generic-saml.mdx
+++ b/src/content/docs/guides/integrations/sso-integrations/generic-saml.mdx
@@ -12,9 +12,15 @@ sidebar:
     text: SAML
 ---
 
-import { Steps } from "@astrojs/starlight/components";
+import { Steps, Aside } from "@astrojs/starlight/components";
 
 This guide walks you through configuring a generic SAML identity provider for your application, enabling secure single sign-on for your users. You'll learn how to set up a SAML application, configure service provider and identity provider settings, and test the connection.
+
+<Aside type="tip" title="Before you begin">
+Make sure you have [registered a redirect URL](/guides/dashboard/redirects/) for your application in the Scalekit Dashboard. SSO login will fail with a "No redirect uris found" error if this step is skipped.
+
+If you haven't started integrating SSO into your app yet, follow [Add modular SSO](/authenticate/sso/add-modular-sso/) first.
+</Aside>
 
 <Steps>
 1. ### Create a SAML application
@@ -119,3 +125,8 @@ This guide walks you through configuring a generic SAML identity provider for yo
 
    With this, we are done configuring your application for an SSO login setup.
 </Steps>
+
+## Next steps
+
+- [Map custom user attributes](/sso/guides/sso-user-attributes/) to pass additional profile details from your IdP to your application.
+- [Test your SSO integration](/sso/guides/test-sso/) end to end to verify the full login flow.

--- a/src/content/docs/guides/integrations/sso-integrations/google-oidc.mdx
+++ b/src/content/docs/guides/integrations/sso-integrations/google-oidc.mdx
@@ -15,6 +15,12 @@ import { Steps, Aside } from "@astrojs/starlight/components"
 
 This guide walks you through configuring Google Workspace as your OIDC identity provider. You'll create a Google OAuth app, configure an OAuth client, provide the required OIDC values in the SSO Configuration Portal, test the connection, and then enable Single Sign-On.
 
+<Aside type="tip" title="Before you begin">
+Make sure you have [registered a redirect URL](/guides/dashboard/redirects/) for your application in the Scalekit Dashboard. SSO login will fail with a "No redirect uris found" error if this step is skipped.
+
+If you haven't started integrating SSO into your app yet, follow [Add modular SSO](/authenticate/sso/add-modular-sso/) first.
+</Aside>
+
 <Steps>
 1. ## Create an OAuth App
 
@@ -76,3 +82,8 @@ This guide walks you through configuring Google Workspace as your OIDC identity 
 
    This completes the Google Workspace OIDC SSO setup for your application.
 </Steps>
+
+## Next steps
+
+- [Map custom user attributes](/sso/guides/sso-user-attributes/) to pass additional profile details from your IdP to your application.
+- [Test your SSO integration](/sso/guides/test-sso/) end to end to verify the full login flow.

--- a/src/content/docs/guides/integrations/sso-integrations/google-saml.mdx
+++ b/src/content/docs/guides/integrations/sso-integrations/google-saml.mdx
@@ -25,6 +25,12 @@ import { Aside, Steps } from '@astrojs/starlight/components'
 
 This guide walks you through configuring Google Workspace as your SAML identity provider for the application you are onboarding, enabling secure single sign-on for your users. You'll learn how to set up an enterprise application and configure SAML settings to the host application. By following these steps, your users will be able to seamlessly authenticate using their Google Workspace credentials.
 
+<Aside type="tip" title="Before you begin">
+Make sure you have [registered a redirect URL](/guides/dashboard/redirects/) for your application in the Scalekit Dashboard. SSO login will fail with a "No redirect uris found" error if this step is skipped.
+
+If you haven't started integrating SSO into your app yet, follow [Add modular SSO](/authenticate/sso/add-modular-sso/) first.
+</Aside>
+
 <Steps>
 
 1. ## Create a custom SAML app in Google Workspace
@@ -174,3 +180,8 @@ Congratulations! You have successfully configured Google SAML for your applicati
 <Aside type="note" title="Google Workspace SSO resources">
 For more detailed information about setting up custom SAML apps in Google Workspace, refer to the [official Google Workspace documentation](https://support.google.com/a/answer/6087519).
 </Aside>
+
+## Next steps
+
+- [Map custom user attributes](/sso/guides/sso-user-attributes/) to pass additional profile details from your IdP to your application.
+- [Test your SSO integration](/sso/guides/test-sso/) end to end to verify the full login flow.

--- a/src/content/docs/guides/integrations/sso-integrations/jumpcloud-oidc.mdx
+++ b/src/content/docs/guides/integrations/sso-integrations/jumpcloud-oidc.mdx
@@ -15,6 +15,12 @@ import { Steps, Aside } from "@astrojs/starlight/components"
 
 This guide walks you through configuring JumpCloud as your OIDC identity provider. You'll create a custom OIDC application, add the redirect URI, provide the required OIDC values in the SSO Configuration Portal, assign access, test the connection, and then enable Single Sign-On.
 
+<Aside type="tip" title="Before you begin">
+Make sure you have [registered a redirect URL](/guides/dashboard/redirects/) for your application in the Scalekit Dashboard. SSO login will fail with a "No redirect uris found" error if this step is skipped.
+
+If you haven't started integrating SSO into your app yet, follow [Add modular SSO](/authenticate/sso/add-modular-sso/) first.
+</Aside>
+
 <Steps>
 1. ## Create an OIDC Application
 
@@ -77,3 +83,8 @@ This guide walks you through configuring JumpCloud as your OIDC identity provide
 
    This completes the JumpCloud OIDC SSO setup for your application.
 </Steps>
+
+## Next steps
+
+- [Map custom user attributes](/sso/guides/sso-user-attributes/) to pass additional profile details from your IdP to your application.
+- [Test your SSO integration](/sso/guides/test-sso/) end to end to verify the full login flow.

--- a/src/content/docs/guides/integrations/sso-integrations/jumpcloud-saml.mdx
+++ b/src/content/docs/guides/integrations/sso-integrations/jumpcloud-saml.mdx
@@ -16,6 +16,12 @@ import { Aside, Steps } from '@astrojs/starlight/components';
 
 This guide walks you through configuring JumpCloud as your SAML identity provider for the application you are onboarding, enabling secure single sign-on for your users. You'll learn how to set up an enterprise application, configure SAML settings to the host application. By following these steps, your users will be able to seamlessly authenticate using their JumpCloud credentials.
 
+<Aside type="tip" title="Before you begin">
+Make sure you have [registered a redirect URL](/guides/dashboard/redirects/) for your application in the Scalekit Dashboard. SSO login will fail with a "No redirect uris found" error if this step is skipped.
+
+If you haven't started integrating SSO into your app yet, follow [Add modular SSO](/authenticate/sso/add-modular-sso/) first.
+</Aside>
+
 ## Download metadata XML
 
 Sign into the SSO Configuration Portal, select **JumpCloud,** then **SAML,** and click on **Configure**
@@ -77,9 +83,13 @@ Under **Service Provider Details,** click on **Download Metadata XML**
 
    ![Locate Attributes section on JumpCloud Portal](@/assets/docs/guides/sso-integrations/jumpcloud-saml/9.png)
 
-2. Map the attributes:
-   - Check the **Attribute Mapping** section in the SSO Configuration Portal
-   - Map the same attributes on your JumpCloud application
+2. The following user profile attributes must be mapped in JumpCloud so that Scalekit receives user details during SSO login:
+
+   - **Email Address** of the user
+   - **First Name** of the user
+   - **Last Name** of the user
+
+   Check the **Attribute Mapping** section in the SSO Configuration Portal for the exact attribute names and values to use, then map the same attributes on your JumpCloud application.
 
    ![Attribute mapping from SSO Configuration Portal](@/assets/docs/guides/sso-integrations/jumpcloud-saml/10.png)
    ![Attribute Mapping on JumpCloud Portal](/images/docs/guides/sso-integrations/jumpcloud-saml/10-5.gif)
@@ -122,3 +132,8 @@ Click on **Enable Connection**. This will let all your selected users login to t
 <Aside type="note">
 You can access the SSO Configuration Portal at <a href="https://your-subdomain.scalekit.dev" target="_blank">https://your-subdomain.scalekit.dev</a> (Development) or <a href="https://your-subdomain.scalekit.com" target="_blank">https://your-subdomain.scalekit.com</a> (Production)
 </Aside>
+
+## Next steps
+
+- [Map custom user attributes](/sso/guides/sso-user-attributes/) to pass additional profile details from your IdP to your application.
+- [Test your SSO integration](/sso/guides/test-sso/) end to end to verify the full login flow.

--- a/src/content/docs/guides/integrations/sso-integrations/microsoft-ad-fs.mdx
+++ b/src/content/docs/guides/integrations/sso-integrations/microsoft-ad-fs.mdx
@@ -22,6 +22,9 @@ To successfully set up AD FS SAML integration, you'll need:
 
 - Elevated access to your AD FS Management Console
 - Access to the Admin Portal of the application you're integrating Microsoft AD FS with
+- A [registered redirect URL](/guides/dashboard/redirects/) for your application in the Scalekit Dashboard
+
+If you haven't started integrating SSO into your app yet, follow [Add modular SSO](/authenticate/sso/add-modular-sso/) first.
 
 <Aside type="tip">
   Having these prerequisites ready before starting will make the configuration process smoother
@@ -142,3 +145,8 @@ To successfully set up AD FS SAML integration, you'll need:
     ![](@/assets/docs/guides/sso-integrations/microsoft-ad-fs/14.png)
 
 </Steps>
+
+## Next steps
+
+- [Map custom user attributes](/sso/guides/sso-user-attributes/) to pass additional profile details from your IdP to your application.
+- [Test your SSO integration](/sso/guides/test-sso/) end to end to verify the full login flow.

--- a/src/content/docs/guides/integrations/sso-integrations/microsoft-entraid-oidc.mdx
+++ b/src/content/docs/guides/integrations/sso-integrations/microsoft-entraid-oidc.mdx
@@ -16,6 +16,12 @@ import { Steps, Aside } from "@astrojs/starlight/components"
 
 This guide walks you through configuring Microsoft Entra ID as your OIDC identity provider. You'll create an app registration, provide OIDC values in the SSO Configuration Portal, map required claims, assign access, test the connection, and enable Single Sign-On.
 
+<Aside type="tip" title="Before you begin">
+Make sure you have [registered a redirect URL](/guides/dashboard/redirects/) for your application in the Scalekit Dashboard. SSO login will fail with a "No redirect uris found" error if this step is skipped.
+
+If you haven't started integrating SSO into your app yet, follow [Add modular SSO](/authenticate/sso/add-modular-sso/) first.
+</Aside>
+
 <Steps>
 1. ## Create an Application
 
@@ -85,3 +91,8 @@ This guide walks you through configuring Microsoft Entra ID as your OIDC identit
 
    This completes the Microsoft Entra ID OIDC SSO setup for your application.
 </Steps>
+
+## Next steps
+
+- [Map custom user attributes](/sso/guides/sso-user-attributes/) to pass additional profile details from your IdP to your application.
+- [Test your SSO integration](/sso/guides/test-sso/) end to end to verify the full login flow.

--- a/src/content/docs/guides/integrations/sso-integrations/okta-oidc.mdx
+++ b/src/content/docs/guides/integrations/sso-integrations/okta-oidc.mdx
@@ -16,6 +16,12 @@ import { Steps, Aside } from "@astrojs/starlight/components"
 
 This guide walks you through configuring Okta as your OIDC identity provider for your application. You'll create an OIDC app integration in Okta, connect it to the SSO Configuration Portal, assign access, test the connection, and then enable Single Sign-On.
 
+<Aside type="tip" title="Before you begin">
+Make sure you have [registered a redirect URL](/guides/dashboard/redirects/) for your application in the Scalekit Dashboard. SSO login will fail with a "No redirect uris found" error if this step is skipped.
+
+If you haven't started integrating SSO into your app yet, follow [Add modular SSO](/authenticate/sso/add-modular-sso/) first.
+</Aside>
+
 <Steps>
 1. ## Create an OIDC Integration
 
@@ -89,3 +95,8 @@ This guide walks you through configuring Okta as your OIDC identity provider for
 
    This completes the Okta OIDC SSO setup for your application.
 </Steps>
+
+## Next steps
+
+- [Map custom user attributes](/sso/guides/sso-user-attributes/) to pass additional profile details from your IdP to your application.
+- [Test your SSO integration](/sso/guides/test-sso/) end to end to verify the full login flow.

--- a/src/content/docs/guides/integrations/sso-integrations/onelogin-oidc.mdx
+++ b/src/content/docs/guides/integrations/sso-integrations/onelogin-oidc.mdx
@@ -15,6 +15,12 @@ import { Steps, Aside } from "@astrojs/starlight/components"
 
 This guide walks you through configuring OneLogin as your OIDC identity provider. You'll create an OIDC application, add the redirect URI, provide the required OIDC values in the SSO Configuration Portal, assign access, test the connection, and then enable Single Sign-On.
 
+<Aside type="tip" title="Before you begin">
+Make sure you have [registered a redirect URL](/guides/dashboard/redirects/) for your application in the Scalekit Dashboard. SSO login will fail with a "No redirect uris found" error if this step is skipped.
+
+If you haven't started integrating SSO into your app yet, follow [Add modular SSO](/authenticate/sso/add-modular-sso/) first.
+</Aside>
+
 <Steps>
 1. ## Create an Application
 
@@ -75,3 +81,8 @@ This guide walks you through configuring OneLogin as your OIDC identity provider
 
    This completes the OneLogin OIDC SSO setup for your application.
 </Steps>
+
+## Next steps
+
+- [Map custom user attributes](/sso/guides/sso-user-attributes/) to pass additional profile details from your IdP to your application.
+- [Test your SSO integration](/sso/guides/test-sso/) end to end to verify the full login flow.

--- a/src/content/docs/guides/integrations/sso-integrations/onelogin-saml.mdx
+++ b/src/content/docs/guides/integrations/sso-integrations/onelogin-saml.mdx
@@ -33,9 +33,15 @@ sidebar:
     text: SAML
 ---
 
-import { Steps } from '@astrojs/starlight/components';
+import { Steps, Aside } from '@astrojs/starlight/components';
 
 This guide walks you through configuring OneLogin as your SAML identity provider for the application you are onboarding, enabling secure single sign-on for your users. You'll learn how to set up an enterprise application, configure SAML settings to the host application. By following these steps, your users will be able to seamlessly authenticate using their OneLogin credentials.
+
+<Aside type="tip" title="Before you begin">
+Make sure you have [registered a redirect URL](/guides/dashboard/redirects/) for your application in the Scalekit Dashboard. SSO login will fail with a "No redirect uris found" error if this step is skipped.
+
+If you haven't started integrating SSO into your app yet, follow [Add modular SSO](/authenticate/sso/add-modular-sso/) first.
+</Aside>
 
 <Steps>
 1. ## Creating enterprise application
@@ -87,7 +93,13 @@ This guide walks you through configuring OneLogin as your SAML identity provider
 
    ![Locate Parameters tab](@/assets/docs/guides/sso-integrations/onelogin-saml/9.png)
 
-   Check the **Attribute Mapping** section in the **SSO Configuration Portal**, and carefully map the **exact** **same attributes** on your **OneLogin Admin Portal**.
+   The following user profile attributes must be mapped in OneLogin so that Scalekit receives user details during SSO login:
+
+   - **Email Address** of the user
+   - **First Name** of the user
+   - **Last Name** of the user
+
+   Check the **Attribute Mapping** section in the **SSO Configuration Portal** for the exact attribute names and values to use, then map the same attributes on your **OneLogin Admin Portal**.
 
    ![Check attributes on SSO Configuration Portal](@/assets/docs/guides/sso-integrations/onelogin-saml/10.png)
 
@@ -141,3 +153,8 @@ This guide walks you through configuring OneLogin as your SAML identity provider
 </Steps>
 
 With this, we are done configuring your **OneLogin Admin Portal** application for an SSO login setup.
+
+## Next steps
+
+- [Map custom user attributes](/sso/guides/sso-user-attributes/) to pass additional profile details from your IdP to your application.
+- [Test your SSO integration](/sso/guides/test-sso/) end to end to verify the full login flow.

--- a/src/content/docs/guides/integrations/sso-integrations/pingidentity-oidc.mdx
+++ b/src/content/docs/guides/integrations/sso-integrations/pingidentity-oidc.mdx
@@ -15,6 +15,12 @@ import { Steps, Aside } from "@astrojs/starlight/components"
 
 This guide walks you through configuring Ping Identity as your OIDC identity provider. You'll create an OIDC web application, add the redirect URL, provide the required OIDC values in the SSO Configuration Portal, configure user claims, test the connection, and then enable Single Sign-On.
 
+<Aside type="tip" title="Before you begin">
+Make sure you have [registered a redirect URL](/guides/dashboard/redirects/) for your application in the Scalekit Dashboard. SSO login will fail with a "No redirect uris found" error if this step is skipped.
+
+If you haven't started integrating SSO into your app yet, follow [Add modular SSO](/authenticate/sso/add-modular-sso/) first.
+</Aside>
+
 <Steps>
 1. ## Create an OIDC App
 
@@ -73,3 +79,8 @@ This guide walks you through configuring Ping Identity as your OIDC identity pro
 
    This completes the Ping Identity OIDC SSO setup for your application.
 </Steps>
+
+## Next steps
+
+- [Map custom user attributes](/sso/guides/sso-user-attributes/) to pass additional profile details from your IdP to your application.
+- [Test your SSO integration](/sso/guides/test-sso/) end to end to verify the full login flow.

--- a/src/content/docs/guides/integrations/sso-integrations/pingidentity-saml.mdx
+++ b/src/content/docs/guides/integrations/sso-integrations/pingidentity-saml.mdx
@@ -12,9 +12,15 @@ sidebar:
     text: SAML
 ---
 
-import { Steps } from '@astrojs/starlight/components';
+import { Steps, Aside } from '@astrojs/starlight/components';
 
 This guide walks you through configuring Ping Identity as your SAML identity provider for the application you are onboarding, enabling secure single sign-on for your users. You'll learn how to set up an enterprise application, configure SAML settings to the host application. By following these steps, your users will be able to seamlessly authenticate using their Ping Identity credentials.
+
+<Aside type="tip" title="Before you begin">
+Make sure you have [registered a redirect URL](/guides/dashboard/redirects/) for your application in the Scalekit Dashboard. SSO login will fail with a "No redirect uris found" error if this step is skipped.
+
+If you haven't started integrating SSO into your app yet, follow [Add modular SSO](/authenticate/sso/add-modular-sso/) first.
+</Aside>
 
 <Steps>
 1. ### Create a custom SAML app in PingIdentity
@@ -112,3 +118,8 @@ This guide walks you through configuring Ping Identity as your SAML identity pro
 
    With this, we are done configuring Ping Identity SAML for your application for an SSO login setup.
 </Steps>
+
+## Next steps
+
+- [Map custom user attributes](/sso/guides/sso-user-attributes/) to pass additional profile details from your IdP to your application.
+- [Test your SSO integration](/sso/guides/test-sso/) end to end to verify the full login flow.

--- a/src/content/docs/guides/integrations/sso-integrations/shibboleth-saml.mdx
+++ b/src/content/docs/guides/integrations/sso-integrations/shibboleth-saml.mdx
@@ -40,6 +40,12 @@ import { Steps, Aside, Badge } from '@astrojs/starlight/components';
 
 This guide walks you through configuring Shibboleth as your SAML identity provider for the application you are onboarding, enabling secure single sign-on for your users. You'll learn how to set up a Shibboleth identity provider, configure SAML settings, map user attributes, and connect it to your application. By following these steps, your users will be able to seamlessly authenticate using their Shibboleth credentials.
 
+<Aside type="tip" title="Before you begin">
+Make sure you have [registered a redirect URL](/guides/dashboard/redirects/) for your application in the Scalekit Dashboard. SSO login will fail with a "No redirect uris found" error if this step is skipped.
+
+If you haven't started integrating SSO into your app yet, follow [Add modular SSO](/authenticate/sso/add-modular-sso/) first.
+</Aside>
+
 <Aside type="note">
 This guide is written for Shibboleth Identity Provider (IdP) version 4.0.1. If you need help with the initial Shibboleth IdP setup, please refer to the [official Shibboleth documentation](https://shibboleth.atlassian.net/wiki/spaces/IDP5/overview) and [download Shibboleth version v4.0.1](https://shibboleth.net/downloads/identity-provider/latest4/). While other versions may work similarly, the specific steps and configuration options shown here are for v4.0.1.
 </Aside>
@@ -338,3 +344,8 @@ Replace `ONBOARDED_APP_SP_ENTITY_ID` with your Entity ID and `YOUR_RELAY_STATE_U
 </Steps>
 
 With this configuration, your Shibboleth IdP is now integrated with your application, enabling secure single sign-on for your users. Users can authenticate using their Shibboleth credentials and access your application seamlessly.
+
+## Next steps
+
+- [Map custom user attributes](/sso/guides/sso-user-attributes/) to pass additional profile details from your IdP to your application.
+- [Test your SSO integration](/sso/guides/test-sso/) end to end to verify the full login flow.


### PR DESCRIPTION
## Problem

[Pylon #914](https://app.usepylon.com/issues?issueNumber=914) revealed that a customer completed an entire IdP SAML setup only to hit `No redirect uris found` because no integration guide mentions this prerequisite. The customer also couldn't figure out which SAML attributes to map because some guides rely entirely on screenshots.

An audit of all 15 IdP-specific integration guides (8 SAML + 7 OIDC) found these gaps are systemic — not just an Okta problem.

## Changes

### 1. "Before you begin" prerequisite (all 15 guides)

Every guide now has an `<Aside>` at the top linking to:
- [Redirect URL configuration](/guides/dashboard/redirects/) — required before SSO login works
- [Add modular SSO](/authenticate/sso/add-modular-sso/) — the developer-side integration guide

### 2. Explicit SAML attribute names (3 guides)

Added text listing the required attributes (**Email Address**, **First Name**, **Last Name**) to the guides that were screenshot-only:
- `azure-ad-saml.mdx`
- `jumpcloud-saml.mdx`
- `onelogin-saml.mdx`

The other 5 SAML guides already had this in text.

### 3. "Next steps" section (all 15 guides)

Every guide now links to:
- [Map custom user attributes](/sso/guides/sso-user-attributes/)
- [Test your SSO integration](/sso/guides/test-sso/)

Previously, most of these pages had **zero outbound links**.

## Scope

| File | Prerequisites | Attributes | Next steps |
|------|:---:|:---:|:---:|
| azure-ad-saml | + | + | + |
| generic-saml | + | (already had) | + |
| google-saml | + | (already had) | + |
| jumpcloud-saml | + | + | + |
| microsoft-ad-fs | + (extended existing) | (already had) | + |
| onelogin-saml | + | + | + |
| pingidentity-saml | + | (already had) | + |
| shibboleth-saml | + | (already had) | + |
| generic-oidc | + | N/A | + |
| google-oidc | + | N/A | + |
| jumpcloud-oidc | + | N/A | + |
| microsoft-entraid-oidc | + | N/A | + |
| okta-oidc | + | N/A | + |
| onelogin-oidc | + | N/A | + |
| pingidentity-oidc | + | N/A | + |

## Note

The Okta SAML guide fix is in a separate PR (#674) since it was the specific guide referenced in the support ticket.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced SSO integration guides with upfront prerequisite instructions, including redirect URL registration in the Scalekit Dashboard to prevent setup failures.
  * Clarified required user attribute mappings across multiple SSO providers.
  * Added "Next steps" sections guiding users through custom attribute mapping and end-to-end integration testing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalekit-inc/developer-docs/pull/675)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->