### PR TITLE
docs: update Apify cookbook for OpenRouter proxy

### DIFF
--- a/src/content/docs/cookbooks/apify-actor-per-user-oauth.mdx
+++ b/src/content/docs/cookbooks/apify-actor-per-user-oauth.mdx
@@ -294,7 +294,7 @@ import { serveAuthPage } from './authServer.js';
 await Actor.init();
 
 const input = await Actor.getInput();
-const { task, llmApiKey } = input;
+const { task } = input;
 
 const { userId } = Actor.getEnv();
 const notionIdentifier = userId;
@@ -355,18 +355,13 @@ The Actor's input form should show only what the end user actually needs to prov
       "type": "string",
       "description": "Natural language task for the agent. Examples: 'List the 5 most recently edited pages in my Notion workspace' or 'Search YouTube for React tutorial channels and append the top 10 to my Research page'.",
       "editor": "textarea"
-    },
-    "llmApiKey": {
-      "title": "LLM API Key",
-      "type": "string",
-      "description": "API key for the LLM endpoint.",
-      "isSecret": true,
-      "editor": "textfield"
     }
   },
-  "required": ["task", "llmApiKey"]
+  "required": ["task"]
 }
 ```
+
+By default the Actor uses [Apify's OpenRouter proxy](https://apify.com/apify/openrouter) for LLM inference, authenticated via `APIFY_TOKEN` (which Apify sets automatically). No external API key is needed — LLM costs are billed to the user's Apify credits. If your Actor needs to support a custom LLM endpoint, add an optional `llmApiKey` field and detect the endpoint at runtime.
 
 Everything else — `notionIdentifier`, `youtubeIdentifier`, timeouts, model name, base URL — is either derived at runtime (`userId`) or hardcoded and deployed as an Actor environment variable.
 
@@ -388,8 +383,7 @@ Provide input in `storage/key_value_stores/default/INPUT.json`:
 
 ```json
 {
-  "task": "List the 5 most recently edited pages in my Notion workspace",
-  "llmApiKey": "sk-..."
+  "task": "List the 5 most recently edited pages in my Notion workspace"
 }
 ```
 


### PR DESCRIPTION
## What

Updates the Apify Actor per-user OAuth cookbook to reflect the switch from requiring an external LLM API key to using Apify's built-in OpenRouter proxy.

Companion to [scalekit-developers/agentkit-apify-actor-example#3](https://github.com/scalekit-developers/agentkit-apify-actor-example/pull/3).

## Changes

- Removed `llmApiKey` from the `main.js` code snippet (Section 7)
- Updated `.actor/input_schema.json` example to remove `llmApiKey` as a required field (Section 8)
- Added note explaining Apify OpenRouter proxy and `APIFY_TOKEN` auth
- Removed `llmApiKey` from the test input JSON (Section 9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified the per-user OAuth recipe by removing the `llmApiKey` requirement from the Actor configuration. The setup now requires only the `task` input parameter. Entry-point code examples, input schemas, and test configurations have been updated to reflect this streamlined setup process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalekit-inc/developer-docs/pull/694?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->