### PR TITLE
Add HubSpot batch tools docs

### DIFF
--- a/src/components/templates/agent-connectors/_section-before-tool-list-hubspot-resource-ids.mdx
+++ b/src/components/templates/agent-connectors/_section-before-tool-list-hubspot-resource-ids.mdx
@@ -1,0 +1,36 @@
+export const sectionTitle = 'Getting resource IDs'
+
+Most HubSpot batch and update tools require record IDs. Always fetch IDs from the API — never guess or hard-code them.
+
+| Resource | Tool to get ID | Field in response |
+|----------|---------------|-------------------|
+| Contact ID | `hubspot_contacts_search` or `hubspot_contacts_list` | `results[].id` |
+| Company ID | `hubspot_companies_search` | `results[].id` |
+| Deal ID | `hubspot_deals_search` | `results[].id` |
+| Ticket ID | `hubspot_tickets_search` | `results[].id` |
+| Line Item ID | `hubspot_deal_line_items_get` | `results[].id` |
+| Product ID | `hubspot_products_list` | `results[].id` |
+| Owner ID | `hubspot_owners_list` | `results[].id` |
+| Pipeline ID | `hubspot_deal_pipelines_list` | `results[].id` |
+| Pipeline Stage ID | `hubspot_deal_pipelines_list` | `results[].stages[].id` |
+| Custom Object Type ID | `hubspot_schemas_list` | `results[].objectTypeId` |
+| Custom Object Record ID | `hubspot_custom_object_records_search` | `results[].id` |
+| Quote ID | `hubspot_quote_get` | `id` |
+
+## Association type IDs
+
+When linking records, use the correct `association_type_id` for the object pair:
+
+| From → To | Association Type ID |
+|-----------|-------------------|
+| Contact → Company (primary) | `1` |
+| Contact → Company | `279` |
+| Contact → Deal | `4` |
+| Contact → Ticket | `15` |
+| Deal → Contact | `3` |
+| Deal → Company | `5` |
+| Ticket → Contact | `16` |
+| Ticket → Company | `340` |
+| Line Item → Deal | `20` |
+| Company → Contact | `280` |
+| Company → Deal | `6` |

--- a/src/components/templates/agent-connectors/_section-before-tool-list-linear-resource-ids.mdx
+++ b/src/components/templates/agent-connectors/_section-before-tool-list-linear-resource-ids.mdx
@@ -1,0 +1,18 @@
+export const sectionTitle = 'Getting resource IDs'
+
+Most Linear tools require one or more IDs. Always fetch IDs from the API — never guess or hard-code them.
+
+| Resource | Tool to get ID | Field in response |
+|----------|---------------|-------------------|
+| Team ID | `linear_teams_list` | `teams.nodes[].id` |
+| Issue ID | `linear_issues_list` or `linear_issue_search` | `issues.nodes[].id` |
+| Project ID | `linear_projects_list` | `projects.nodes[].id` |
+| Cycle ID | `linear_cycles_list` | `cycles.nodes[].id` |
+| Label ID | `linear_labels_list` | `issueLabels.nodes[].id` |
+| Workflow State ID | `linear_workflow_states_list` | `workflowStates.nodes[].id` |
+| User ID | `linear_users_list` | `users.nodes[].id` |
+| Comment ID | `linear_comments_list` | `comments.nodes[].id` |
+| Attachment ID | issue response with attachments | `issue.attachments.nodes[].id` |
+| Webhook ID | `linear_webhooks_list` | `webhooks.nodes[].id` |
+| Milestone ID | `linear_project_milestones_list` | `projectMilestones.nodes[].id` |
+| Roadmap ID | `linear_roadmaps_list` | `roadmaps.nodes[].id` |

--- a/src/components/templates/agent-connectors/_section-before-tool-list-linear-resource-ids.mdx
+++ b/src/components/templates/agent-connectors/_section-before-tool-list-linear-resource-ids.mdx
@@ -12,7 +12,7 @@ Most Linear tools require one or more IDs. Always fetch IDs from the API — nev
 | Workflow State ID | `linear_workflow_states_list` | `workflowStates.nodes[].id` |
 | User ID | `linear_users_list` | `users.nodes[].id` |
 | Comment ID | `linear_comments_list` | `comments.nodes[].id` |
-| Attachment ID | issue response with attachments | `issue.attachments.nodes[].id` |
+| Attachment ID | `linear_issue_get` (include attachments) | `issue.attachments.nodes[].id` |
 | Webhook ID | `linear_webhooks_list` | `webhooks.nodes[].id` |
 | Milestone ID | `linear_project_milestones_list` | `projectMilestones.nodes[].id` |
 | Roadmap ID | `linear_roadmaps_list` | `roadmaps.nodes[].id` |

--- a/src/components/templates/agent-connectors/index.ts
+++ b/src/components/templates/agent-connectors/index.ts
@@ -70,6 +70,7 @@ export { default as ConnectedAccountBigqueryserviceaccountSection } from './_con
 export { default as SectionAfterToolListSalesforceMetadataApiSoap } from './_section-after-tool-list-salesforce-metadata-api-soap.mdx'
 export { default as SectionBeforeToolListXeroCommonPatterns } from './_section-before-tool-list-xero-common-patterns.mdx'
 export { default as SectionBeforeToolListDatadogResourceIds } from './_section-before-tool-list-datadog-resource-ids.mdx'
+export { default as SectionBeforeToolListHubspotResourceIds } from './_section-before-tool-list-hubspot-resource-ids.mdx'
 export { default as SectionBeforeToolListTableauResourceIds } from './_section-before-tool-list-tableau-resource-ids.mdx'
 export { default as UsageAirtableSection } from './_usage-airtable.mdx'
 export { default as UsageApifymcpSection } from './_usage-apifymcp.mdx'

--- a/src/content/docs/agentkit/connectors/hubspot.mdx
+++ b/src/content/docs/agentkit/connectors/hubspot.mdx
@@ -16,22 +16,24 @@ import ToolList from '@/components/ToolList.astro'
 import { tools } from '@/data/agent-connectors/hubspot'
 import { SetupHubspotSection } from '@components/templates'
 import { UsageHubspotSection } from '@components/templates'
+import { SectionBeforeToolListHubspotResourceIds } from '@components/templates'
 
 ## What you can do
 
 Connect this agent connector to let your agent:
 
-- **Manage contacts** — create, update, list, and search contacts; batch-create up to 100 at once
-- **Manage companies** — create and update company records with industry, location, and revenue data
-- **Manage deals** — create deals, move them through pipeline stages, and search by any property
-- **Manage tickets** — create and update support tickets with priority and pipeline stage
+- **Manage contacts** — create, update, search, and list contacts; batch create, update, upsert, read, and archive
+- **Manage companies** — create and update company records; batch create, update, upsert, read, and archive
+- **Manage deals** — create deals, move them through pipeline stages, search; batch create, update, upsert, read, and archive
+- **Manage tickets** — create and update support tickets; batch create, update, upsert, read, and archive
+- **Batch operations with inline associations** — create contacts, companies, deals, or tickets and link them to related records in a single call
 - **Log engagements** — record calls, meetings, notes, and emails against any CRM record
 - **Manage tasks** — create tasks with due dates and priorities, and mark them complete
-- **Work with products, line items, and quotes** — build out deal proposals end-to-end
+- **Work with products, line items, and quotes** — build out deal proposals end-to-end; batch read and archive line items and products
 - **Manage custom objects** — create, update, and search records for any custom schema
 - **Access marketing data** — list forms, retrieve submissions, and inspect campaigns and email events
 - **Search and paginate** — full-text search and filter across all CRM object types
-- **Manage associations** — link any two CRM objects (e.g. associate a contact with a ticket)
+- **Manage associations** — batch create or remove associations between any two CRM objects using the v4 API
 - **List owners and properties** — look up user IDs and discover all available fields per object type
 
 ## Authentication
@@ -55,6 +57,10 @@ Before calling this connector from your code, create the HubSpot connection in *
 <UsageHubspotSection />
 
 </details>
+
+## Getting resource IDs
+
+<SectionBeforeToolListHubspotResourceIds />
 
 ## Tool list
 

--- a/src/content/docs/agentkit/connectors/linear.mdx
+++ b/src/content/docs/agentkit/connectors/linear.mdx
@@ -17,15 +17,6 @@ import { tools } from '@/data/agent-connectors/linear'
 import { SetupLinearSection } from '@components/templates'
 import { UsageLinearSection } from '@components/templates'
 
-## What you can do
-
-Connect this agent connector to let your agent:
-
-- **Read issues** — fetch issues, projects, cycles, and team details
-- **Create and update issues** — file new issues, update status, set priority, and assign teammates
-- **Manage projects** — create and update project metadata and milestones
-- **Search** — find issues by keyword, assignee, label, or state
-
 ## Authentication
 
 This connector uses **OAuth 2.0**. Scalekit acts as the OAuth client: it redirects your user to Linear, obtains an access token, and automatically refreshes it before it expires. Your agent code never handles tokens directly — you only pass a `connectionName` and a user `identifier`.

