### PR TITLE
fix: correct cluster_terminate description — terminate does not delete

### DIFF
--- a/src/data/agent-connectors/databricksworkspace.ts
+++ b/src/data/agent-connectors/databricksworkspace.ts
@@ -27,7 +27,7 @@ export const tools: Tool[] = [
   },
   {
     name: 'databricksworkspace_cluster_terminate',
-    description: `Terminate a Databricks cluster by cluster ID. The cluster will be deleted and all its associated resources released.`,
+    description: `Terminate a Databricks cluster by cluster ID. The cluster transitions to a terminated state and can be restarted. To permanently delete a cluster, use the permanent delete operation.`,
     params: [
       {
         name: 'cluster_id',


### PR DESCRIPTION
## What

Fixes the inaccurate description for `databricksworkspace_cluster_terminate` in the connector data source.

**Before:** "The cluster will be deleted and all its associated resources released."
**After:** "The cluster transitions to a terminated state and can be restarted. To permanently delete a cluster, use the permanent delete operation."

## Why

The Databricks `POST /api/2.1/clusters/delete` (terminate) endpoint moves a cluster to `TERMINATED` state — it does **not** permanently delete it. The cluster can be restarted. Permanent deletion is a separate `permanent-delete` endpoint.

## References

- [Databricks Clusters Delete API](https://docs.databricks.com/api/workspace/clusters/delete)
- [Databricks Clusters Permanent Delete API](https://docs.databricks.com/api/workspace/clusters/permanentdelete)

Closes #595