### PR TITLE
docs: clarify execute_tool response shape — payload is under response.data

### DIFF
--- a/src/content/docs/agentkit/quickstart.mdx
+++ b/src/content/docs/agentkit/quickstart.mdx
@@ -234,7 +234,10 @@ Complete these steps in the Scalekit dashboard before writing any code:
                 "max_results": 5,
             },
         )
-        print(response)
+        # Tool payload is under response.data
+        emails = response.data.get("emails", [])
+        for email in emails:
+            print(f"From: {email.get('from')} — {email.get('subject')}")
         ```
       </TabItem>
       <TabItem label="Node.js">

--- a/src/content/docs/agentkit/tools/scalekit-optimized-tools.mdx
+++ b/src/content/docs/agentkit/tools/scalekit-optimized-tools.mdx
@@ -105,6 +105,27 @@ console.log(result.data);
   </TabItem>
 </Tabs>
 
+## Response shape
+
+The SDK wraps every tool response in a response object. The tool-specific payload is always under `response.data` (Python) or `result.data` (Node.js). Access tool-specific fields from that object:
+
+```python frame="none" showLineNumbers=false
+# Example: Google Calendar list_events
+response = actions.execute_tool(
+    tool_name="googlecalendar_list_events",
+    identifier="user_123",
+    tool_input={"max_results": 10},
+)
+
+# Tool payload is under response.data
+events = response.data.get("events", [])
+next_page_token = response.data.get("next_page_token", "")
+```
+
+<Aside type="caution">
+A common mistake is treating the response as a flat object. If you parse `response` directly instead of `response.data`, you'll see the raw wrapper and may get empty results. Always read from `response.data`.
+</Aside>
+
 ## Wire into your LLM
 
 The full agent loop: fetch scoped tools → pass to LLM → execute tool calls → feed results back.


### PR DESCRIPTION
## Summary

Fixes a common developer pitfall: calling `execute_tool` and parsing the response as a flat object instead of reading from `response.data`.

## Changes

1. **Quickstart** (`agentkit/quickstart.mdx`): Fixed Python example to show `response.data.get("emails", [])` extraction instead of `print(response)`
2. **Tools reference** (`agentkit/tools/scalekit-optimized-tools.mdx`): Added a "Response shape" section explaining that the tool payload lives under `response.data`, with a Google Calendar example showing extraction of `events` and `next_page_token`

## Context

From a reported integration issue where a Google Calendar integration parsed zero events because it treated the response as a flat object instead of reading `response.data["events"]`.

The broader work of generating response schemas from upstream metadata (mentioned in the issue) is a separate effort that requires API changes.

Closes #652

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated quickstart guide examples to demonstrate proper tool response data access patterns
  * Added "Response shape" documentation clarifying how tool responses are structured and how to access payloads in Python and Node.js
  * Added guidance on correctly accessing nested response data to prevent empty or misread results

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalekit-inc/developer-docs/pull/688)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->