### PR TITLE
Combine Claude Code install steps into single CLI command

### DIFF
--- a/public/AGENTS.md
+++ b/public/AGENTS.md
@@ -8,9 +8,8 @@ hallucinations and enabling faster, more accurate code generation.
 
 ### Claude Code
 
-```
-/plugin marketplace add scalekit-inc/claude-code-authstack
-/plugin install <auth-type>@scalekit-auth-stack
+```bash
+claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install <auth-type>@scalekit-auth-stack
 ```
 
 ### GitHub Copilot CLI

--- a/src/components/templates/coding-agents/_agentkit-claude-code.mdx
+++ b/src/components/templates/coding-agents/_agentkit-claude-code.mdx
@@ -1,42 +1,17 @@
 import { Steps, Aside } from '@astrojs/starlight/components'
 
 <Steps>
-1. ## Add the Scalekit Auth Stack marketplace
+1. ## Install the Scalekit Auth Stack
 
    Not yet on Claude Code? Follow the [official quickstart guide](https://code.claude.com/docs/en/quickstart) to install it.
 
-   Register Scalekit's plugin marketplace to access pre-configured authentication skills. This marketplace provides context-aware prompts and implementation guides that help coding agents generate correct Agent Auth code.
-
-   Start the Claude Code REPL:
+   Register Scalekit's plugin marketplace and install the Agent Auth plugin in a single command:
 
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   claude
-   ```
-
-   Then add the marketplace:
-
-   ```bash title="Claude REPL" showLineNumbers=false
-   /plugin marketplace add scalekit-inc/claude-code-authstack
-   ```
-
-   When the marketplace registers successfully, you'll see confirmation output:
-
-   ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   ❯ /plugin marketplace add scalekit-inc/claude-code-authstack
-      ⎿  Successfully added marketplace: scalekit-auth-stack
+   claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install agent-auth@scalekit-auth-stack
    ```
 
    The marketplace provides specialized authentication plugins that understand Agent Auth patterns and OAuth 2.0 security requirements. These plugins guide the coding agent to generate implementation code that matches your project structure.
-
-2. ## Enable authentication plugins
-
-   Select which authentication capabilities to activate in your development environment. Each plugin provides specific skills that the coding agent uses to generate authentication code.
-
-   Directly install the specific plugin:
-
-   ```bash title="Claude REPL" showLineNumbers=false
-   /plugin install agent-auth@scalekit-auth-stack
-   ```
 
    <details>
    <summary>Alternative: Enable authentication plugins via plugin wizard</summary>
@@ -55,7 +30,7 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
    </details>
 
-3. ## Generate authentication implementation
+2. ## Generate authentication implementation
 
    Use a structured prompt to direct the coding agent. A well-formed prompt ensures the agent generates complete, production-ready Agent Auth code that includes all required security components.
 
@@ -71,7 +46,7 @@ import { Steps, Aside } from '@astrojs/starlight/components'
    Always review AI-generated authentication code before deployment. Verify that environment variables, token validation logic, and error handling match your security requirements. The coding agent provides a foundation, but you must ensure it aligns with your application's specific needs.
    </Aside>
 
-4. ## Verify just-in-time implementation
+3. ## Verify just-in-time implementation
 
    After the coding agent completes, verify that all authentication components are properly configured:
 

--- a/src/components/templates/coding-agents/_fsa-claude-code.mdx
+++ b/src/components/templates/coding-agents/_fsa-claude-code.mdx
@@ -2,42 +2,17 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
 <Steps>
 
-1. ## Add the Scalekit Auth Stack marketplace
+1. ## Install the Scalekit Auth Stack
 
    Not yet on Claude Code? Follow the [official quickstart guide](https://code.claude.com/docs/en/quickstart) to install it.
 
-   Register Scalekit's plugin marketplace to access pre-configured authentication skills. This marketplace provides context-aware prompts and implementation guides that help coding agents generate correct Full Stack Auth code.
-
-   Start the Claude Code REPL:
+   Register Scalekit's plugin marketplace and install the Full Stack Auth plugin in a single command:
 
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   claude
-   ```
-
-   Then add the marketplace:
-
-   ```bash title="Claude REPL" showLineNumbers=false
-   /plugin marketplace add scalekit-inc/claude-code-authstack
-   ```
-
-   When the marketplace registers successfully, you'll see confirmation output:
-
-   ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   ❯ /plugin marketplace add scalekit-inc/claude-code-authstack
-      ⎿  Successfully added marketplace: scalekit-auth-stack
+   claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install full-stack-auth@scalekit-auth-stack
    ```
 
    The marketplace provides specialized authentication plugins that understand full-stack auth patterns and OAuth 2.0 security requirements. These plugins guide the coding agent to generate implementation code that matches your project structure.
-
-2. ## Enable authentication plugins
-
-   Select which authentication capabilities to activate in your development environment. Each plugin provides specific skills that the coding agent uses to generate authentication code.
-
-   Directly install the specific plugin:
-
-   ```bash title="Claude REPL" showLineNumbers=false
-   /plugin install full-stack-auth@scalekit-auth-stack
-   ```
 
    <details>
    <summary>Alternative: Enable authentication plugins via plugin wizard</summary>
@@ -56,7 +31,7 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
    </details>
 
-3. ## Generate authentication implementation
+2. ## Generate authentication implementation
 
    Use a structured prompt to direct the coding agent. A well-formed prompt ensures the agent generates complete, production-ready Full Stack Auth code that includes all required security components.
 
@@ -72,7 +47,7 @@ import { Steps, Aside } from '@astrojs/starlight/components'
    Always review AI-generated authentication code before deployment. Verify that environment variables, token validation logic, and error handling match your security requirements. The coding agent provides a foundation, but you must ensure it aligns with your application's specific needs.
    </Aside>
 
-4. ## Verify the implementation
+3. ## Verify the implementation
 
    After the coding agent completes, verify that all authentication components are properly configured:
 

--- a/src/components/templates/coding-agents/_mcp-auth-claude-code.mdx
+++ b/src/components/templates/coding-agents/_mcp-auth-claude-code.mdx
@@ -5,42 +5,17 @@ import skillActivationImage from '@/assets/docs/ai-assisted-mcp-quickstart/skill
 
 <Steps>
 
-1. ## Add the Scalekit Auth Stack marketplace
+1. ## Install the Scalekit Auth Stack
 
    Not yet on Claude Code? Follow the [official quickstart guide](https://code.claude.com/docs/en/quickstart) to install it.
 
-   Register Scalekit's plugin marketplace to access pre-configured authentication skills. This marketplace provides context-aware prompts and implementation guides that help coding agents generate correct authentication code.
-
-   Start the Claude Code REPL:
+   Register Scalekit's plugin marketplace and install the MCP Auth plugin in a single command:
 
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   claude
-   ```
-
-   Then add the marketplace:
-
-   ```bash title="Claude REPL" showLineNumbers=false
-   /plugin marketplace add scalekit-inc/claude-code-authstack
-   ```
-
-   When the marketplace registers successfully, you'll see confirmation output:
-
-   ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   ❯ /plugin marketplace add scalekit-inc/claude-code-authstack
-      ⎿  Successfully added marketplace: scalekit-auth-stack
+   claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install mcp-auth@scalekit-auth-stack
    ```
 
    The marketplace provides specialized authentication plugins that understand MCP server architectures and OAuth 2.1 security requirements. These plugins guide the coding agent to generate implementation code that matches your project structure.
-
-2. ## Enable authentication plugins
-
-   Select which authentication capabilities to activate in your development environment. Each plugin provides specific skills that the coding agent uses to generate authentication code.
-
-   Directly install the specific plugin:
-
-   ```bash title="Claude REPL" showLineNumbers=false
-   /plugin install mcp-auth@scalekit-auth-stack
-   ```
 
    <details>
    <summary>Alternative: Enable authentication plugins via plugin wizard</summary>
@@ -67,7 +42,7 @@ import skillActivationImage from '@/assets/docs/ai-assisted-mcp-quickstart/skill
 
    </details>
 
-3. ## Generate authentication implementation
+2. ## Generate authentication implementation
 
    Use a structured prompt to direct the coding agent. A well-formed prompt ensures the agent generates complete, production-ready authentication code that includes all required security components.
 
@@ -88,7 +63,7 @@ import skillActivationImage from '@/assets/docs/ai-assisted-mcp-quickstart/skill
    Always review AI-generated authentication code before deployment. Verify that environment variables, token validation logic, and error handling match your security requirements. The coding agent provides a foundation, but you must ensure it aligns with your application's specific needs.
    </Aside>
 
-4. ## Verify and test the implementation
+3. ## Verify and test the implementation
 
    After the coding agent completes, verify that all authentication components are properly configured:
 

--- a/src/components/templates/coding-agents/_scim-claude-code.mdx
+++ b/src/components/templates/coding-agents/_scim-claude-code.mdx
@@ -2,42 +2,17 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
 <Steps>
 
-1. ## Add the Scalekit Auth Stack marketplace
+1. ## Install the Scalekit Auth Stack
 
    Not yet on Claude Code? Follow the [official quickstart guide](https://code.claude.com/docs/en/quickstart) to install it.
 
-   Register Scalekit's plugin marketplace to access pre-configured SCIM skills. This marketplace provides context-aware prompts and implementation guides that help coding agents generate correct directory sync code.
-
-   Start the Claude Code REPL:
+   Register Scalekit's plugin marketplace and install the Modular SCIM plugin in a single command:
 
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   claude
-   ```
-
-   Then add the marketplace:
-
-   ```bash title="Claude REPL" showLineNumbers=false
-   /plugin marketplace add scalekit-inc/claude-code-authstack
-   ```
-
-   When the marketplace registers successfully, you'll see confirmation output:
-
-   ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   ❯ /plugin marketplace add scalekit-inc/claude-code-authstack
-      ⎿  Successfully added marketplace: scalekit-auth-stack
+   claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install modular-scim@scalekit-auth-stack
    ```
 
    The marketplace provides specialized SCIM plugins that understand directory sync patterns and webhook security requirements. These plugins guide the coding agent to generate implementation code that matches your project structure.
-
-2. ## Enable SCIM plugins
-
-   Select which directory sync capabilities to activate in your development environment. Each plugin provides specific skills that the coding agent uses to generate SCIM webhook handling code.
-
-   Directly install the specific plugin:
-
-   ```bash title="Claude REPL" showLineNumbers=false
-   /plugin install modular-scim@scalekit-auth-stack
-   ```
 
    <details>
    <summary>Alternative: Enable SCIM plugins via plugin wizard</summary>
@@ -56,7 +31,7 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
    </details>
 
-3. ## Generate SCIM implementation
+2. ## Generate SCIM implementation
 
    Use a structured prompt to direct the coding agent. A well-formed prompt ensures the agent generates complete, production-ready SCIM code that includes all required security components.
 
@@ -72,7 +47,7 @@ import { Steps, Aside } from '@astrojs/starlight/components'
    Always review AI-generated SCIM code before deployment. Verify that webhook signature validation, event handling logic, and database operations match your security requirements. The coding agent provides a foundation, but you must ensure it aligns with your application's specific needs.
    </Aside>
 
-4. ## Verify the implementation
+3. ## Verify the implementation
 
    After the coding agent completes, verify that all SCIM components are properly configured:
 

--- a/src/components/templates/coding-agents/_sso-claude-code.mdx
+++ b/src/components/templates/coding-agents/_sso-claude-code.mdx
@@ -2,42 +2,17 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
 <Steps>
 
-1. ## Add the Scalekit Auth Stack marketplace
+1. ## Install the Scalekit Auth Stack
 
    Not yet on Claude Code? Follow the [official quickstart guide](https://code.claude.com/docs/en/quickstart) to install it.
 
-   Register Scalekit's plugin marketplace to access pre-configured authentication skills. This marketplace provides context-aware prompts and implementation guides that help coding agents generate correct Modular SSO code.
-
-   Start the Claude Code REPL:
+   Register Scalekit's plugin marketplace and install the Modular SSO plugin in a single command:
 
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   claude
-   ```
-
-   Then add the marketplace:
-
-   ```bash title="Claude REPL" showLineNumbers=false
-   /plugin marketplace add scalekit-inc/claude-code-authstack
-   ```
-
-   When the marketplace registers successfully, you'll see confirmation output:
-
-   ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   ❯ /plugin marketplace add scalekit-inc/claude-code-authstack
-      ⎿  Successfully added marketplace: scalekit-auth-stack
+   claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install modular-sso@scalekit-auth-stack
    ```
 
    The marketplace provides specialized authentication plugins that understand SSO patterns and SAML/OIDC security requirements. These plugins guide the coding agent to generate implementation code that matches your project structure.
-
-2. ## Enable authentication plugins
-
-   Select which authentication capabilities to activate in your development environment. Each plugin provides specific skills that the coding agent uses to generate SSO code.
-
-   Directly install the specific plugin:
-
-   ```bash title="Claude REPL" showLineNumbers=false
-   /plugin install modular-sso@scalekit-auth-stack
-   ```
 
    <details>
    <summary>Alternative: Enable authentication plugins via plugin wizard</summary>
@@ -56,7 +31,7 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
    </details>
 
-3. ## Generate SSO implementation
+2. ## Generate SSO implementation
 
    Use a structured prompt to direct the coding agent. A well-formed prompt ensures the agent generates complete, production-ready SSO code that includes all required security components.
 
@@ -72,7 +47,7 @@ import { Steps, Aside } from '@astrojs/starlight/components'
    Always review AI-generated authentication code before deployment. Verify that environment variables, token validation logic, and error handling match your security requirements. The coding agent provides a foundation, but you must ensure it aligns with your application's specific needs.
    </Aside>
 
-4. ## Verify the implementation
+3. ## Verify the implementation
 
    After the coding agent completes, verify that all SSO components are properly configured:
 

--- a/src/configs/agent-instructions.ts
+++ b/src/configs/agent-instructions.ts
@@ -9,8 +9,7 @@ If you're using an AI coding agent, install the official Scalekit plugin.
 It gives your agent full awareness of the Scalekit API — reducing hallucinations and enabling faster, more accurate code generation.
 
 Claude Code:
-  /plugin marketplace add scalekit-inc/claude-code-authstack
-  /plugin install <auth-type>@scalekit-auth-stack
+  claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install <auth-type>@scalekit-auth-stack
 
 GitHub Copilot CLI:
   copilot plugin marketplace add scalekit-inc/github-copilot-authstack
@@ -33,7 +32,7 @@ Full guide: https://docs.scalekit.com/dev-kit/build-with-ai/ -->
 export const AGENT_PLUGIN_INLINE = `Building with AI coding agents?
 If you're using an AI coding agent, install the official Scalekit plugin. It gives your agent full awareness of the Scalekit API — reducing hallucinations and enabling faster, more accurate code generation.
 
