### PR TITLE
add HubSpot batch tools documentation

### DIFF
--- a/src/components/templates/agent-connectors/_section-before-tool-list-hubspot-resource-ids.mdx
+++ b/src/components/templates/agent-connectors/_section-before-tool-list-hubspot-resource-ids.mdx
@@ -1,0 +1,36 @@
+export const sectionTitle = 'Getting resource IDs'
+
+Most HubSpot batch and update tools require record IDs. Always fetch IDs from the API — never guess or hard-code them.
+
+| Resource | Tool to get ID | Field in response |
+|----------|---------------|-------------------|
+| Contact ID | `hubspot_contacts_search` or `hubspot_contacts_list` | `results[].id` |
+| Company ID | `hubspot_companies_search` | `results[].id` |
+| Deal ID | `hubspot_deals_search` | `results[].id` |
+| Ticket ID | `hubspot_tickets_search` | `results[].id` |
+| Line Item ID | `hubspot_deal_line_items_get` | `results[].id` |
+| Product ID | `hubspot_products_list` | `results[].id` |
+| Owner ID | `hubspot_owners_list` | `results[].id` |
+| Pipeline ID | `hubspot_deal_pipelines_list` | `results[].id` |
+| Pipeline Stage ID | `hubspot_deal_pipelines_list` | `results[].stages[].id` |
+| Custom Object Type ID | `hubspot_schemas_list` | `results[].objectTypeId` |
+| Custom Object Record ID | `hubspot_custom_object_records_search` | `results[].id` |
+| Quote ID | `hubspot_quote_get` | `id` |
+
+## Association type IDs
+
+When linking records, use the correct `association_type_id` for the object pair:
+
+| From → To | Association Type ID |
+|-----------|-------------------|
+| Contact → Company (primary) | `1` |
+| Contact → Company | `279` |
+| Contact → Deal | `4` |
+| Contact → Ticket | `15` |
+| Deal → Contact | `3` |
+| Deal → Company | `5` |
+| Ticket → Contact | `16` |
+| Ticket → Company | `340` |
+| Line Item → Deal | `20` |
+| Company → Contact | `280` |
+| Company → Deal | `6` |

--- a/src/components/templates/agent-connectors/_section-before-tool-list-hubspot-resource-ids.mdx
+++ b/src/components/templates/agent-connectors/_section-before-tool-list-hubspot-resource-ids.mdx
@@ -17,7 +17,7 @@ Most HubSpot batch and update tools require record IDs. Always fetch IDs from th
 | Custom Object Record ID | `hubspot_custom_object_records_search` | `results[].id` |
 | Quote ID | `hubspot_quote_get` | `id` |
 
-## Association type IDs
+### Association type IDs
 
 When linking records, use the correct `association_type_id` for the object pair:
 

--- a/src/components/templates/agent-connectors/index.ts
+++ b/src/components/templates/agent-connectors/index.ts
@@ -142,6 +142,7 @@ export { default as SectionAfterSetupZendeskCommonWorkflows } from './_section-a
 export { default as SectionAfterSetupZoomCommonWorkflows } from './_section-after-setup-zoom-common-workflows.mdx'
 export { default as SectionAfterToolListSalesforceMetadataApiSoap } from './_section-after-tool-list-salesforce-metadata-api-soap.mdx'
 export { default as SectionBeforeToolListDatadogResourceIds } from './_section-before-tool-list-datadog-resource-ids.mdx'
+export { default as SectionBeforeToolListHubspotResourceIds } from './_section-before-tool-list-hubspot-resource-ids.mdx'
 export { default as SectionBeforeToolListTableauResourceIds } from './_section-before-tool-list-tableau-resource-ids.mdx'
 export { default as SectionBeforeToolListXeroCommonPatterns } from './_section-before-tool-list-xero-common-patterns.mdx'
 export { default as QuickstartGenericApikeySection } from './_quickstart-generic-apikey.astro'

--- a/src/content/docs/agentkit/connectors/hubspot.mdx
+++ b/src/content/docs/agentkit/connectors/hubspot.mdx
@@ -26,6 +26,7 @@ import { AgentKitCredentials } from '@components/templates'
 import { SetupHubspotSection } from '@components/templates'
 import { QuickstartHubspotSection } from '@components/templates'
 import { SectionAfterSetupHubspotCommonWorkflows } from '@components/templates'
+import { SectionBeforeToolListHubspotResourceIds } from '@components/templates'
 
 <Steps>
 
@@ -71,14 +72,27 @@ import { SectionAfterSetupHubspotCommonWorkflows } from '@components/templates'
 
 Connect this agent connector to let your agent:
 
-- **Read CRM records** — retrieve contacts, companies, deals, and tickets
-- **Create and update records** — add contacts, update deal stages, and log company data
-- **Log engagements** — record calls, emails, meetings, and notes against any CRM record
-- **Search and filter** — query CRM objects by property values and associations
+- **Manage contacts** — create, update, search, and list contacts; batch create, update, upsert, read, and archive
+- **Manage companies** — create and update company records; batch create, update, upsert, read, and archive
+- **Manage deals** — create deals, move them through pipeline stages, search; batch create, update, upsert, read, and archive
+- **Manage tickets** — create and update support tickets; batch create, update, upsert, read, and archive
+- **Batch operations with inline associations** — create contacts, companies, deals, or tickets and link them to related records in a single call
+- **Log engagements** — record calls, meetings, notes, and emails against any CRM record
+- **Manage tasks** — create tasks with due dates and priorities, and mark them complete
+- **Work with products, line items, and quotes** — build out deal proposals end-to-end; batch read and archive line items and products
+- **Manage custom objects** — create, update, and search records for any custom schema
+- **Access marketing data** — list forms, retrieve submissions, and inspect campaigns and email events
+- **Search and paginate** — full-text search and filter across all CRM object types
+- **Manage associations** — batch create or remove associations between any two CRM objects using the v4 API
+- **List owners and properties** — look up user IDs and discover all available fields per object type
 
 ## Common workflows
 
 <SectionAfterSetupHubspotCommonWorkflows />
+
+## Getting resource IDs
+
+<SectionBeforeToolListHubspotResourceIds />
 
 ## Tool list
 

--- a/src/content/docs/agentkit/connectors/hubspot.mdx
+++ b/src/content/docs/agentkit/connectors/hubspot.mdx
@@ -73,18 +73,11 @@ import { SectionBeforeToolListHubspotResourceIds } from '@components/templates'
 Connect this agent connector to let your agent:
 
 - **Manage contacts** — create, update, search, and list contacts; batch create, update, upsert, read, and archive
-- **Manage companies** — create and update company records; batch create, update, upsert, read, and archive
-- **Manage deals** — create deals, move them through pipeline stages, search; batch create, update, upsert, read, and archive
-- **Manage tickets** — create and update support tickets; batch create, update, upsert, read, and archive
+- **Manage companies and deals** — create and update company records and deals; batch create, update, upsert, read, and archive
+- **Manage tickets and tasks** — create and update support tickets; create tasks with due dates and priorities
 - **Batch operations with inline associations** — create contacts, companies, deals, or tickets and link them to related records in a single call
 - **Log engagements** — record calls, meetings, notes, and emails against any CRM record
-- **Manage tasks** — create tasks with due dates and priorities, and mark them complete
-- **Work with products, line items, and quotes** — build out deal proposals end-to-end; batch read and archive line items and products
-- **Manage custom objects** — create, update, and search records for any custom schema
-- **Access marketing data** — list forms, retrieve submissions, and inspect campaigns and email events
-- **Search and paginate** — full-text search and filter across all CRM object types
-- **Manage associations** — batch create or remove associations between any two CRM objects using the v4 API
-- **List owners and properties** — look up user IDs and discover all available fields per object type
+- **Search, associate, and extend** — full-text search across all CRM objects, batch-manage associations, list owners, discover properties, and work with custom objects
 
 ## Common workflows
 

