### PR TITLE
chore: sync Monday and ClickUp tools from production API

### DIFF
--- a/src/content/docs/agentkit/connectors/clickup.mdx
+++ b/src/content/docs/agentkit/connectors/clickup.mdx
@@ -19,10 +19,12 @@ head:
       }
 ---
 
+import ToolList from '@/components/ToolList.astro'
+import { tools } from '@/data/agent-connectors/clickup'
 import { Steps, Tabs, TabItem } from '@astrojs/starlight/components'
 import { AgentKitCredentials } from '@components/templates'
 import { SetupClickupSection } from '@components/templates'
-import { QuickstartGenericOauthNotoolsSection } from '@components/templates'
+import { QuickstartGenericOauthSection } from '@components/templates'
 import { SectionAfterSetupClickupCommonWorkflows } from '@components/templates'
 
 <Steps>
@@ -61,10 +63,27 @@ import { SectionAfterSetupClickupCommonWorkflows } from '@components/templates'
 
 4. ### Authorize and make your first call
 
-   <QuickstartGenericOauthNotoolsSection connector="clickup" providerName="ClickUp" verifyPath="/api/v2/user" verifyMethod="GET" />
+   <QuickstartGenericOauthSection connector="clickup" toolName="clickup_user_get" providerName="ClickUp" />
 
 </Steps>
+
+## What you can do
+
+Connect this agent connector to let your agent:
+
+- **Get comment, folder, space** — Retrieve comments on a ClickUp task
+- **Delete space, space tag, comment** — Permanently delete a ClickUp space from your workspace
+- **Create time entry, checklist item, webhook** — Log a time entry for a task in a ClickUp Workspace
+- **Update task, goal, webhook** — Update an existing ClickUp task
+- **List update, space views, view tasks** — Update an existing ClickUp list
+- **Search task** — Search and filter tasks across an entire ClickUp workspace (team)
 
 ## Common workflows
 
 <SectionAfterSetupClickupCommonWorkflows />
+
+## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
+
+<ToolList tools={tools} />

--- a/src/content/docs/agentkit/connectors/monday.mdx
+++ b/src/content/docs/agentkit/connectors/monday.mdx
@@ -19,6 +19,8 @@ head:
       }
 ---
 
+import ToolList from '@/components/ToolList.astro'
+import { tools } from '@/data/agent-connectors/monday'
 import { Steps, Tabs, TabItem } from '@astrojs/starlight/components'
 import { AgentKitCredentials } from '@components/templates'
 import { SetupMondaySection } from '@components/templates'
@@ -65,6 +67,23 @@ import { SectionAfterSetupMondayCommonWorkflows } from '@components/templates'
 
 </Steps>
 
+## What you can do
+
+Connect this agent connector to let your agent:
+
+- **Create board, notification, item** — Create a new board in Monday.com
+- **List docs, updates, workspaces** — List documents (monday Docs) in your account
+- **Delete group, column, board** — Permanently delete a group from a board
+- **Update edit, board, delete** — Edit the text of an existing update/comment
+- **Duplicate item, group, board** — Create a copy of an item on the same board
+- **Board item move to** — Transfer an item to a different board
+
 ## Common workflows
 
 <SectionAfterSetupMondayCommonWorkflows />
+
+## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
+
+<ToolList tools={tools} />