-Claude Code: /plugin marketplace add scalekit-inc/claude-code-authstack then /plugin install <auth-type>@scalekit-auth-stack
+Claude Code: claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install <auth-type>@scalekit-auth-stack
 GitHub Copilot CLI: copilot plugin marketplace add scalekit-inc/github-copilot-authstack then copilot plugin install <auth-type>@scalekit-auth-stack
 Codex: run the bash installer, restart Codex, then open Plugin Directory and enable <auth-type>
 Skills CLI (Windsurf, Cline, and 40+ agents): npx skills add scalekit-inc/skills --list then npx skills add scalekit-inc/skills --skill <skill-name>
@@ -51,8 +50,7 @@ export const AGENT_PLUGIN_DETAILS_MD = `## Building with AI coding agents?
 If you're using an AI coding agent, install the official Scalekit plugin. It gives your agent full awareness of the Scalekit API — reducing hallucinations and enabling faster, more accurate code generation.
 
 **Claude Code**:
-1. \`/plugin marketplace add scalekit-inc/claude-code-authstack\`
-2. \`/plugin install <auth-type>@scalekit-auth-stack\`
+\`claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install <auth-type>@scalekit-auth-stack\`
 
 **GitHub Copilot CLI**:
 1. \`copilot plugin marketplace add scalekit-inc/github-copilot-authstack\`
@@ -80,7 +78,7 @@ If you're using an AI coding agent, install the official Scalekit plugin. It giv
  */
 export const AGENT_PLUGIN_VISIBLE_MD = `> **Building with AI coding agents?** If you're using an AI coding agent, install the official Scalekit plugin. It gives your agent full awareness of the Scalekit API — reducing hallucinations and enabling faster, more accurate code generation.
 >
