### PR TITLE
docs: add troubleshooting entries for MCP OAuth popup and AgentKit connector errors

### DIFF
--- a/src/content/docs/agentkit/connections.mdx
+++ b/src/content/docs/agentkit/connections.mdx
@@ -113,9 +113,9 @@ Each connection has its own name, which you use to identify it in API calls and 
 <details>
 <summary>Why am I seeing a `failed_to_exchange_token` error after the consent screen?</summary>
 
-This error means the OAuth token exchange failed after the user completed the provider's consent screen. The error description may include `Error executing post auth hooks`.
+This error means the OAuth token exchange failed after the user completed the provider's consent screen. The error description may include `Error executing post-auth hooks`.
 
-**Common causes:** the verification session timed out because the user waited too long, a transient platform issue during the token exchange, or a network interruption between the provider and Scalekit.
+**Common causes:** the verification session timed out because you waited too long to complete consent, a transient platform issue during the token exchange, or a network interruption between the provider and Scalekit.
 
 **What to try:**
 
@@ -130,7 +130,7 @@ An error that resolves on retry is almost always transient. If it fails consiste
 <details>
 <summary>Why does the callback page say "session expired or invalid"?</summary>
 
-The OAuth verification session has a time limit. If the user takes too long to complete authentication with the provider (for example, they step away mid-flow or the consent screen loads slowly), the session expires before the callback arrives.
+The OAuth verification session has a time limit. If you take too long to complete authentication with the provider (for example, you step away mid-flow or the consent screen loads slowly), the session expires before the callback arrives.
 
 Close the window and start the connection flow again. No configuration change is needed.
 

--- a/src/content/docs/agentkit/connections.mdx
+++ b/src/content/docs/agentkit/connections.mdx
@@ -107,3 +107,50 @@ You can create more than one connection for the same connector. This is useful w
 - You're integrating with multiple instances of the same service (for example, two different Salesforce orgs)
 
 Each connection has its own name, which you use to identify it in API calls and in the dashboard.