--- a/src/data/agent-connectors/clickup.ts
+++ b/src/data/agent-connectors/clickup.ts
@@ -1,4 +1,503 @@
 import type { Tool } from '../../types/agent-connectors'
 
 export const tools: Tool[] = [
+  {
+    name: 'clickup_checklist_item_create',
+    description: `Add a new item to an existing ClickUp task checklist.`,
+    params: [
+      { name: 'checklist_id', type: 'string', required: true, description: `Checklist ID (UUID)` },
+      { name: 'name', type: 'string', required: true, description: `Item label` },
+      { name: 'assignee', type: 'integer', required: false, description: `User ID to assign to this item` },
+    ],
+  },
+  {
+    name: 'clickup_comment_create',
+    description: `Add a new comment to a ClickUp task. Supports assigning the comment to a user and sending notifications.`,
+    params: [
+      { name: 'comment_text', type: 'string', required: true, description: `The content of the comment` },
+      { name: 'notify_all', type: 'boolean', required: true, description: `When true, notifies the comment creator in addition to other watchers` },
+      { name: 'task_id', type: 'string', required: true, description: `The unique identifier of the task to comment on` },
+      { name: 'assignee', type: 'integer', required: false, description: `User ID to assign this comment to` },
+    ],
+  },
+  {
+    name: 'clickup_comment_create_list',
+    description: `Add a new comment to a ClickUp list. Supports assigning the comment to a user and sending notifications.`,
+    params: [
+      { name: 'assignee', type: 'integer', required: true, description: `User ID to assign this comment to` },
+      { name: 'comment_text', type: 'string', required: true, description: `The content of the comment` },
+      { name: 'list_id', type: 'string', required: true, description: `The unique identifier of the list to comment on` },
+      { name: 'notify_all', type: 'boolean', required: true, description: `When true, also notifies the comment creator` },
+    ],
+  },
+  {
+    name: 'clickup_comment_delete',
+    description: `Permanently delete a ClickUp comment by comment ID. This action cannot be undone.`,
+    params: [
+      { name: 'comment_id', type: 'string', required: true, description: `The unique identifier of the comment to delete` },
+    ],
+  },
+  {
+    name: 'clickup_comment_get_list',
+    description: `Retrieve comments on a ClickUp list. Returns up to 25 most recent comments by default. Use start and start_id for pagination.`,
+    params: [
+      { name: 'list_id', type: 'string', required: true, description: `The unique identifier of the list` },
+      { name: 'start', type: 'integer', required: false, description: `Unix timestamp in milliseconds of a reference comment for pagination` },
+      { name: 'start_id', type: 'string', required: false, description: `ID of a reference comment for pagination` },
+    ],
+  },
+  {
+    name: 'clickup_comment_get_task',
+    description: `Retrieve comments on a ClickUp task. Returns up to 25 most recent comments. Use start and start_id for pagination.`,
+    params: [
+      { name: 'task_id', type: 'string', required: true, description: `The unique identifier of the task` },
+      { name: 'start', type: 'integer', required: false, description: `Unix timestamp in milliseconds of a reference comment for pagination` },
+      { name: 'start_id', type: 'string', required: false, description: `ID of a reference comment for pagination` },
+    ],
+  },
+  {
+    name: 'clickup_comment_update',
+    description: `Update an existing ClickUp comment. Supports changing comment text, assignee, and resolved status.`,
+    params: [
+      { name: 'assignee', type: 'integer', required: true, description: `User ID to assign this comment to` },
+      { name: 'comment_id', type: 'string', required: true, description: `The unique identifier of the comment to update` },
+      { name: 'comment_text', type: 'string', required: true, description: `New text content for the comment` },
+      { name: 'resolved', type: 'boolean', required: true, description: `Whether the comment is marked as resolved` },
+    ],
+  },
+  {
+    name: 'clickup_folder_create',
+    description: `Create a new folder within a ClickUp space to organize lists and tasks.`,
+    params: [
+      { name: 'name', type: 'string', required: true, description: `The name for the new folder` },
+      { name: 'space_id', type: 'string', required: true, description: `The ID of the space to create the folder in` },
+    ],
+  },
+  {
+    name: 'clickup_folder_delete',
+    description: `Permanently delete a ClickUp folder. This action cannot be undone.`,
+    params: [
+      { name: 'folder_id', type: 'string', required: true, description: `The unique identifier of the folder to delete` },
+    ],
+  },
+  {
+    name: 'clickup_folder_get',
+    description: `Retrieve details of a specific ClickUp folder by folder ID, including the lists it contains.`,
+    params: [
+      { name: 'folder_id', type: 'string', required: true, description: `The unique identifier of the folder` },
+    ],
+  },
+  {
+    name: 'clickup_folder_get_all',
+    description: `Retrieve all folders within a ClickUp space. Optionally filter to include archived folders.`,
+    params: [
+      { name: 'space_id', type: 'string', required: true, description: `The unique identifier of the space` },
+      { name: 'archived', type: 'boolean', required: false, description: `Include archived folders in results` },
+    ],
+  },
+  {
+    name: 'clickup_folder_update',
+    description: `Rename an existing ClickUp folder.`,
+    params: [
+      { name: 'folder_id', type: 'string', required: true, description: `The unique identifier of the folder to update` },
+      { name: 'name', type: 'string', required: true, description: `New name for the folder` },
+    ],
+  },
+  {
+    name: 'clickup_goal_create',
+    description: `Create a new goal in a ClickUp workspace. Goals help track high-level objectives with due dates and owner assignments.`,
+    params: [
+      { name: 'color', type: 'string', required: true, description: `Color for the goal (hex code)` },
+      { name: 'description', type: 'string', required: true, description: `Description of the goal` },
+      { name: 'due_date', type: 'integer', required: true, description: `Due date as Unix timestamp in milliseconds` },
+      { name: 'multiple_owners', type: 'boolean', required: true, description: `Allow multiple owners for this goal` },
+      { name: 'name', type: 'string', required: true, description: `Name of the goal` },
+      { name: 'team_id', type: 'string', required: true, description: `The workspace (team) ID` },
+    ],
+  },
+  {
+    name: 'clickup_goal_delete',
+    description: `Remove a Goal from a ClickUp Workspace.`,
+    params: [
+      { name: 'goal_id', type: 'string', required: true, description: `Goal ID (UUID)` },
+    ],
+  },
+  {
+    name: 'clickup_goal_get',
+    description: `Retrieve the details of a ClickUp Goal including its targets.`,
+    params: [
+      { name: 'goal_id', type: 'string', required: true, description: `Goal ID (UUID)` },
+    ],
+  },
+  {
+    name: 'clickup_goal_get_all',
+    description: `Retrieve all goals in a ClickUp workspace. Optionally filter to include or exclude completed goals.`,
+    params: [
+      { name: 'team_id', type: 'string', required: true, description: `The workspace (team) ID` },
+      { name: 'include_completed', type: 'boolean', required: false, description: `Include completed goals in results (defaults to true)` },
+    ],
+  },
+  {
+    name: 'clickup_goal_update',
+    description: `Update an existing ClickUp goal. Supports renaming, changing due date, description, color, and managing owners.`,
+    params: [
+      { name: 'color', type: 'string', required: true, description: `Updated color for the goal (hex code)` },
+      { name: 'description', type: 'string', required: true, description: `Updated description of the goal` },
+      { name: 'due_date', type: 'integer', required: true, description: `Updated due date as Unix timestamp in milliseconds` },
+      { name: 'goal_id', type: 'string', required: true, description: `The unique identifier (UUID) of the goal to update` },
+      { name: 'name', type: 'string', required: true, description: `New name for the goal` },
+    ],
+  },
+  {
+    name: 'clickup_list_create',
+    description: `Create a new list within a ClickUp folder. Supports setting name, description, due date, priority, and assignee.`,
+    params: [
+      { name: 'folder_id', type: 'string', required: true, description: `The ID of the folder to create the list in` },
+      { name: 'name', type: 'string', required: true, description: `The name for the new list` },
+      { name: 'assignee', type: 'integer', required: false, description: `User ID to assign to the list` },
+      { name: 'content', type: 'string', required: false, description: `Description of the list` },
+      { name: 'due_date', type: 'integer', required: false, description: `Due date for the list as Unix timestamp in milliseconds` },
+      { name: 'priority', type: 'integer', required: false, description: `Priority level: 1 (urgent), 2 (high), 3 (normal), 4 (low)` },
+    ],
+  },
+  {
+    name: 'clickup_list_create_folderless',
+    description: `Create a new list directly within a ClickUp space (not inside a folder). Useful for top-level organization.`,
+    params: [
+      { name: 'name', type: 'string', required: true, description: `The name for the new list` },
+      { name: 'space_id', type: 'string', required: true, description: `The ID of the space to create the list in` },
+      { name: 'content', type: 'string', required: false, description: `Description of the list` },
+      { name: 'due_date', type: 'integer', required: false, description: `Due date as Unix timestamp in milliseconds` },
+      { name: 'priority', type: 'integer', required: false, description: `Priority level: 1 (urgent), 2 (high), 3 (normal), 4 (low)` },
+    ],
+  },
+  {
+    name: 'clickup_list_delete',
+    description: `Permanently delete a ClickUp list and all its contents. This action cannot be undone.`,
+    params: [
+      { name: 'list_id', type: 'string', required: true, description: `The unique identifier of the list to delete` },
+    ],
+  },
+  {
+    name: 'clickup_list_get',
+    description: `Retrieve details of a specific ClickUp list by list ID.`,
+    params: [
+      { name: 'list_id', type: 'string', required: true, description: `The unique identifier of the list` },
+    ],
+  },
+  {
+    name: 'clickup_list_get_all',
+    description: `Retrieve all lists within a ClickUp folder. Optionally filter to include or exclude archived lists.`,
+    params: [
+      { name: 'folder_id', type: 'string', required: true, description: `The unique identifier of the folder` },
+      { name: 'archived', type: 'boolean', required: false, description: `Include archived lists in results` },
+    ],
+  },
+  {
+    name: 'clickup_list_get_folderless',
+    description: `Retrieve all lists in a ClickUp space that are not inside a folder. These are top-level lists within the space.`,
+    params: [
+      { name: 'space_id', type: 'string', required: true, description: `The unique identifier of the space` },
+      { name: 'archived', type: 'boolean', required: false, description: `Include archived lists in results` },
+    ],
+  },
+  {
+    name: 'clickup_list_members_list',
+    description: `Retrieve Workspace members who have explicit access to a specific ClickUp List.`,
+    params: [
+      { name: 'list_id', type: 'integer', required: true, description: `List ID` },
+    ],
+  },
+  {
+    name: 'clickup_list_update',
+    description: `Update an existing ClickUp list. Supports renaming, updating description, due date, priority, assignee, and status color.`,
+    params: [
+      { name: 'list_id', type: 'string', required: true, description: `The unique identifier of the list to update` },
+      { name: 'name', type: 'string', required: true, description: `New name for the list` },
+      { name: 'content', type: 'string', required: false, description: `Updated description for the list` },
+      { name: 'due_date', type: 'integer', required: false, description: `Updated due date as Unix timestamp in milliseconds` },
+      { name: 'priority', type: 'integer', required: false, description: `Priority level: 1 (urgent), 2 (high), 3 (normal), 4 (low)` },
+      { name: 'unset_status', type: 'boolean', required: false, description: `Set to true to remove the list color` },
+    ],
+  },
+  {
+    name: 'clickup_list_views_list',
+    description: `Retrieve all views in a ClickUp List.`,
+    params: [
+      { name: 'list_id', type: 'integer', required: true, description: `List ID` },
+    ],
+  },
+  {
+    name: 'clickup_space_create',
+    description: `Create a new space within a ClickUp workspace. Spaces are the top-level organizational units that contain folders and lists.`,
+    params: [
+      { name: 'multiple_assignees', type: 'boolean', required: true, description: `Allow multiple assignees on tasks in this space` },
+      { name: 'name', type: 'string', required: true, description: `The name for the new space` },
+      { name: 'team_id', type: 'string', required: true, description: `The workspace (team) ID to create the space in` },
+    ],
+  },
+  {
+    name: 'clickup_space_delete',
+    description: `Permanently delete a ClickUp space from your workspace. This action cannot be undone.`,
+    params: [
+      { name: 'space_id', type: 'string', required: true, description: `The unique identifier of the space to delete` },
+    ],
+  },
+  {
+    name: 'clickup_space_get',
+    description: `Retrieve details of a specific ClickUp space by space ID.`,
+    params: [
+      { name: 'space_id', type: 'string', required: true, description: `The unique identifier of the space` },
+    ],
+  },
+  {
+    name: 'clickup_space_get_all',
+    description: `Retrieve all spaces available in a ClickUp workspace (team). Optionally include archived spaces.`,
+    params: [
+      { name: 'team_id', type: 'string', required: true, description: `The workspace (team) ID` },
+      { name: 'archived', type: 'boolean', required: false, description: `Include archived spaces in results` },
+    ],
+  },
+  {
+    name: 'clickup_space_tag_create',
+    description: `Create a new tag in a ClickUp Space.`,
+    params: [
+      { name: 'space_id', type: 'string', required: true, description: `Space ID` },
+      { name: 'tag_name', type: 'string', required: true, description: `Tag name` },
+      { name: 'tag_bg', type: 'string', required: false, description: `Background color (hex)` },
+      { name: 'tag_fg', type: 'string', required: false, description: `Foreground color (hex)` },
+    ],
+  },
+  {
+    name: 'clickup_space_tag_delete',
+    description: `Remove a tag from a ClickUp Space.`,
+    params: [
+      { name: 'space_id', type: 'string', required: true, description: `Space ID` },
+      { name: 'tag_name', type: 'string', required: true, description: `Tag name to delete` },
+      { name: 'tag_bg', type: 'string', required: false, description: `Background color (hex)` },
+      { name: 'tag_fg', type: 'string', required: false, description: `Foreground color (hex)` },
+    ],
+  },
+  {
+    name: 'clickup_space_tags_list',
+    description: `Retrieve all task tags available in a ClickUp Space.`,
+    params: [
+      { name: 'space_id', type: 'string', required: true, description: `Space ID` },
+    ],
+  },
+  {
+    name: 'clickup_space_update',
+    description: `Update an existing ClickUp space. Supports renaming, changing color, privacy settings, and enabling multiple assignees.`,
+    params: [
+      { name: 'color', type: 'string', required: true, description: `Color for the space (hex code)` },
+      { name: 'multiple_assignees', type: 'boolean', required: true, description: `Allow multiple assignees on tasks` },
+      { name: 'name', type: 'string', required: true, description: `New name for the space` },
+      { name: 'private', type: 'boolean', required: true, description: `Whether this space is private` },
+      { name: 'space_id', type: 'string', required: true, description: `The unique identifier of the space to update` },
+    ],
+  },
+  {
+    name: 'clickup_space_views_list',
+    description: `Retrieve all views in a ClickUp Space.`,
+    params: [
+      { name: 'space_id', type: 'integer', required: true, description: `Space ID` },
+    ],
+  },
+  {
+    name: 'clickup_task_checklist_create',
+    description: `Add a new checklist to a ClickUp task.`,
+    params: [
+      { name: 'name', type: 'string', required: true, description: `Checklist name` },
+      { name: 'task_id', type: 'string', required: true, description: `Task ID` },
+      { name: 'custom_task_ids', type: 'boolean', required: false, description: `Use custom task IDs` },
+      { name: 'team_id', type: 'integer', required: false, description: `Workspace ID (required if custom_task_ids=true)` },
+    ],
+  },
+  {
+    name: 'clickup_task_create',
+    description: `Create a new task in a ClickUp list. Supports setting name, description, assignees, status, priority, due date, start date, and more.`,
+    params: [
+      { name: 'list_id', type: 'string', required: true, description: `The ID of the list to create the task in` },
+      { name: 'name', type: 'string', required: true, description: `The name or title of the task` },
+      { name: 'description', type: 'string', required: false, description: `Plain text description of the task` },
+      { name: 'due_date', type: 'integer', required: false, description: `Due date as Unix timestamp in milliseconds` },
+      { name: 'notify_all', type: 'boolean', required: false, description: `When true, notifies task creator and all assignees/watchers` },
+      { name: 'parent', type: 'string', required: false, description: `ID of a parent task to create this as a subtask` },
+      { name: 'priority', type: 'integer', required: false, description: `Priority level: 1 (urgent), 2 (high), 3 (normal), 4 (low)` },
+      { name: 'start_date', type: 'integer', required: false, description: `Start date as Unix timestamp in milliseconds` },
+      { name: 'status', type: 'string', required: false, description: `The status of the task (must match a status in the list)` },
+    ],
+  },
+  {
+    name: 'clickup_task_create_from_template',
+    description: `Create a new ClickUp task using an existing task template. The template must be added to your workspace before use.`,
+    params: [
+      { name: 'list_id', type: 'string', required: true, description: `The ID of the list where the task will be created` },
+      { name: 'name', type: 'string', required: true, description: `The name for the new task being created from the template` },
+      { name: 'template_id', type: 'string', required: true, description: `The ID of the task template to use` },
+    ],
+  },
+  {
+    name: 'clickup_task_delete',
+    description: `Permanently delete a ClickUp task by task ID. This action cannot be undone.`,
+    params: [
+      { name: 'task_id', type: 'string', required: true, description: `The unique identifier of the task to delete` },
+    ],
+  },
+  {
+    name: 'clickup_task_get',
+    description: `Retrieve details of a specific ClickUp task by task ID. Returns task properties, assignees, status, dates, and custom fields.`,
+    params: [
+      { name: 'task_id', type: 'string', required: true, description: `The unique identifier of the task` },
+      { name: 'include_markdown_description', type: 'boolean', required: false, description: `Return task description in Markdown format` },
+      { name: 'include_subtasks', type: 'boolean', required: false, description: `Include subtasks in the response` },
+    ],
+  },
+  {
+    name: 'clickup_task_list',
+    description: `Retrieve tasks from a specific ClickUp list. Supports filtering by status, assignee, tags, and date ranges. Returns up to 100 tasks per page.`,
+    params: [
+      { name: 'list_id', type: 'string', required: true, description: `The ID of the list to retrieve tasks from` },
+      { name: 'archived', type: 'boolean', required: false, description: `Return archived tasks` },
+      { name: 'include_closed', type: 'boolean', required: false, description: `Include closed tasks in the results` },
+      { name: 'order_by', type: 'string', required: false, description: `Field to sort tasks by: id, created, updated, or due_date` },
+      { name: 'page', type: 'integer', required: false, description: `Page number for pagination (starts at 0)` },
+      { name: 'reverse', type: 'boolean', required: false, description: `Display results in reverse order` },
+      { name: 'subtasks', type: 'boolean', required: false, description: `Include subtasks in the results` },
+    ],
+  },
+  {
+    name: 'clickup_task_members_list',
+    description: `Retrieve Workspace members who have access to a specific ClickUp task.`,
+    params: [
+      { name: 'task_id', type: 'string', required: true, description: `Task ID` },
+    ],
+  },
+  {
+    name: 'clickup_task_search',
+    description: `Search and filter tasks across an entire ClickUp workspace (team). Supports filtering by spaces, lists, folders, statuses, assignees, tags, and date ranges.`,
+    params: [
+      { name: 'team_id', type: 'string', required: true, description: `The workspace (team) ID to search tasks within` },
+      { name: 'due_date_gt', type: 'integer', required: false, description: `Filter tasks with due date greater than this Unix timestamp in milliseconds` },
+      { name: 'due_date_lt', type: 'integer', required: false, description: `Filter tasks with due date less than this Unix timestamp in milliseconds` },
+      { name: 'include_closed', type: 'boolean', required: false, description: `Include closed tasks in the results` },
+      { name: 'order_by', type: 'string', required: false, description: `Sort field: id, created, updated, or due_date` },
+      { name: 'page', type: 'integer', required: false, description: `Page number for pagination (starts at 0)` },
+      { name: 'reverse', type: 'boolean', required: false, description: `Display results in reverse order` },
+      { name: 'subtasks', type: 'boolean', required: false, description: `Include subtasks in the results` },
+    ],
+  },
+  {
+    name: 'clickup_task_update',
+    description: `Update an existing ClickUp task. Supports updating name, description, status, priority, due date, start date, and other fields.`,
+    params: [
+      { name: 'task_id', type: 'string', required: true, description: `The unique identifier of the task to update` },
+      { name: 'archived', type: 'boolean', required: false, description: `Set to true to archive the task` },
+      { name: 'description', type: 'string', required: false, description: `Updated task description. Use a space character to clear the description.` },
+      { name: 'due_date', type: 'integer', required: false, description: `Due date as Unix timestamp in milliseconds` },
+      { name: 'name', type: 'string', required: false, description: `New name for the task` },
+      { name: 'priority', type: 'integer', required: false, description: `Priority level: 1 (urgent), 2 (high), 3 (normal), 4 (low)` },
+      { name: 'start_date', type: 'integer', required: false, description: `Start date as Unix timestamp in milliseconds` },
+      { name: 'status', type: 'string', required: false, description: `New status for the task` },
+      { name: 'time_estimate', type: 'integer', required: false, description: `Time estimate in milliseconds` },
+    ],
+  },
+  {
+    name: 'clickup_time_entries_list',
+    description: `Retrieve time entries within a date range for a ClickUp Workspace.`,
+    params: [
+      { name: 'team_id', type: 'string', required: true, description: `Workspace ID` },
+      { name: 'assignee', type: 'integer', required: false, description: `Filter by user ID` },
+      { name: 'end_date', type: 'integer', required: false, description: `End date (Unix ms)` },
+      { name: 'folder_id', type: 'integer', required: false, description: `Filter by folder ID` },
+      { name: 'is_billable', type: 'boolean', required: false, description: `Filter by billable status` },
+      { name: 'list_id', type: 'integer', required: false, description: `Filter by list ID` },
+      { name: 'space_id', type: 'integer', required: false, description: `Filter by space ID` },
+      { name: 'start_date', type: 'integer', required: false, description: `Start date (Unix ms)` },
+      { name: 'task_id', type: 'string', required: false, description: `Filter by task ID` },
+    ],
+  },
+  {
+    name: 'clickup_time_entry_create',
+    description: `Log a time entry for a task in a ClickUp Workspace.`,
+    params: [
+      { name: 'duration', type: 'integer', required: true, description: `Duration in milliseconds` },
+      { name: 'start', type: 'integer', required: true, description: `Start timestamp (Unix ms)` },
+      { name: 'team_id', type: 'string', required: true, description: `Workspace ID` },
+      { name: 'assignee', type: 'integer', required: false, description: `User ID to assign entry to` },
+      { name: 'billable', type: 'boolean', required: false, description: `Mark as billable` },
+      { name: 'description', type: 'string', required: false, description: `Time entry description` },
+      { name: 'tid', type: 'string', required: false, description: `Task ID to associate with` },
+    ],
+  },
+  {
+    name: 'clickup_user_get',
+    description: `Retrieve the details of the authenticated ClickUp user account.`,
+    params: [
+    ],
+  },
+  {
+    name: 'clickup_view_tasks_list',
+    description: `Retrieve all tasks in a specific ClickUp view.`,
+    params: [
+      { name: 'view_id', type: 'string', required: true, description: `View ID` },
+      { name: 'page', type: 'integer', required: false, description: `Page number (starts at 0)` },
+    ],
+  },
+  {
+    name: 'clickup_webhook_create',
+    description: `Create a new webhook in a ClickUp workspace to monitor specific events. Use '*' for the events field to subscribe to all events.`,
+    params: [
+      { name: 'endpoint', type: 'string', required: true, description: `The URL that will receive webhook payloads` },
+      { name: 'events', type: 'string', required: true, description: `Comma-separated list of events to subscribe to, or '*' for all events` },
+      { name: 'team_id', type: 'string', required: true, description: `The workspace (team) ID` },
+      { name: 'list_id', type: 'integer', required: false, description: `Filter webhook to a specific list ID` },
+      { name: 'space_id', type: 'integer', required: false, description: `Filter webhook to a specific space ID` },
+      { name: 'task_id', type: 'string', required: false, description: `Filter webhook to a specific task ID` },
+    ],
+  },
+  {
+    name: 'clickup_webhook_delete',
+    description: `Delete a ClickUp webhook, stopping it from monitoring events. This action cannot be undone.`,
+    params: [
+      { name: 'webhook_id', type: 'string', required: true, description: `The unique identifier (UUID) of the webhook to delete` },
+    ],
+  },
+  {
+    name: 'clickup_webhook_get_all',
+    description: `Retrieve all webhooks created via the API for a ClickUp workspace. Only returns webhooks created by the authenticated user.`,
+    params: [
+      { name: 'team_id', type: 'string', required: true, description: `The workspace (team) ID` },
+    ],
+  },
+  {
+    name: 'clickup_webhook_update',
+    description: `Update an existing ClickUp webhook. Change the endpoint URL, subscribed events, or webhook status.`,
+    params: [
+      { name: 'endpoint', type: 'string', required: true, description: `New destination URL for the webhook` },
+      { name: 'events', type: 'string', required: true, description: `Events to subscribe to, or '*' for all events` },
+      { name: 'status', type: 'string', required: true, description: `Status of the webhook (active or inactive)` },
+      { name: 'webhook_id', type: 'string', required: true, description: `The unique identifier (UUID) of the webhook to update` },
+    ],
+  },
+  {
+    name: 'clickup_workspace_members_list',
+    description: `Retrieve all members in a ClickUp Workspace.`,
+    params: [
+      { name: 'team_id', type: 'string', required: true, description: `Workspace ID` },
+    ],
+  },
+  {
+    name: 'clickup_workspace_seats_get',
+    description: `Retrieve seat utilization data for a ClickUp Workspace, showing member and guest seat counts.`,
+    params: [
+      { name: 'team_id', type: 'string', required: true, description: `Workspace ID` },
+    ],
+  },
+  {
+    name: 'clickup_workspaces_list',
+    description: `Retrieve all ClickUp Workspaces available to the authenticated user.`,
+    params: [
+    ],
+  },
 ]