-> - **Claude Code**: \`/plugin marketplace add scalekit-inc/claude-code-authstack\` then \`/plugin install <auth-type>@scalekit-auth-stack\`
+> - **Claude Code**: \`claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install <auth-type>@scalekit-auth-stack\`
 > - **GitHub Copilot CLI**: \`copilot plugin marketplace add scalekit-inc/github-copilot-authstack\` then \`copilot plugin install <auth-type>@scalekit-auth-stack\`
 > - **Codex**: run the bash installer, restart, then open Plugin Directory and enable \`<auth-type>\`
 > - **Skills CLI** (Windsurf, Cline, 40+ agents): \`npx skills add scalekit-inc/skills --list\` then \`--skill <skill-name>\`
@@ -108,7 +106,7 @@ export const AGENT_DOCS_FOOTER = `
 /** Single-line string safe for an HTML meta content attribute. */
 export const AGENT_PLUGIN_META =
   'Building with AI coding agents? Install the official Scalekit plugin for full API awareness and reduced hallucinations. ' +
-  'Claude Code: /plugin marketplace add scalekit-inc/claude-code-authstack then /plugin install <auth-type>@scalekit-auth-stack. ' +
+  'Claude Code: claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install <auth-type>@scalekit-auth-stack. ' +
   'GitHub Copilot CLI: copilot plugin marketplace add scalekit-inc/github-copilot-authstack then copilot plugin install <auth-type>@scalekit-auth-stack. ' +
   'Codex: run bash installer, restart, enable in Plugin Directory. ' +
   'Skills CLI (Windsurf, Cline, 40+ agents): npx skills add scalekit-inc/skills --list then --skill <skill-name>. ' +