--- a/src/data/agent-connectors/capabilities.json
+++ b/src/data/agent-connectors/capabilities.json
@@ -56,10 +56,12 @@
   ],
 
   "hubspot": [
-    "**Read CRM records** — retrieve contacts, companies, deals, and tickets",
-    "**Create and update records** — add contacts, update deal stages, and log company data",
-    "**Log engagements** — record calls, emails, meetings, and notes against any CRM record",
-    "**Search and filter** — query CRM objects by property values and associations"
+    "**Manage contacts** — create, update, search, and list contacts; batch create, update, upsert, read, and archive",
+    "**Manage companies and deals** — create and update company records and deals; batch create, update, upsert, read, and archive",
+    "**Manage tickets and tasks** — create and update support tickets; create tasks with due dates and priorities",
+    "**Batch operations with inline associations** — create contacts, companies, deals, or tickets and link them to related records in a single call",
+    "**Log engagements** — record calls, meetings, notes, and emails against any CRM record",
+    "**Search, associate, and extend** — full-text search across all CRM objects, batch-manage associations, list owners, discover properties, and work with custom objects"
   ],
 
   "jira": [

--- a/src/data/agent-connectors/hubspot.ts
+++ b/src/data/agent-connectors/hubspot.ts
@@ -1,523 +1,2569 @@
 import type { Tool } from '../../types/agent-connectors'
 
 export const tools: Tool[] = [
-  {
-    name: 'hubspot_association_create',
-    description: `Create a default association between two HubSpot CRM objects. For example, associate a contact with a deal, or a company with a ticket.`,
-    params: [
-      { name: 'from_object_id', type: 'string', required: true, description: `ID of the source object` },
-      { name: 'from_object_type', type: 'string', required: true, description: `Type of the source object (e.g. contacts, companies, deals, tickets)` },
-      { name: 'to_object_id', type: 'string', required: true, description: `ID of the target object` },
-      { name: 'to_object_type', type: 'string', required: true, description: `Type of the target object (e.g. contacts, companies, deals, tickets)` },
-    ],
-  },
-  {
-    name: 'hubspot_call_log',
-    description: `Log a call engagement in HubSpot CRM. Records details of a phone call including title, duration, notes, status, and direction.`,
-    params: [
-      { name: 'hs_call_title', type: 'string', required: true, description: `Title or subject of the call` },
-      { name: 'hs_timestamp', type: 'string', required: true, description: `Date and time when the call took place (ISO 8601 format)` },
-      { name: 'hs_call_body', type: 'string', required: false, description: `Notes or transcript from the call` },
-      { name: 'hs_call_direction', type: 'string', required: false, description: `Direction of the call` },
-      { name: 'hs_call_duration', type: 'number', required: false, description: `Duration of the call in milliseconds` },
-      { name: 'hs_call_status', type: 'string', required: false, description: `Outcome status of the call` },
-    ],
-  },
-  {
-    name: 'hubspot_calls_search',
-    description: `Search HubSpot call engagements using filters and full-text search. Returns logged calls with their properties.`,
-    params: [
-      { name: 'after', type: 'string', required: false, description: `Pagination offset to get results starting from a specific position` },
-      { name: 'filterGroups', type: 'string', required: false, description: `JSON string containing filter groups for advanced filtering` },
-      { name: 'limit', type: 'number', required: false, description: `Number of results to return per page (max 100)` },
-      { name: 'properties', type: 'string', required: false, description: `Comma-separated list of properties to include in the response` },
-      { name: 'query', type: 'string', required: false, description: `Full-text search term across call properties` },
-    ],
-  },
-  {
-    name: 'hubspot_campaign_get',
-    description: `Retrieve details of a specific HubSpot marketing campaign by campaign ID.`,
-    params: [
-      { name: 'campaign_id', type: 'string', required: true, description: `ID of the campaign to retrieve` },
-    ],
-  },
-  {
-    name: 'hubspot_campaigns_list',
-    description: `List all HubSpot marketing campaigns with pagination support.`,
-    params: [
-      { name: 'after', type: 'string', required: false, description: `Pagination cursor for the next page of results` },
-      { name: 'limit', type: 'number', required: false, description: `Number of campaigns to return per page` },
-    ],
-  },
-  {
-    name: 'hubspot_companies_search',
-    description: `Search HubSpot companies using full-text search and pagination. Returns matching companies with specified properties.`,
-    params: [
-      { name: 'after', type: 'string', required: false, description: `Pagination offset to get results starting from a specific position` },
-      { name: 'filterGroups', type: 'string', required: false, description: `JSON string containing filter groups for advanced filtering` },
-      { name: 'limit', type: 'number', required: false, description: `Number of results to return per page (max 100)` },
-      { name: 'properties', type: 'string', required: false, description: `Comma-separated list of properties to include in the response` },
-      { name: 'query', type: 'string', required: false, description: `Search term for full-text search across company properties` },
-    ],
-  },
+  // ─── Companies ────────────────────────────────────────────────────────────────
   {
     name: 'hubspot_company_create',
-    description: `Create a new company in HubSpot CRM. Requires a company name as the unique identifier. Supports additional properties like domain, industry, phone, location, and revenue information.`,
+    description:
+      'Create a new company in HubSpot CRM. Requires a company name as the unique identifier. Supports additional properties like domain, industry, phone, location, and revenue information.',
     params: [
-      { name: 'name', type: 'string', required: true, description: `Company name (required, serves as primary identifier)` },
-      { name: 'annualrevenue', type: 'number', required: false, description: `Annual revenue of the company` },
-      { name: 'city', type: 'string', required: false, description: `Company city location` },
-      { name: 'country', type: 'string', required: false, description: `Company country location` },
-      { name: 'description', type: 'string', required: false, description: `Company description or overview` },
-      { name: 'domain', type: 'string', required: false, description: `Company website domain` },
-      { name: 'industry', type: 'string', required: false, description: `Industry type of the company` },
-      { name: 'numberofemployees', type: 'number', required: false, description: `Number of employees at the company` },
-      { name: 'phone', type: 'string', required: false, description: `Company phone number` },
-      { name: 'state', type: 'string', required: false, description: `Company state or region` },
+      {
+        name: 'name',
+        type: 'string',
+        required: true,
+        description: 'Company name (required, serves as primary identifier).',
+      },
+      {
+        name: 'domain',
+        type: 'string',
+        required: false,
+        description: 'Company website domain (e.g. `example.com`).',
+      },
+      {
+        name: 'phone',
+        type: 'string',
+        required: false,
+        description: 'Primary phone number for the company.',
+      },
+      {
+        name: 'industry',
+        type: 'string',
+        required: false,
+        description: 'Industry type of the company.',
+      },
+      {
+        name: 'description',
+        type: 'string',
+        required: false,
+        description: 'Company description or overview.',
+      },
+      {
+        name: 'city',
+        type: 'string',
+        required: false,
+        description: 'City where the company is located.',
+      },
+      {
+        name: 'state',
+        type: 'string',
+        required: false,
+        description: 'State or region where the company is located.',
+      },
+      {
+        name: 'country',
+        type: 'string',
+        required: false,
+        description: 'Country where the company is located.',
+      },
+      {
+        name: 'annualrevenue',
+        type: 'number',
+        required: false,
+        description: 'Annual revenue of the company in dollars.',
+      },
+      {
+        name: 'numberofemployees',
+        type: 'number',
+        required: false,
+        description: 'Number of employees at the company.',
+      },
     ],
   },
   {
     name: 'hubspot_company_get',
-    description: `Retrieve details of a specific company from HubSpot by company ID. Returns company properties and associated data.`,
+    description:
+      'Retrieve details of a specific company from HubSpot by company ID. Returns company properties and associated data.',
     params: [
-      { name: 'company_id', type: 'string', required: true, description: `ID of the company to retrieve` },
-      { name: 'properties', type: 'string', required: false, description: `Comma-separated list of properties to include in the response` },
+      {
+        name: 'company_id',
+        type: 'string',
+        required: true,
+        description: 'The unique identifier of the company in HubSpot.',
+      },
+      {
+        name: 'properties',
+        type: 'string',
+        required: false,
+        description:
+          'Comma-separated list of properties to include in the response (e.g. `name,domain,industry,phone`).',
+      },
     ],
   },
   {
     name: 'hubspot_company_update',
-    description: `Update an existing company in HubSpot CRM by company ID. Provide any fields to update.`,
+    description:
+      'Update an existing company in HubSpot CRM by company ID. Provide any fields to update.',
     params: [
-      { name: 'company_id', type: 'string', required: true, description: `ID of the company to update` },
-      { name: 'annualrevenue', type: 'string', required: false, description: `Annual revenue of the company` },
-      { name: 'city', type: 'string', required: false, description: `City where the company is located` },
-      { name: 'country', type: 'string', required: false, description: `Country where the company is located` },
-      { name: 'description', type: 'string', required: false, description: `Description of the company` },
-      { name: 'domain', type: 'string', required: false, description: `Company website domain` },
-      { name: 'industry', type: 'string', required: false, description: `Industry the company operates in` },
-      { name: 'name', type: 'string', required: false, description: `Name of the company` },
-      { name: 'numberofemployees', type: 'number', required: false, description: `Number of employees at the company` },
-      { name: 'phone', type: 'string', required: false, description: `Company phone number` },
-      { name: 'state', type: 'string', required: false, description: `State or region where the company is located` },
-      { name: 'website', type: 'string', required: false, description: `Company website URL` },
+      {
+        name: 'company_id',
+        type: 'string',
+        required: true,
+        description: 'The unique identifier of the company in HubSpot.',
+      },
+      {
+        name: 'name',
+        type: 'string',
+        required: false,
+        description: 'Updated name of the company.',
+      },
+      {
+        name: 'domain',
+        type: 'string',
+        required: false,
+        description: 'Updated company website domain.',
+      },
+      {
+        name: 'phone',
+        type: 'string',
+        required: false,
+        description: 'Updated primary phone number.',
+      },
+      {
+        name: 'city',
+        type: 'string',
+        required: false,
+        description: 'Updated city.',
+      },
+      {
+        name: 'state',
+        type: 'string',
+        required: false,
+        description: 'Updated state or region.',
+      },
+      {
+        name: 'country',
+        type: 'string',
+        required: false,
+        description: 'Updated country.',
+      },
+      {
+        name: 'industry',
+        type: 'string',
+        required: false,
+        description: 'Updated industry.',
+      },
+      {
+        name: 'description',
+        type: 'string',
+        required: false,
+        description: 'Updated company description.',
+      },
+      {
+        name: 'website',
+        type: 'string',
+        required: false,
+        description: 'Full URL of the company website.',
+      },
+      {
+        name: 'annualrevenue',
+        type: 'number',
+        required: false,
+        description: 'Updated annual revenue.',
+      },
+      {
+        name: 'numberofemployees',
+        type: 'number',
+        required: false,
+        description: 'Updated number of employees.',
+      },
     ],
   },
+  {
+    name: 'hubspot_companies_search',
+    description:
+      'Search HubSpot companies using full-text search and pagination. Returns matching companies with specified properties.',
+    params: [
+      {
+        name: 'query',
+        type: 'string',
+        required: false,
+        description: 'Search term for full-text search across company properties.',
+      },
+      {
+        name: 'filterGroups',
+        type: 'string',
+        required: false,
+        description:
+          'JSON string containing filter groups (e.g. `[{"filters":[{"propertyName":"industry","operator":"EQ","value":"Technology"}]}]`).',
+      },
+      {
+        name: 'properties',
+        type: 'string',
+        required: false,
+        description: 'Comma-separated list of properties to include.',
+      },
+      {
+        name: 'limit',
+        type: 'number',
+        required: false,
+        description: 'Number of results per page (max 100).',
+      },
+      {
+        name: 'after',
+        type: 'string',
+        required: false,
+        description: 'Pagination offset from previous response.',
+      },
+    ],
+  },
+
+  // ─── Contacts ─────────────────────────────────────────────────────────────────
   {
     name: 'hubspot_contact_create',
-    description: `Create a new contact in HubSpot CRM. Requires an email address as the unique identifier. Supports additional properties like name, company, phone, and lifecycle stage.`,
+    description:
+      'Create a new contact in HubSpot CRM. Requires an email address as the unique identifier. Supports additional properties like name, company, phone, and lifecycle stage.',
     params: [
-      { name: 'email', type: 'string', required: true, description: `Primary email address for the contact (required, serves as unique identifier)` },
-      { name: 'company', type: 'string', required: false, description: `Company name where the contact works` },
-      { name: 'firstname', type: 'string', required: false, description: `First name of the contact` },
-      { name: 'hs_lead_status', type: 'string', required: false, description: `Lead status of the contact` },
-      { name: 'jobtitle', type: 'string', required: false, description: `Job title of the contact` },
-      { name: 'lastname', type: 'string', required: false, description: `Last name of the contact` },
-      { name: 'lifecyclestage', type: 'string', required: false, description: `Lifecycle stage of the contact` },
-      { name: 'phone', type: 'string', required: false, description: `Phone number of the contact` },
-      { name: 'website', type: 'string', required: false, description: `Personal or company website URL` },
-    ],
-  },
-  {
-    name: 'hubspot_contact_email_events_get',
-    description: `Retrieve marketing email events for a specific contact by their email address. Returns open, click, bounce, and unsubscribe events.`,
-    params: [
-      { name: 'email', type: 'string', required: true, description: `Email address of the contact to retrieve events for` },
-      { name: 'eventType', type: 'string', required: false, description: `Filter by event type (e.g., OPEN, CLICK, BOUNCE, UNSUBSCRIBE)` },
-      { name: 'limit', type: 'number', required: false, description: `Number of events to return per page` },
+      {
+        name: 'email',
+        type: 'string',
+        required: true,
+        description: 'Primary email address (required, must be unique in HubSpot).',
+      },
+      {
+        name: 'firstname',
+        type: 'string',
+        required: false,
+        description: "Contact's first name.",
+      },
+      {
+        name: 'lastname',
+        type: 'string',
+        required: false,
+        description: "Contact's last name.",
+      },
+      {
+        name: 'phone',
+        type: 'string',
+        required: false,
+        description: "Contact's primary phone number.",
+      },
+      {
+        name: 'company',
+        type: 'string',
+        required: false,
+        description: 'Company name where the contact works.',
+      },
+      {
+        name: 'jobtitle',
+        type: 'string',
+        required: false,
+        description: "Contact's job title or role.",
+      },
+      {
+        name: 'website',
+        type: 'string',
+        required: false,
+        description: 'Personal or company website URL.',
+      },
+      {
+        name: 'lifecyclestage',
+        type: 'string',
+        required: false,
+        description:
+          'Lifecycle stage: `subscriber`, `lead`, `marketingqualifiedlead`, `salesqualifiedlead`, `opportunity`, `customer`, `evangelist`, or `other`.',
+      },
+      {
+        name: 'hs_lead_status',
+        type: 'string',
+        required: false,
+        description:
+          'Lead status: `NEW`, `OPEN`, `IN_PROGRESS`, `OPEN_DEAL`, `UNQUALIFIED`, `ATTEMPTED_TO_CONTACT`, `CONNECTED`, or `BAD_TIMING`.',
+      },
     ],
   },
   {
     name: 'hubspot_contact_get',
-    description: `Retrieve details of a specific contact from HubSpot by contact ID. Returns contact properties and associated data.`,
+    description:
+      'Retrieve details of a specific contact from HubSpot by contact ID. Returns contact properties and associated data.',
     params: [
-      { name: 'contact_id', type: 'string', required: true, description: `ID of the contact to retrieve` },
-      { name: 'properties', type: 'string', required: false, description: `Comma-separated list of properties to include in the response` },
-    ],
-  },
-  {
-    name: 'hubspot_contact_list_membership_get',
-    description: `Retrieve all HubSpot lists that a specific contact belongs to, identified by contact ID.`,
-    params: [
-      { name: 'contact_id', type: 'string', required: true, description: `ID of the contact to retrieve list memberships for` },
+      {
+        name: 'contact_id',
+        type: 'string',
+        required: true,
+        description: 'The unique identifier of the contact in HubSpot.',
+      },
+      {
+        name: 'properties',
+        type: 'string',
+        required: false,
+        description:
+          'Comma-separated list of properties to include (e.g. `firstname,lastname,email,company`).',
+      },
     ],
   },
   {
     name: 'hubspot_contact_update',
-    description: `Update an existing contact in HubSpot CRM by contact ID. Provide any fields to update.`,
+    description:
+      'Update an existing contact in HubSpot CRM by contact ID. Provide any fields to update.',
     params: [
-      { name: 'contact_id', type: 'string', required: true, description: `ID of the contact to update` },
-      { name: 'company', type: 'string', required: false, description: `Company name where the contact works` },
-      { name: 'email', type: 'string', required: false, description: `Primary email address of the contact` },
-      { name: 'firstname', type: 'string', required: false, description: `First name of the contact` },
-      { name: 'hs_lead_status', type: 'string', required: false, description: `Lead status of the contact` },
-      { name: 'jobtitle', type: 'string', required: false, description: `Job title of the contact` },
-      { name: 'lastname', type: 'string', required: false, description: `Last name of the contact` },
-      { name: 'lifecyclestage', type: 'string', required: false, description: `Lifecycle stage of the contact` },
-      { name: 'phone', type: 'string', required: false, description: `Phone number of the contact` },
-      { name: 'website', type: 'string', required: false, description: `Website URL of the contact` },
-    ],
-  },
-  {
-    name: 'hubspot_contacts_batch_create',
-    description: `Create multiple contacts in HubSpot CRM in a single API call. Each contact requires an email address. Supports up to 100 contacts per request.`,
-    params: [
-      { name: 'contacts', type: 'array', required: true, description: `Array of contact objects to create. Each contact requires an email address.` },
+      {
+        name: 'contact_id',
+        type: 'string',
+        required: true,
+        description: 'The unique identifier of the contact in HubSpot.',
+      },
+      {
+        name: 'email',
+        type: 'string',
+        required: false,
+        description: 'Updated email address (must be unique in HubSpot).',
+      },
+      {
+        name: 'firstname',
+        type: 'string',
+        required: false,
+        description: 'Updated first name.',
+      },
+      {
+        name: 'lastname',
+        type: 'string',
+        required: false,
+        description: 'Updated last name.',
+      },
+      {
+        name: 'phone',
+        type: 'string',
+        required: false,
+        description: 'Updated phone number.',
+      },
+      {
+        name: 'company',
+        type: 'string',
+        required: false,
+        description: 'Updated company name.',
+      },
+      {
+        name: 'jobtitle',
+        type: 'string',
+        required: false,
+        description: 'Updated job title.',
+      },
+      {
+        name: 'website',
+        type: 'string',
+        required: false,
+        description: 'Updated website URL.',
+      },
+      {
+        name: 'lifecyclestage',
+        type: 'string',
+        required: false,
+        description: 'Updated lifecycle stage (e.g. `lead`, `customer`).',
+      },
+      {
+        name: 'hs_lead_status',
+        type: 'string',
+        required: false,
+        description: 'Updated lead status (e.g. `IN_PROGRESS`, `CONNECTED`).',
+      },
     ],
   },
   {
     name: 'hubspot_contacts_list',
-    description: `Retrieve a list of contacts from HubSpot with filtering and pagination. Returns contact properties and supports pagination through cursor-based navigation.`,
+    description:
+      'Retrieve a list of contacts from HubSpot with filtering and pagination. Returns contact properties and supports cursor-based navigation.',
     params: [
-      { name: 'after', type: 'string', required: false, description: `Pagination cursor to get the next set of results` },
-      { name: 'archived', type: 'boolean', required: false, description: `Whether to include archived contacts in the results` },
-      { name: 'limit', type: 'number', required: false, description: `Number of results to return per page (max 100)` },
-      { name: 'properties', type: 'string', required: false, description: `Comma-separated list of properties to include in the response` },
+      {
+        name: 'properties',
+        type: 'string',
+        required: false,
+        description: 'Comma-separated list of properties to return.',
+      },
+      {
+        name: 'limit',
+        type: 'number',
+        required: false,
+        description: 'Number of contacts to return per page (max 100).',
+      },
+      {
+        name: 'after',
+        type: 'string',
+        required: false,
+        description: 'Cursor value from previous response to get next page.',
+      },
+      {
+        name: 'archived',
+        type: 'boolean',
+        required: false,
+        description: 'Include archived contacts (default: false).',
+      },
     ],
   },
   {
     name: 'hubspot_contacts_search',
-    description: `Search HubSpot contacts using full-text search and pagination. Returns matching contacts with specified properties.`,
+    description:
+      'Search HubSpot contacts using full-text search and pagination. Returns matching contacts with specified properties.',
     params: [
-      { name: 'after', type: 'string', required: false, description: `Pagination offset to get results starting from a specific position` },
-      { name: 'filterGroups', type: 'string', required: false, description: `JSON string containing filter groups for advanced filtering` },
-      { name: 'limit', type: 'number', required: false, description: `Number of results to return per page (max 100)` },
-      { name: 'properties', type: 'string', required: false, description: `Comma-separated list of properties to include in the response` },
-      { name: 'query', type: 'string', required: false, description: `Search term for full-text search across contact properties` },
+      {
+        name: 'query',
+        type: 'string',
+        required: false,
+        description: 'Search term for full-text search across contact properties.',
+      },
+      {
+        name: 'filterGroups',
+        type: 'string',
+        required: false,
+        description:
+          'JSON string containing filter groups (e.g. `[{"filters":[{"propertyName":"lifecyclestage","operator":"EQ","value":"customer"}]}]`).',
+      },
+      {
+        name: 'properties',
+        type: 'string',
+        required: false,
+        description: 'Comma-separated list of properties to include.',
+      },
+      {
+        name: 'limit',
+        type: 'number',
+        required: false,
+        description: 'Number of results per page (max 100).',
+      },
+      {
+        name: 'after',
+        type: 'string',
+        required: false,
+        description: 'Pagination offset from previous response.',
+      },
     ],
   },
   {
-    name: 'hubspot_custom_object_record_create',
-    description: `Create a new record for a HubSpot custom object type.`,
+    name: 'hubspot_contacts_batch_create',
+    description:
+      'Create a contact in HubSpot CRM using the batch API. Accepts individual fields for a clean form experience. Optionally associate the contact with another object on creation.',
     params: [
-      { name: 'object_type_id', type: 'string', required: true, description: `The object type ID of the custom object (e.g., 2-1234567)` },
-      { name: 'properties', type: 'string', required: true, description: `JSON object containing the properties for the new record` },
+      {
+        name: 'email',
+        type: 'string',
+        required: true,
+        description: 'Primary email address (required, unique identifier).',
+      },
+      { name: 'firstname', type: 'string', required: false, description: "Contact's first name." },
+      { name: 'lastname', type: 'string', required: false, description: "Contact's last name." },
+      { name: 'phone', type: 'string', required: false, description: "Contact's phone number." },
+      {
+        name: 'company',
+        type: 'string',
+        required: false,
+        description: 'Company the contact works at.',
+      },
+      { name: 'jobtitle', type: 'string', required: false, description: "Contact's job title." },
+      { name: 'website', type: 'string', required: false, description: "Contact's website URL." },
+      {
+        name: 'lifecyclestage',
+        type: 'string',
+        required: false,
+        description:
+          'Lifecycle stage: `subscriber`, `lead`, `marketingqualifiedlead`, `salesqualifiedlead`, `opportunity`, `customer`, `evangelist`.',
+      },
+      {
+        name: 'associate_to_id',
+        type: 'string',
+        required: false,
+        description: 'ID of a company, deal, or ticket to associate with this contact on creation.',
+      },
+      {
+        name: 'association_type_id',
+        type: 'number',
+        required: false,
+        description:
+          'Association type ID. `279`=contact→company, `4`=contact→deal, `15`=contact→ticket. Required if `associate_to_id` is set.',
+      },
     ],
   },
   {
-    name: 'hubspot_custom_object_record_get',
-    description: `Retrieve a specific record of a HubSpot custom object by object type ID and record ID.`,
+    name: 'hubspot_contacts_batch_update',
+    description:
+      'Update a contact in HubSpot CRM using the batch API. Provide the contact ID and any fields to update.',
     params: [
-      { name: 'object_type_id', type: 'string', required: true, description: `The object type ID of the custom object (e.g., 2-1234567)` },
-      { name: 'record_id', type: 'string', required: true, description: `ID of the record to retrieve` },
-      { name: 'properties', type: 'string', required: false, description: `Comma-separated list of properties to include in the response` },
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description:
+          'HubSpot contact record ID. Get from `hubspot_contacts_search` or `hubspot_contact_get`.',
+      },
+      {
+        name: 'email',
+        type: 'string',
+        required: false,
+        description: 'Updated email address (must be unique in HubSpot).',
+      },
+      { name: 'firstname', type: 'string', required: false, description: 'Updated first name.' },
+      { name: 'lastname', type: 'string', required: false, description: 'Updated last name.' },
+      { name: 'phone', type: 'string', required: false, description: 'Updated phone number.' },
+      { name: 'company', type: 'string', required: false, description: 'Updated company name.' },
+      { name: 'jobtitle', type: 'string', required: false, description: 'Updated job title.' },
+      { name: 'website', type: 'string', required: false, description: 'Updated website URL.' },
+      {
+        name: 'lifecyclestage',
+        type: 'string',
+        required: false,
+        description: 'Updated lifecycle stage (e.g. `lead`, `customer`).',
+      },
+      {
+        name: 'hs_lead_status',
+        type: 'string',
+        required: false,
+        description: 'Updated lead status (e.g. `IN_PROGRESS`, `CONNECTED`).',
+      },
     ],
   },
   {
-    name: 'hubspot_custom_object_record_update',
-    description: `Update an existing record of a HubSpot custom object by object type ID and record ID. Use hubspot_schemas_list to discover available object type IDs and their properties.`,
+    name: 'hubspot_contacts_batch_upsert',
+    description:
+      'Create or update a contact in HubSpot CRM using the batch API. Uses email as the unique identifier — creates a new contact if not found, updates if found.',
     params: [
-      { name: 'object_type_id', type: 'string', required: true, description: `The object type ID of the custom object (e.g., 2-1234567)` },
-      { name: 'properties', type: 'object', required: true, description: `Key-value pairs of custom object properties to update` },
-      { name: 'record_id', type: 'string', required: true, description: `ID of the record to update` },
+      {
+        name: 'email',
+        type: 'string',
+        required: true,
+        description: 'Primary email address used to look up or create the contact.',
+      },
+      { name: 'firstname', type: 'string', required: false, description: "Contact's first name." },
+      { name: 'lastname', type: 'string', required: false, description: "Contact's last name." },
+      { name: 'phone', type: 'string', required: false, description: "Contact's phone number." },
+      {
+        name: 'company',
+        type: 'string',
+        required: false,
+        description: 'Company the contact works at.',
+      },
+      { name: 'jobtitle', type: 'string', required: false, description: "Contact's job title." },
+      { name: 'website', type: 'string', required: false, description: "Contact's website URL." },
+      {
+        name: 'lifecyclestage',
+        type: 'string',
+        required: false,
+        description: 'Lifecycle stage (e.g. `lead`, `customer`).',
+      },
     ],
   },
   {
-    name: 'hubspot_custom_object_records_search',
-    description: `Search records of a HubSpot custom object by object type ID. Use hubspot_schemas_list to find the objectTypeId for your custom object.`,
+    name: 'hubspot_contacts_batch_read',
+    description:
+      'Retrieve a contact record from HubSpot CRM using the batch read API. Returns the specified properties for the record.',
     params: [
-      { name: 'object_type_id', type: 'string', required: true, description: `The object type ID of the custom object (e.g., 2-1234567)` },
-      { name: 'after', type: 'string', required: false, description: `Pagination offset to get results starting from a specific position` },
-      { name: 'filterGroups', type: 'string', required: false, description: `JSON string containing filter groups for advanced filtering` },
-      { name: 'limit', type: 'number', required: false, description: `Number of results to return per page (max 100)` },
-      { name: 'properties', type: 'string', required: false, description: `Comma-separated list of properties to include in the response` },
-      { name: 'query', type: 'string', required: false, description: `Full-text search term across record properties` },
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description:
+          'HubSpot contact record ID. Get from `hubspot_contacts_search` or `hubspot_contact_get`.',
+      },
+      {
+        name: 'properties',
+        type: 'array',
+        required: false,
+        description:
+          'Array of property names to return (e.g. `["firstname","email","company"]`). Returns default properties if not specified.',
+      },
     ],
   },