--- a/src/data/agent-connectors/monday.ts
+++ b/src/data/agent-connectors/monday.ts
@@ -1,4 +1,403 @@
 import type { Tool } from '../../types/agent-connectors'
 
 export const tools: Tool[] = [
+  {
+    name: 'monday_board_archive',
+    description: `Archive a board in Monday.com.`,
+    params: [
+      { name: 'board_id', type: 'string', required: true, description: `ID of the board to archive` },
+    ],
+  },
+  {
+    name: 'monday_board_create',
+    description: `Create a new board in Monday.com.`,
+    params: [
+      { name: 'board_kind', type: 'string', required: true, description: `Board type: public, private, or share` },
+      { name: 'board_name', type: 'string', required: true, description: `Name for the new board` },
+      { name: 'description', type: 'string', required: false, description: `Description for the board` },
+      { name: 'folder_id', type: 'integer', required: false, description: `Folder ID to place the board in` },
+      { name: 'template_id', type: 'integer', required: false, description: `Template ID to base the board on` },
+      { name: 'workspace_id', type: 'integer', required: false, description: `ID of the workspace to create the board in` },
+    ],
+  },
+  {
+    name: 'monday_board_delete',
+    description: `Permanently delete a board from Monday.com.`,
+    params: [
+      { name: 'board_id', type: 'string', required: true, description: `ID of the board to delete` },
+    ],
+  },
+  {
+    name: 'monday_board_duplicate',
+    description: `Create a copy of an existing board.`,
+    params: [
+      { name: 'board_id', type: 'string', required: true, description: `ID of the board to duplicate` },
+      { name: 'duplicate_type', type: 'string', required: true, description: `What to duplicate: duplicate_board_with_structure, duplicate_board_with_pulses, or duplicate_board_with_pulses_and_updates` },
+      { name: 'board_name', type: 'string', required: false, description: `Name for the duplicated board` },
+      { name: 'keep_subscribers', type: 'boolean', required: false, description: `Whether to keep board subscribers` },
+      { name: 'workspace_id', type: 'string', required: false, description: `Destination workspace ID` },
+    ],
+  },
+  {
+    name: 'monday_board_subscribers_add',
+    description: `Subscribe users to a board so they receive notifications.`,
+    params: [
+      { name: 'board_id', type: 'string', required: true, description: `ID of the board to add subscribers to` },
+      { name: 'user_ids', type: 'array', required: true, description: `Array of user IDs to subscribe` },
+      { name: 'kind', type: 'string', required: false, description: `Role: subscriber or owner` },
+    ],
+  },
+  {
+    name: 'monday_board_update',
+    description: `Update a board's name, description, or communication settings.`,
+    params: [
+      { name: 'board_attribute', type: 'string', required: true, description: `Attribute to update: name, description, or communication` },
+      { name: 'board_id', type: 'string', required: true, description: `ID of the board to update` },
+      { name: 'new_value', type: 'string', required: true, description: `New value for the attribute` },
+    ],
+  },
+  {
+    name: 'monday_boards_list',
+    description: `Retrieve a list of boards from your Monday.com account with optional filtering.`,
+    params: [
+      { name: 'board_kind', type: 'string', required: false, description: `Filter by kind: public, private, share` },
+      { name: 'limit', type: 'integer', required: false, description: `Number of boards to return (default 10)` },
+      { name: 'order_by', type: 'string', required: false, description: `Sort order: created_at or used_at` },
+      { name: 'page', type: 'integer', required: false, description: `Page number for pagination` },
+      { name: 'state', type: 'string', required: false, description: `Filter by state: active, archived, deleted, all` },
+      { name: 'workspace_ids', type: 'array', required: false, description: `Filter by workspace IDs` },
+    ],
+  },
+  {
+    name: 'monday_column_create',
+    description: `Add a new column to a Monday.com board.`,
+    params: [
+      { name: 'board_id', type: 'string', required: true, description: `ID of the board to add the column to` },
+      { name: 'column_type', type: 'string', required: true, description: `Column type: text, long_text, numbers, status, dropdown, date, timeline, people, checkbox, email, phone, link, file, color_picker, rating, time_tracking, formula, auto_number, etc.` },
+      { name: 'title', type: 'string', required: true, description: `Title/name for the new column` },
+      { name: 'after_column_id', type: 'string', required: false, description: `Column ID to insert this column after` },
+      { name: 'defaults', type: 'string', required: false, description: `JSON of default settings for the column` },
+      { name: 'description', type: 'string', required: false, description: `Optional description for the column` },
+    ],
+  },
+  {
+    name: 'monday_column_delete',
+    description: `Permanently delete a column from a board.`,
+    params: [
+      { name: 'board_id', type: 'string', required: true, description: `ID of the board` },
+      { name: 'column_id', type: 'string', required: true, description: `ID of the column to delete` },
+    ],
+  },
+  {
+    name: 'monday_column_title_change',
+    description: `Rename a column on a board.`,
+    params: [
+      { name: 'board_id', type: 'string', required: true, description: `ID of the board` },
+      { name: 'column_id', type: 'string', required: true, description: `ID of the column to rename` },
+      { name: 'title', type: 'string', required: true, description: `New title for the column` },
+    ],
+  },
+  {
+    name: 'monday_docs_list',
+    description: `List documents (monday Docs) in your account.`,
+    params: [
+      { name: 'ids', type: 'array', required: false, description: `Filter by specific doc IDs` },
+      { name: 'limit', type: 'integer', required: false, description: `Number of docs to return` },
+      { name: 'page', type: 'integer', required: false, description: `Page number for pagination` },
+      { name: 'workspace_ids', type: 'array', required: false, description: `Filter by workspace IDs` },
+    ],
+  },
+  {
+    name: 'monday_group_archive',
+    description: `Archive a group on a board.`,
+    params: [
+      { name: 'board_id', type: 'string', required: true, description: `ID of the board` },
+      { name: 'group_id', type: 'string', required: true, description: `ID of the group to archive` },
+    ],
+  },
+  {
+    name: 'monday_group_create',
+    description: `Create a new group on a Monday.com board.`,
+    params: [
+      { name: 'board_id', type: 'string', required: true, description: `ID of the board to add the group to` },
+      { name: 'group_name', type: 'string', required: true, description: `Name of the group to create` },
+      { name: 'position_relative_method', type: 'string', required: false, description: `Positioning: before_at or after_at` },
+      { name: 'relative_to', type: 'string', required: false, description: `Group ID to position this group relative to` },
+    ],
+  },
+  {
+    name: 'monday_group_delete',
+    description: `Permanently delete a group from a board.`,
+    params: [
+      { name: 'board_id', type: 'string', required: true, description: `ID of the board` },
+      { name: 'group_id', type: 'string', required: true, description: `ID of the group to delete` },
+    ],
+  },
+  {
+    name: 'monday_group_duplicate',
+    description: `Create a copy of a group on a board.`,
+    params: [
+      { name: 'board_id', type: 'string', required: true, description: `ID of the board` },
+      { name: 'group_id', type: 'string', required: true, description: `ID of the group to duplicate` },
+      { name: 'add_to_top', type: 'boolean', required: false, description: `Whether to add the duplicate at the top of the board` },
+    ],
+  },
+  {
+    name: 'monday_group_update',
+    description: `Update a group's name, color, or position on a board.`,
+    params: [
+      { name: 'attribute', type: 'string', required: true, description: `Attribute to update: title or color` },
+      { name: 'board_id', type: 'string', required: true, description: `ID of the board` },
+      { name: 'group_id', type: 'string', required: true, description: `ID of the group to update` },
+      { name: 'new_value', type: 'string', required: true, description: `New value for the attribute` },
+    ],
+  },
+  {
+    name: 'monday_item_archive',
+    description: `Archive an item on a Monday.com board.`,
+    params: [
+      { name: 'item_id', type: 'string', required: true, description: `ID of the item to archive` },
+    ],
+  },
+  {
+    name: 'monday_item_column_value_change',
+    description: `Update the value of a single column on an item.`,
+    params: [
+      { name: 'board_id', type: 'string', required: true, description: `ID of the board the item belongs to` },
+      { name: 'column_id', type: 'string', required: true, description: `ID of the column to update (e.g., status, date4, text)` },
+      { name: 'item_id', type: 'string', required: true, description: `ID of the item to update` },
+      { name: 'value', type: 'string', required: true, description: `New value as a JSON string. Format varies by column type.` },
+      { name: 'create_labels_if_missing', type: 'boolean', required: false, description: `Auto-create labels if they don't exist` },
+    ],
+  },
+  {
+    name: 'monday_item_column_values_change',
+    description: `Update multiple column values on an item in a single request (up to 50 columns).`,
+    params: [
+      { name: 'board_id', type: 'string', required: true, description: `ID of the board the item belongs to` },
+      { name: 'column_values', type: 'string', required: true, description: `JSON object mapping column IDs to their new values` },
+      { name: 'item_id', type: 'string', required: true, description: `ID of the item to update` },
+      { name: 'create_labels_if_missing', type: 'boolean', required: false, description: `Auto-create labels if they don't exist` },
+    ],
+  },
+  {
+    name: 'monday_item_create',
+    description: `Create a new item (row) on a Monday.com board.`,
+    params: [
+      { name: 'board_id', type: 'string', required: true, description: `ID of the board to create the item on` },
+      { name: 'item_name', type: 'string', required: true, description: `Name of the item to create` },
+      { name: 'column_values', type: 'string', required: false, description: `JSON string of column values to set` },
+      { name: 'create_labels_if_missing', type: 'boolean', required: false, description: `Auto-create status/dropdown labels if they don't exist` },
+      { name: 'group_id', type: 'string', required: false, description: `ID of the group to add the item to` },
+    ],
+  },
+  {
+    name: 'monday_item_delete',
+    description: `Permanently delete an item from a Monday.com board.`,
+    params: [
+      { name: 'item_id', type: 'string', required: true, description: `ID of the item to delete` },
+    ],
+  },
+  {
+    name: 'monday_item_duplicate',
+    description: `Create a copy of an item on the same board.`,
+    params: [
+      { name: 'board_id', type: 'string', required: true, description: `ID of the board the item belongs to` },
+      { name: 'item_id', type: 'string', required: true, description: `ID of the item to duplicate` },
+      { name: 'with_updates', type: 'boolean', required: false, description: `Whether to copy the item's updates/comments` },
+    ],
+  },
+  {
+    name: 'monday_item_move_to_board',
+    description: `Transfer an item to a different board.`,
+    params: [
+      { name: 'board_id', type: 'string', required: true, description: `ID of the destination board` },
+      { name: 'group_id', type: 'string', required: true, description: `ID of the group on the destination board` },
+      { name: 'item_id', type: 'string', required: true, description: `ID of the item to move` },
+      { name: 'columns_mapping', type: 'string', required: false, description: `JSON array mapping source column IDs to destination column IDs` },
+    ],
+  },
+  {
+    name: 'monday_item_move_to_group',
+    description: `Move an item to a different group on the same board.`,
+    params: [
+      { name: 'group_id', type: 'string', required: true, description: `ID of the destination group` },
+      { name: 'item_id', type: 'string', required: true, description: `ID of the item to move` },
+    ],
+  },
+  {
+    name: 'monday_items_list',
+    description: `Retrieve items from a Monday.com board. Returns items with their column values, group, and creator details.`,
+    params: [
+      { name: 'board_id', type: 'string', required: true, description: `ID of the board to list items from` },
+      { name: 'cursor', type: 'string', required: false, description: `Pagination cursor from a previous response` },
+      { name: 'group_id', type: 'string', required: false, description: `Filter by group ID` },
+      { name: 'limit', type: 'integer', required: false, description: `Number of items to return per page (max 500)` },
+    ],
+  },
+  {
+    name: 'monday_items_search',
+    description: `Search for items on a board filtered by specific column values.`,
+    params: [
+      { name: 'board_id', type: 'string', required: true, description: `ID of the board to search` },
+      { name: 'column_id', type: 'string', required: true, description: `ID of the column to filter by` },
+      { name: 'column_value', type: 'string', required: true, description: `Value to search for in the column` },
+      { name: 'cursor', type: 'string', required: false, description: `Pagination cursor from a previous response` },
+      { name: 'limit', type: 'integer', required: false, description: `Number of items to return per page` },
+    ],
+  },
+  {
+    name: 'monday_me_get',
+    description: `Retrieve the profile of the currently authenticated Monday.com user.`,
+    params: [
+    ],
+  },
+  {
+    name: 'monday_notification_create',
+    description: `Send a notification to a user in Monday.com.`,
+    params: [
+      { name: 'target_id', type: 'string', required: true, description: `ID of the target item or board for context` },
+      { name: 'target_type', type: 'string', required: true, description: `Target type: Project (board) or Post (item)` },
+      { name: 'text', type: 'string', required: true, description: `Notification message text` },
+      { name: 'user_id', type: 'string', required: true, description: `ID of the user to notify` },
+    ],
+  },
+  {
+    name: 'monday_subitem_create',
+    description: `Create a subitem (child item) under a parent item.`,
+    params: [
+      { name: 'item_name', type: 'string', required: true, description: `Name of the subitem` },
+      { name: 'parent_item_id', type: 'string', required: true, description: `ID of the parent item` },
+      { name: 'column_values', type: 'string', required: false, description: `JSON object of column values to set on creation` },
+      { name: 'create_labels_if_missing', type: 'boolean', required: false, description: `Auto-create labels if they don't exist` },
+    ],
+  },
+  {
+    name: 'monday_tag_create_or_get',
+    description: `Create a new tag or retrieve an existing one by name.`,
+    params: [
+      { name: 'tag_name', type: 'string', required: true, description: `Name of the tag to create or retrieve` },
+      { name: 'board_id', type: 'string', required: false, description: `ID of the board to associate the tag with` },
+    ],
+  },
+  {
+    name: 'monday_tags_list',
+    description: `Retrieve tags from Monday.com.`,
+    params: [
+      { name: 'ids', type: 'array', required: false, description: `Filter by specific tag IDs` },
+    ],
+  },
+  {
+    name: 'monday_team_users_add',
+    description: `Add one or more users to a Monday.com team.`,
+    params: [
+      { name: 'team_id', type: 'string', required: true, description: `ID of the team to add users to` },
+      { name: 'user_ids', type: 'array', required: true, description: `Array of user IDs to add to the team` },
+    ],
+  },
+  {
+    name: 'monday_team_users_remove',
+    description: `Remove one or more users from a Monday.com team.`,
+    params: [
+      { name: 'team_id', type: 'string', required: true, description: `ID of the team to remove users from` },
+      { name: 'user_ids', type: 'array', required: true, description: `Array of user IDs to remove from the team` },
+    ],
+  },
+  {
+    name: 'monday_teams_list',
+    description: `List teams in your Monday.com account.`,
+    params: [
+      { name: 'ids', type: 'array', required: false, description: `Filter by specific team IDs` },
+    ],
+  },
+  {
+    name: 'monday_update_create',
+    description: `Post a comment or update on a Monday.com item.`,
+    params: [
+      { name: 'body', type: 'string', required: true, description: `Content of the update/comment (HTML supported)` },
+      { name: 'item_id', type: 'string', required: true, description: `ID of the item to post the update on` },
+    ],
+  },
+  {
+    name: 'monday_update_delete',
+    description: `Delete an update/comment from an item.`,
+    params: [
+      { name: 'id', type: 'string', required: true, description: `ID of the update to delete` },
+    ],
+  },
+  {
+    name: 'monday_update_edit',
+    description: `Edit the text of an existing update/comment.`,
+    params: [
+      { name: 'body', type: 'string', required: true, description: `New content for the update` },
+      { name: 'id', type: 'string', required: true, description: `ID of the update to edit` },
+    ],
+  },
+  {
+    name: 'monday_updates_list',
+    description: `Retrieve updates (comments/activity posts) from Monday.com.`,
+    params: [
+      { name: 'item_id', type: 'string', required: false, description: `Filter updates by item ID` },
+      { name: 'limit', type: 'integer', required: false, description: `Number of updates to return` },
+      { name: 'page', type: 'integer', required: false, description: `Page number for pagination` },
+    ],
+  },
+  {
+    name: 'monday_users_list',
+    description: `List users in your Monday.com account.`,
+    params: [
+      { name: 'emails', type: 'array', required: false, description: `Filter by email addresses` },
+      { name: 'ids', type: 'array', required: false, description: `Filter by specific user IDs` },
+      { name: 'kind', type: 'string', required: false, description: `User kind: all, non_guests, guests, non_pending` },
+      { name: 'limit', type: 'integer', required: false, description: `Number of users to return` },
+      { name: 'name', type: 'string', required: false, description: `Filter by name (partial match)` },
+      { name: 'newest_first', type: 'boolean', required: false, description: `Sort newest users first` },
+      { name: 'page', type: 'integer', required: false, description: `Page number for pagination` },
+    ],
+  },
+  {
+    name: 'monday_webhook_create',
+    description: `Register a new webhook for a board event.`,
+    params: [
+      { name: 'board_id', type: 'string', required: true, description: `ID of the board to watch` },
+      { name: 'event', type: 'string', required: true, description: `Event to trigger on: change_column_value, create_item, delete_item, create_update, change_status_column_value, change_subitem_column_value, create_subitem, move_item_to_group, etc.` },
+      { name: 'url', type: 'string', required: true, description: `URL to send webhook payloads to` },
+      { name: 'config', type: 'string', required: false, description: `Optional JSON configuration for the event (e.g., specific column filter)` },
+    ],
+  },
+  {
+    name: 'monday_webhook_delete',
+    description: `Delete a webhook registration.`,
+    params: [
+      { name: 'id', type: 'string', required: true, description: `ID of the webhook to delete` },
+    ],
+  },
+  {
+    name: 'monday_webhooks_list',
+    description: `List all webhooks registered for a board.`,
+    params: [
+      { name: 'board_id', type: 'string', required: true, description: `ID of the board to list webhooks for` },
+      { name: 'app_webhooks_only', type: 'boolean', required: false, description: `Return only webhooks created by the current app` },
+    ],
+  },
+  {
+    name: 'monday_workspace_create',
+    description: `Create a new workspace in Monday.com.`,
+    params: [
+      { name: 'kind', type: 'string', required: true, description: `Workspace type: open or closed` },
+      { name: 'name', type: 'string', required: true, description: `Name for the new workspace` },
+      { name: 'description', type: 'string', required: false, description: `Optional description for the workspace` },
+    ],
+  },
+  {
+    name: 'monday_workspaces_list',
+    description: `List all workspaces in your Monday.com account.`,
+    params: [
+      { name: 'ids', type: 'array', required: false, description: `Filter by specific workspace IDs` },
+      { name: 'kind', type: 'string', required: false, description: `Workspace kind: open or closed` },
+      { name: 'limit', type: 'integer', required: false, description: `Number of workspaces to return` },
+      { name: 'page', type: 'integer', required: false, description: `Page number for pagination` },
+      { name: 'state', type: 'string', required: false, description: `Workspace state: all, active, archived, deleted` },
+    ],
+  },
 ]


### PR DESCRIPTION
Syncs `monday.ts` (44 tools) and `clickup.ts` (55 tools) from the production Scalekit API — same as how `linear.ts` was previously synced to main.

Both files were empty arrays on main; this populates them so the connector pages render the full tool list in production docs.

Preview:
- https://deploy-preview-{PR_NUMBER}--scalekit-starlight.netlify.app/agentkit/connectors/monday/
- https://deploy-preview-{PR_NUMBER}--scalekit-starlight.netlify.app/agentkit/connectors/clickup/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * ClickUp connector documentation now displays a comprehensive catalog of available tools and operations
  * Monday.com connector documentation now displays a comprehensive catalog of available tools and operations
  * Added "What you can do" sections describing supported connector capabilities for both ClickUp and Monday.com
  * Tool sections provide guidance on using exact tool names with `execute_tool`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalekit-inc/developer-docs/pull/690)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->