--- a/src/content/docs/authenticate/fsa/quickstart.mdx
+++ b/src/content/docs/authenticate/fsa/quickstart.mdx
@@ -80,11 +80,8 @@ Scalekit handles the complex authentication flow while you focus on your core pr
 >
   <Tabs syncKey="build-with-agent">
    <TabItem label="Claude Code" icon="claude">
-     ```bash title="Claude REPL" showLineNumbers=false frame="none"
-     /plugin marketplace add scalekit-inc/claude-code-authstack
-     ```
-     ```bash title="Claude REPL" showLineNumbers=false frame="none"
-     /plugin install full-stack-auth@scalekit-auth-stack
+     ```bash title="Terminal" frame="terminal" showLineNumbers=false
+     claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install full-stack-auth@scalekit-auth-stack
      ```
    </TabItem>
    <TabItem label="Codex" icon="codex">

--- a/src/content/docs/authenticate/mcp/quickstart.mdx
+++ b/src/content/docs/authenticate/mcp/quickstart.mdx
@@ -52,11 +52,8 @@ This guide shows you how to add production-ready OAuth 2.1 authorization to your
 >
   <Tabs syncKey="build-with-agent">
    <TabItem label="Claude Code" icon="claude">
-     ```bash title="Claude REPL" showLineNumbers=false frame="none"
-     /plugin marketplace add scalekit-inc/claude-code-authstack
-     ```
-     ```bash title="Claude REPL" showLineNumbers=false frame="none"
-     /plugin install mcp-auth@scalekit-auth-stack
+     ```bash title="Terminal" frame="terminal" showLineNumbers=false
+     claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install mcp-auth@scalekit-auth-stack
      ```
    </TabItem>
    <TabItem label="Codex" icon="codex">

