### PR TITLE
docs(connections): clarify DCR pre-filled credentials for OAuth connectors

### DIFF
--- a/src/content/docs/agentkit/connections.mdx
+++ b/src/content/docs/agentkit/connections.mdx
@@ -34,6 +34,10 @@ The sections below walk through both patterns.
 
 OAuth connections require you to create an OAuth app with the provider and link it to Scalekit. Scalekit provides the Redirect URI; you bring the Client ID and Client Secret.
 
+<Aside type="tip" title="Pre-filled credentials mean DCR succeeded">
+  For some connectors, Scalekit automatically completes **Dynamic Client Registration (DCR)** with the provider. If the **Client ID**, **Client Secret**, **OAuth Authorization URL**, and **Token Endpoint** fields are already filled in when you open the connection form, DCR was successful — skip steps 2–4 and go directly to configuring scopes. If the fields are empty, the provider does not support DCR and you need to register your own OAuth app manually using the steps below.
+</Aside>
+
 <Steps>
 1. ### Open the connection form
 

--- a/src/content/docs/agentkit/connections.mdx
+++ b/src/content/docs/agentkit/connections.mdx
@@ -34,9 +34,14 @@ The sections below walk through both patterns.
 
 OAuth connections require you to create an OAuth app with the provider and link it to Scalekit. Scalekit provides the Redirect URI; you bring the Client ID and Client Secret.
 
-<Aside type="tip" title="Pre-filled credentials mean DCR succeeded">
-  For some connectors, Scalekit automatically completes **Dynamic Client Registration (DCR)** with the provider. If the **Client ID**, **Client Secret**, **OAuth Authorization URL**, and **Token Endpoint** fields are already filled in when you open the connection form, DCR was successful — skip steps 2–4 and go directly to configuring scopes. If the fields are empty, the provider does not support DCR and you need to register your own OAuth app manually using the steps below.
-</Aside>
+<details>
+<summary>Already see pre-filled credentials? DCR handled registration for you.</summary>
+
+For some connectors, Scalekit automatically completes **Dynamic Client Registration (DCR)** with the provider. If the **Client ID**, **Client Secret**, **OAuth Authorization URL**, and **Token Endpoint** fields are already filled in when you open the connection form, DCR was successful — skip steps 2–4 below and go directly to [configuring scopes](#configure-scopes).
+
+If the fields are empty, the provider does not support DCR. Follow the manual registration steps below.
+
+</details>
 
 <Steps>
 1. ### Open the connection form


### PR DESCRIPTION
## Summary

Adds a tip callout to the "Set up an OAuth connection" section of the connections guide explaining what pre-filled Client ID, Client Secret, and OAuth endpoint fields mean.

**Root cause:** Developers configuring an OAuth connection for an MCP connector were unsure whether pre-filled credentials meant they still needed to register their own OAuth app. The answer — that Scalekit completed Dynamic Client Registration (DCR) automatically — was not documented anywhere in the UI guide.

**Change:** One `<Aside type="tip">` added above the `<Steps>` block in `src/content/docs/agentkit/connections.mdx`:
- Pre-filled fields → DCR succeeded, skip steps 2–4 and go straight to scopes
- Empty fields → provider doesn't support DCR, follow the manual registration steps

## Preview

https://deploy-preview-699--scalekit-starlight.netlify.app/agentkit/connections/

## Related

See also GitHub issue #698 for the related Python SDK version tracking work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an inline callout to the OAuth setup guide explaining Dynamic Client Registration (DCR) can pre-fill OAuth fields (Client ID, Client Secret, Authorization URL, Token Endpoint). If fields are pre-filled, skip steps 2–4 and proceed to configuring scopes; otherwise follow manual OAuth app registration steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalekit-inc/developer-docs/pull/699?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->