+  {
+    name: 'hubspot_contacts_batch_archive',
+    description:
+      'Archive (soft delete) a contact in HubSpot CRM using the batch archive API. Archived contacts are hidden from the UI but can be restored.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description:
+          'HubSpot contact record ID to archive. Get from `hubspot_contacts_search` or `hubspot_contact_get`.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_contact_list_membership_get',
+    description:
+      'Retrieve all HubSpot lists that a specific contact belongs to, identified by contact ID.',
+    params: [
+      {
+        name: 'contact_id',
+        type: 'string',
+        required: true,
+        description: 'The unique identifier of the contact in HubSpot.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_contact_email_events_get',
+    description:
+      'Retrieve marketing email events for a specific contact by their email address. Returns open, click, bounce, and unsubscribe events.',
+    params: [
+      {
+        name: 'email',
+        type: 'string',
+        required: true,
+        description: "The contact's email address.",
+      },
+      {
+        name: 'eventType',
+        type: 'string',
+        required: false,
+        description: 'Filter by event type: `OPEN`, `CLICK`, `BOUNCE`, or `UNSUBSCRIBE`.',
+      },
+      {
+        name: 'limit',
+        type: 'number',
+        required: false,
+        description: 'Number of events to return per page (default: 100).',
+      },
+    ],
+  },
+
+  {
+    name: 'hubspot_companies_batch_create',
+    description:
+      'Create a company in HubSpot CRM using the batch API. Accepts individual fields for a clean form experience. Optionally associate the company with another object on creation.',
+    params: [
+      { name: 'name', type: 'string', required: true, description: 'Company name (required).' },
+      {
+        name: 'domain',
+        type: 'string',
+        required: false,
+        description: 'Primary domain of the company (without `https://`).',
+      },
+      { name: 'phone', type: 'string', required: false, description: 'Main company phone number.' },
+      {
+        name: 'city',
+        type: 'string',
+        required: false,
+        description: "City of the company's primary office.",
+      },
+      { name: 'state', type: 'string', required: false, description: 'State or region.' },
+      { name: 'country', type: 'string', required: false, description: 'Country of headquarters.' },
+      {
+        name: 'industry',
+        type: 'string',
+        required: false,
+        description: 'Industry classification (e.g. `TECHNOLOGY`, `FINANCE`, `HEALTHCARE`).',
+      },
+      {
+        name: 'numberofemployees',
+        type: 'number',
+        required: false,
+        description: 'Total employee count.',
+      },
+      {
+        name: 'annualrevenue',
+        type: 'string',
+        required: false,
+        description: 'Annual revenue in USD.',
+      },
+      {
+        name: 'hubspot_owner_id',
+        type: 'string',
+        required: false,
+        description: 'Owner user ID. Get from `hubspot_owners_list`.',
+      },
+      {
+        name: 'associate_to_id',
+        type: 'string',
+        required: false,
+        description: 'ID of a contact or deal to associate with this company on creation.',
+      },
+      {
+        name: 'association_type_id',
+        type: 'number',
+        required: false,
+        description:
+          'Association type ID. `280`=company→contact, `6`=company→deal. Required if `associate_to_id` is set.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_companies_batch_update',
+    description:
+      'Update a company in HubSpot CRM using the batch API. Provide the company ID and any fields to update.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description:
+          'HubSpot company record ID. Get from `hubspot_companies_search` or `hubspot_company_get`.',
+      },
+      { name: 'name', type: 'string', required: false, description: 'Updated company name.' },
+      { name: 'domain', type: 'string', required: false, description: 'Updated primary domain.' },
+      { name: 'phone', type: 'string', required: false, description: 'Updated phone number.' },
+      { name: 'city', type: 'string', required: false, description: 'Updated city.' },
+      { name: 'state', type: 'string', required: false, description: 'Updated state or region.' },
+      { name: 'country', type: 'string', required: false, description: 'Updated country.' },
+      {
+        name: 'industry',
+        type: 'string',
+        required: false,
+        description: 'Updated industry classification.',
+      },
+      {
+        name: 'numberofemployees',
+        type: 'number',
+        required: false,
+        description: 'Updated employee count.',
+      },
+      {
+        name: 'annualrevenue',
+        type: 'string',
+        required: false,
+        description: 'Updated annual revenue in USD.',
+      },
+      {
+        name: 'hubspot_owner_id',
+        type: 'string',
+        required: false,
+        description: 'Updated owner user ID. Get from `hubspot_owners_list`.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_companies_batch_upsert',
+    description:
+      'Create or update a company in HubSpot CRM using the batch API. Uses domain as the unique identifier — creates a new company if the domain is not found, updates if found.',
+    params: [
+      {
+        name: 'domain',
+        type: 'string',
+        required: true,
+        description:
+          'Company domain used to look up or create the company (without `https://`). Must be unique in HubSpot.',
+      },
+      { name: 'name', type: 'string', required: false, description: 'Company name.' },
+      { name: 'phone', type: 'string', required: false, description: 'Main phone number.' },
+      { name: 'city', type: 'string', required: false, description: 'City.' },
+      { name: 'state', type: 'string', required: false, description: 'State or region.' },
+      { name: 'country', type: 'string', required: false, description: 'Country.' },
+      {
+        name: 'industry',
+        type: 'string',
+        required: false,
+        description: 'Industry classification.',
+      },
+      {
+        name: 'numberofemployees',
+        type: 'number',
+        required: false,
+        description: 'Employee count.',
+      },
+      {
+        name: 'annualrevenue',
+        type: 'string',
+        required: false,
+        description: 'Annual revenue in USD.',
+      },
+      {
+        name: 'hubspot_owner_id',
+        type: 'string',
+        required: false,
+        description: 'Owner user ID. Get from `hubspot_owners_list`.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_companies_batch_read',
+    description:
+      'Retrieve a company record from HubSpot CRM using the batch read API. Returns the specified properties for the record.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description:
+          'HubSpot company record ID. Get from `hubspot_companies_search` or `hubspot_company_get`.',
+      },
+      {
+        name: 'properties',
+        type: 'array',
+        required: false,
+        description:
+          'Array of property names to return (e.g. `["name","domain","industry"]`). Returns default properties if not specified.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_companies_batch_archive',
+    description:
+      'Archive (soft delete) a company in HubSpot CRM using the batch archive API. Archived companies are hidden from the UI but can be restored.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description:
+          'HubSpot company record ID to archive. Get from `hubspot_companies_search` or `hubspot_company_get`.',
+      },
+    ],
+  },
+
+  // ─── Deals ────────────────────────────────────────────────────────────────────
   {
     name: 'hubspot_deal_create',
-    description: `Create a new deal in HubSpot CRM. Requires dealname and dealstage. Supports additional properties like amount, pipeline, close date, and deal type.`,
+    description:
+      'Create a new deal in HubSpot CRM. Requires dealname and dealstage. Supports additional properties like amount, pipeline, close date, and deal type.',
     params: [
-      { name: 'dealname', type: 'string', required: true, description: `Name of the deal (required)` },
-      { name: 'dealstage', type: 'string', required: true, description: `Current stage of the deal (required)` },
-      { name: 'amount', type: 'number', required: false, description: `Deal amount/value` },
-      { name: 'closedate', type: 'string', required: false, description: `Expected close date (YYYY-MM-DD format)` },
-      { name: 'dealtype', type: 'string', required: false, description: `Type of deal` },
-      { name: 'description', type: 'string', required: false, description: `Deal description` },
-      { name: 'hs_priority', type: 'string', required: false, description: `Deal priority (high, medium, low)` },
-      { name: 'pipeline', type: 'string', required: false, description: `Deal pipeline` },
+      {
+        name: 'dealname',
+        type: 'string',
+        required: true,
+        description: 'Name of the deal.',
+      },
+      {
+        name: 'dealstage',
+        type: 'string',
+        required: true,
+        description: 'Current stage of the deal (e.g. `qualifiedtobuy`, `closedwon`).',
+      },
+      {
+        name: 'amount',
+        type: 'number',
+        required: false,
+        description: 'Monetary value of the deal.',
+      },
+      {
+        name: 'closedate',
+        type: 'string',
+        required: false,
+        description: 'Expected close date in `YYYY-MM-DD` format.',
+      },
+      {
+        name: 'pipeline',
+        type: 'string',
+        required: false,
+        description: 'The pipeline this deal belongs to (e.g. `default`).',
+      },
+      {
+        name: 'dealtype',
+        type: 'string',
+        required: false,
+        description: 'Classification of the deal type (e.g. `newbusiness`, `existingbusiness`).',
+      },
+      {
+        name: 'description',
+        type: 'string',
+        required: false,
+        description: 'Additional details about the deal.',
+      },
+      {
+        name: 'hs_priority',
+        type: 'string',
+        required: false,
+        description: 'Deal priority: `high`, `medium`, or `low`.',
+      },
     ],
   },
   {
     name: 'hubspot_deal_get',
-    description: `Retrieve details of a specific deal from HubSpot by deal ID. Returns deal properties and associated data.`,
+    description:
+      'Retrieve details of a specific deal from HubSpot by deal ID. Returns deal properties and associated data.',
     params: [
-      { name: 'deal_id', type: 'string', required: true, description: `ID of the deal to retrieve` },
-      { name: 'associations', type: 'string', required: false, description: `Comma-separated list of object types to retrieve associations for` },
-      { name: 'properties', type: 'string', required: false, description: `Comma-separated list of properties to include in the response` },
-    ],
-  },
-  {
-    name: 'hubspot_deal_line_items_get',
-    description: `Retrieve all line items associated with a specific HubSpot deal.`,
-    params: [
-      { name: 'deal_id', type: 'string', required: true, description: `ID of the deal to retrieve line items for` },
-    ],
-  },
-  {
-    name: 'hubspot_deal_pipelines_list',
-    description: `Retrieve all deal pipelines in HubSpot, including pipeline stages. Use this to get valid pipeline IDs and stage IDs for creating or updating deals.`,
-    params: [
-      { name: 'archived', type: 'string', required: false, description: `Include archived pipelines in the response` },
+      {
+        name: 'deal_id',
+        type: 'string',
+        required: true,
+        description: 'The unique identifier of the deal in HubSpot.',
+      },
+      {
+        name: 'properties',
+        type: 'string',
+        required: false,
+        description:
+          'Comma-separated list of properties to return (e.g. `dealname,amount,dealstage,closedate`).',
+      },
+      {
+        name: 'associations',
+        type: 'string',
+        required: false,
+        description:
+          'Comma-separated object types to retrieve associations for (e.g. `contacts,companies,line_items`).',
+      },
     ],
   },
   {
     name: 'hubspot_deal_update',
-    description: `Update an existing deal in HubSpot CRM by deal ID. Provide any fields to update.`,
+    description: 'Update an existing deal in HubSpot CRM by deal ID. Provide any fields to update.',
     params: [
-      { name: 'deal_id', type: 'string', required: true, description: `ID of the deal to update` },
-      { name: 'amount', type: 'number', required: false, description: `Updated deal amount/value` },
-      { name: 'closedate', type: 'string', required: false, description: `Updated expected close date (YYYY-MM-DD format)` },
-      { name: 'dealname', type: 'string', required: false, description: `Updated name of the deal` },
-      { name: 'dealstage', type: 'string', required: false, description: `Updated stage of the deal` },
-      { name: 'dealtype', type: 'string', required: false, description: `Updated type of deal` },
-      { name: 'description', type: 'string', required: false, description: `Updated deal description` },
-      { name: 'hs_priority', type: 'string', required: false, description: `Updated deal priority` },
-      { name: 'pipeline', type: 'string', required: false, description: `Updated deal pipeline` },
+      {
+        name: 'deal_id',
+        type: 'string',
+        required: true,
+        description: 'The unique identifier of the deal in HubSpot.',
+      },
+      {
+        name: 'dealname',
+        type: 'string',
+        required: false,
+        description: 'Updated name of the deal.',
+      },
+      {
+        name: 'dealstage',
+        type: 'string',
+        required: false,
+        description: 'Updated pipeline stage (e.g. `closedwon`).',
+      },
+      {
+        name: 'amount',
+        type: 'number',
+        required: false,
+        description: 'Updated monetary value of the deal.',
+      },
+      {
+        name: 'closedate',
+        type: 'string',
+        required: false,
+        description: 'Updated expected close date in `YYYY-MM-DD` format.',
+      },
+      {
+        name: 'pipeline',
+        type: 'string',
+        required: false,
+        description: 'Updated pipeline.',
+      },
+      {
+        name: 'dealtype',
+        type: 'string',
+        required: false,
+        description: 'Updated deal type.',
+      },
+      {
+        name: 'description',
+        type: 'string',
+        required: false,
+        description: 'Updated deal description.',
+      },
+      {
+        name: 'hs_priority',
+        type: 'string',
+        required: false,
+        description: 'Updated priority: `high`, `medium`, or `low`.',
+      },
     ],
   },
   {
     name: 'hubspot_deals_search',
-    description: `Search HubSpot deals using full-text search and pagination. Returns matching deals with specified properties.`,
+    description:
+      'Search HubSpot deals using full-text search and pagination. Returns matching deals with specified properties.',
     params: [
-      { name: 'after', type: 'string', required: false, description: `Pagination offset to get results starting from a specific position` },
-      { name: 'filterGroups', type: 'string', required: false, description: `JSON string containing filter groups for advanced filtering` },
-      { name: 'limit', type: 'number', required: false, description: `Number of results to return per page (max 100)` },
-      { name: 'properties', type: 'string', required: false, description: `Comma-separated list of properties to include in the response` },
-      { name: 'query', type: 'string', required: false, description: `Search term for full-text search across deal properties` },
+      {
+        name: 'query',
+        type: 'string',
+        required: false,
+        description: 'Search term for full-text search across deal properties.',
+      },
+      {
+        name: 'filterGroups',
+        type: 'string',
+        required: false,
+        description:
+          'JSON string containing filter groups (e.g. `[{"filters":[{"propertyName":"dealstage","operator":"EQ","value":"closedwon"}]}]`).',
+      },
+      {
+        name: 'properties',
+        type: 'string',
+        required: false,
+        description: 'Comma-separated list of properties to include.',
+      },
+      {
+        name: 'limit',
+        type: 'number',
+        required: false,
+        description: 'Number of results per page (max 100).',
+      },
+      {
+        name: 'after',
+        type: 'string',
+        required: false,
+        description: 'Pagination offset from previous response.',
+      },
     ],
   },
   {
-    name: 'hubspot_emails_search',
-    description: `Search HubSpot email engagements (logged emails) using filters and full-text search. Returns logged email records with their properties.`,
+    name: 'hubspot_deal_pipelines_list',
+    description:
+      'Retrieve all pipelines for a HubSpot CRM object type (e.g. `deals` or `tickets`), including pipeline stages. Use this to get valid pipeline IDs and stage IDs for creating or updating deals and tickets.',
     params: [
-      { name: 'after', type: 'string', required: false, description: `Pagination offset to get results starting from a specific position` },
-      { name: 'filterGroups', type: 'string', required: false, description: `JSON string containing filter groups for advanced filtering` },
-      { name: 'limit', type: 'number', required: false, description: `Number of results to return per page (max 100)` },
-      { name: 'properties', type: 'string', required: false, description: `Comma-separated list of properties to include in the response` },
-      { name: 'query', type: 'string', required: false, description: `Full-text search term across email properties` },
+      {
+        name: 'archived',
+        type: 'boolean',
+        required: false,
+        description: 'Set to `true` to include archived pipelines.',
+      },
     ],
   },
   {
-    name: 'hubspot_engagements_list',
-    description: `List engagements (notes, tasks, calls, emails, meetings) from HubSpot CRM. Supports filtering by engagement type and pagination.`,
+    name: 'hubspot_deal_line_items_get',
+    description: 'Retrieve all line items associated with a specific HubSpot deal.',
     params: [
-      { name: 'engagement_type', type: 'string', required: true, description: `Type of engagement to list` },
-      { name: 'after', type: 'string', required: false, description: `Pagination cursor to get the next page of results` },
-      { name: 'limit', type: 'integer', required: false, description: `Number of results to return (max 100)` },
+      {
+        name: 'deal_id',
+        type: 'string',
+        required: true,
+        description: 'The HubSpot ID of the deal.',
+      },
+    ],
+  },
+
+  {
+    name: 'hubspot_deals_batch_create',
+    description:
+      'Create a deal in HubSpot CRM using the batch API. Accepts individual fields for a clean form experience. Optionally associate the deal with a contact or company on creation.',
+    params: [
+      {
+        name: 'dealname',
+        type: 'string',
+        required: true,
+        description: 'Name of the deal (required).',
+      },
+      {
+        name: 'dealstage',
+        type: 'string',
+        required: false,
+        description:
+          'Deal stage ID (e.g. `appointmentscheduled`, `closedwon`). Get valid IDs from `hubspot_deal_pipelines_list`.',
+      },
+      {
+        name: 'pipeline',
+        type: 'string',
+        required: false,
+        description: 'Pipeline ID (default: `default`).',
+      },
+      {
+        name: 'closedate',
+        type: 'string',
+        required: false,
+        description: 'Expected close date in `YYYY-MM-DD` format.',
+      },
+      {
+        name: 'amount',
+        type: 'string',
+        required: false,
+        description: 'Monetary value of the deal (e.g. `10000`).',
+      },
+      {
+        name: 'hubspot_owner_id',
+        type: 'string',
+        required: false,
+        description: 'Owner user ID. Get from `hubspot_owners_list`.',
+      },
+      {
+        name: 'associate_to_id',
+        type: 'string',
+        required: false,
+        description: 'ID of a contact or company to associate with this deal on creation.',
+      },
+      {
+        name: 'association_type_id',
+        type: 'number',
+        required: false,
+        description:
+          'Association type ID. `3`=deal→contact, `5`=deal→company. Required if `associate_to_id` is set.',
+      },
     ],
   },
   {
-    name: 'hubspot_form_submissions_get',
-    description: `Retrieve all submissions for a specific HubSpot form. Returns submitted field values and submission timestamps.`,
+    name: 'hubspot_deals_batch_update',
+    description:
+      'Update a deal in HubSpot CRM using the batch API. Provide the deal ID and any fields to update.',
     params: [
-      { name: 'form_id', type: 'string', required: true, description: `ID of the form to retrieve submissions for` },
-      { name: 'after', type: 'string', required: false, description: `Pagination offset token for the next page` },
-      { name: 'limit', type: 'number', required: false, description: `Number of submissions to return per page` },
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description:
+          'HubSpot deal record ID. Get from `hubspot_deals_search` or `hubspot_deal_get`.',
+      },
+      { name: 'dealname', type: 'string', required: false, description: 'Updated deal name.' },
+      {
+        name: 'dealstage',
+        type: 'string',
+        required: false,
+        description: 'Updated deal stage ID (e.g. `closedwon`).',
+      },
+      { name: 'pipeline', type: 'string', required: false, description: 'Updated pipeline ID.' },
+      {
+        name: 'closedate',
+        type: 'string',
+        required: false,
+        description: 'Updated close date in `YYYY-MM-DD` format.',
+      },
+      { name: 'amount', type: 'string', required: false, description: 'Updated deal amount.' },
+      {
+        name: 'hubspot_owner_id',
+        type: 'string',
+        required: false,
+        description: 'Updated owner user ID. Get from `hubspot_owners_list`.',
+      },
     ],
   },
   {
-    name: 'hubspot_forms_list',
-    description: `List all HubSpot marketing forms. Returns form IDs, names, and field definitions.`,
+    name: 'hubspot_deals_batch_upsert',
+    description:
+      'Create or update a deal in HubSpot CRM using the batch API. Uses deal name as the lookup identifier. Note: `dealname` must be configured as a unique property in your HubSpot portal for upsert to work correctly.',
     params: [
-      { name: 'after', type: 'string', required: false, description: `Pagination cursor for the next page of results` },
-      { name: 'formTypes', type: 'string', required: false, description: `Comma-separated list of form types to filter by (e.g., hubspot,captured,flow)` },
-      { name: 'limit', type: 'number', required: false, description: `Number of forms to return per page (max 50)` },
+      {
+        name: 'dealname',
+        type: 'string',
+        required: true,
+        description:
+          'Deal name used to look up or create the deal. Must be unique in your HubSpot portal for upsert to work.',
+      },
+      { name: 'dealstage', type: 'string', required: false, description: 'Deal stage ID.' },
+      { name: 'pipeline', type: 'string', required: false, description: 'Pipeline ID.' },
+      {
+        name: 'closedate',
+        type: 'string',
+        required: false,
+        description: 'Close date in `YYYY-MM-DD` format.',
+      },
+      { name: 'amount', type: 'string', required: false, description: 'Deal amount.' },
+      {
+        name: 'hubspot_owner_id',
+        type: 'string',
+        required: false,
+        description: 'Owner user ID. Get from `hubspot_owners_list`.',
+      },
     ],
   },
   {
-    name: 'hubspot_line_item_create',
-    description: `Create a new line item in HubSpot. Line items represent individual products or services in a deal.`,
+    name: 'hubspot_deals_batch_read',
+    description:
+      'Retrieve a deal record from HubSpot CRM using the batch read API. Returns the specified properties for the record.',
     params: [
-      { name: 'name', type: 'string', required: true, description: `Name of the line item` },
-      { name: 'deal_id', type: 'string', required: false, description: `ID of the deal to associate this line item with` },
-      { name: 'hs_product_id', type: 'string', required: false, description: `ID of the associated product from HubSpot product library` },
-      { name: 'price', type: 'string', required: false, description: `Unit price of the line item` },
-      { name: 'quantity', type: 'string', required: false, description: `Quantity of the line item` },
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description:
+          'HubSpot deal record ID. Get from `hubspot_deals_search` or `hubspot_deal_get`.',
+      },
+      {
+        name: 'properties',
+        type: 'array',
+        required: false,
+        description:
+          'Array of property names to return (e.g. `["dealname","amount","dealstage"]`). Returns default properties if not specified.',
+      },
     ],
   },
   {
-    name: 'hubspot_meeting_log',
-    description: `Log a meeting engagement in HubSpot CRM. Records details of a meeting including title, start/end time, description, and outcome.`,
+    name: 'hubspot_deals_batch_archive',
+    description:
+      'Archive (soft delete) a deal in HubSpot CRM using the batch archive API. Archived deals are hidden from the UI but can be restored.',
     params: [
-      { name: 'hs_meeting_end_time', type: 'string', required: true, description: `End time of the meeting (ISO 8601 format)` },
-      { name: 'hs_meeting_start_time', type: 'string', required: true, description: `Start time of the meeting (ISO 8601 format)` },
-      { name: 'hs_meeting_title', type: 'string', required: true, description: `Title of the meeting` },
-      { name: 'hs_timestamp', type: 'string', required: true, description: `Timestamp for the meeting (ISO 8601 format)` },
-      { name: 'hs_meeting_body', type: 'string', required: false, description: `Description or agenda for the meeting` },
-      { name: 'hs_meeting_outcome', type: 'string', required: false, description: `Outcome of the meeting` },
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description:
+          'HubSpot deal record ID to archive. Get from `hubspot_deals_search` or `hubspot_deal_get`.',
+      },
     ],
   },
-  {
-    name: 'hubspot_meetings_search',
-    description: `Search HubSpot meeting engagements using filters and full-text search. Returns logged meetings with their properties.`,
-    params: [
-      { name: 'after', type: 'string', required: false, description: `Pagination offset to get results starting from a specific position` },
-      { name: 'filterGroups', type: 'string', required: false, description: `JSON string containing filter groups for advanced filtering` },
-      { name: 'limit', type: 'number', required: false, description: `Number of results to return per page (max 100)` },
-      { name: 'properties', type: 'string', required: false, description: `Comma-separated list of properties to include in the response` },
-      { name: 'query', type: 'string', required: false, description: `Full-text search term across meeting properties` },
-    ],
-  },
-  {
-    name: 'hubspot_note_create',
-    description: `Create a note in HubSpot CRM to log interactions, meeting summaries, or important information. Notes can be associated with contacts, companies, or deals.`,
-    params: [
-      { name: 'props', type: 'object', required: true, description: `Note properties. hs_note_body (required) is the note content. hs_timestamp (required) is Unix ms timestamp e.g. 1700000000000.` },
-    ],
-  },
-  {
-    name: 'hubspot_note_log',
-    description: `Log a note engagement in HubSpot CRM. Creates a text note that can be associated with contacts, companies, or deals.`,
-    params: [
-      { name: 'hs_note_body', type: 'string', required: true, description: `Content of the note` },
-      { name: 'hs_timestamp', type: 'string', required: true, description: `Timestamp for the note (ISO 8601 format)` },
-    ],
-  },
-  {
-    name: 'hubspot_notes_search',
-    description: `Search HubSpot note engagements using filters and full-text search. Returns logged notes with their content and timestamps.`,
-    params: [
-      { name: 'after', type: 'string', required: false, description: `Pagination offset to get results starting from a specific position` },
-      { name: 'filterGroups', type: 'string', required: false, description: `JSON string containing filter groups for advanced filtering` },
-      { name: 'limit', type: 'number', required: false, description: `Number of results to return per page (max 100)` },
-      { name: 'properties', type: 'string', required: false, description: `Comma-separated list of properties to include in the response` },
-      { name: 'query', type: 'string', required: false, description: `Full-text search term across note content` },
-    ],
-  },
-  {
-    name: 'hubspot_object_properties_list',
-    description: `Retrieve all properties defined for a HubSpot CRM object type (contacts, companies, deals, tickets, etc.).`,
-    params: [
-      { name: 'object_type', type: 'string', required: true, description: `The CRM object type to list properties for` },
-      { name: 'archived', type: 'string', required: false, description: `Include archived properties in the response` },
-    ],
-  },
-  {
-    name: 'hubspot_owners_list',
-    description: `List all HubSpot owners (users). Use this to find owner IDs for assigning contacts, deals, tickets, and other CRM records.`,
-    params: [
-      { name: 'after', type: 'string', required: false, description: `Pagination cursor for the next page of results` },
-      { name: 'email', type: 'string', required: false, description: `Filter owners by email address` },
-      { name: 'limit', type: 'number', required: false, description: `Number of owners to return per page (max 500)` },
-    ],
-  },
-  {
-    name: 'hubspot_product_create',
-    description: `Create a new product in the HubSpot product library.`,
-    params: [
-      { name: 'name', type: 'string', required: true, description: `Name of the product` },
-      { name: 'description', type: 'string', required: false, description: `Description of the product` },
-      { name: 'hs_sku', type: 'string', required: false, description: `Stock keeping unit (SKU) identifier for the product` },
-      { name: 'price', type: 'string', required: false, description: `Price of the product` },
-    ],
-  },
-  {
-    name: 'hubspot_products_list',
-    description: `Retrieve a list of products from the HubSpot product library.`,
-    params: [
-      { name: 'after', type: 'string', required: false, description: `Pagination cursor for the next page of results` },
-      { name: 'limit', type: 'number', required: false, description: `Number of products to return per page (max 100)` },
-      { name: 'properties', type: 'string', required: false, description: `Comma-separated list of product properties to include in response` },
-    ],
-  },
-  {
-    name: 'hubspot_quote_create',
-    description: `Create a new quote in HubSpot for a deal.`,
-    params: [
-      { name: 'hs_language', type: 'string', required: true, description: `Language of the quote (ISO 639-1 code, e.g. en, de, fr, es)` },
-      { name: 'hs_title', type: 'string', required: true, description: `Title of the quote` },
-      { name: 'deal_id', type: 'string', required: false, description: `ID of the deal to associate this quote with` },
-      { name: 'hs_expiration_date', type: 'string', required: false, description: `Expiration date of the quote (YYYY-MM-DD format)` },
-      { name: 'hs_status', type: 'string', required: false, description: `Status of the quote (DRAFT, PENDING_APPROVAL, APPROVED, REJECTED)` },
-    ],
-  },
-  {
-    name: 'hubspot_quote_get',
-    description: `Retrieve a specific HubSpot quote by its ID.`,
-    params: [
-      { name: 'quote_id', type: 'string', required: true, description: `ID of the quote to retrieve` },
-      { name: 'properties', type: 'string', required: false, description: `Comma-separated list of quote properties to include in response` },
-    ],
-  },
-  {
-    name: 'hubspot_schemas_list',
-    description: `List all custom object schemas defined in HubSpot. Returns object type IDs, labels, and property definitions needed to work with custom objects.`,
-    params: [
-      { name: 'archived', type: 'string', required: false, description: `Include archived schemas in the response` },
-    ],
-  },
-  {
-    name: 'hubspot_task_complete',
-    description: `Mark a HubSpot task as completed or update its status. Use the task ID from hubspot_tasks_search or hubspot_task_create.`,
-    params: [
-      { name: 'task_id', type: 'string', required: true, description: `ID of the task to update` },
-      { name: 'hs_task_body', type: 'string', required: false, description: `Updated notes for the task` },
-      { name: 'hs_task_status', type: 'string', required: false, description: `New status to set for the task` },
-    ],
-  },
-  {
-    name: 'hubspot_task_create',
-    description: `Create a new task in HubSpot CRM. Tasks can be assigned to owners and associated with contacts, companies, or deals.`,
-    params: [
-      { name: 'hs_task_subject', type: 'string', required: true, description: `Subject or title of the task` },
-      { name: 'hs_timestamp', type: 'string', required: true, description: `Due date and time for the task (ISO 8601 format)` },
-      { name: 'hs_task_body', type: 'string', required: false, description: `Notes or description for the task` },
-      { name: 'hs_task_priority', type: 'string', required: false, description: `Priority level of the task` },
-      { name: 'hs_task_status', type: 'string', required: false, description: `Status of the task` },
-      { name: 'hs_task_type', type: 'string', required: false, description: `Type of task` },
-    ],
-  },
-  {
-    name: 'hubspot_tasks_search',
-    description: `Search HubSpot tasks using filters and full-text search. Returns tasks with their subject, status, due date, and priority.`,
-    params: [
-      { name: 'after', type: 'string', required: false, description: `Pagination offset to get results starting from a specific position` },
-      { name: 'filterGroups', type: 'string', required: false, description: `JSON string containing filter groups for advanced filtering` },
-      { name: 'limit', type: 'number', required: false, description: `Number of results to return per page (max 100)` },
-      { name: 'properties', type: 'string', required: false, description: `Comma-separated list of properties to include in the response` },
-      { name: 'query', type: 'string', required: false, description: `Full-text search term across task properties` },
-    ],
-  },
+
+  // ─── Tickets ──────────────────────────────────────────────────────────────────
   {
     name: 'hubspot_ticket_create',
-    description: `Create a new support ticket in HubSpot. Use hubspot_deal_pipelines_list with object type 'tickets' to find valid pipeline and stage IDs.`,
+    description:
+      'Create a new support ticket in HubSpot. Use `hubspot_deal_pipelines_list` with `object_type: tickets` to find valid pipeline and stage IDs.',
     params: [
-      { name: 'hs_pipeline_stage', type: 'string', required: true, description: `Pipeline stage ID for the ticket` },
-      { name: 'subject', type: 'string', required: true, description: `Subject of the ticket` },
-      { name: 'content', type: 'string', required: false, description: `Detailed description of the support issue` },
-      { name: 'hs_pipeline', type: 'string', required: false, description: `Pipeline ID for the ticket (defaults to '0' for the default pipeline)` },
-      { name: 'hs_ticket_priority', type: 'string', required: false, description: `Priority level of the ticket` },
+      {
+        name: 'subject',
+        type: 'string',
+        required: true,
+        description: 'A short descriptive title for the support ticket.',
+      },
+      {
+        name: 'hs_pipeline_stage',
+        type: 'string',
+        required: true,
+        description: 'Pipeline stage ID for the ticket (e.g. `1` for New).',
+      },
+      {
+        name: 'content',
+        type: 'string',
+        required: false,
+        description: 'Detailed description of the support issue.',
+      },
+      {
+        name: 'hs_pipeline',
+        type: 'string',
+        required: false,
+        description: "Pipeline ID (use `'0'` for the default Support Pipeline).",
+      },
+      {
+        name: 'hs_ticket_priority',
+        type: 'string',
+        required: false,
+        description: 'Priority level: `HIGH`, `MEDIUM`, or `LOW`.',
+      },
     ],
   },
   {
     name: 'hubspot_ticket_get',
-    description: `Retrieve details of a specific HubSpot support ticket by ticket ID.`,
+    description: 'Retrieve details of a specific HubSpot support ticket by ticket ID.',
     params: [
-      { name: 'ticket_id', type: 'string', required: true, description: `ID of the ticket to retrieve` },
-      { name: 'properties', type: 'string', required: false, description: `Comma-separated list of properties to include in the response` },
+      {
+        name: 'ticket_id',
+        type: 'string',
+        required: true,
+        description: 'The unique identifier of the ticket in HubSpot.',
+      },
+      {
+        name: 'properties',
+        type: 'string',
+        required: false,
+        description: 'Comma-separated list of properties to return.',
+      },
     ],
   },
   {
     name: 'hubspot_ticket_update',
-    description: `Update an existing HubSpot support ticket by ticket ID. Provide any fields to update.`,
+    description:
+      'Update an existing HubSpot support ticket by ticket ID. Provide any fields to update.',
     params: [
-      { name: 'ticket_id', type: 'string', required: true, description: `ID of the ticket to update` },
-      { name: 'content', type: 'string', required: false, description: `Updated description of the support issue` },
-      { name: 'hs_pipeline', type: 'string', required: false, description: `Updated pipeline ID for the ticket` },
-      { name: 'hs_pipeline_stage', type: 'string', required: false, description: `Updated pipeline stage ID for the ticket` },
-      { name: 'hs_ticket_priority', type: 'string', required: false, description: `Updated priority level of the ticket` },
-      { name: 'subject', type: 'string', required: false, description: `Updated subject of the ticket` },
+      {
+        name: 'ticket_id',
+        type: 'string',
+        required: true,
+        description: 'The unique identifier of the ticket in HubSpot.',
+      },
+      {
+        name: 'subject',
+        type: 'string',
+        required: false,
+        description: 'Updated subject of the ticket.',
+      },
+      {
+        name: 'content',
+        type: 'string',
+        required: false,
+        description: 'Updated description of the support issue.',
+      },
+      {
+        name: 'hs_pipeline_stage',
+        type: 'string',
+        required: false,
+        description: 'Updated pipeline stage ID.',
+      },
+      {
+        name: 'hs_pipeline',
+        type: 'string',
+        required: false,
+        description: 'Updated pipeline ID.',
+      },
+      {
+        name: 'hs_ticket_priority',
+        type: 'string',
+        required: false,
+        description: 'Updated priority: `HIGH`, `MEDIUM`, or `LOW`.',
+      },
     ],
   },
   {
     name: 'hubspot_tickets_search',
-    description: `Search HubSpot support tickets using filters and full-text search. Returns matching tickets with their properties.`,
+    description:
+      'Search HubSpot support tickets using filters and full-text search. Returns matching tickets with their properties.',
     params: [
-      { name: 'after', type: 'string', required: false, description: `Pagination offset to get results starting from a specific position` },
-      { name: 'filterGroups', type: 'string', required: false, description: `JSON string containing filter groups for advanced filtering` },
-      { name: 'limit', type: 'number', required: false, description: `Number of results to return per page (max 100)` },
-      { name: 'properties', type: 'string', required: false, description: `Comma-separated list of properties to include in the response` },
-      { name: 'query', type: 'string', required: false, description: `Full-text search term across ticket properties` },
+      {
+        name: 'query',
+        type: 'string',
+        required: false,
+        description: 'Full-text search term across ticket subjects and content.',
+      },
+      {
+        name: 'filterGroups',
+        type: 'string',
+        required: false,
+        description:
+          'JSON string containing filter groups (e.g. `[{"filters":[{"propertyName":"hs_ticket_priority","operator":"EQ","value":"HIGH"}]}]`).',
+      },
+      {
+        name: 'properties',
+        type: 'string',
+        required: false,
+        description: 'Comma-separated list of properties to include.',
+      },
+      {
+        name: 'limit',
+        type: 'number',
+        required: false,
+        description: 'Number of results per page (max 100).',
+      },
+      {
+        name: 'after',
+        type: 'string',
+        required: false,
+        description: 'Pagination offset from previous response.',
+      },
+    ],
+  },
+
+  {
+    name: 'hubspot_tickets_batch_create',
+    description:
+      'Create a support ticket in HubSpot CRM using the batch API. Accepts individual fields for a clean form experience. Optionally associate the ticket with a contact or company on creation.',
+    params: [
+      {
+        name: 'subject',
+        type: 'string',
+        required: true,
+        description: 'Short description of the support issue (required).',
+      },
+      {
+        name: 'hs_pipeline_stage',
+        type: 'string',
+        required: true,
+        description:
+          'Pipeline stage ID: `1`=New, `2`=Waiting on contact, `3`=Waiting on us, `4`=Closed. Get from `hubspot_deal_pipelines_list`.',
+      },
+      {
+        name: 'hs_pipeline',
+        type: 'string',
+        required: false,
+        description: "Pipeline ID. Defaults to `'0'` (default support pipeline).",
+      },
+      {
+        name: 'hs_ticket_priority',
+        type: 'string',
+        required: false,
+        description: 'Priority: `LOW`, `MEDIUM`, or `HIGH`.',
+      },
+      {
+        name: 'content',
+        type: 'string',
+        required: false,
+        description: 'Detailed description of the support issue.',
+      },
+      {
+        name: 'hubspot_owner_id',
+        type: 'string',
+        required: false,
+        description: 'Owner user ID. Get from `hubspot_owners_list`.',
+      },
+      {
+        name: 'associate_to_id',
+        type: 'string',
+        required: false,
+        description: 'ID of a contact or company to associate with this ticket on creation.',
+      },
+      {
+        name: 'association_type_id',
+        type: 'number',
+        required: false,
+        description:
+          'Association type ID. `16`=ticket→contact, `340`=ticket→company. Required if `associate_to_id` is set.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_tickets_batch_update',
+    description:
+      'Update a support ticket in HubSpot CRM using the batch API. Provide the ticket ID and any fields to update.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description:
+          'HubSpot ticket record ID. Get from `hubspot_tickets_search` or `hubspot_ticket_get`.',
+      },
+      { name: 'subject', type: 'string', required: false, description: 'Updated ticket subject.' },
+      { name: 'hs_pipeline', type: 'string', required: false, description: 'Updated pipeline ID.' },
+      {
+        name: 'hs_pipeline_stage',
+        type: 'string',
+        required: false,
+        description: 'Updated pipeline stage ID.',
+      },
+      {
+        name: 'hs_ticket_priority',
+        type: 'string',
+        required: false,
+        description: 'Updated priority: `LOW`, `MEDIUM`, or `HIGH`.',
+      },
+      {
+        name: 'content',
+        type: 'string',
+        required: false,
+        description: 'Updated ticket description.',
+      },
+      {
+        name: 'hubspot_owner_id',
+        type: 'string',
+        required: false,
+        description: 'Updated owner user ID. Get from `hubspot_owners_list`.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_tickets_batch_upsert',
+    description:
+      'Create or update a support ticket in HubSpot CRM using the batch API. Uses subject as the lookup identifier. Note: `subject` must be configured as a unique property in your HubSpot portal for upsert to work correctly.',
+    params: [
+      {
+        name: 'subject',
+        type: 'string',
+        required: true,
+        description:
+          'Ticket subject used to look up or create the ticket. Must be unique in your HubSpot portal for upsert to work.',
+      },
+      {
+        name: 'hs_pipeline_stage',
+        type: 'string',
+        required: true,
+        description:
+          'Pipeline stage ID: `1`=New, `2`=Waiting on contact, `3`=Waiting on us, `4`=Closed.',
+      },
+      {
+        name: 'hs_pipeline',
+        type: 'string',
+        required: false,
+        description: 'Pipeline ID (default: `0`).',
+      },
+      {
+        name: 'hs_ticket_priority',
+        type: 'string',
+        required: false,
+        description: 'Priority: `LOW`, `MEDIUM`, or `HIGH`.',
+      },
+      { name: 'content', type: 'string', required: false, description: 'Ticket description.' },
+      {
+        name: 'hubspot_owner_id',
+        type: 'string',
+        required: false,
+        description: 'Owner user ID. Get from `hubspot_owners_list`.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_tickets_batch_read',
+    description:
+      'Retrieve a support ticket record from HubSpot CRM using the batch read API. Returns the specified properties for the record.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description:
+          'HubSpot ticket record ID. Get from `hubspot_tickets_search` or `hubspot_ticket_get`.',
+      },
+      {
+        name: 'properties',
+        type: 'array',
+        required: false,
+        description:
+          'Array of property names to return (e.g. `["subject","hs_ticket_priority","hs_pipeline_stage"]`). Returns default properties if not specified.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_tickets_batch_archive',
+    description:
+      'Archive (soft delete) a support ticket in HubSpot CRM using the batch archive API. Archived tickets are hidden from the UI but can be restored.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description:
+          'HubSpot ticket record ID to archive. Get from `hubspot_tickets_search` or `hubspot_ticket_get`.',
+      },
+    ],
+  },
+
+  // ─── Tasks ────────────────────────────────────────────────────────────────────
+  {
+    name: 'hubspot_task_create',
+    description:
+      'Create a new task in HubSpot CRM. Tasks can be assigned to owners and associated with contacts, companies, or deals.',
+    params: [
+      {
+        name: 'hs_task_subject',
+        type: 'string',
+        required: true,
+        description: 'A descriptive subject for the task.',
+      },
+      {
+        name: 'hs_timestamp',
+        type: 'string',
+        required: true,
+        description:
+          'Due date and time for the task in ISO 8601 format (e.g. `2024-01-20T10:00:00Z`).',
+      },
+      {
+        name: 'hs_task_status',
+        type: 'string',
+        required: false,
+        description: 'Status: `NOT_STARTED`, `IN_PROGRESS`, `COMPLETED`, `DEFERRED`, or `WAITING`.',
+      },
+      {
+        name: 'hs_task_priority',
+        type: 'string',
+        required: false,
+        description: 'Priority: `HIGH`, `MEDIUM`, or `LOW`.',
+      },
+      {
+        name: 'hs_task_type',
+        type: 'string',
+        required: false,
+        description: 'Type of task: `EMAIL`, `CALL`, or `TODO`.',
+      },
+      {
+        name: 'hs_task_body',
+        type: 'string',
+        required: false,
+        description: 'Additional notes or context for the task.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_task_complete',
+    description:
+      'Mark a HubSpot task as completed or update its status. Use the task ID from `hubspot_tasks_search` or `hubspot_task_create`.',
+    params: [
+      {
+        name: 'task_id',
+        type: 'string',
+        required: true,
+        description: 'The unique identifier of the task in HubSpot.',
+      },
+      {
+        name: 'hs_task_status',
+        type: 'string',
+        required: false,
+        description:
+          'New status: `NOT_STARTED`, `IN_PROGRESS`, `COMPLETED`, `DEFERRED`, or `WAITING`.',
+      },
+      {
+        name: 'hs_task_body',
+        type: 'string',
+        required: false,
+        description: 'Updated notes when completing the task.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_tasks_search',
+    description:
+      'Search HubSpot tasks using filters and full-text search. Returns tasks with their subject, status, due date, and priority.',
+    params: [
+      {
+        name: 'query',
+        type: 'string',
+        required: false,
+        description: 'Full-text search term across task subjects and notes.',
+      },
+      {
+        name: 'filterGroups',
+        type: 'string',
+        required: false,
+        description:
+          'JSON string containing filter groups (e.g. `[{"filters":[{"propertyName":"hs_task_status","operator":"NEQ","value":"COMPLETED"}]}]`).',
+      },
+      {
+        name: 'properties',
+        type: 'string',
+        required: false,
+        description: 'Comma-separated list of properties to include.',
+      },
+      {
+        name: 'limit',
+        type: 'number',
+        required: false,
+        description: 'Number of results per page (max 100).',
+      },
+      {
+        name: 'after',
+        type: 'string',
+        required: false,
+        description: 'Pagination offset from previous response.',
+      },
+    ],
+  },
+
+  // ─── Meetings ─────────────────────────────────────────────────────────────────
+  {
+    name: 'hubspot_meeting_log',
+    description:
+      'Log a meeting engagement in HubSpot CRM. Records details of a meeting including title, start/end time, description, and outcome.',
+    params: [
+      {
+        name: 'hs_meeting_title',
+        type: 'string',
+        required: true,
+        description: 'A descriptive title for the meeting.',
+      },
+      {
+        name: 'hs_meeting_start_time',
+        type: 'string',
+        required: true,
+        description: 'Start time of the meeting in ISO 8601 format (e.g. `2024-01-15T14:00:00Z`).',
+      },
+      {
+        name: 'hs_meeting_end_time',
+        type: 'string',
+        required: true,
+        description: 'End time of the meeting in ISO 8601 format.',
+      },
+      {
+        name: 'hs_timestamp',
+        type: 'string',
+        required: true,
+        description: 'Timestamp when the meeting was logged in ISO 8601 format.',
+      },
+      {
+        name: 'hs_meeting_body',
+        type: 'string',
+        required: false,
+        description: 'Notes, agenda, or description of the meeting.',
+      },
+      {
+        name: 'hs_meeting_outcome',
+        type: 'string',
+        required: false,
+        description: 'Outcome of the meeting: `SCHEDULED`, `COMPLETED`, `NO_SHOW`, or `CANCELED`.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_meetings_search',
+    description:
+      'Search HubSpot meeting engagements using filters and full-text search. Returns logged meetings with their properties.',
+    params: [
+      {
+        name: 'query',
+        type: 'string',
+        required: false,
+        description: 'Full-text search term across meeting titles and descriptions.',
+      },
+      {
+        name: 'filterGroups',
+        type: 'string',
+        required: false,
+        description:
+          'JSON string containing filter groups (e.g. `[{"filters":[{"propertyName":"hs_meeting_outcome","operator":"EQ","value":"COMPLETED"}]}]`).',
+      },
+      {
+        name: 'properties',
+        type: 'string',
+        required: false,
+        description: 'Comma-separated list of properties to include.',
+      },
+      {
+        name: 'limit',
+        type: 'number',
+        required: false,
+        description: 'Number of results per page (max 100).',
+      },
+      {
+        name: 'after',
+        type: 'string',
+        required: false,
+        description: 'Pagination offset from previous response.',
+      },
+    ],
+  },
+
+  // ─── Calls ────────────────────────────────────────────────────────────────────
+  {
+    name: 'hubspot_call_log',
+    description:
+      'Log a call engagement in HubSpot CRM. Records details of a phone call including title, duration, notes, status, and direction.',
+    params: [
+      {
+        name: 'hs_call_title',
+        type: 'string',
+        required: true,
+        description: 'A descriptive title for the call.',
+      },
+      {
+        name: 'hs_timestamp',
+        type: 'string',
+        required: true,
+        description: 'Date and time when the call took place in ISO 8601 format.',
+      },
+      {
+        name: 'hs_call_body',
+        type: 'string',
+        required: false,
+        description: 'Notes or transcript from the call.',
+      },
+      {
+        name: 'hs_call_direction',
+        type: 'string',
+        required: false,
+        description: 'Direction of the call: `INBOUND` or `OUTBOUND`.',
+      },
+      {
+        name: 'hs_call_duration',
+        type: 'number',
+        required: false,
+        description: 'Duration of the call in milliseconds (e.g. `300000` = 5 minutes).',
+      },
+      {
+        name: 'hs_call_status',
+        type: 'string',
+        required: false,
+        description:
+          'Outcome status: `COMPLETED`, `BUSY`, `FAILED`, `NO_ANSWER`, `CANCELED`, `QUEUED`, or `IN_PROGRESS`.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_calls_search',
+    description:
+      'Search HubSpot call engagements using filters and full-text search. Returns logged calls with their properties.',
+    params: [
+      {
+        name: 'query',
+        type: 'string',
+        required: false,
+        description: 'Full-text search term across call titles, notes, and other text fields.',
+      },
+      {
+        name: 'filterGroups',
+        type: 'string',
+        required: false,
+        description:
+          'JSON string containing filter groups (e.g. `[{"filters":[{"propertyName":"hs_call_status","operator":"EQ","value":"COMPLETED"}]}]`).',
+      },
+      {
+        name: 'properties',
+        type: 'string',
+        required: false,
+        description: 'Comma-separated list of properties to include.',
+      },
+      {
+        name: 'limit',
+        type: 'number',
+        required: false,
+        description: 'Number of results per page (max 100).',
+      },
+      {
+        name: 'after',
+        type: 'string',
+        required: false,
+        description: 'Pagination offset from previous response.',
+      },
+    ],
+  },
+
+  // ─── Notes ────────────────────────────────────────────────────────────────────
+  {
+    name: 'hubspot_note_create',
+    description:
+      'Create a note in HubSpot CRM to log interactions, meeting summaries, or important information. Notes can be associated with contacts, companies, or deals.',
+    params: [
+      {
+        name: 'hs_note_body',
+        type: 'string',
+        required: true,
+        description: 'Content of the note. Supports HTML.',
+      },
+      {
+        name: 'hs_timestamp',
+        type: 'string',
+        required: true,
+        description: 'Timestamp for the note in ISO 8601 format (e.g. `2024-01-15T10:30:00Z`).',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_note_log',
+    description:
+      'Log a note engagement in HubSpot CRM. Creates a text note that can be associated with contacts, companies, or deals.',
+    params: [
+      {
+        name: 'hs_note_body',
+        type: 'string',
+        required: true,
+        description: 'Content of the note. Supports HTML.',
+      },
+      {
+        name: 'hs_timestamp',
+        type: 'string',
+        required: true,
+        description: 'Timestamp for the note in ISO 8601 format (e.g. `2024-01-15T10:30:00Z`).',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_notes_search',
+    description:
+      'Search HubSpot note engagements using filters and full-text search. Returns logged notes with their content and timestamps.',
+    params: [
+      {
+        name: 'query',
+        type: 'string',
+        required: false,
+        description: 'Full-text search term across note body text.',
+      },
+      {
+        name: 'filterGroups',
+        type: 'string',
+        required: false,
+        description: 'JSON string containing filter groups for advanced filtering.',
+      },
+      {
+        name: 'properties',
+        type: 'string',
+        required: false,
+        description: 'Comma-separated list of properties to include.',
+      },
+      {
+        name: 'limit',
+        type: 'number',
+        required: false,
+        description: 'Number of results per page (max 100).',
+      },
+      {
+        name: 'after',
+        type: 'string',
+        required: false,
+        description: 'Pagination offset from previous response.',
+      },
+    ],
+  },
+
+  // ─── Emails ───────────────────────────────────────────────────────────────────
+  {
+    name: 'hubspot_emails_search',
+    description:
+      'Search HubSpot email engagements (logged emails) using filters and full-text search. Returns logged email records with their properties.',
+    params: [
+      {
+        name: 'query',
+        type: 'string',
+        required: false,
+        description: 'Full-text search term across email subject lines and body text.',
+      },
+      {
+        name: 'filterGroups',
+        type: 'string',
+        required: false,
+        description: 'JSON string containing filter groups for advanced filtering.',
+      },
+      {
+        name: 'properties',
+        type: 'string',
+        required: false,
+        description:
+          'Comma-separated list of properties to include (e.g. `hs_email_subject,hs_email_text,hs_timestamp`).',
+      },
+      {
+        name: 'limit',
+        type: 'number',
+        required: false,
+        description: 'Number of results per page (max 100).',
+      },
+      {
+        name: 'after',
+        type: 'string',
+        required: false,
+        description: 'Pagination offset from previous response.',
+      },
+    ],
+  },
+
+  // ─── Engagements ──────────────────────────────────────────────────────────────
+  {
+    name: 'hubspot_engagements_list',
+    description:
+      'List engagements (notes, tasks, calls, emails, meetings) from HubSpot CRM. Supports filtering by engagement type and pagination.',
+    params: [
+      {
+        name: 'engagement_type',
+        type: 'string',
+        required: true,
+        description:
+          'Type of engagement to list: `notes`, `tasks`, `calls`, `emails`, or `meetings`.',
+      },
+      {
+        name: 'limit',
+        type: 'number',
+        required: false,
+        description: 'Number of engagements to return per page (max 100).',
+      },
+      {
+        name: 'after',
+        type: 'string',
+        required: false,
+        description: 'Cursor from previous response to fetch next page.',
+      },
+    ],
+  },
+
+  // ─── Owners ───────────────────────────────────────────────────────────────────
+  {
+    name: 'hubspot_owners_list',
+    description:
+      'List all HubSpot owners (users). Use this to find owner IDs for assigning contacts, deals, tickets, and other CRM records.',
+    params: [
+      {
+        name: 'email',
+        type: 'string',
+        required: false,
+        description: 'Filter owners by email address.',
+      },
+      {
+        name: 'limit',
+        type: 'number',
+        required: false,
+        description: 'Number of owners to return per page (max 500).',
+      },
+      {
+        name: 'after',
+        type: 'string',
+        required: false,
+        description: 'Pagination cursor from previous response.',
+      },
+    ],
+  },
+
+  // ─── Associations ─────────────────────────────────────────────────────────────
+  {
+    name: 'hubspot_associations_batch_create',
+    description:
+      'Create an association between two HubSpot CRM objects using the v4 associations API. Specify the object types, the record IDs, and the association type.',
+    params: [
+      {
+        name: 'from_object_type',
+        type: 'string',
+        required: true,
+        description:
+          'Source object type: `contacts`, `companies`, `deals`, `tickets`, `line_items`, `products`.',
+      },
+      {
+        name: 'to_object_type',
+        type: 'string',
+        required: true,
+        description:
+          'Target object type: `contacts`, `companies`, `deals`, `tickets`, `line_items`, `products`.',
+      },
+      {
+        name: 'from_id',
+        type: 'string',
+        required: true,
+        description: 'HubSpot record ID of the source object.',
+      },
+      {
+        name: 'to_id',
+        type: 'string',
+        required: true,
+        description: 'HubSpot record ID of the target object.',
+      },
+      {
+        name: 'association_type_id',
+        type: 'number',
+        required: true,
+        description:
+          'HubSpot association type ID. Common values: `1`=contact→company (primary), `279`=contact→company, `3`=deal→contact, `5`=deal→company, `16`=ticket→contact, `340`=ticket→company, `20`=line-item→deal.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_associations_batch_archive',
+    description:
+      'Remove an association between two HubSpot CRM objects using the v4 associations API.',
+    params: [
+      {
+        name: 'from_object_type',
+        type: 'string',
+        required: true,
+        description:
+          'Source object type: `contacts`, `companies`, `deals`, `tickets`, `line_items`, `products`.',
+      },
+      {
+        name: 'to_object_type',
+        type: 'string',
+        required: true,
+        description:
+          'Target object type: `contacts`, `companies`, `deals`, `tickets`, `line_items`, `products`.',
+      },
+      {
+        name: 'from_id',
+        type: 'string',
+        required: true,
+        description: 'HubSpot record ID of the source object.',
+      },
+      {
+        name: 'to_id',
+        type: 'string',
+        required: true,
+        description: 'HubSpot record ID of the target object.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_association_create',
+    description:
+      'Create a default association between two HubSpot CRM objects. For example, associate a contact with a deal, or a company with a ticket.',
+    params: [
+      {
+        name: 'from_object_type',
+        type: 'string',
+        required: true,
+        description:
+          'Type of the source object (e.g. `contacts`, `companies`, `deals`, `tickets`).',
+      },
+      {
+        name: 'from_object_id',
+        type: 'string',
+        required: true,
+        description: 'HubSpot ID of the source record.',
+      },
+      {
+        name: 'to_object_type',
+        type: 'string',
+        required: true,
+        description: 'Type of the target object (e.g. `contacts`, `deals`).',
+      },
+      {
+        name: 'to_object_id',
+        type: 'string',
+        required: true,
+        description: 'HubSpot ID of the target record.',
+      },
+    ],
+  },
+
+  // ─── Marketing ────────────────────────────────────────────────────────────────
+  {
+    name: 'hubspot_campaigns_list',
+    description: 'List all HubSpot marketing campaigns with pagination support.',
+    params: [
+      {
+        name: 'limit',
+        type: 'number',
+        required: false,
+        description: 'Number of campaigns to return per page (default: 20).',
+      },
+      {
+        name: 'after',
+        type: 'string',
+        required: false,
+        description: 'Pagination cursor from previous response.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_campaign_get',
+    description: 'Retrieve details of a specific HubSpot marketing campaign by campaign ID.',
+    params: [
+      {
+        name: 'campaign_id',
+        type: 'string',
+        required: true,
+        description: 'The unique identifier of the campaign in HubSpot.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_forms_list',
+    description:
+      'List all HubSpot marketing forms. Returns form IDs, names, and field definitions.',
+    params: [
+      {
+        name: 'formTypes',
+        type: 'string',
+        required: false,
+        description:
+          'Comma-separated list of form types to filter by (e.g. `hubspot`, `captured`, `flow`).',
+      },
+      {
+        name: 'limit',
+        type: 'number',
+        required: false,
+        description: 'Number of forms to return per page (max 50).',
+      },
+      {
+        name: 'after',
+        type: 'string',
+        required: false,
+        description: 'Pagination cursor from previous response.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_form_submissions_get',
+    description:
+      'Retrieve all submissions for a specific HubSpot form. Returns submitted field values and submission timestamps.',
+    params: [
+      {
+        name: 'form_id',
+        type: 'string',
+        required: true,
+        description: 'The unique identifier of the HubSpot form. Get it from `hubspot_forms_list`.',
+      },
+      {
+        name: 'limit',
+        type: 'number',
+        required: false,
+        description: 'Number of submissions to return per page (default: 20).',
+      },
+      {
+        name: 'after',
+        type: 'string',
+        required: false,
+        description: 'Pagination offset token for the next page.',
+      },
+    ],
+  },
+
+  // ─── Products ─────────────────────────────────────────────────────────────────
+  {
+    name: 'hubspot_product_create',
+    description: 'Create a new product in the HubSpot product library.',
+    params: [
+      {
+        name: 'name',
+        type: 'string',
+        required: true,
+        description: 'The product name as it will appear in HubSpot.',
+      },
+      {
+        name: 'description',
+        type: 'string',
+        required: false,
+        description: 'A description of the product or service.',
+      },
+      {
+        name: 'hs_sku',
+        type: 'string',
+        required: false,
+        description: 'Unique product SKU or identifier.',
+      },
+      {
+        name: 'price',
+        type: 'string',
+        required: false,
+        description: 'Unit price of the product (e.g. `999.00`).',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_products_list',
+    description: 'Retrieve a list of products from the HubSpot product library.',
+    params: [
+      {
+        name: 'properties',
+        type: 'string',
+        required: false,
+        description:
+          'Comma-separated list of product properties to include (e.g. `name,price,description`).',
+      },
+      {
+        name: 'limit',
+        type: 'number',
+        required: false,
+        description: 'Number of products to return per page (max 100).',
+      },
+      {
+        name: 'after',
+        type: 'string',
+        required: false,
+        description: 'Pagination cursor from previous response.',
+      },
+    ],
+  },
+
+  // ─── Line Items ───────────────────────────────────────────────────────────────
+  {
+    name: 'hubspot_line_items_batch_create',
+    description:
+      'Create a line item (product on a deal) in HubSpot CRM using the batch API. Optionally associate the line item with a deal on creation.',
+    params: [
+      {
+        name: 'name',
+        type: 'string',
+        required: true,
+        description: 'Name of the product or service for this line item (required).',
+      },
+      {
+        name: 'quantity',
+        type: 'string',
+        required: true,
+        description: 'Number of units (required).',
+      },
+      {
+        name: 'hs_product_id',
+        type: 'string',
+        required: false,
+        description:
+          'ID of the product from your HubSpot product catalog. Links this line item to that product.',
+      },
+      {
+        name: 'price',
+        type: 'string',
+        required: false,
+        description: 'Price per unit (e.g. `299.99`). Required if not linked to a product.',
+      },
+      { name: 'hs_sku', type: 'string', required: false, description: 'SKU or product code.' },
+      {
+        name: 'description',
+        type: 'string',
+        required: false,
+        description: 'Additional details about this line item.',
+      },
+      {
+        name: 'discount',
+        type: 'string',
+        required: false,
+        description: 'Discount value applied to this line item.',
+      },
+      {
+        name: 'associate_to_id',
+        type: 'string',
+        required: false,
+        description:
+          'Deal ID to link this line item to. This is the standard way to add a line item to a deal.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_line_items_batch_update',
+    description:
+      'Update a line item in HubSpot CRM using the batch API. Provide the line item ID and any fields to update.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description: 'HubSpot line item record ID. Get from `hubspot_deal_line_items_get`.',
+      },
+      {
+        name: 'name',
+        type: 'string',
+        required: false,
+        description: 'Updated name of the product or service.',
+      },
+      {
+        name: 'quantity',
+        type: 'string',
+        required: false,
+        description: 'Updated number of units.',
+      },
+      { name: 'price', type: 'string', required: false, description: 'Updated price per unit.' },
+      {
+        name: 'hs_sku',
+        type: 'string',
+        required: false,
+        description: 'Updated SKU or product code.',
+      },
+      { name: 'description', type: 'string', required: false, description: 'Updated description.' },
+      { name: 'discount', type: 'string', required: false, description: 'Updated discount value.' },
+    ],
+  },
+  {
+    name: 'hubspot_line_items_batch_read',
+    description: 'Retrieve a line item record from HubSpot CRM using the batch read API.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description: 'HubSpot line item record ID. Get from `hubspot_deal_line_items_get`.',
+      },
+      {
+        name: 'properties',
+        type: 'array',
+        required: false,
+        description: 'Array of property names to return (e.g. `["name","quantity","price"]`).',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_line_items_batch_archive',
+    description: 'Archive (soft delete) a line item in HubSpot CRM using the batch archive API.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description:
+          'HubSpot line item record ID to archive. Get from `hubspot_deal_line_items_get`.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_line_item_create',
+    description:
+      'Create a new line item in HubSpot. Line items represent individual products or services in a deal.',
+    params: [
+      {
+        name: 'name',
+        type: 'string',
+        required: true,
+        description: 'The name of the product or service for this line item.',
+      },
+      {
+        name: 'hs_product_id',
+        type: 'string',
+        required: false,
+        description: 'Link this line item to a product in the HubSpot product library.',
+      },
+      {
+        name: 'price',
+        type: 'string',
+        required: false,
+        description: 'The price per unit for this line item.',
+      },
+      {
+        name: 'quantity',
+        type: 'string',
+        required: false,
+        description: 'Number of units for this line item.',
+      },
+      {
+        name: 'deal_id',
+        type: 'string',
+        required: false,
+        description: 'The HubSpot deal ID to associate this line item with.',
+      },
+    ],
+  },
+
+  {
+    name: 'hubspot_products_batch_read',
+    description:
+      'Retrieve a product record from the HubSpot product library using the batch read API.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description: 'HubSpot product record ID. Get from `hubspot_products_list`.',
+      },
+      {
+        name: 'properties',
+        type: 'array',
+        required: false,
+        description: 'Array of property names to return (e.g. `["name","price","hs_sku"]`).',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_products_batch_archive',
+    description:
+      'Archive (soft delete) a product from the HubSpot product library using the batch archive API.',
+    params: [
+      {
+        name: 'id',
+        type: 'string',
+        required: true,
+        description: 'HubSpot product record ID to archive. Get from `hubspot_products_list`.',
+      },
+    ],
+  },
+
+  // ─── Quotes ───────────────────────────────────────────────────────────────────
+  {
+    name: 'hubspot_quote_create',
+    description: 'Create a new quote in HubSpot for a deal.',
+    params: [
+      {
+        name: 'hs_title',
+        type: 'string',
+        required: true,
+        description: 'The display title for the quote.',
+      },
+      {
+        name: 'hs_language',
+        type: 'string',
+        required: true,
+        description:
+          'Language of the quote as an ISO 639-1 code (e.g. `en`, `de`, `fr`). Required by HubSpot.',
+      },
+      {
+        name: 'deal_id',
+        type: 'string',
+        required: false,
+        description: 'The HubSpot deal ID to link this quote to.',
+      },
+      {
+        name: 'hs_expiration_date',
+        type: 'string',
+        required: false,
+        description: 'Expiration date of the quote in `YYYY-MM-DD` format.',
+      },
+      {
+        name: 'hs_status',
+        type: 'string',
+        required: false,
+        description: 'Status of the quote: `DRAFT`, `PENDING_APPROVAL`, `APPROVED`, or `REJECTED`.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_quote_get',
+    description: 'Retrieve a specific HubSpot quote by its ID.',
+    params: [
+      {
+        name: 'quote_id',
+        type: 'string',
+        required: true,
+        description: 'The HubSpot ID of the quote.',
+      },
+      {
+        name: 'properties',
+        type: 'string',
+        required: false,
+        description:
+          'Comma-separated list of quote properties to include (e.g. `hs_title,hs_status,hs_expiration_date`).',
+      },
+    ],
+  },
+
+  // ─── Custom Objects ───────────────────────────────────────────────────────────
+  {
+    name: 'hubspot_schemas_list',
+    description:
+      'List all custom object schemas defined in HubSpot. Returns object type IDs, labels, and property definitions needed to work with custom objects.',
+    params: [
+      {
+        name: 'archived',
+        type: 'boolean',
+        required: false,
+        description: 'Set to `true` to include archived custom object schemas.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_custom_object_record_create',
+    description: 'Create a new record for a HubSpot custom object type.',
+    params: [
+      {
+        name: 'object_type_id',
+        type: 'string',
+        required: true,
+        description:
+          'The custom object type ID (e.g. `2-1234567`). Get it from `hubspot_schemas_list`.',
+      },
+      {
+        name: 'properties',
+        type: 'object',
+        required: true,
+        description:
+          'Key-value pairs for the new record (e.g. `{"name": "Example Record"}`). Use `hubspot_schemas_list` to discover valid property names.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_custom_object_record_get',
+    description:
+      'Retrieve a specific record of a HubSpot custom object by object type ID and record ID.',
+    params: [
+      {
+        name: 'object_type_id',
+        type: 'string',
+        required: true,
+        description: 'The custom object type ID (e.g. `2-1234567`).',
+      },
+      {
+        name: 'record_id',
+        type: 'string',
+        required: true,
+        description: 'The HubSpot ID of the specific record.',
+      },
+      {
+        name: 'properties',
+        type: 'string',
+        required: false,
+        description: 'Comma-separated list of properties to return.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_custom_object_record_update',
+    description:
+      'Update an existing record of a HubSpot custom object by object type ID and record ID. Use hubspot_schemas_list to discover available object type IDs and their properties.',
+    params: [
+      {
+        name: 'object_type_id',
+        type: 'string',
+        required: true,
+        description:
+          'The custom object type ID (e.g. `2-1234567`). Get it from `hubspot_schemas_list`.',
+      },
+      {
+        name: 'record_id',
+        type: 'string',
+        required: true,
+        description:
+          'The HubSpot ID of the record to update. Get it from `hubspot_custom_object_records_search`.',
+      },
+      {
+        name: 'properties',
+        type: 'object',
+        required: true,
+        description:
+          'JSON object of property names and updated values (e.g. `{"name": "Updated Name", "status": "active"}`). Use `hubspot_schemas_list` to discover valid property names.',
+      },
+    ],
+  },
+  {
+    name: 'hubspot_custom_object_records_search',
+    description:
+      'Search records of a HubSpot custom object by object type ID. Use `hubspot_schemas_list` to find the objectTypeId for your custom object.',
+    params: [
+      {
+        name: 'object_type_id',
+        type: 'string',
+        required: true,
+        description: 'The custom object type ID (e.g. `2-1234567`).',
+      },
+      {
+        name: 'query',
+        type: 'string',
+        required: false,
+        description: 'Full-text search term across record properties.',
+      },
+      {
+        name: 'filterGroups',
+        type: 'string',
+        required: false,
+        description: 'JSON string containing filter groups for advanced filtering.',
+      },
+      {
+        name: 'properties',
+        type: 'string',
+        required: false,
+        description: 'Comma-separated list of properties to include.',
+      },
+      {
+        name: 'limit',
+        type: 'number',
+        required: false,
+        description: 'Number of results per page (max 100).',
+      },
+      {
+        name: 'after',
+        type: 'string',
+        required: false,
+        description: 'Pagination offset from previous response.',
+      },
+    ],
+  },
+
+  // ─── Properties ───────────────────────────────────────────────────────────────
+  {
+    name: 'hubspot_object_properties_list',
+    description:
+      'Retrieve all properties defined for a HubSpot CRM object type (contacts, companies, deals, tickets, etc.).',
+    params: [
+      {
+        name: 'object_type',
+        type: 'string',
+        required: true,
+        description:
+          'CRM object type to list properties for (e.g. `contacts`, `companies`, `deals`, `tickets`, `products`, or a custom object type ID).',
+      },
+      {
+        name: 'archived',
+        type: 'boolean',
+        required: false,
+        description: 'Set to `true` to include archived properties.',
+      },
     ],
   },
 ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable "Getting resource IDs" documentation section for HubSpot integrations.
* **Documentation**
  * Expanded HubSpot connector "What you can do" list to cover contacts, companies/deals, tickets/tasks, batch operations with inline associations, engagement logging, full-text search, and discovery of associations, custom objects, and properties.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalekit-inc/developer-docs/pull/680)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->