--- a/src/content/docs/authenticate/sso/add-modular-sso.mdx
+++ b/src/content/docs/authenticate/sso/add-modular-sso.mdx
@@ -69,11 +69,8 @@ Choose Modular SSO when you:
 >
   <Tabs syncKey="build-with-agent">
    <TabItem label="Claude Code" icon="claude">
-     ```bash title="Claude REPL" showLineNumbers=false frame="none"
-     /plugin marketplace add scalekit-inc/claude-code-authstack
-     ```
-     ```bash title="Claude REPL" showLineNumbers=false frame="none"
-     /plugin install modular-sso@scalekit-auth-stack
+     ```bash title="Terminal" frame="terminal" showLineNumbers=false
+     claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install modular-sso@scalekit-auth-stack
      ```
    </TabItem>
    <TabItem label="Codex" icon="codex">

--- a/src/content/docs/dev-kit/build-with-ai/index.mdx
+++ b/src/content/docs/dev-kit/build-with-ai/index.mdx
@@ -20,13 +20,9 @@ Pick the auth feature you need below. Each page gives you a ready-to-paste promp
 
 <Tabs syncKey="coding-agent">
   <TabItem label="Claude Code" icon="claude">
-    ```bash title="Step 1 — Add the marketplace (Claude REPL)" showLineNumbers=false
-    /plugin marketplace add scalekit-inc/claude-code-authstack
-    ```
-
-    ```bash title="Step 2 — Install your auth plugin (Claude REPL)" showLineNumbers=false
+    ```bash title="Install the Scalekit Auth Stack" frame="terminal" showLineNumbers=false
     # options: full-stack-auth, agent-auth, mcp-auth, modular-sso, modular-scim
-    /plugin install agent-auth@scalekit-auth-stack
+    claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install agent-auth@scalekit-auth-stack
     ```
 
     Now ask your agent to implement Scalekit auth in natural language.