+
+## Troubleshoot connection errors
+
+### failed_to_exchange_token
+
+**Symptom:** After the user completes the OAuth consent screen, the callback redirects to an error page with `error=failed_to_exchange_token`. The error description may include `Error executing post auth hooks`.
+
+**Common causes:**
+
+- **Session expired:** The user waited too long between starting the OAuth flow and completing consent. The verification session timed out.
+- **Transient platform issue:** A temporary error occurred during the token exchange between the provider and Scalekit. This includes post-auth hook failures.
+- **Network interruption:** Connectivity between the provider and Scalekit was disrupted during the callback.
+
+**Resolution:**
+
+1. Close the error page and restart the connection flow from your application
+2. If the error persists after retrying, check the [Scalekit status page](https://status.scalekit.com) for ongoing incidents
+3. If no incident is reported and retries continue to fail, contact [support](mailto:support@scalekit.com) with the full error URL and timestamp
+
+<Aside type="tip" title="Distinguish transient errors from misconfigurations">
+A `failed_to_exchange_token` error that resolves on retry is almost always a transient issue. If it happens consistently for the same connection, check your OAuth app credentials and redirect URI configuration.
+</Aside>
+
+### Session expired or invalid
+
+**Symptom:** The callback page shows *"Your verification session has expired or is no longer valid. Please close this window and restart the connection flow."*
+
+**Cause:** The OAuth verification session has a time limit. If the user takes too long to complete authentication with the provider (for example, they step away mid-flow or the provider's consent screen loads slowly), the session expires before the callback arrives.
+
+**Resolution:** Close the window and start the connection flow again. No configuration change is needed.
+
+### redirect_uri_mismatch
+
+**Symptom:** The provider returns a `redirect_uri_mismatch` error instead of completing the OAuth flow.
+
+**Cause:** The redirect URI registered in the provider's OAuth app does not match the URI that Scalekit sends in the authorization request.
+
+**Resolution:**
+
+1. In Scalekit Dashboard, go to **AgentKit** > **Connections** and open the affected connection
+2. Copy the **Redirect URI** shown in the connection form
+3. In the provider's developer console, verify the redirect URI matches exactly -- including protocol (`https` vs `http`), trailing slashes, and port numbers
+4. Save and retry the connection flow
+
+<Aside type="caution" title="Character-for-character match required">
+Providers enforce an exact string match on redirect URIs. Common mismatches: a trailing slash (`/callback/` vs `/callback`), `http` vs `https`, or a missing port number.
+</Aside>

--- a/src/content/docs/agentkit/connections.mdx
+++ b/src/content/docs/agentkit/connections.mdx
@@ -108,49 +108,44 @@ You can create more than one connection for the same connector. This is useful w
 
 Each connection has its own name, which you use to identify it in API calls and in the dashboard.
 
-## Troubleshoot connection errors
+## Common scenarios
 
-### failed_to_exchange_token
+<details>
+<summary>Why am I seeing a `failed_to_exchange_token` error after the consent screen?</summary>
 
-**Symptom:** After the user completes the OAuth consent screen, the callback redirects to an error page with `error=failed_to_exchange_token`. The error description may include `Error executing post auth hooks`.
+This error means the OAuth token exchange failed after the user completed the provider's consent screen. The error description may include `Error executing post auth hooks`.
 
-**Common causes:**
+**Common causes:** the verification session timed out because the user waited too long, a transient platform issue during the token exchange, or a network interruption between the provider and Scalekit.
 
-- **Session expired:** The user waited too long between starting the OAuth flow and completing consent. The verification session timed out.
-- **Transient platform issue:** A temporary error occurred during the token exchange between the provider and Scalekit. This includes post-auth hook failures.
-- **Network interruption:** Connectivity between the provider and Scalekit was disrupted during the callback.
+**What to try:**
 
-**Resolution:**
+1. Close the error page and restart the connection flow
+2. If the error persists, check the [Scalekit status page](https://status.scalekit.com) for ongoing incidents
+3. If no incident is reported, contact [support](mailto:support@scalekit.com) with the full error URL and timestamp
 
-1. Close the error page and restart the connection flow from your application
-2. If the error persists after retrying, check the [Scalekit status page](https://status.scalekit.com) for ongoing incidents
-3. If no incident is reported and retries continue to fail, contact [support](mailto:support@scalekit.com) with the full error URL and timestamp
+An error that resolves on retry is almost always transient. If it fails consistently for the same connection, check your OAuth app credentials and redirect URI configuration.
 
-<Aside type="tip" title="Distinguish transient errors from misconfigurations">
-A `failed_to_exchange_token` error that resolves on retry is almost always a transient issue. If it happens consistently for the same connection, check your OAuth app credentials and redirect URI configuration.
-</Aside>
+</details>
 
-### Session expired or invalid
+<details>
+<summary>Why does the callback page say "session expired or invalid"?</summary>
 
-**Symptom:** The callback page shows *"Your verification session has expired or is no longer valid. Please close this window and restart the connection flow."*
+The OAuth verification session has a time limit. If the user takes too long to complete authentication with the provider (for example, they step away mid-flow or the consent screen loads slowly), the session expires before the callback arrives.
 
-**Cause:** The OAuth verification session has a time limit. If the user takes too long to complete authentication with the provider (for example, they step away mid-flow or the provider's consent screen loads slowly), the session expires before the callback arrives.
+Close the window and start the connection flow again. No configuration change is needed.
 
-**Resolution:** Close the window and start the connection flow again. No configuration change is needed.
+</details>
 
-### redirect_uri_mismatch
+<details>
+<summary>Why am I getting a `redirect_uri_mismatch` error?</summary>
 
-**Symptom:** The provider returns a `redirect_uri_mismatch` error instead of completing the OAuth flow.
-
-**Cause:** The redirect URI registered in the provider's OAuth app does not match the URI that Scalekit sends in the authorization request.
-
-**Resolution:**
+The redirect URI registered in the provider's OAuth app does not match the URI that Scalekit sends in the authorization request. Providers enforce an exact string match.
 
 1. In Scalekit Dashboard, go to **AgentKit** > **Connections** and open the affected connection
 2. Copy the **Redirect URI** shown in the connection form
-3. In the provider's developer console, verify the redirect URI matches exactly -- including protocol (`https` vs `http`), trailing slashes, and port numbers
+3. In the provider's developer console, verify the URI matches exactly -- including protocol (`https` vs `http`), trailing slashes, and port numbers
 4. Save and retry the connection flow
 
-<Aside type="caution" title="Character-for-character match required">
-Providers enforce an exact string match on redirect URIs. Common mismatches: a trailing slash (`/callback/` vs `/callback`), `http` vs `https`, or a missing port number.
-</Aside>
+Common mismatches: a trailing slash (`/callback/` vs `/callback`), `http` vs `https`, or a missing port number.
+
+</details>

--- a/src/content/docs/authenticate/mcp/troubleshooting.mdx
+++ b/src/content/docs/authenticate/mcp/troubleshooting.mdx
@@ -185,6 +185,36 @@ Recent versions of Claude Desktop have introduced Connectors functionality, elim
 To avoid duplicate authentication flows, ensure you're using only one MCP client at a time.
 </Aside>
 
+### OAuth popup closes immediately or shows "window closed too soon"
+
+MCP clients that use a popup-based OAuth flow (such as Amazon Q) may report that the popup closed too soon or that authentication failed, even though the OAuth flow completed successfully in the popup window.
+
+**Root cause:** Your application's login page returns a `Cross-Origin-Opener-Policy: same-origin` HTTP header. When a cross-origin MCP client (for example, `quick.aws.com`) opens a popup that navigates to a page with this header, the browser severs the opener's reference to the popup. The MCP client sees the popup as `closed` immediately, before the OAuth callback can complete.
+
+**Diagnosis:**
+
+Check the response headers on your login or redirect endpoint:
+
+```sh frame="terminal"
+curl -sI https://your-app.com/login | grep -i cross-origin-opener-policy
+```
+
+If the output includes `cross-origin-opener-policy: same-origin`, this is the cause.
+
+**Resolution:**
+
+Remove the `Cross-Origin-Opener-Policy` header from your login and OAuth callback endpoints, or change its value to `unsafe-none`:
+
+```
+Cross-Origin-Opener-Policy: unsafe-none
+```
+
+You can scope this change to only the endpoints involved in the OAuth flow rather than your entire application. After the change, retry the MCP client connection.
+
+<Aside type="note" title="This is an application-side fix">
+This header is set by your application or its hosting platform, not by Scalekit. Common sources include framework defaults (for example, Next.js, Rails), CDN or reverse proxy settings, and security middleware.
+</Aside>
+
 ### My browser is not getting invoked during authentication
 
 Some MCP clients require permission to open your default browser during the authentication flow. If your browser doesn't launch, the authentication handshake may timeout, preventing successful authentication.


### PR DESCRIPTION
## Summary

Adds targeted troubleshooting documentation for two user-reported issues:

### MCP OAuth popup failure (COOP header)
- New entry under **Client-Specific Issues** in `authenticate/mcp/troubleshooting.mdx`
- Covers the `Cross-Origin-Opener-Policy: same-origin` header breaking popup-based OAuth flows in MCP clients (e.g. Amazon Q)
- Includes symptom description, root cause explanation, diagnostic curl command, and resolution steps
- Ref: Pylon #852

### AgentKit connector errors
- New **Troubleshoot connection errors** section at the bottom of `agentkit/connections.mdx`
- Documents three error codes: `failed_to_exchange_token`, session expired/invalid, and `redirect_uri_mismatch`
- Ref: Pylon #802

Addresses GH #641 and GH #671.

---

**Preview links** (available once the deploy preview builds):
- https://deploy-preview-678--scalekit-starlight.netlify.app/authenticate/mcp/troubleshooting/
- https://deploy-preview-678--scalekit-starlight.netlify.app/agentkit/connections/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced AgentKit connections troubleshooting with a new "Common scenarios" section covering token-exchange failures, session expiration, and redirect-URI mismatch—includes symptoms, diagnostics, verification steps, and resolution guidance.
  * Added MCP OAuth popup troubleshooting for popup-closure issues caused by Cross-Origin-Opener-Policy, with diagnostic command and recommended configuration fixes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalekit-inc/developer-docs/pull/678)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->