--- a/src/data/agent-connectors/hubspot.ts
+++ b/src/data/agent-connectors/hubspot.ts
@@ -430,14 +430,147 @@ export const tools: Tool[] = [
   {
     name: 'hubspot_contacts_batch_create',
     description:
-      'Create multiple contacts in HubSpot CRM in a single API call. Each contact requires an email address. Supports up to 100 contacts per request.',
+      'Create a contact in HubSpot CRM using the batch API. Accepts individual fields for a clean form experience. Optionally associate the contact with another object on creation.',
     params: [
       {
-        name: 'contacts',
-        type: 'array',
+        name: 'email',
+        type: 'string',
+        required: true,
+        description: 'Primary email address (required, unique identifier).',
+      },
+      { name: 'firstname', type: 'string', required: false, description: "Contact's first name." },
+      { name: 'lastname', type: 'string', required: false, description: "Contact's last name." },
+      { name: 'phone', type: 'string', required: false, description: "Contact's phone number." },
+      {
+        name: 'company',
+        type: 'string',
+        required: false,
+        description: 'Company the contact works at.',
+      },
+      { name: 'jobtitle', type: 'string', required: false, description: "Contact's job title." },
+      { name: 'website', type: 'string', required: false, description: "Contact's website URL." },
+      {
+        name: 'lifecyclestage',
+        type: 'string',
+        required: false,
+        description:
+          'Lifecycle stage: `subscriber`, `lead`, `marketingqualifiedlead`, `salesqualifiedlead`, `opportunity`, `customer`, `evangelist`.',
+      },
+      {
+        name: 'associate_to_id',
+        type: 'string',
+        required: false,
+        description: 'ID of a company, deal, or ticket to associate with this contact on creation.',
+      },
+      {
+        name: 'association_type_id',
+        type: 'number',
+        required: false,
+        description:
+          'Association type ID. `279`=contact→company, `4`=contact→deal, `15`=contact→ticket. Required if `associate_to_id` is set.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_contacts_batch_update',
+    description:
+      'Update a contact in HubSpot CRM using the batch API. Provide the contact ID and any fields to update.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
         required: true,
         description:
-          'Array of contact objects to create. Each object supports: `email` (required), `firstname`, `lastname`, `phone`, `company`, `jobtitle`, `website`, `lifecyclestage`. Max 100 contacts.',
+          'HubSpot contact record ID. Get from `hubspot_contacts_search` or `hubspot_contact_get`.',
+      },
+      {
+        name: 'email',
+        type: 'string',
+        required: false,
+        description: 'Updated email address (must be unique in HubSpot).',
+      },
+      { name: 'firstname', type: 'string', required: false, description: 'Updated first name.' },
+      { name: 'lastname', type: 'string', required: false, description: 'Updated last name.' },
+      { name: 'phone', type: 'string', required: false, description: 'Updated phone number.' },
+      { name: 'company', type: 'string', required: false, description: 'Updated company name.' },
+      { name: 'jobtitle', type: 'string', required: false, description: 'Updated job title.' },
+      { name: 'website', type: 'string', required: false, description: 'Updated website URL.' },
+      {
+        name: 'lifecyclestage',
+        type: 'string',
+        required: false,
+        description: 'Updated lifecycle stage (e.g. `lead`, `customer`).',
+      },
+      {
+        name: 'hs_lead_status',
+        type: 'string',
+        required: false,
+        description: 'Updated lead status (e.g. `IN_PROGRESS`, `CONNECTED`).',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_contacts_batch_upsert',
+    description:
+      'Create or update a contact in HubSpot CRM using the batch API. Uses email as the unique identifier — creates a new contact if not found, updates if found.',
+    params: [
+      {
+        name: 'email',
+        type: 'string',
+        required: true,
+        description: 'Primary email address used to look up or create the contact.',
+      },
+      { name: 'firstname', type: 'string', required: false, description: "Contact's first name." },
+      { name: 'lastname', type: 'string', required: false, description: "Contact's last name." },
+      { name: 'phone', type: 'string', required: false, description: "Contact's phone number." },
+      {
+        name: 'company',
+        type: 'string',
+        required: false,
+        description: 'Company the contact works at.',
+      },
+      { name: 'jobtitle', type: 'string', required: false, description: "Contact's job title." },
+      { name: 'website', type: 'string', required: false, description: "Contact's website URL." },
+      {
+        name: 'lifecyclestage',
+        type: 'string',
+        required: false,
+        description: 'Lifecycle stage (e.g. `lead`, `customer`).',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_contacts_batch_read',
+    description:
+      'Retrieve a contact record from HubSpot CRM using the batch read API. Returns the specified properties for the record.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description:
+          'HubSpot contact record ID. Get from `hubspot_contacts_search` or `hubspot_contact_get`.',
+      },
+      {
+        name: 'properties',
+        type: 'array',
+        required: false,
+        description:
+          'Array of property names to return (e.g. `["firstname","email","company"]`). Returns default properties if not specified.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_contacts_batch_archive',
+    description:
+      'Archive (soft delete) a contact in HubSpot CRM using the batch archive API. Archived contacts are hidden from the UI but can be restored.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description:
+          'HubSpot contact record ID to archive. Get from `hubspot_contacts_search` or `hubspot_contact_get`.',
       },
     ],
   },
@@ -476,6 +609,189 @@ export const tools: Tool[] = [
         type: 'number',
         required: false,
         description: 'Number of events to return per page (default: 100).',
+      },
+    ],
+  },
+
+  {
+    name: 'hubspot_companies_batch_create',
+    description:
+      'Create a company in HubSpot CRM using the batch API. Accepts individual fields for a clean form experience. Optionally associate the company with another object on creation.',
+    params: [
+      { name: 'name', type: 'string', required: true, description: 'Company name (required).' },
+      {
+        name: 'domain',
+        type: 'string',
+        required: false,
+        description: 'Primary domain of the company (without `https://`).',
+      },
+      { name: 'phone', type: 'string', required: false, description: 'Main company phone number.' },
+      {
+        name: 'city',
+        type: 'string',
+        required: false,
+        description: "City of the company's primary office.",
+      },
+      { name: 'state', type: 'string', required: false, description: 'State or region.' },
+      { name: 'country', type: 'string', required: false, description: 'Country of headquarters.' },
+      {
+        name: 'industry',
+        type: 'string',
+        required: false,
+        description: 'Industry classification (e.g. `TECHNOLOGY`, `FINANCE`, `HEALTHCARE`).',
+      },
+      {
+        name: 'numberofemployees',
+        type: 'number',
+        required: false,
+        description: 'Total employee count.',
+      },
+      {
+        name: 'annualrevenue',
+        type: 'string',
+        required: false,
+        description: 'Annual revenue in USD.',
+      },
+      {
+        name: 'hubspot_owner_id',
+        type: 'string',
+        required: false,
+        description: 'Owner user ID. Get from `hubspot_owners_list`.',
+      },
+      {
+        name: 'associate_to_id',
+        type: 'string',
+        required: false,
+        description: 'ID of a contact or deal to associate with this company on creation.',
+      },
+      {
+        name: 'association_type_id',
+        type: 'number',
+        required: false,
+        description:
+          'Association type ID. `280`=company→contact, `6`=company→deal. Required if `associate_to_id` is set.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_companies_batch_update',
+    description:
+      'Update a company in HubSpot CRM using the batch API. Provide the company ID and any fields to update.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description:
+          'HubSpot company record ID. Get from `hubspot_companies_search` or `hubspot_company_get`.',
+      },
+      { name: 'name', type: 'string', required: false, description: 'Updated company name.' },
+      { name: 'domain', type: 'string', required: false, description: 'Updated primary domain.' },
+      { name: 'phone', type: 'string', required: false, description: 'Updated phone number.' },
+      { name: 'city', type: 'string', required: false, description: 'Updated city.' },
+      { name: 'state', type: 'string', required: false, description: 'Updated state or region.' },
+      { name: 'country', type: 'string', required: false, description: 'Updated country.' },
+      {
+        name: 'industry',
+        type: 'string',
+        required: false,
+        description: 'Updated industry classification.',
+      },
+      {
+        name: 'numberofemployees',
+        type: 'number',
+        required: false,
+        description: 'Updated employee count.',
+      },
+      {
+        name: 'annualrevenue',
+        type: 'string',
+        required: false,
+        description: 'Updated annual revenue in USD.',
+      },
+      {
+        name: 'hubspot_owner_id',
+        type: 'string',
+        required: false,
+        description: 'Updated owner user ID. Get from `hubspot_owners_list`.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_companies_batch_upsert',
+    description:
+      'Create or update a company in HubSpot CRM using the batch API. Uses domain as the unique identifier — creates a new company if the domain is not found, updates if found.',
+    params: [
+      {
+        name: 'domain',
+        type: 'string',
+        required: true,
+        description:
+          'Company domain used to look up or create the company (without `https://`). Must be unique in HubSpot.',
+      },
+      { name: 'name', type: 'string', required: false, description: 'Company name.' },
+      { name: 'phone', type: 'string', required: false, description: 'Main phone number.' },
+      { name: 'city', type: 'string', required: false, description: 'City.' },
+      { name: 'state', type: 'string', required: false, description: 'State or region.' },
+      { name: 'country', type: 'string', required: false, description: 'Country.' },
+      {
+        name: 'industry',
+        type: 'string',
+        required: false,
+        description: 'Industry classification.',
+      },
+      {
+        name: 'numberofemployees',
+        type: 'number',
+        required: false,
+        description: 'Employee count.',
+      },
+      {
+        name: 'annualrevenue',
+        type: 'string',
+        required: false,
+        description: 'Annual revenue in USD.',
+      },
+      {
+        name: 'hubspot_owner_id',
+        type: 'string',
+        required: false,
+        description: 'Owner user ID. Get from `hubspot_owners_list`.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_companies_batch_read',
+    description:
+      'Retrieve a company record from HubSpot CRM using the batch read API. Returns the specified properties for the record.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description:
+          'HubSpot company record ID. Get from `hubspot_companies_search` or `hubspot_company_get`.',
+      },
+      {
+        name: 'properties',
+        type: 'array',
+        required: false,
+        description:
+          'Array of property names to return (e.g. `["name","domain","industry"]`). Returns default properties if not specified.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_companies_batch_archive',
+    description:
+      'Archive (soft delete) a company in HubSpot CRM using the batch archive API. Archived companies are hidden from the UI but can be restored.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description:
+          'HubSpot company record ID to archive. Get from `hubspot_companies_search` or `hubspot_company_get`.',
       },
     ],
   },
@@ -565,8 +881,7 @@ export const tools: Tool[] = [
   },
   {
     name: 'hubspot_deal_update',
-    description:
-      'Update an existing deal in HubSpot CRM by deal ID. Provide any fields to update.',
+    description: 'Update an existing deal in HubSpot CRM by deal ID. Provide any fields to update.',
     params: [
       {
         name: 'deal_id',
@@ -688,11 +1003,168 @@ export const tools: Tool[] = [
     ],
   },
 
+  {
+    name: 'hubspot_deals_batch_create',
+    description:
+      'Create a deal in HubSpot CRM using the batch API. Accepts individual fields for a clean form experience. Optionally associate the deal with a contact or company on creation.',
+    params: [
+      {
+        name: 'dealname',
+        type: 'string',
+        required: true,
+        description: 'Name of the deal (required).',
+      },
+      {
+        name: 'dealstage',
+        type: 'string',
+        required: false,
+        description:
+          'Deal stage ID (e.g. `appointmentscheduled`, `closedwon`). Get valid IDs from `hubspot_deal_pipelines_list`.',
+      },
+      {
+        name: 'pipeline',
+        type: 'string',
+        required: false,
+        description: 'Pipeline ID (default: `default`).',
+      },
+      {
+        name: 'closedate',
+        type: 'string',
+        required: false,
+        description: 'Expected close date in `YYYY-MM-DD` format.',
+      },
+      {
+        name: 'amount',
+        type: 'string',
+        required: false,
+        description: 'Monetary value of the deal (e.g. `10000`).',
+      },
+      {
+        name: 'hubspot_owner_id',
+        type: 'string',
+        required: false,
+        description: 'Owner user ID. Get from `hubspot_owners_list`.',
+      },
+      {
+        name: 'associate_to_id',
+        type: 'string',
+        required: false,
+        description: 'ID of a contact or company to associate with this deal on creation.',
+      },
+      {
+        name: 'association_type_id',
+        type: 'number',
+        required: false,
+        description:
+          'Association type ID. `3`=deal→contact, `5`=deal→company. Required if `associate_to_id` is set.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_deals_batch_update',
+    description:
+      'Update a deal in HubSpot CRM using the batch API. Provide the deal ID and any fields to update.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description:
+          'HubSpot deal record ID. Get from `hubspot_deals_search` or `hubspot_deal_get`.',
+      },
+      { name: 'dealname', type: 'string', required: false, description: 'Updated deal name.' },
+      {
+        name: 'dealstage',
+        type: 'string',
+        required: false,
+        description: 'Updated deal stage ID (e.g. `closedwon`).',
+      },
+      { name: 'pipeline', type: 'string', required: false, description: 'Updated pipeline ID.' },
+      {
+        name: 'closedate',
+        type: 'string',
+        required: false,
+        description: 'Updated close date in `YYYY-MM-DD` format.',
+      },
+      { name: 'amount', type: 'string', required: false, description: 'Updated deal amount.' },
+      {
+        name: 'hubspot_owner_id',
+        type: 'string',
+        required: false,
+        description: 'Updated owner user ID. Get from `hubspot_owners_list`.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_deals_batch_upsert',
+    description:
+      'Create or update a deal in HubSpot CRM using the batch API. Uses deal name as the lookup identifier. Note: `dealname` must be configured as a unique property in your HubSpot portal for upsert to work correctly.',
+    params: [
+      {
+        name: 'dealname',
+        type: 'string',
+        required: true,
+        description:
+          'Deal name used to look up or create the deal. Must be unique in your HubSpot portal for upsert to work.',
+      },
+      { name: 'dealstage', type: 'string', required: false, description: 'Deal stage ID.' },
+      { name: 'pipeline', type: 'string', required: false, description: 'Pipeline ID.' },
+      {
+        name: 'closedate',
+        type: 'string',
+        required: false,
+        description: 'Close date in `YYYY-MM-DD` format.',
+      },
+      { name: 'amount', type: 'string', required: false, description: 'Deal amount.' },
+      {
+        name: 'hubspot_owner_id',
+        type: 'string',
+        required: false,
+        description: 'Owner user ID. Get from `hubspot_owners_list`.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_deals_batch_read',
+    description:
+      'Retrieve a deal record from HubSpot CRM using the batch read API. Returns the specified properties for the record.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description:
+          'HubSpot deal record ID. Get from `hubspot_deals_search` or `hubspot_deal_get`.',
+      },
+      {
+        name: 'properties',
+        type: 'array',
+        required: false,
+        description:
+          'Array of property names to return (e.g. `["dealname","amount","dealstage"]`). Returns default properties if not specified.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_deals_batch_archive',
+    description:
+      'Archive (soft delete) a deal in HubSpot CRM using the batch archive API. Archived deals are hidden from the UI but can be restored.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description:
+          'HubSpot deal record ID to archive. Get from `hubspot_deals_search` or `hubspot_deal_get`.',
+      },
+    ],
+  },
+
   // ─── Tickets ──────────────────────────────────────────────────────────────────
   {
     name: 'hubspot_ticket_create',
     description:
-      "Create a new support ticket in HubSpot. Use `hubspot_deal_pipelines_list` with `object_type: tickets` to find valid pipeline and stage IDs.",
+      'Create a new support ticket in HubSpot. Use `hubspot_deal_pipelines_list` with `object_type: tickets` to find valid pipeline and stage IDs.',
     params: [
       {
         name: 'subject',
@@ -826,6 +1298,179 @@ export const tools: Tool[] = [
     ],
   },
 
+  {
+    name: 'hubspot_tickets_batch_create',
+    description:
+      'Create a support ticket in HubSpot CRM using the batch API. Accepts individual fields for a clean form experience. Optionally associate the ticket with a contact or company on creation.',
+    params: [
+      {
+        name: 'subject',
+        type: 'string',
+        required: true,
+        description: 'Short description of the support issue (required).',
+      },
+      {
+        name: 'hs_pipeline_stage',
+        type: 'string',
+        required: true,
+        description:
+          'Pipeline stage ID: `1`=New, `2`=Waiting on contact, `3`=Waiting on us, `4`=Closed. Get from `hubspot_deal_pipelines_list`.',
+      },
+      {
+        name: 'hs_pipeline',
+        type: 'string',
+        required: false,
+        description: "Pipeline ID. Defaults to `'0'` (default support pipeline).",
+      },
+      {
+        name: 'hs_ticket_priority',
+        type: 'string',
+        required: false,
+        description: 'Priority: `LOW`, `MEDIUM`, or `HIGH`.',
+      },
+      {
+        name: 'content',
+        type: 'string',
+        required: false,
+        description: 'Detailed description of the support issue.',
+      },
+      {
+        name: 'hubspot_owner_id',
+        type: 'string',
+        required: false,
+        description: 'Owner user ID. Get from `hubspot_owners_list`.',
+      },
+      {
+        name: 'associate_to_id',
+        type: 'string',
+        required: false,
+        description: 'ID of a contact or company to associate with this ticket on creation.',
+      },
+      {
+        name: 'association_type_id',
+        type: 'number',
+        required: false,
+        description:
+          'Association type ID. `16`=ticket→contact, `340`=ticket→company. Required if `associate_to_id` is set.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_tickets_batch_update',
+    description:
+      'Update a support ticket in HubSpot CRM using the batch API. Provide the ticket ID and any fields to update.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description:
+          'HubSpot ticket record ID. Get from `hubspot_tickets_search` or `hubspot_ticket_get`.',
+      },
+      { name: 'subject', type: 'string', required: false, description: 'Updated ticket subject.' },
+      { name: 'hs_pipeline', type: 'string', required: false, description: 'Updated pipeline ID.' },
+      {
+        name: 'hs_pipeline_stage',
+        type: 'string',
+        required: false,
+        description: 'Updated pipeline stage ID.',
+      },
+      {
+        name: 'hs_ticket_priority',
+        type: 'string',
+        required: false,
+        description: 'Updated priority: `LOW`, `MEDIUM`, or `HIGH`.',
+      },
+      {
+        name: 'content',
+        type: 'string',
+        required: false,
+        description: 'Updated ticket description.',
+      },
+      {
+        name: 'hubspot_owner_id',
+        type: 'string',
+        required: false,
+        description: 'Updated owner user ID. Get from `hubspot_owners_list`.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_tickets_batch_upsert',
+    description:
+      'Create or update a support ticket in HubSpot CRM using the batch API. Uses subject as the lookup identifier. Note: `subject` must be configured as a unique property in your HubSpot portal for upsert to work correctly.',
+    params: [
+      {
+        name: 'subject',
+        type: 'string',
+        required: true,
+        description:
+          'Ticket subject used to look up or create the ticket. Must be unique in your HubSpot portal for upsert to work.',
+      },
+      {
+        name: 'hs_pipeline_stage',
+        type: 'string',
+        required: true,
+        description:
+          'Pipeline stage ID: `1`=New, `2`=Waiting on contact, `3`=Waiting on us, `4`=Closed.',
+      },
+      {
+        name: 'hs_pipeline',
+        type: 'string',
+        required: false,
+        description: 'Pipeline ID (default: `0`).',
+      },
+      {
+        name: 'hs_ticket_priority',
+        type: 'string',
+        required: false,
+        description: 'Priority: `LOW`, `MEDIUM`, or `HIGH`.',
+      },
+      { name: 'content', type: 'string', required: false, description: 'Ticket description.' },
+      {
+        name: 'hubspot_owner_id',
+        type: 'string',
+        required: false,
+        description: 'Owner user ID. Get from `hubspot_owners_list`.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_tickets_batch_read',
+    description:
+      'Retrieve a support ticket record from HubSpot CRM using the batch read API. Returns the specified properties for the record.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description:
+          'HubSpot ticket record ID. Get from `hubspot_tickets_search` or `hubspot_ticket_get`.',
+      },
+      {
+        name: 'properties',
+        type: 'array',
+        required: false,
+        description:
+          'Array of property names to return (e.g. `["subject","hs_ticket_priority","hs_pipeline_stage"]`). Returns default properties if not specified.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_tickets_batch_archive',
+    description:
+      'Archive (soft delete) a support ticket in HubSpot CRM using the batch archive API. Archived tickets are hidden from the UI but can be restored.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description:
+          'HubSpot ticket record ID to archive. Get from `hubspot_tickets_search` or `hubspot_ticket_get`.',
+      },
+    ],
+  },
+
   // ─── Tasks ────────────────────────────────────────────────────────────────────
   {
     name: 'hubspot_task_create',
@@ -849,8 +1494,7 @@ export const tools: Tool[] = [
         name: 'hs_task_status',
         type: 'string',
         required: false,
-        description:
-          'Status: `NOT_STARTED`, `IN_PROGRESS`, `COMPLETED`, `DEFERRED`, or `WAITING`.',
+        description: 'Status: `NOT_STARTED`, `IN_PROGRESS`, `COMPLETED`, `DEFERRED`, or `WAITING`.',
       },
       {
         name: 'hs_task_priority',
@@ -977,8 +1621,7 @@ export const tools: Tool[] = [
         name: 'hs_meeting_outcome',
         type: 'string',
         required: false,
-        description:
-          'Outcome of the meeting: `SCHEDULED`, `COMPLETED`, `NO_SHOW`, or `CANCELED`.',
+        description: 'Outcome of the meeting: `SCHEDULED`, `COMPLETED`, `NO_SHOW`, or `CANCELED`.',
       },
     ],
   },
@@ -1140,8 +1783,7 @@ export const tools: Tool[] = [
         name: 'hs_timestamp',
         type: 'string',
         required: true,
-        description:
-          'Timestamp for the note in ISO 8601 format (e.g. `2024-01-15T10:30:00Z`).',
+        description: 'Timestamp for the note in ISO 8601 format (e.g. `2024-01-15T10:30:00Z`).',
       },
     ],
   },
@@ -1280,6 +1922,79 @@ export const tools: Tool[] = [
 
   // ─── Associations ─────────────────────────────────────────────────────────────
   {
+    name: 'hubspot_associations_batch_create',
+    description:
+      'Create an association between two HubSpot CRM objects using the v4 associations API. Specify the object types, the record IDs, and the association type.',
+    params: [
+      {
+        name: 'from_object_type',
+        type: 'string',
+        required: true,
+        description:
+          'Source object type: `contacts`, `companies`, `deals`, `tickets`, `line_items`, `products`.',
+      },
+      {
+        name: 'to_object_type',
+        type: 'string',
+        required: true,
+        description:
+          'Target object type: `contacts`, `companies`, `deals`, `tickets`, `line_items`, `products`.',
+      },
+      {
+        name: 'from_id',
+        type: 'string',
+        required: true,
+        description: 'HubSpot record ID of the source object.',
+      },
+      {
+        name: 'to_id',
+        type: 'string',
+        required: true,
+        description: 'HubSpot record ID of the target object.',
+      },
+      {
+        name: 'association_type_id',
+        type: 'number',
+        required: true,
+        description:
+          'HubSpot association type ID. Common values: `1`=contact→company (primary), `279`=contact→company, `3`=deal→contact, `5`=deal→company, `16`=ticket→contact, `340`=ticket→company, `20`=line-item→deal.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_associations_batch_archive',
+    description:
+      'Remove an association between two HubSpot CRM objects using the v4 associations API.',
+    params: [
+      {
+        name: 'from_object_type',
+        type: 'string',
+        required: true,
+        description:
+          'Source object type: `contacts`, `companies`, `deals`, `tickets`, `line_items`, `products`.',
+      },
+      {
+        name: 'to_object_type',
+        type: 'string',
+        required: true,
+        description:
+          'Target object type: `contacts`, `companies`, `deals`, `tickets`, `line_items`, `products`.',
+      },
+      {
+        name: 'from_id',
+        type: 'string',
+        required: true,
+        description: 'HubSpot record ID of the source object.',
+      },
+      {
+        name: 'to_id',
+        type: 'string',
+        required: true,
+        description: 'HubSpot record ID of the target object.',
+      },
+    ],
+  },
+  {
     name: 'hubspot_association_create',
     description:
       'Create a default association between two HubSpot CRM objects. For example, associate a contact with a deal, or a company with a ticket.',
@@ -1378,8 +2093,7 @@ export const tools: Tool[] = [
         name: 'form_id',
         type: 'string',
         required: true,
-        description:
-          'The unique identifier of the HubSpot form. Get it from `hubspot_forms_list`.',
+        description: 'The unique identifier of the HubSpot form. Get it from `hubspot_forms_list`.',
       },
       {
         name: 'limit',
@@ -1455,6 +2169,123 @@ export const tools: Tool[] = [
 
   // ─── Line Items ───────────────────────────────────────────────────────────────
   {
+    name: 'hubspot_line_items_batch_create',
+    description:
+      'Create a line item (product on a deal) in HubSpot CRM using the batch API. Optionally associate the line item with a deal on creation.',
+    params: [
+      {
+        name: 'name',
+        type: 'string',
+        required: true,
+        description: 'Name of the product or service for this line item (required).',
+      },
+      {
+        name: 'quantity',
+        type: 'string',
+        required: true,
+        description: 'Number of units (required).',
+      },
+      {
+        name: 'hs_product_id',
+        type: 'string',
+        required: false,
+        description:
+          'ID of the product from your HubSpot product catalog. Links this line item to that product.',
+      },
+      {
+        name: 'price',
+        type: 'string',
+        required: false,
+        description: 'Price per unit (e.g. `299.99`). Required if not linked to a product.',
+      },
+      { name: 'hs_sku', type: 'string', required: false, description: 'SKU or product code.' },
+      {
+        name: 'description',
+        type: 'string',
+        required: false,
+        description: 'Additional details about this line item.',
+      },
+      {
+        name: 'discount',
+        type: 'string',
+        required: false,
+        description: 'Discount value applied to this line item.',
+      },
+      {
+        name: 'associate_to_id',
+        type: 'string',
+        required: false,
+        description:
+          'Deal ID to link this line item to. This is the standard way to add a line item to a deal.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_line_items_batch_update',
+    description:
+      'Update a line item in HubSpot CRM using the batch API. Provide the line item ID and any fields to update.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description: 'HubSpot line item record ID. Get from `hubspot_deal_line_items_get`.',
+      },
+      {
+        name: 'name',
+        type: 'string',
+        required: false,
+        description: 'Updated name of the product or service.',
+      },
+      {
+        name: 'quantity',
+        type: 'string',
+        required: false,
+        description: 'Updated number of units.',
+      },
+      { name: 'price', type: 'string', required: false, description: 'Updated price per unit.' },
+      {
+        name: 'hs_sku',
+        type: 'string',
+        required: false,
+        description: 'Updated SKU or product code.',
+      },
+      { name: 'description', type: 'string', required: false, description: 'Updated description.' },
+      { name: 'discount', type: 'string', required: false, description: 'Updated discount value.' },
+    ],
+  },
+  {
+    name: 'hubspot_line_items_batch_read',
+    description: 'Retrieve a line item record from HubSpot CRM using the batch read API.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description: 'HubSpot line item record ID. Get from `hubspot_deal_line_items_get`.',
+      },
+      {
+        name: 'properties',
+        type: 'array',
+        required: false,
+        description: 'Array of property names to return (e.g. `["name","quantity","price"]`).',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_line_items_batch_archive',
+    description: 'Archive (soft delete) a line item in HubSpot CRM using the batch archive API.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description:
+          'HubSpot line item record ID to archive. Get from `hubspot_deal_line_items_get`.',
+      },
+    ],
+  },
+  {
     name: 'hubspot_line_item_create',
     description:
       'Create a new line item in HubSpot. Line items represent individual products or services in a deal.',
@@ -1492,6 +2323,39 @@ export const tools: Tool[] = [
     ],
   },
 
+  {
+    name: 'hubspot_products_batch_read',
+    description:
+      'Retrieve a product record from the HubSpot product library using the batch read API.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description: 'HubSpot product record ID. Get from `hubspot_products_list`.',
+      },
+      {
+        name: 'properties',
+        type: 'array',
+        required: false,
+        description: 'Array of property names to return (e.g. `["name","price","hs_sku"]`).',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_products_batch_archive',
+    description:
+      'Archive (soft delete) a product from the HubSpot product library using the batch archive API.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description: 'HubSpot product record ID to archive. Get from `hubspot_products_list`.',
+      },
+    ],
+  },
+
   // ─── Quotes ───────────────────────────────────────────────────────────────────
   {
     name: 'hubspot_quote_create',
@@ -1507,7 +2371,8 @@ export const tools: Tool[] = [
         name: 'hs_language',
         type: 'string',
         required: true,
-        description: 'Language of the quote as an ISO 639-1 code (e.g. `en`, `de`, `fr`). Required by HubSpot.',
+        description:
+          'Language of the quote as an ISO 639-1 code (e.g. `en`, `de`, `fr`). Required by HubSpot.',
       },
       {
         name: 'deal_id',
@@ -1525,8 +2390,7 @@ export const tools: Tool[] = [
         name: 'hs_status',
         type: 'string',
         required: false,
-        description:
-          'Status of the quote: `DRAFT`, `PENDING_APPROVAL`, `APPROVED`, or `REJECTED`.',
+        description: 'Status of the quote: `DRAFT`, `PENDING_APPROVAL`, `APPROVED`, or `REJECTED`.',
       },
     ],
   },
@@ -1618,19 +2482,22 @@ export const tools: Tool[] = [
         name: 'object_type_id',
         type: 'string',
         required: true,
-        description: 'The custom object type ID (e.g. `2-1234567`). Get it from `hubspot_schemas_list`.',
+        description:
+          'The custom object type ID (e.g. `2-1234567`). Get it from `hubspot_schemas_list`.',
       },
       {
         name: 'record_id',
         type: 'string',
         required: true,
-        description: 'The HubSpot ID of the record to update. Get it from `hubspot_custom_object_records_search`.',
+        description:
+          'The HubSpot ID of the record to update. Get it from `hubspot_custom_object_records_search`.',
       },
       {
         name: 'properties',
         type: 'object',
         required: true,
-        description: 'JSON object of property names and updated values (e.g. `{"name": "Updated Name", "status": "active"}`). Use `hubspot_schemas_list` to discover valid property names.',
+        description:
+          'JSON object of property names and updated values (e.g. `{"name": "Updated Name", "status": "active"}`). Use `hubspot_schemas_list` to discover valid property names.',
       },
     ],
   },

--- a/src/data/agent-connectors/linear.ts
+++ b/src/data/agent-connectors/linear.ts
@@ -2,161 +2,1207 @@ import type { Tool } from '../../types/agent-connectors'
 
 export const tools: Tool[] = [
   {
-    name: 'linear_graphql_query',
-    description: `Execute a custom GraphQL query or mutation against the Linear API. Allows running any valid GraphQL operation with variables support for advanced use cases.`,
+    name: 'linear_attachment_create',
+    description: 'Create an external link attachment on a Linear issue.',
     params: [
       {
-        name: 'query',
+        name: 'issueId',
         type: 'string',
         required: true,
-        description: `The GraphQL query or mutation to execute`,
+        description: 'ID of the issue to attach the link to',
       },
       {
-        name: 'variables',
-        type: 'object',
+        name: 'subtitle',
+        type: 'string | null',
         required: false,
-        description: `Variables to pass to the GraphQL query`,
+        description: 'Subtitle or description for the attachment',
+      },
+      {
+        name: 'title',
+        type: 'string',
+        required: true,
+        description: 'Attachment title',
+      },
+      {
+        name: 'url',
+        type: 'string',
+        required: true,
+        description: 'URL of the attachment',
       },
     ],
   },
   {
-    name: 'linear_issue_create',
-    description: `Create a new issue in Linear using the issueCreate mutation. Requires a team ID and title at minimum.`,
+    name: 'linear_attachment_delete',
+    description: 'Delete an attachment from a Linear issue.',
+    params: [
+      {
+        name: 'attachmentId',
+        type: 'string',
+        required: true,
+        description: 'ID of the attachment to delete',
+      },
+    ],
+  },
+  {
+    name: 'linear_attachment_update',
+    description: 'Update the title or subtitle of an existing attachment on a Linear issue.',
+    params: [
+      {
+        name: 'attachmentId',
+        type: 'string',
+        required: true,
+        description: 'ID of the attachment to update',
+      },
+      {
+        name: 'title',
+        type: 'string',
+        required: true,
+        description: 'New title for the attachment',
+      },
+      {
+        name: 'subtitle',
+        type: 'string | null',
+        required: false,
+        description: 'New subtitle or description',
+      },
+    ],
+  },
+  {
+    name: 'linear_comment_create',
+    description: 'Create a comment on a Linear issue.',
+    params: [
+      {
+        name: 'body',
+        type: 'string',
+        required: true,
+        description: 'Comment text',
+      },
+      {
+        name: 'issueId',
+        type: 'string',
+        required: true,
+        description: 'ID of the issue to comment on',
+      },
+    ],
+  },
+  {
+    name: 'linear_comment_delete',
+    description: 'Permanently delete a comment from a Linear issue.',
+    params: [
+      {
+        name: 'commentId',
+        type: 'string',
+        required: true,
+        description: 'ID of the comment to delete',
+      },
+    ],
+  },
+  {
+    name: 'linear_comment_get',
+    description: 'Retrieve a single comment by its ID.',
+    params: [
+      {
+        name: 'commentId',
+        type: 'string',
+        required: true,
+        description: 'ID of the comment to retrieve',
+      },
+    ],
+  },
+  {
+    name: 'linear_comment_update',
+    description: 'Update the text body of an existing Linear comment.',
+    params: [
+      {
+        name: 'body',
+        type: 'string',
+        required: true,
+        description: 'Updated comment text',
+      },
+      {
+        name: 'commentId',
+        type: 'string',
+        required: true,
+        description: 'ID of the comment to update',
+      },
+    ],
+  },
+  {
+    name: 'linear_comments_list',
+    description: 'List all comments on a specific Linear issue with pagination support.',
+    params: [
+      {
+        name: 'after',
+        type: 'string | null',
+        required: false,
+        description: 'Pagination cursor for fetching the next page',
+      },
+      {
+        name: 'first',
+        type: 'integer | null',
+        required: false,
+        description: 'Number of comments to return',
+      },
+      {
+        name: 'issueId',
+        type: 'string',
+        required: true,
+        description: 'ID of the issue to list comments for',
+      },
+    ],
+  },
+  {
+    name: 'linear_cycle_create',
+    description: 'Create a new cycle (sprint) for a Linear team. Requires a team ID, start date, and end date.',
     params: [
       {
         name: 'teamId',
         type: 'string',
         required: true,
-        description: `ID of the team to create the issue in`,
+        description: 'ID of the team to create the cycle in',
       },
-      { name: 'title', type: 'string', required: true, description: `Title of the issue` },
       {
-        name: 'assigneeId',
+        name: 'startsAt',
         type: 'string',
+        required: true,
+        description: 'Cycle start date-time in ISO 8601 format',
+      },
+      {
+        name: 'endsAt',
+        type: 'string',
+        required: true,
+        description: 'Cycle end date-time in ISO 8601 format',
+      },
+      {
+        name: 'name',
+        type: 'string | null',
         required: false,
-        description: `ID of the user to assign the issue to`,
+        description: 'Optional custom name for the cycle',
       },
       {
         name: 'description',
-        type: 'string',
+        type: 'string | null',
         required: false,
-        description: `Description of the issue`,
+        description: 'Optional description of the cycle',
+      },
+    ],
+  },
+  {
+    name: 'linear_cycle_get',
+    description: 'Get a specific Linear cycle by ID, including its issues.',
+    params: [
+      {
+        name: 'cycleId',
+        type: 'string',
+        required: true,
+        description: 'ID of the cycle to retrieve',
+      },
+    ],
+  },
+  {
+    name: 'linear_cycle_issues_list',
+    description: 'List all issues in a specific Linear cycle with pagination support.',
+    params: [
+      {
+        name: 'after',
+        type: 'string | null',
+        required: false,
+        description: 'Pagination cursor for fetching the next page',
+      },
+      {
+        name: 'cycleId',
+        type: 'string',
+        required: true,
+        description: 'ID of the cycle to list issues for',
+      },
+      {
+        name: 'first',
+        type: 'integer | null',
+        required: false,
+        description: 'Number of issues to return',
+      },
+    ],
+  },
+  {
+    name: 'linear_cycle_update',
+    description: 'Update an existing cycle (sprint) in Linear.',
+    params: [
+      {
+        name: 'cycleId',
+        type: 'string',
+        required: true,
+        description: 'ID of the cycle to update',
+      },
+      {
+        name: 'name',
+        type: 'string | null',
+        required: false,
+        description: 'New name for the cycle',
+      },
+      {
+        name: 'description',
+        type: 'string | null',
+        required: false,
+        description: 'New description for the cycle',
+      },
+      {
+        name: 'startsAt',
+        type: 'string | null',
+        required: false,
+        description: 'New start date-time in ISO 8601 format',
+      },
+      {
+        name: 'endsAt',
+        type: 'string | null',
+        required: false,
+        description: 'New end date-time in ISO 8601 format',
+      },
+    ],
+  },
+  {
+    name: 'linear_cycles_list',
+    description: 'List cycles (sprints) for a Linear team with pagination support.',
+    params: [
+      {
+        name: 'after',
+        type: 'string | null',
+        required: false,
+        description: 'Pagination cursor for fetching the next page',
+      },
+      {
+        name: 'first',
+        type: 'integer | null',
+        required: false,
+        description: 'Number of cycles to return',
+      },
+      {
+        name: 'teamId',
+        type: 'string',
+        required: true,
+        description: 'Team ID to list cycles for',
+      },
+    ],
+  },
+  {
+    name: 'linear_graphql_query',
+    description: 'Execute a custom GraphQL query or mutation against the Linear API. Allows running any valid GraphQL operation with variables support for advanced use cases.',
+    params: [
+      {
+        name: 'query',
+        type: 'string',
+        required: true,
+        description: 'The GraphQL query or mutation to execute',
+      },
+      {
+        name: 'variables',
+        type: 'object | null',
+        required: false,
+        description: 'Variables to pass to the GraphQL query',
+      },
+    ],
+  },
+  {
+    name: 'linear_issue_archive',
+    description: 'Archive a Linear issue by ID using the issueArchive mutation.',
+    params: [
+      {
+        name: 'issueId',
+        type: 'string',
+        required: true,
+        description: 'ID of the issue to archive',
+      },
+    ],
+  },
+  {
+    name: 'linear_issue_create',
+    description: 'Create a new issue in Linear using the issueCreate mutation. Requires a team ID and title at minimum.',
+    params: [
+      {
+        name: 'assigneeId',
+        type: 'string | null',
+        required: false,
+        description: 'ID of the user to assign the issue to',
+      },
+      {
+        name: 'description',
+        type: 'string | null',
+        required: false,
+        description: 'Description of the issue',
       },
       {
         name: 'estimate',
-        type: 'string',
+        type: 'string | null',
         required: false,
-        description: `Story point estimate for the issue`,
+        description: 'Story point estimate for the issue',
       },
       {
         name: 'labelIds',
-        type: 'array',
+        type: 'array | null',
         required: false,
-        description: `Array of label IDs to apply to the issue`,
+        description: 'Array of label IDs to apply to the issue',
       },
       {
         name: 'priority',
-        type: 'string',
+        type: 'string | null',
         required: false,
-        description: `Priority level of the issue (1-4, where 1 is urgent)`,
+        description: 'Priority level of the issue (1-4, where 1 is urgent)',
       },
       {
         name: 'projectId',
-        type: 'string',
+        type: 'string | null',
         required: false,
-        description: `ID of the project to associate the issue with`,
+        description: 'ID of the project to associate the issue with',
       },
       {
         name: 'stateId',
-        type: 'string',
+        type: 'string | null',
         required: false,
-        description: `ID of the workflow state to set`,
+        description: 'ID of the workflow state to set',
+      },
+      {
+        name: 'teamId',
+        type: 'string',
+        required: true,
+        description: 'ID of the team to create the issue in',
+      },
+      {
+        name: 'title',
+        type: 'string',
+        required: true,
+        description: 'Title of the issue',
+      },
+    ],
+  },
+  {
+    name: 'linear_issue_delete',
+    description: 'Permanently delete a Linear issue by ID using the issueDelete mutation.',
+    params: [
+      {
+        name: 'issueId',
+        type: 'string',
+        required: true,
+        description: 'ID of the issue to delete',
+      },
+    ],
+  },
+  {
+    name: 'linear_issue_get',
+    description: 'Get a single Linear issue by ID, including its state, assignee, team, labels, and project details.',
+    params: [
+      {
+        name: 'issueId',
+        type: 'string',
+        required: true,
+        description: 'ID of the issue to retrieve',
+      },
+    ],
+  },
+  {
+    name: 'linear_issue_relation_create',
+    description: 'Create a relation between two issues. Valid types: blocks, duplicate, related, similar.',
+    params: [
+      {
+        name: 'issueId',
+        type: 'string',
+        required: true,
+        description: 'ID of the issue',
+      },
+      {
+        name: 'relatedIssueId',
+        type: 'string',
+        required: true,
+        description: 'ID of the related issue',
+      },
+      {
+        name: 'type',
+        type: 'string',
+        required: true,
+        description: 'Relation type: blocks, duplicate, related, or similar',
+      },
+    ],
+  },
+  {
+    name: 'linear_issue_relation_delete',
+    description: 'Delete an issue relation by its ID.',
+    params: [
+      {
+        name: 'relationId',
+        type: 'string',
+        required: true,
+        description: 'ID of the issue relation to delete',
+      },
+    ],
+  },
+  {
+    name: 'linear_issue_relations_list',
+    description: 'List all relations for a specific issue (blocks, duplicates, related, similar).',
+    params: [
+      {
+        name: 'issueId',
+        type: 'string',
+        required: true,
+        description: 'ID of the issue to get relations for',
+      },
+    ],
+  },
+  {
+    name: 'linear_issue_search',
+    description: 'Full-text search for issues across the workspace by query string.',
+    params: [
+      {
+        name: 'query',
+        type: 'string',
+        required: true,
+        description: 'Text to search for across issue titles and descriptions',
+      },
+      {
+        name: 'first',
+        type: 'integer | null',
+        required: false,
+        description: 'Number of results to return (max 250)',
+      },
+      {
+        name: 'teamId',
+        type: 'string | null',
+        required: false,
+        description: 'Restrict search to a specific team ID',
+      },
+    ],
+  },
+  {
+    name: 'linear_issue_unarchive',
+    description: 'Restore an archived issue back to active status.',
+    params: [
+      {
+        name: 'issueId',
+        type: 'string',
+        required: true,
+        description: 'ID of the archived issue to restore',
       },
     ],
   },
   {
     name: 'linear_issue_update',
-    description: `Update an existing issue in Linear. You can update title, description, priority, state, and assignee.`,
+    description: 'Update an existing issue in Linear. You can update title, description, priority, state, and assignee.',
     params: [
-      { name: 'issueId', type: 'string', required: true, description: `ID of the issue to update` },
       {
         name: 'assigneeId',
-        type: 'string',
+        type: 'string | null',
         required: false,
-        description: `ID of the user to assign the issue to`,
+        description: 'ID of the user to assign the issue to',
       },
       {
         name: 'description',
-        type: 'string',
+        type: 'string | null',
         required: false,
-        description: `New description for the issue`,
+        description: 'New description for the issue',
+      },
+      {
+        name: 'issueId',
+        type: 'string',
+        required: true,
+        description: 'ID of the issue to update',
       },
       {
         name: 'priority',
-        type: 'string',
+        type: 'string | null',
         required: false,
-        description: `Priority level of the issue (1-4, where 1 is urgent)`,
+        description: 'Priority level of the issue (1-4, where 1 is urgent)',
       },
       {
         name: 'stateId',
-        type: 'string',
+        type: 'string | null',
         required: false,
-        description: `ID of the workflow state to set`,
+        description: 'ID of the workflow state to set',
       },
-      { name: 'title', type: 'string', required: false, description: `New title for the issue` },
+      {
+        name: 'title',
+        type: 'string | null',
+        required: false,
+        description: 'New title for the issue',
+      },
     ],
   },
   {
     name: 'linear_issues_list',
-    description: `List issues in Linear using the issues query with simple filtering and pagination support.`,
+    description: 'List issues in Linear using the issues query with simple filtering and pagination support.',
     params: [
       {
         name: 'after',
-        type: 'string',
+        type: 'string | null',
         required: false,
-        description: `Cursor for pagination (returns issues after this cursor)`,
+        description: 'Cursor for pagination (returns issues after this cursor)',
       },
       {
         name: 'assignee',
-        type: 'string',
+        type: 'string | null',
         required: false,
-        description: `Filter by assignee email (e.g., 'user@example.com')`,
+        description: 'Filter by assignee email (e.g., \'user@example.com\')',
       },
       {
         name: 'before',
-        type: 'string',
+        type: 'string | null',
         required: false,
-        description: `Cursor for pagination (returns issues before this cursor)`,
+        description: 'Cursor for pagination (returns issues before this cursor)',
       },
       {
         name: 'first',
-        type: 'integer',
+        type: 'integer | null',
         required: false,
-        description: `Number of issues to return (pagination)`,
+        description: 'Number of issues to return (pagination)',
       },
       {
         name: 'labels',
-        type: 'array',
+        type: 'array | null',
         required: false,
-        description: `Filter by label names (array of strings)`,
+        description: 'Filter by label names (array of strings)',
       },
       {
         name: 'priority',
-        type: 'string',
+        type: 'string | null',
         required: false,
-        description: `Filter by priority level (1=Urgent, 2=High, 3=Medium, 4=Low)`,
+        description: 'Filter by priority level (1=Urgent, 2=High, 3=Medium, 4=Low)',
       },
       {
         name: 'project',
-        type: 'string',
+        type: 'string | null',
         required: false,
-        description: `Filter by project name (e.g., 'Q4 Goals')`,
+        description: 'Filter by project name (e.g., \'Q4 Goals\')',
       },
       {
         name: 'state',
-        type: 'string',
+        type: 'string | null',
         required: false,
-        description: `Filter by state name (e.g., 'In Progress', 'Done')`,
+        description: 'Filter by state name (e.g., \'In Progress\', \'Done\')',
+      },
+    ],
+  },
+  {
+    name: 'linear_label_create',
+    description: 'Create a new issue label in a Linear team.',
+    params: [
+      {
+        name: 'color',
+        type: 'string | null',
+        required: false,
+        description: 'Label color as hex code',
+      },
+      {
+        name: 'description',
+        type: 'string | null',
+        required: false,
+        description: 'Label description',
+      },
+      {
+        name: 'name',
+        type: 'string',
+        required: true,
+        description: 'Label name',
+      },
+      {
+        name: 'teamId',
+        type: 'string',
+        required: true,
+        description: 'Team ID to create the label in',
+      },
+    ],
+  },
+  {
+    name: 'linear_labels_list',
+    description: 'List issue labels in the Linear workspace, optionally filtered by team.',
+    params: [
+      {
+        name: 'first',
+        type: 'integer | null',
+        required: false,
+        description: 'Number of labels to return',
+      },
+      {
+        name: 'teamId',
+        type: 'string | null',
+        required: false,
+        description: 'Filter labels by team ID',
+      },
+    ],
+  },
+  {
+    name: 'linear_project_create',
+    description: 'Create a new project in Linear with optional description, state, and date fields.',
+    params: [
+      {
+        name: 'description',
+        type: 'string | null',
+        required: false,
+        description: 'Description of the project',
+      },
+      {
+        name: 'name',
+        type: 'string',
+        required: true,
+        description: 'Name of the project',
+      },
+      {
+        name: 'startDate',
+        type: 'string | null',
+        required: false,
+        description: 'Start date in YYYY-MM-DD format',
+      },
+      {
+        name: 'state',
+        type: 'string | null',
+        required: false,
+        description: 'Project state: planned, started, paused, completed, cancelled',
+      },
+      {
+        name: 'targetDate',
+        type: 'string | null',
+        required: false,
+        description: 'Target date in YYYY-MM-DD format',
+      },
+      {
+        name: 'teamIds',
+        type: 'array',
+        required: true,
+        description: 'Array of team IDs to associate with the project',
+      },
+    ],
+  },
+  {
+    name: 'linear_project_get',
+    description: 'Get a single Linear project by ID, including teams, members, and associated issues.',
+    params: [
+      {
+        name: 'projectId',
+        type: 'string',
+        required: true,
+        description: 'ID of the project to retrieve',
+      },
+    ],
+  },
+  {
+    name: 'linear_project_milestone_create',
+    description: 'Create a new milestone for a project.',
+    params: [
+      {
+        name: 'projectId',
+        type: 'string',
+        required: true,
+        description: 'ID of the project to add the milestone to',
+      },
+      {
+        name: 'name',
+        type: 'string',
+        required: true,
+        description: 'Name of the milestone',
+      },
+      {
+        name: 'description',
+        type: 'string | null',
+        required: false,
+        description: 'Description of the milestone',
+      },
+      {
+        name: 'targetDate',
+        type: 'string | null',
+        required: false,
+        description: 'Target completion date (YYYY-MM-DD)',
+      },
+    ],
+  },
+  {
+    name: 'linear_project_milestone_delete',
+    description: 'Delete a project milestone by its ID.',
+    params: [
+      {
+        name: 'milestoneId',
+        type: 'string',
+        required: true,
+        description: 'ID of the milestone to delete',
+      },
+    ],
+  },
+  {
+    name: 'linear_project_milestone_update',
+    description: 'Update an existing project milestone.',
+    params: [
+      {
+        name: 'milestoneId',
+        type: 'string',
+        required: true,
+        description: 'ID of the milestone to update',
+      },
+      {
+        name: 'name',
+        type: 'string | null',
+        required: false,
+        description: 'New name for the milestone',
+      },
+      {
+        name: 'description',
+        type: 'string | null',
+        required: false,
+        description: 'New description',
+      },
+      {
+        name: 'targetDate',
+        type: 'string | null',
+        required: false,
+        description: 'New target date (YYYY-MM-DD)',
+      },
+    ],
+  },
+  {
+    name: 'linear_project_milestones_list',
+    description: 'List milestones for a specific project.',
+    params: [
+      {
+        name: 'projectId',
+        type: 'string',
+        required: true,
+        description: 'ID of the project to list milestones for',
+      },
+      {
+        name: 'first',
+        type: 'integer | null',
+        required: false,
+        description: 'Number of milestones to return',
+      },
+    ],
+  },
+  {
+    name: 'linear_project_update',
+    description: 'Update an existing Linear project\'s name, description, state, or dates.',
+    params: [
+      {
+        name: 'description',
+        type: 'string | null',
+        required: false,
+        description: 'Updated description of the project',
+      },
+      {
+        name: 'name',
+        type: 'string | null',
+        required: false,
+        description: 'Updated name of the project',
+      },
+      {
+        name: 'projectId',
+        type: 'string',
+        required: true,
+        description: 'ID of the project to update',
+      },
+      {
+        name: 'startDate',
+        type: 'string | null',
+        required: false,
+        description: 'Updated start date in YYYY-MM-DD format',
+      },
+      {
+        name: 'state',
+        type: 'string | null',
+        required: false,
+        description: 'Updated project state: planned, started, paused, completed, cancelled',
+      },
+      {
+        name: 'targetDate',
+        type: 'string | null',
+        required: false,
+        description: 'Updated target date in YYYY-MM-DD format',
+      },
+    ],
+  },
+  {
+    name: 'linear_projects_list',
+    description: 'List all projects in the Linear workspace with pagination support.',
+    params: [
+      {
+        name: 'after',
+        type: 'string | null',
+        required: false,
+        description: 'Pagination cursor for fetching the next page',
+      },
+      {
+        name: 'first',
+        type: 'integer | null',
+        required: false,
+        description: 'Number of projects to return',
+      },
+    ],
+  },
+  {
+    name: 'linear_roadmaps_list',
+    description: 'List all roadmaps in the Linear workspace with pagination support.',
+    params: [
+      {
+        name: 'after',
+        type: 'string | null',
+        required: false,
+        description: 'Pagination cursor for fetching the next page',
+      },
+      {
+        name: 'first',
+        type: 'integer | null',
+        required: false,
+        description: 'Number of roadmaps to return',
+      },
+    ],
+  },
+  {
+    name: 'linear_team_create',
+    description: 'Create a new team in the Linear workspace.',
+    params: [
+      {
+        name: 'name',
+        type: 'string',
+        required: true,
+        description: 'Name of the team',
+      },
+      {
+        name: 'key',
+        type: 'string | null',
+        required: false,
+        description: 'Short identifier key for the team (e.g. PLAT)',
+      },
+      {
+        name: 'description',
+        type: 'string | null',
+        required: false,
+        description: 'Description of the team',
+      },
+      {
+        name: 'color',
+        type: 'string | null',
+        required: false,
+        description: 'Team color as hex code',
+      },
+      {
+        name: 'private',
+        type: 'boolean | null',
+        required: false,
+        description: 'Whether the team is private',
+      },
+    ],
+  },
+  {
+    name: 'linear_team_get',
+    description: 'Get a single Linear team by ID, including its members and workflow states.',
+    params: [
+      {
+        name: 'teamId',
+        type: 'string',
+        required: true,
+        description: 'ID of the team to retrieve',
+      },
+    ],
+  },
+  {
+    name: 'linear_team_update',
+    description: 'Update an existing team\'s name, description, or settings.',
+    params: [
+      {
+        name: 'teamId',
+        type: 'string',
+        required: true,
+        description: 'ID of the team to update',
+      },
+      {
+        name: 'name',
+        type: 'string | null',
+        required: false,
+        description: 'New name for the team',
+      },
+      {
+        name: 'description',
+        type: 'string | null',
+        required: false,
+        description: 'New description for the team',
+      },
+      {
+        name: 'color',
+        type: 'string | null',
+        required: false,
+        description: 'New team color as hex code',
+      },
+    ],
+  },
+  {
+    name: 'linear_teams_list',
+    description: 'List all teams in the Linear workspace with their members and pagination support.',
+    params: [
+      {
+        name: 'after',
+        type: 'string | null',
+        required: false,
+        description: 'Pagination cursor for fetching the next page',
+      },
+      {
+        name: 'first',
+        type: 'integer | null',
+        required: false,
+        description: 'Number of teams to return',
+      },
+    ],
+  },
+  {
+    name: 'linear_user_get',
+    description: 'Retrieve a single Linear user by their ID.',
+    params: [
+      {
+        name: 'userId',
+        type: 'string',
+        required: true,
+        description: 'ID of the user to retrieve',
+      },
+    ],
+  },
+  {
+    name: 'linear_users_list',
+    description: 'List all users in the Linear workspace with pagination support.',
+    params: [
+      {
+        name: 'after',
+        type: 'string | null',
+        required: false,
+        description: 'Pagination cursor for fetching the next page',
+      },
+      {
+        name: 'first',
+        type: 'integer | null',
+        required: false,
+        description: 'Number of users to return',
+      },
+    ],
+  },
+  {
+    name: 'linear_viewer_get',
+    description: 'Get the currently authenticated Linear user (viewer), including their teams.',
+    params: [],
+  },
+  {
+    name: 'linear_webhook_create',
+    description: 'Create a new webhook for Linear events. Specify the URL and the resource types to subscribe to.',
+    params: [
+      {
+        name: 'url',
+        type: 'string',
+        required: true,
+        description: 'The URL to receive webhook payloads',
+      },
+      {
+        name: 'resourceTypes',
+        type: 'array',
+        required: true,
+        description: 'List of resource types to subscribe to (e.g. Issue, Comment, Project)',
+      },
+      {
+        name: 'teamId',
+        type: 'string | null',
+        required: false,
+        description: 'Restrict webhook to a specific team ID',
+      },
+      {
+        name: 'label',
+        type: 'string | null',
+        required: false,
+        description: 'Human-readable label for the webhook',
+      },
+      {
+        name: 'secret',
+        type: 'string | null',
+        required: false,
+        description: 'Secret token to sign the webhook payload',
+      },
+      {
+        name: 'enabled',
+        type: 'boolean | null',
+        required: false,
+        description: 'Whether the webhook is active (default: true)',
+      },
+    ],
+  },
+  {
+    name: 'linear_webhook_delete',
+    description: 'Delete a webhook by its ID.',
+    params: [
+      {
+        name: 'webhookId',
+        type: 'string',
+        required: true,
+        description: 'ID of the webhook to delete',
+      },
+    ],
+  },
+  {
+    name: 'linear_webhook_get',
+    description: 'Retrieve a single webhook by its ID.',
+    params: [
+      {
+        name: 'webhookId',
+        type: 'string',
+        required: true,
+        description: 'ID of the webhook',
+      },
+    ],
+  },
+  {
+    name: 'linear_webhook_update',
+    description: 'Update an existing webhook\'s URL, resource types, label, or enabled status.',
+    params: [
+      {
+        name: 'webhookId',
+        type: 'string',
+        required: true,
+        description: 'ID of the webhook to update',
+      },
+      {
+        name: 'url',
+        type: 'string | null',
+        required: false,
+        description: 'New URL to receive webhook payloads',
+      },
+      {
+        name: 'resourceTypes',
+        type: 'array | null',
+        required: false,
+        description: 'Updated list of resource types to subscribe to',
+      },
+      {
+        name: 'label',
+        type: 'string | null',
+        required: false,
+        description: 'New label for the webhook',
+      },
+      {
+        name: 'secret',
+        type: 'string | null',
+        required: false,
+        description: 'New secret token for signing payloads',
+      },
+      {
+        name: 'enabled',
+        type: 'boolean | null',
+        required: false,
+        description: 'Enable or disable the webhook',
+      },
+    ],
+  },
+  {
+    name: 'linear_webhooks_list',
+    description: 'List all webhooks configured for the current workspace.',
+    params: [
+      {
+        name: 'first',
+        type: 'integer | null',
+        required: false,
+        description: 'Number of webhooks to return',
+      },
+      {
+        name: 'after',
+        type: 'string | null',
+        required: false,
+        description: 'Pagination cursor',
+      },
+    ],
+  },
+  {
+    name: 'linear_workflow_state_create',
+    description: 'Create a new workflow state for a Linear team. Valid types: backlog, unstarted, started, completed, canceled.',
+    params: [
+      {
+        name: 'teamId',
+        type: 'string',
+        required: true,
+        description: 'ID of the team to create the state in',
+      },
+      {
+        name: 'name',
+        type: 'string',
+        required: true,
+        description: 'Name of the workflow state',
+      },
+      {
+        name: 'color',
+        type: 'string',
+        required: true,
+        description: 'Color of the state as a hex code',
+      },
+      {
+        name: 'type',
+        type: 'string',
+        required: true,
+        description: 'State type: backlog, unstarted, started, completed, or canceled',
+      },
+      {
+        name: 'description',
+        type: 'string | null',
+        required: false,
+        description: 'Optional description of the state',
+      },
+      {
+        name: 'position',
+        type: 'number | null',
+        required: false,
+        description: 'Position of the state in the workflow',
+      },
+    ],
+  },
+  {
+    name: 'linear_workflow_state_get',
+    description: 'Retrieve a single workflow state by its ID.',
+    params: [
+      {
+        name: 'stateId',
+        type: 'string',
+        required: true,
+        description: 'ID of the workflow state',
+      },
+    ],
+  },
+  {
+    name: 'linear_workflow_state_update',
+    description: 'Update an existing workflow state in Linear.',
+    params: [
+      {
+        name: 'stateId',
+        type: 'string',
+        required: true,
+        description: 'ID of the workflow state to update',
+      },
+      {
+        name: 'name',
+        type: 'string | null',
+        required: false,
+        description: 'New name for the state',
+      },
+      {
+        name: 'color',
+        type: 'string | null',
+        required: false,
+        description: 'New color as hex code',
+      },
+      {
+        name: 'description',
+        type: 'string | null',
+        required: false,
+        description: 'New description for the state',
+      },
+    ],
+  },
+  {
+    name: 'linear_workflow_states_list',
+    description: 'List workflow states in the Linear workspace, optionally filtered by team.',
+    params: [
+      {
+        name: 'first',
+        type: 'integer | null',
+        required: false,
+        description: 'Number of workflow states to return',
+      },
+      {
+        name: 'teamId',
+        type: 'string | null',
+        required: false,
+        description: 'Filter by team ID',
       },
     ],
   },


### PR DESCRIPTION
## Summary

- Added 27 new batch tool entries for HubSpot connectors: batch create, update, upsert, read, and archive operations for contacts, companies, deals, tickets, line items, and products
- Added associations batch tools for creating and archiving multiple associations
- Created resource IDs reference section with association type ID lookup table
- Updated "What you can do" summary to reflect new batch write capabilities

## What changed

- **New resource ID section**: `_section-before-tool-list-hubspot-resource-ids.mdx` with comprehensive HubSpot resource type and association type IDs
- **Updated connector documentation**: Enhanced HubSpot connector page with resource ID reference and updated capabilities list
- **Batch tool definitions**: Added 27 new tools to `hubspot.ts` data file (contacts, companies, deals, tickets, line items, products batch operations)
- **Template export**: Updated `index.ts` to export the new resource ID section template

## Preview

https://deploy-preview-679--scalekit-starlight.netlify.app/agentkit/connectors/hubspot/