--- a/src/content/docs/directory/scim/quickstart.mdx
+++ b/src/content/docs/directory/scim/quickstart.mdx
@@ -100,11 +100,8 @@ Scalekit -> Directory Provider: Fetch latest data \n from directory provider
 >
   <Tabs syncKey="build-with-agent">
    <TabItem label="Claude Code" icon="claude">
-     ```bash title="Claude REPL" showLineNumbers=false frame="none"
-     /plugin marketplace add scalekit-inc/claude-code-authstack
-     ```
-     ```bash title="Claude REPL" showLineNumbers=false frame="none"
-     /plugin install modular-scim@scalekit-auth-stack
+     ```bash title="Terminal" frame="terminal" showLineNumbers=false
+     claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install modular-scim@scalekit-auth-stack
      ```
    </TabItem>
    <TabItem label="Codex" icon="codex">

--- a/src/content/docs/home/saaskit/index.mdx
+++ b/src/content/docs/home/saaskit/index.mdx
@@ -202,13 +202,9 @@ import complianceImage from '@/content/docs/compliance.svg'
       <p style="font-size: 0.875rem; color: var(--sl-color-text-muted); margin: 0 0 0.75rem;">2 steps · ~5 minutes · works with any AI coding agent</p>
       <Tabs syncKey="coding-agent">
         <TabItem label="Claude Code" icon="claude">
-          ```bash title="Step 1 — Add the marketplace (Claude REPL)" showLineNumbers=false
-          /plugin marketplace add scalekit-inc/claude-code-authstack
-          ```
-
-          ```bash title="Step 2 — Install your auth plugin (Claude REPL)" showLineNumbers=false
+          ```bash title="Install the Scalekit Auth Stack" frame="terminal" showLineNumbers=false
           # options: full-stack-auth, agent-auth, mcp-auth, modular-sso, modular-scim
-          /plugin install full-stack-auth@scalekit-auth-stack
+          claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install full-stack-auth@scalekit-auth-stack
           ```
 
           Now ask your agent to implement Scalekit auth in natural language. [See example starting prompts →](/agentkit/quickstart/)

--- a/src/content/docs/passwordless/oidc.mdx
+++ b/src/content/docs/passwordless/oidc.mdx
@@ -77,11 +77,8 @@ Your app -> User: "Create session and grant access"
 >
   <Tabs syncKey="build-with-agent">
    <TabItem label="Claude Code" icon="claude">
