### PR TITLE
build: add CI workflow with production build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm astro check
+
+      - name: Format check
+        run: pnpm run format:check
+
+      - name: Agent markdown audit
+        run: node scripts/agent-markdown-audit.js --strict
+
+      - name: Production build
+        run: pnpm run build


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ci.yml` that runs on every push and PR, including the production build step that was missing from the original PR #635.

## Steps in the workflow

1. **Type check** — `pnpm astro check`
2. **Format check** — `pnpm run format:check`
3. **Agent markdown audit** — `node scripts/agent-markdown-audit.js --strict`
4. **Production build** — `pnpm run build` (the key addition from #644)

Uses Node 20 with pnpm caching. The build command matches the documented local build: `astro build && node scripts/generate-llms-index.js`.

## Why

PR #635 was closed without merge. This picks up that work and adds the build step so build regressions are caught before merge.

Closes #644

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated quality assurance: Added continuous integration workflow that validates code formatting, runs audits, and verifies production builds on every commit and pull request to maintain code reliability standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalekit-inc/developer-docs/pull/686)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->