-    ```bash title="Claude REPL" showLineNumbers=false frame="none"
-    /plugin marketplace add scalekit-inc/claude-code-authstack
-    ```
-    ```bash title="Claude REPL" showLineNumbers=false frame="none"
-    /plugin install full-stack-auth@scalekit-auth-stack
+    ```bash title="Terminal" frame="terminal" showLineNumbers=false
+    claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install full-stack-auth@scalekit-auth-stack
     ```
    </TabItem>
    <TabItem label="GitHub Copilot CLI" icon="githubcopilot">

--- a/src/content/docs/passwordless/quickstart.mdx
+++ b/src/content/docs/passwordless/quickstart.mdx
@@ -89,11 +89,8 @@ Coming soon
 >
   <Tabs syncKey="build-with-agent">
    <TabItem label="Claude Code" icon="claude">
-    ```bash title="Claude REPL" showLineNumbers=false frame="none"
-    /plugin marketplace add scalekit-inc/claude-code-authstack
-    ```
-    ```bash title="Claude REPL" showLineNumbers=false frame="none"
-    /plugin install full-stack-auth@scalekit-auth-stack
+    ```bash title="Terminal" frame="terminal" showLineNumbers=false
+    claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install full-stack-auth@scalekit-auth-stack
     ```
    </TabItem>
    <TabItem label="GitHub Copilot CLI" icon="githubcopilot">

--- a/src/content/docs/sso/quickstart.mdx
+++ b/src/content/docs/sso/quickstart.mdx
@@ -118,11 +118,8 @@ Choose Modular SSO when you:
 >
   <Tabs syncKey="build-with-agent">
    <TabItem label="Claude Code" icon="claude">
-    ```bash title="Claude REPL" showLineNumbers=false frame="none"
-    /plugin marketplace add scalekit-inc/claude-code-authstack
-    ```
-    ```bash title="Claude REPL" showLineNumbers=false frame="none"
-    /plugin install modular-sso@scalekit-auth-stack
+    ```bash title="Terminal" frame="terminal" showLineNumbers=false
+    claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install modular-sso@scalekit-auth-stack
     ```
    </TabItem>
    <TabItem label="GitHub Copilot CLI" icon="githubcopilot">


### PR DESCRIPTION
Replaces the two-step Claude REPL install flow with a single `claude` CLI command that adds the marketplace and installs the auth plugin in one go.

**Scope:** All pages and templates that reference Claude Code plugin installation — content pages, reusable template components, agent instruction configs, and `public/AGENTS.md`.

**Changed files:**
- `src/content/docs/dev-kit/build-with-ai/index.mdx`
- `src/content/docs/home/saaskit/index.mdx`
- `src/content/docs/authenticate/sso/add-modular-sso.mdx`
- `src/content/docs/authenticate/fsa/quickstart.mdx`
- `src/content/docs/authenticate/mcp/quickstart.mdx`
- `src/content/docs/sso/quickstart.mdx`
- `src/content/docs/passwordless/quickstart.mdx`
- `src/content/docs/passwordless/oidc.mdx`
- `src/content/docs/directory/scim/quickstart.mdx`
- `src/components/templates/coding-agents/_agentkit-claude-code.mdx`
- `src/components/templates/coding-agents/_mcp-auth-claude-code.mdx`
- `src/components/templates/coding-agents/_sso-claude-code.mdx`
- `src/components/templates/coding-agents/_scim-claude-code.mdx`
- `src/components/templates/coding-agents/_fsa-claude-code.mdx`
- `src/configs/agent-instructions.ts`
- `public/AGENTS.md`

---

**Preview:** https://deploy-preview-683--scalekit-starlight.netlify.app/dev-kit/build-with-ai/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Consolidated and simplified the "Claude Code" installation instructions for the Scalekit Auth Stack: replaced the previous multi-step REPL-style setup with a single Terminal/bash command that adds the Scalekit marketplace and installs the appropriate auth plugin in one step, clarifying headings and renumbering subsequent guide steps for a smoother onboarding flow.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalekit-inc/developer-docs/pull/683)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->