### PR TITLE
Sync OpenAPI spec: add details and session-policy endpoints, apply API visibility review

### DIFF
--- a/public/api/scalekit.scalar.yaml
+++ b/public/api/scalekit.scalar.yaml
@@ -384,7 +384,7 @@ paths:
         credential information - use appropriate access controls.
       tags:
         - Connected Accounts
-      summary: Get connected account details
+      summary: Get connected account auth credentials
       operationId: ConnectedAccountService_GetConnectedAccountAuth
       parameters:
         - schema:
@@ -448,7 +448,7 @@ paths:
         organization (or user), connector, and external identifier.
       tags:
         - Connected Accounts
-      summary: Get connected account details
+      summary: Get connected account metadata
       operationId: ConnectedAccountService_GetConnectedAccountDetails
       parameters:
         - schema:

--- a/public/api/scalekit.scalar.yaml
+++ b/public/api/scalekit.scalar.yaml
@@ -175,18 +175,18 @@ info:
     ```
   title: Scalekit APIs
   contact:
-    name: 'Scalekit Inc'
-    url: 'https://scalekit.com'
-    email: 'support@scalekit.com'
+    name: "Scalekit Inc"
+    url: "https://scalekit.com"
+    email: "support@scalekit.com"
   license:
-    name: 'Apache 2.0'
-    url: 'http://www.apache.org/licenses/LICENSE-2.0'
-  version: '1.0.0'
+    name: "Apache 2.0"
+    url: "http://www.apache.org/licenses/LICENSE-2.0"
+  version: "1.0.0"
   x-scalar-sdk-installation:
     - lang: shell
-      description: 'Set up OAuth 2.0 Client Credentials authentication to access Scalekit
+      description: "Set up OAuth 2.0 Client Credentials authentication to access Scalekit
         APIs. Includes credential configuration, token exchange, and authenticated
-        API request examples.'
+        API request examples."
       source: |2
 
         # 1. Obtain API Credentials
@@ -211,9 +211,9 @@ info:
 paths:
   /api/v1/connected_accounts:
     get:
-      description: Retrieves a paginated list of connected accounts for
-        third-party integrations. Filter by organization, user, connector type,
-        provider, or identifier. Returns OAuth tokens, API keys, and connection
+      description: Retrieves a paginated list of connected accounts for 
+        third-party integrations. Filter by organization, user, connector type, 
+        provider, or identifier. Returns OAuth tokens, API keys, and connection 
         status for each account. Use pagination tokens to navigate through large
         result sets.
       tags:
@@ -223,79 +223,79 @@ paths:
       parameters:
         - schema:
             type: string
-          description: Filter by organization ID. Returns only connected
+          description: Filter by organization ID. Returns only connected 
             accounts associated with this organization.
           name: organization_id
           in: query
         - schema:
             type: string
-          description: Filter by user ID. Returns only connected accounts
+          description: Filter by user ID. Returns only connected accounts 
             associated with this user.
           name: user_id
           in: query
         - schema:
             type: string
-          description: Filter by connector type. Connector identifier such as
-            'notion', 'slack', 'google', etc. Alphanumeric with spaces, hyphens,
-            underscores, and colons allowed.
+          description: Filter by connector type (e.g., 'notion', 'slack', 
+            'google'). Alphanumeric characters, spaces, hyphens, underscores, 
+            and colons are allowed.
           name: connector
           in: query
         - schema:
             type: string
-          description: Filter by account identifier. The unique identifier for
-            the connected account within the third-party service (e.g., email
+          description: Filter by account identifier. The unique identifier for 
+            the connected account within the third-party service (e.g., email 
             address, workspace ID).
           name: identifier
           in: query
         - schema:
             type: string
-          description: Filter by OAuth provider. The authentication provider
+          description: Filter by OAuth provider. The authentication provider 
             name such as 'google', 'microsoft', 'github', etc.
           name: provider
           in: query
         - schema:
             type: integer
             format: int64
-          description: Maximum number of connected accounts to return per page.
+          description: Maximum number of connected accounts to return per page. 
             Must be between 0 and 100. Default is typically 10.
           name: page_size
           in: query
         - schema:
             type: string
-          description: Pagination token from a previous response. Use the
-            next_page_token value from ListConnectedAccountsResponse to fetch
+          description: Pagination token from a previous response. Use the 
+            next_page_token value from ListConnectedAccountsResponse to fetch 
             the next page.
           name: page_token
           in: query
         - schema:
             type: string
-          description: Text search query to filter connected accounts by name,
+          description: Text search query to filter connected accounts by name, 
             identifier, or other searchable fields. Case-insensitive.
           name: query
           in: query
       responses:
-        '200':
-          description: Successfully retrieved the list of connected accounts
+        "200":
+          description: Successfully retrieved the list of connected accounts 
             with their authentication details and status
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/connected_accountsListConnectedAccountsResponse'
-        '400':
-          description: Invalid request - occurs when query parameters are
+                $ref: "#/components/schemas/connected_accountsListConnectedAccountsResponse"
+        "400":
+          description: Invalid request - occurs when query parameters are 
             malformed or validation fails
           content:
             application/json:
               schema: {}
-        '401':
+        "401":
           description: Authentication required - missing or invalid access token
           content:
             application/json:
               schema: {}
     put:
-      description: Updates authentication credentials and configuration for an
-        existing connected account. Modify OAuth tokens, refresh tokens, access
-        scopes, or API configuration settings. Specify the account by ID, or by
+      description: Updates authentication credentials and configuration for an 
+        existing connected account. Modify OAuth tokens, refresh tokens, access 
+        scopes, or API configuration settings. Specify the account by ID, or by 
         combination of organization/user, connector, and identifier. Returns the
         updated account with new token expiry and status information.
       tags:
@@ -303,26 +303,26 @@ paths:
       summary: Update connected account credentials
       operationId: ConnectedAccountService_UpdateConnectedAccount
       responses:
-        '200':
-          description: Connected account updated successfully with new
+        "200":
+          description: Connected account updated successfully with new 
             credentials or configuration
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/connected_accountsUpdateConnectedAccountResponse'
-        '400':
-          description: Invalid request - missing required fields, invalid
+                $ref: "#/components/schemas/connected_accountsUpdateConnectedAccountResponse"
+        "400":
+          description: Invalid request - missing required fields, invalid 
             authorization details, or validation failed
           content:
             application/json:
               schema: {}
-        '401':
+        "401":
           description: Authentication required - missing or invalid access token
           content:
             application/json:
               schema: {}
-        '404':
-          description: Connected account not found - the specified account does
+        "404":
+          description: Connected account not found - the specified account does 
             not exist
           content:
             application/json:
@@ -331,40 +331,40 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/connected_accountsUpdateConnectedAccountRequest'
+              $ref: "#/components/schemas/connected_accountsUpdateConnectedAccountRequest"
         required: true
     post:
-      description: Creates a new connected account with OAuth tokens or API
-        credentials for third-party service integration. Supply authorization
-        details including access tokens, refresh tokens, scopes, and optional
+      description: Creates a new connected account with OAuth tokens or API 
+        credentials for third-party service integration. Supply authorization 
+        details including access tokens, refresh tokens, scopes, and optional 
         API configuration. The account can be scoped to an organization or user.
-        Returns the created account with its unique identifier and
+        Returns the created account with its unique identifier and 
         authentication status.
       tags:
         - Connected Accounts
       summary: Create a connected account
       operationId: ConnectedAccountService_CreateConnectedAccount
       responses:
-        '201':
-          description: Connected account created successfully with
+        "201":
+          description: Connected account created successfully with 
             authentication credentials stored securely
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/connected_accountsCreateConnectedAccountResponse'
-        '400':
-          description: Invalid request - missing required fields, invalid
+                $ref: "#/components/schemas/connected_accountsCreateConnectedAccountResponse"
+        "400":
+          description: Invalid request - missing required fields, invalid 
             authorization details, or validation failed
           content:
             application/json:
               schema: {}
-        '401':
+        "401":
           description: Authentication required - missing or invalid access token
           content:
             application/json:
               schema: {}
-        '409':
-          description: Conflict - connected account with the same identifier
+        "409":
+          description: Conflict - connected account with the same identifier 
             already exists
           content:
             application/json:
@@ -373,14 +373,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/connected_accountsCreateConnectedAccountRequest'
+              $ref: "#/components/schemas/connected_accountsCreateConnectedAccountRequest"
         required: true
   /api/v1/connected_accounts/auth:
     get:
-      description: Retrieves complete authentication details for a connected
-        account including OAuth tokens, refresh tokens, scopes, and API
-        configuration. Query by account ID or by combination of
-        organization/user, connector, and identifier. Returns sensitive
+      description: Retrieves complete authentication details for a connected 
+        account including OAuth tokens, refresh tokens, scopes, and API 
+        configuration. Query by account ID or by combination of 
+        organization/user, connector, and identifier. Returns sensitive 
         credential information - use appropriate access controls.
       tags:
         - Connected Accounts
@@ -399,13 +399,15 @@ paths:
           in: query
         - schema:
             type: string
-          description: Connector identifier
+          description: Connector identifier (e.g., 'notion', 'slack', 'google').
+            Alphanumeric characters, spaces, hyphens, underscores, and colons 
+            are allowed.
           name: connector
           in: query
         - schema:
             type: string
-          description: The unique identifier for the connected account within
-            the third-party service (e.g., email address, user ID, workspace
+          description: The unique identifier for the connected account within 
+            the third-party service (e.g., email address, user ID, workspace 
             identifier).
           name: identifier
           in: query
@@ -415,55 +417,118 @@ paths:
           name: id
           in: query
       responses:
-        '200':
-          description: Successfully retrieved connected account with full
+        "200":
+          description: Successfully retrieved connected account with full 
             authentication details
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/connected_accountsGetConnectedAccountByIdentifierResponse'
-        '400':
+                $ref: "#/components/schemas/connected_accountsGetConnectedAccountByIdentifierResponse"
+        "400":
           description: Invalid request - missing required query parameters
           content:
             application/json:
               schema: {}
-        '401':
+        "401":
           description: Authentication required - missing or invalid access token
           content:
             application/json:
               schema: {}
-        '404':
-          description: Connected account not found - no account matches the
+        "404":
+          description: Connected account not found - no account matches the 
+            specified criteria
+          content:
+            application/json:
+              schema: {}
+  /api/v1/connected_accounts/details:
+    get:
+      description: Returns metadata for a connected account including status, 
+        connector type, provider, and configuration without exposing stored 
+        authorization credentials. Look up by account ID, or by a combination of
+        organization (or user), connector, and external identifier.
+      tags:
+        - Connected Accounts
+      summary: Get connected account details
+      operationId: ConnectedAccountService_GetConnectedAccountDetails
+      parameters:
+        - schema:
+            type: string
+          description: Organization ID for the connector
+          name: organization_id
+          in: query
+        - schema:
+            type: string
+          description: User ID for the connector
+          name: user_id
+          in: query
+        - schema:
+            type: string
+          description: Connector identifier (e.g., 'notion', 'slack', 'google').
+            Alphanumeric characters, spaces, hyphens, underscores, and colons 
+            are allowed.
+          name: connector
+          in: query
+        - schema:
+            type: string
+          description: The unique identifier for the connected account within 
+            the third-party service (e.g., email address, user ID, workspace 
+            identifier).
+          name: identifier
+          in: query
+        - schema:
+            type: string
+          description: Unique identifier for the connected account
+          name: id
+          in: query
+      responses:
+        "200":
+          description: Successfully retrieved connected account details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/connected_accountsGetConnectedAccountByIdentifierResponse"
+        "400":
+          description: Invalid request - missing required query parameters
+          content:
+            application/json:
+              schema: {}
+        "401":
+          description: Authentication required - missing or invalid access token
+          content:
+            application/json:
+              schema: {}
+        "404":
+          description: Connected account not found - no account matches the 
             specified criteria
           content:
             application/json:
               schema: {}
   /api/v1/connected_accounts/magic_link:
     post:
-      description: Creates a time-limited magic link for connecting or
-        re-authorizing a third-party account. The link directs users to the
-        OAuth authorization flow for the specified connector. Returns the
-        generated link URL and expiration timestamp. Links typically expire
+      description: Creates a time-limited magic link for connecting or 
+        re-authorizing a third-party account. The link directs users to the 
+        OAuth authorization flow for the specified connector. Returns the 
+        generated link URL and expiration timestamp. Links typically expire 
         after a short duration for security.
       tags:
         - Connected Accounts
       summary: Generate authentication magic link
       operationId: ConnectedAccountService_GetMagicLinkForConnectedAccount
       responses:
-        '200':
-          description: Magic link generated successfully with authorization URL
+        "200":
+          description: Magic link generated successfully with authorization URL 
             and expiry time
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/connected_accountsGetMagicLinkForConnectedAccountResponse'
-        '400':
-          description: Invalid request - missing required parameters or invalid
+                $ref: "#/components/schemas/connected_accountsGetMagicLinkForConnectedAccountResponse"
+        "400":
+          description: Invalid request - missing required parameters or invalid 
             connector
           content:
             application/json:
               schema: {}
-        '401':
+        "401":
           description: Authentication required - missing or invalid access token
           content:
             application/json:
@@ -472,42 +537,42 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/connected_accountsGetMagicLinkForConnectedAccountRequest'
+              $ref: "#/components/schemas/connected_accountsGetMagicLinkForConnectedAccountRequest"
         required: true
   /api/v1/connected_accounts/user/verify:
     post:
-      description: Confirms the user assertion and activates the connected
-        account after the user completes third-party OAuth. Called by the B2B
-        app server with auth_request_id and identifier. Validates that the
-        asserted identifier matches the one stored on the auth request and
+      description: Confirms the user assertion and activates the connected 
+        account after the user completes third-party OAuth. Called by the B2B 
+        app server with auth_request_id and identifier. Validates that the 
+        asserted identifier matches the one stored on the auth request and 
         promotes pending tokens to live.
       tags:
         - Connected Accounts
       summary: Verify connected account user
       operationId: ConnectedAccountService_VerifyConnectedAccountUser
       responses:
-        '200':
+        "200":
           description: Verification successful; connected account is now ACTIVE
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/connected_accountsVerifyConnectedAccountUserResponse'
-        '400':
+                $ref: "#/components/schemas/connected_accountsVerifyConnectedAccountUserResponse"
+        "400":
           description: Invalid request - missing or malformed fields
           content:
             application/json:
               schema: {}
-        '401':
+        "401":
           description: Unauthorized - invalid or missing access token
           content:
             application/json:
               schema: {}
-        '403':
+        "403":
           description: Forbidden - identifier mismatch
           content:
             application/json:
               schema: {}
-        '404':
+        "404":
           description: Not found - no pending flow for the given auth_request_id
             or already consumed
           content:
@@ -517,11 +582,11 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/connected_accountsVerifyConnectedAccountUserRequest'
+              $ref: "#/components/schemas/connected_accountsVerifyConnectedAccountUserRequest"
         required: true
   /api/v1/connected_accounts:delete:
     post:
-      description: Permanently removes a connected account and revokes all
+      description: Permanently removes a connected account and revokes all 
         associated authentication credentials. Identify the account by ID, or by
         combination of organization/user, connector, and identifier. This action
         cannot be undone. All OAuth tokens and API keys for this account will be
@@ -531,25 +596,25 @@ paths:
       summary: Delete a connected account
       operationId: ConnectedAccountService_DeleteConnectedAccount
       responses:
-        '200':
-          description: Connected account deleted successfully and all
+        "200":
+          description: Connected account deleted successfully and all 
             credentials revoked
           content:
             application/json:
               schema: {}
-        '400':
-          description: Invalid request - malformed parameters or validation
+        "400":
+          description: Invalid request - malformed parameters or validation 
             failed
           content:
             application/json:
               schema: {}
-        '401':
+        "401":
           description: Authentication required - missing or invalid access token
           content:
             application/json:
               schema: {}
-        '404':
-          description: Connected account not found - the specified account does
+        "404":
+          description: Connected account not found - the specified account does 
             not exist
           content:
             application/json:
@@ -558,14 +623,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/connected_accountsDeleteConnectedAccountRequest'
+              $ref: "#/components/schemas/connected_accountsDeleteConnectedAccountRequest"
         required: true
   /api/v1/connected_accounts:search:
     get:
-      description: Search for connected accounts in your environment using a
-        text query that matches against identifiers, providers, or connectors.
-        The search performs case-insensitive matching across account details.
-        Returns paginated results with account status and authentication type
+      description: Search for connected accounts in your environment using a 
+        text query that matches against identifiers, providers, or connectors. 
+        The search performs case-insensitive matching across account details. 
+        Returns paginated results with account status and authentication type 
         information.
       tags:
         - Connected Accounts
@@ -574,21 +639,21 @@ paths:
       parameters:
         - schema:
             type: string
-          description: Search term to match against connected account
-            identifiers, providers, or connectors. Must be at least 3
+          description: Search term to match against connected account 
+            identifiers, providers, or connectors. Must be at least 3 
             characters. Case insensitive.
           name: query
           in: query
         - schema:
             type: integer
             format: int64
-          description: Maximum number of connected accounts to return per page.
+          description: Maximum number of connected accounts to return per page. 
             Value must be between 1 and 30.
           name: page_size
           in: query
         - schema:
             type: string
-          description: Token from a previous response for pagination. Provide
+          description: Token from a previous response for pagination. Provide 
             this to retrieve the next page of results.
           name: page_token
           in: query
@@ -598,20 +663,20 @@ paths:
           name: connection_id
           in: query
       responses:
-        '200':
-          description: Successfully retrieved matching connected accounts with
+        "200":
+          description: Successfully retrieved matching connected accounts with 
             pagination support
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/connected_accountsSearchConnectedAccountsResponse'
-        '400':
+                $ref: "#/components/schemas/connected_accountsSearchConnectedAccountsResponse"
+        "400":
           description: Invalid request - query parameter is too short (minimum 3
             characters) or validation failed
           content:
             application/json:
               schema: {}
-        '401':
+        "401":
           description: Authentication required - missing or invalid access token
           content:
             application/json:
@@ -631,24 +696,24 @@ paths:
           in: query
         - schema:
             type: string
-          description: Filter connections by email domain associated with the
+          description: Filter connections by email domain associated with the 
             organization
           name: domain
           in: query
         - schema:
             type: string
-          description: Filter connections by status. Use 'all' to include all
+          description: Filter connections by status. Use 'all' to include all 
             connections regardless of status. Default behavior shows only active
             (completed and enabled) connections
           name: include
           in: query
       responses:
-        '200':
+        "200":
           description: Successfully retrieved connections
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/connectionsListConnectionsResponse'
+                $ref: "#/components/schemas/connectionsListConnectionsResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -701,44 +766,44 @@ paths:
               ).listConnectionsByDomain("your-domain.com");
   /api/v1/execute_tool:
     post:
-      description: Executes a tool action using authentication credentials from
-        a connected account. Specify the tool by name and provide required
+      description: Executes a tool action using authentication credentials from 
+        a connected account. Specify the tool by name and provide required 
         parameters as JSON. The connected account can be identified by ID, or by
         combination of organization/user, connector, and identifier. Returns the
-        execution result data and a unique execution ID for tracking. Use this
-        endpoint to perform actions like sending emails, creating calendar
+        execution result data and a unique execution ID for tracking. Use this 
+        endpoint to perform actions like sending emails, creating calendar 
         events, or managing resources in external services.
       tags:
         - Connected Accounts
       summary: Execute a tool using a connected account
       operationId: ToolService_ExecuteTool
       responses:
-        '200':
+        "200":
           description: Tool executed successfully with result data and execution
             ID
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/toolsExecuteToolResponse'
-        '400':
-          description: Invalid request - occurs when tool name is missing,
+                $ref: "#/components/schemas/toolsExecuteToolResponse"
+        "400":
+          description: Invalid request - occurs when tool name is missing, 
             parameters are malformed, or tool definition validation fails
           content:
             application/json:
               schema: {}
-        '401':
+        "401":
           description: Authentication required - missing or invalid access token
           content:
             application/json:
               schema: {}
-        '404':
-          description: Tool or connected account not found - occurs when the
+        "404":
+          description: Tool or connected account not found - occurs when the 
             specified tool name or connected account does not exist
           content:
             application/json:
               schema: {}
-        '500':
-          description: Tool execution failed - occurs when the external service
+        "500":
+          description: Tool execution failed - occurs when the external service 
             returns an error or the tool encounters a runtime exception
           content:
             application/json:
@@ -747,17 +812,17 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/toolsExecuteToolRequest'
+              $ref: "#/components/schemas/toolsExecuteToolRequest"
         required: true
   /api/v1/invites/organizations/{organization_id}/users/{id}/resend:
     patch:
-      description: Resends an invitation email to a user who has a pending or
-        expired invitation in the specified organization. If the invitation has
+      description: Resends an invitation email to a user who has a pending or 
+        expired invitation in the specified organization. If the invitation has 
         expired, a new invitation will be automatically created and sent. If the
-        invitation is still valid, a reminder email will be sent instead. Use
-        this endpoint when a user hasn't responded to their initial invitation
+        invitation is still valid, a reminder email will be sent instead. Use 
+        this endpoint when a user hasn't responded to their initial invitation 
         and you need to send them a reminder or when the original invitation has
-        expired. The invitation email includes a secure magic link that allows
+        expired. The invitation email includes a secure magic link that allows 
         the user to complete their account setup and join the organization. Each
         resend operation increments the resent counter.
       tags:
@@ -767,69 +832,69 @@ paths:
       parameters:
         - schema:
             type: string
-          description: Unique identifier of the organization containing the
-            pending invitation. Must start with 'org_' and be 1-32 characters
+          description: Unique identifier of the organization containing the 
+            pending invitation. Must start with 'org_' and be 1-32 characters 
             long.
           name: organization_id
           in: path
           required: true
         - schema:
             type: string
-          description: System-generated user ID of the user who has a pending
+          description: System-generated user ID of the user who has a pending 
             invitation. Must start with 'usr_' and be 19-25 characters long.
           name: id
           in: path
           required: true
       responses:
-        '200':
-          description: Successfully resent the invitation email. Returns the
-            updated invitation object with organization ID, user ID, membership
-            status, timestamps, and resent count. If expired, a new invitation
+        "200":
+          description: Successfully resent the invitation email. Returns the 
+            updated invitation object with organization ID, user ID, membership 
+            status, timestamps, and resent count. If expired, a new invitation 
             is created; otherwise, the existing one is resent.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/usersResendInviteResponse'
-        '400':
-          description: Invalid request — common causes include user ID or
-            organization ID is invalid, full-stack authentication is disabled,
-            user profile is missing, invite already accepted, or missing expiry
+                $ref: "#/components/schemas/usersResendInviteResponse"
+        "400":
+          description: Invalid request — common causes include user ID or 
+            organization ID is invalid, full-stack authentication is disabled, 
+            user profile is missing, invite already accepted, or missing expiry 
             time in user management settings.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/errdetailsErrorInfo'
-        '404':
-          description: Resource not found — the specified user, organization,
-            membership, or invitation could not be found in the specified
-            environment. Verify that all IDs are correct and that the resources
+                $ref: "#/components/schemas/errdetailsErrorInfo"
+        "404":
+          description: Resource not found — the specified user, organization, 
+            membership, or invitation could not be found in the specified 
+            environment. Verify that all IDs are correct and that the resources 
             exist before attempting to resend an invitation.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/errdetailsErrorInfo'
-        '500':
-          description: Internal server error — an unexpected error occurred
-            while processing the invitation resend request. This may be due to
-            database connectivity issues, problems generating the secure magic
-            link, email delivery service failures, or transaction errors during
+                $ref: "#/components/schemas/errdetailsErrorInfo"
+        "500":
+          description: Internal server error — an unexpected error occurred 
+            while processing the invitation resend request. This may be due to 
+            database connectivity issues, problems generating the secure magic 
+            link, email delivery service failures, or transaction errors during 
             invitation processing. Contact support if the problem persists.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/errdetailsErrorInfo'
+                $ref: "#/components/schemas/errdetailsErrorInfo"
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UserServiceResendInviteBody'
+              $ref: "#/components/schemas/UserServiceResendInviteBody"
         required: true
   /api/v1/memberships/organizations/{organization_id}/users/{id}:
     post:
-      description: Adds an existing user to an organization and assigns them
+      description: Adds an existing user to an organization and assigns them 
         specific roles and permissions. Use this endpoint when you want to grant
-        an existing user access to a particular organization. You can specify
-        roles, metadata, and other membership details during the invitation
+        an existing user access to a particular organization. You can specify 
+        roles, metadata, and other membership details during the invitation 
         process.
       tags:
         - Users
@@ -838,38 +903,38 @@ paths:
       parameters:
         - schema:
             type: string
-          description: Unique identifier of the target organization. Must start
+          description: Unique identifier of the target organization. Must start 
             with 'org_' and be 1-32 characters long.
           name: organization_id
           in: path
           required: true
         - schema:
             type: string
-          description: System-generated user ID. Must start with 'usr_' (19-25
+          description: System-generated user ID. Must start with 'usr_' (19-25 
             characters)
           name: id
           in: path
           required: true
         - schema:
             type: string
-          description: External system identifier from connected directories.
+          description: External system identifier from connected directories. 
             Must be unique across the system
           name: external_id
           in: query
         - schema:
             type: boolean
-          description: If true, sends an activation email to the user. Defaults
+          description: If true, sends an activation email to the user. Defaults 
             to true.
           name: send_invitation_email
           in: query
       responses:
-        '201':
-          description: User successfully added to the organization. Returns
+        "201":
+          description: User successfully added to the organization. Returns 
             details of the updated membership details
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/usersCreateMembershipResponse'
+                $ref: "#/components/schemas/usersCreateMembershipResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -960,12 +1025,14 @@ paths:
             schema:
               description: Membership details to create. Required fields must be
                 provided.
-              $ref: '#/components/schemas/v1usersCreateMembership'
+              required:
+                - membership
+              $ref: "#/components/schemas/v1usersCreateMembership"
         required: true
     delete:
-      description: Removes a user from an organization by user ID or external
+      description: Removes a user from an organization by user ID or external 
         ID. If the user has no memberships left and cascade is true, the user is
-        also deleted. This action is irreversible and may also remove related
+        also deleted. This action is irreversible and may also remove related 
         group memberships.
       tags:
         - Users
@@ -974,27 +1041,27 @@ paths:
       parameters:
         - schema:
             type: string
-          description: Unique organization identifier. Must start with 'org_'
+          description: Unique organization identifier. Must start with 'org_' 
             and be 1-32 characters long
           name: organization_id
           in: path
           required: true
         - schema:
             type: string
-          description: System-generated user ID. Must start with 'usr_' (19-25
+          description: System-generated user ID. Must start with 'usr_' (19-25 
             characters)
           name: id
           in: path
           required: true
         - schema:
             type: string
-          description: External system identifier from connected directories.
+          description: External system identifier from connected directories. 
             Must match existing records
           name: external_id
           in: query
       responses:
-        '200':
-          description: User successfully marked for deletion. No content
+        "200":
+          description: User successfully marked for deletion. No content 
             returned
           content:
             application/json:
@@ -1016,14 +1083,14 @@ paths:
       parameters:
         - schema:
             type: string
-          description: Unique identifier of the organization containing the
+          description: Unique identifier of the organization containing the 
             membership. Must start with 'org_' and be 1-32 characters long.
           name: organization_id
           in: path
           required: true
         - schema:
             type: string
-          description: System-generated user ID. Must start with 'usr_' and be
+          description: System-generated user ID. Must start with 'usr_' and be 
             19-25 characters long.
           name: id
           in: path
@@ -1034,27 +1101,27 @@ paths:
           name: external_id
           in: query
       responses:
-        '200':
+        "200":
           description: Membership updated successfully. Returns the updated user
             object.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/usersUpdateMembershipResponse'
+                $ref: "#/components/schemas/usersUpdateMembershipResponse"
       requestBody:
         content:
           application/json:
             schema:
-              description: Membership fields to update. Only specified fields
+              description: Membership fields to update. Only specified fields 
                 will be modified.
-              $ref: '#/components/schemas/v1usersUpdateMembership'
+              $ref: "#/components/schemas/v1usersUpdateMembership"
               examples:
                 - role: admin
         required: true
   /api/v1/organizations:
     get:
-      description: Retrieve a paginated list of organizations within your
-        environment. The response includes a `page_token` that can be used to
+      description: Retrieve a paginated list of organizations within your 
+        environment. The response includes a `page_token` that can be used to 
         access subsequent pages of results.
       tags:
         - Organizations
@@ -1064,30 +1131,30 @@ paths:
         - schema:
             type: integer
             format: int64
-          description: Maximum number of organizations to return per page. Must
+          description: Maximum number of organizations to return per page. Must 
             be between 10 and 100
           name: page_size
           in: query
         - schema:
             type: string
-          description: Pagination token from the previous response. Use to
+          description: Pagination token from the previous response. Use to 
             retrieve the next page of organizations
           name: page_token
           in: query
         - schema:
             type: string
-          description: Your application's unique identifier for this
+          description: Your application's unique identifier for this 
             organization, used to link Scalekit with your system
           name: external_id
           in: query
       responses:
-        '200':
+        "200":
           description: Successfully retrieved the list of organizations
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/organizationsListOrganizationsResponse'
-        '400':
+                $ref: "#/components/schemas/organizationsListOrganizationsResponse"
+        "400":
           description: Invalid page token
           content:
             application/json:
@@ -1119,26 +1186,26 @@ paths:
             )
         - label: Java SDK
           lang: java
-          source: ListOrganizationsResponse organizations =
+          source: ListOrganizationsResponse organizations = 
             scalekitClient.organizations().listOrganizations(10, "");
     post:
-      description: Creates a new organization in your environment. Use this
-        endpoint to add a new tenant that can be configured with various
+      description: Creates a new organization in your environment. Use this 
+        endpoint to add a new tenant that can be configured with various 
         settings and metadata
       tags:
         - Organizations
       summary: Create an organization
       operationId: OrganizationService_CreateOrganization
       responses:
-        '201':
-          description: Returns the newly created organization with its unique
+        "201":
+          description: Returns the newly created organization with its unique 
             identifier and settings
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/organizationsCreateOrganizationResponse'
+                $ref: "#/components/schemas/organizationsCreateOrganizationResponse"
       x-badges:
-        - name: ''
+        - name: ""
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -1183,12 +1250,12 @@ paths:
           application/json:
             schema:
               description: Required parameters for creating a new organization
-              $ref: '#/components/schemas/v1organizationsCreateOrganization'
+              $ref: "#/components/schemas/v1organizationsCreateOrganization"
         description: Organization details
         required: true
   /api/v1/organizations/{id}:
     get:
-      description: Retrieves organization details by Scalekit ID, including
+      description: Retrieves organization details by Scalekit ID, including 
         name, region, metadata, and settings
       tags:
         - Organizations
@@ -1197,19 +1264,21 @@ paths:
       parameters:
         - schema:
             type: string
-          description: Unique scalekit-generated identifier that uniquely
-            references an organization
+          description: Unique Scalekit-generated identifier for an organization.
+            Use this with the GetOrganization endpoint. Do not pass this 
+            parameter when calling GetOrganizationByExternalId — use external_id
+            instead.
           name: id
           in: path
           required: true
       responses:
-        '200':
+        "200":
           description: Returns the complete organization object with ID, display
             name, settings, and metadata
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/organizationsGetOrganizationResponse'
+                $ref: "#/components/schemas/organizationsGetOrganizationResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -1261,7 +1330,7 @@ paths:
             Organization organization =
             scalekitClient.organizations().getById(organizationId);
     delete:
-      description: Remove an existing organization from the environment using
+      description: Remove an existing organization from the environment using 
         its unique identifier
       tags:
         - Organizations
@@ -1270,14 +1339,14 @@ paths:
       parameters:
         - schema:
             type: string
-          description: Unique scalekit-generated identifier that uniquely
+          description: Unique scalekit-generated identifier that uniquely 
             references an organization
           name: id
           in: path
           required: true
       responses:
-        '200':
-          description: Organization successfully deleted and no longer
+        "200":
+          description: Organization successfully deleted and no longer 
             accessible
           content:
             application/json:
@@ -1285,11 +1354,12 @@ paths:
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
-          source: await
+          source: await 
             scalekit.organization.deleteOrganization(organizationId);
         - label: Python SDK
           lang: python
-          source: scalekit_client.organization.delete_organization(organization_id)
+          source: 
+            scalekit_client.organization.delete_organization(organization_id)
         - label: Go SDK
           lang: go
           source: |-
@@ -1308,8 +1378,8 @@ paths:
 
             scalekitClient.organizations().deleteById(organizationId);
     patch:
-      description: Updates an organization's display name, external ID, or
-        metadata. Requires a valid organization identifier. Region code cannot
+      description: Updates an organization's display name, external ID, or 
+        metadata. Requires a valid organization identifier. Region code cannot 
         be modified through this endpoint.
       tags:
         - Organizations
@@ -1323,13 +1393,13 @@ paths:
           in: path
           required: true
       responses:
-        '200':
+        "200":
           description: Returns the updated organization with all current details
             reflected in the response.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/organizationsUpdateOrganizationResponse'
+                $ref: "#/components/schemas/organizationsUpdateOrganizationResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -1374,13 +1444,13 @@ paths:
           application/json:
             schema:
               description: Organization Parameters to be updated
-              $ref: '#/components/schemas/v1organizationsUpdateOrganization'
+              $ref: "#/components/schemas/v1organizationsUpdateOrganization"
         required: true
   /api/v1/organizations/{id}/portal_links:
     put:
-      description: Creates a single use Admin Portal URL valid for 1 minute.
+      description: Creates a single use Admin Portal URL valid for 1 minute. 
         Once the generated admin portal URL is accessed or rendered, a temporary
-        session of 6 hours is created to allow the admin to update SSO/SCIM
+        session of 6 hours is created to allow the admin to update SSO/SCIM 
         configuration.
       tags:
         - Organizations
@@ -1421,17 +1491,17 @@ paths:
           name: features
           in: query
       responses:
-        '200':
-          description: Admin Portal link generated successfully. Returns the
+        "200":
+          description: Admin Portal link generated successfully. Returns the 
             portal URL and expiration timestamp.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/organizationsGeneratePortalLinkResponse'
+                $ref: "#/components/schemas/organizationsGeneratePortalLinkResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
-          source: const link = await
+          source: const link = await 
             scalekit.organization.generatePortalLink(organizationId);
         - label: Python SDK
           lang: python
@@ -1454,9 +1524,9 @@ paths:
               .generatePortalLink(organizationId, Arrays.asList(Feature.sso, Feature.dir_sync));
   /api/v1/organizations/{id}/settings:
     patch:
-      description: Updates configuration settings for an organization. Supports
-        modifying SSO configuration, directory synchronization settings, and
-        session parameters. Requires organization ID and the specific settings
+      description: Updates configuration settings for an organization. Supports 
+        modifying SSO configuration, directory synchronization settings, and 
+        session parameters. Requires organization ID and the specific settings 
         to update.
       tags:
         - Organizations
@@ -1471,22 +1541,22 @@ paths:
           in: path
           required: true
       responses:
-        '200':
-          description: Returns the complete organization object with updated
-            settings applied. Contains all organization details including ID,
+        "200":
+          description: Returns the complete organization object with updated 
+            settings applied. Contains all organization details including ID, 
             display name, and the modified settings.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/organizationsGetOrganizationResponse'
-        '400':
-          description: Invalid request - occurs when the settings payload
+                $ref: "#/components/schemas/organizationsGetOrganizationResponse"
+        "400":
+          description: Invalid request - occurs when the settings payload 
             contains invalid values or unsupported configuration
           content:
             application/json:
               schema: {}
-        '404':
-          description: Organization not found - the specified organization ID
+        "404":
+          description: Organization not found - the specified organization ID 
             doesn't exist
           content:
             application/json:
@@ -1579,10 +1649,10 @@ paths:
         content:
           application/json:
             schema:
-              description: Settings configuration to apply to the organization.
+              description: Settings configuration to apply to the organization. 
                 Contains feature toggles for SSO, directory synchronization, and
                 other organization capabilities
-              $ref: '#/components/schemas/organizationsOrganizationSettings'
+              $ref: "#/components/schemas/organizationsOrganizationSettings"
               examples:
                 - features:
                     - enabled: true
@@ -1592,11 +1662,11 @@ paths:
         required: true
   /api/v1/organizations/{org_id}/roles:
     get:
-      description: Retrieves all environment roles and organization specific
-        roles. Use this endpoint to view all role definitions, including custom
-        roles and their configurations. You can optionally include permission
-        details for each role to understand their capabilities. This is useful
-        for role management, auditing organization access controls, or
+      description: Retrieves all environment roles and organization specific 
+        roles. Use this endpoint to view all role definitions, including custom 
+        roles and their configurations. You can optionally include permission 
+        details for each role to understand their capabilities. This is useful 
+        for role management, auditing organization access controls, or 
         understanding the available access levels within the organization.
       tags:
         - Roles
@@ -1616,22 +1686,22 @@ paths:
           name: include
           in: query
       responses:
-        '200':
-          description: Successfully retrieved list of organization roles.
-            Returns all roles with their metadata and optionally their
+        "200":
+          description: Successfully retrieved list of organization roles. 
+            Returns all roles with their metadata and optionally their 
             permissions.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rolesListOrganizationRolesResponse'
+                $ref: "#/components/schemas/rolesListOrganizationRolesResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
-          source: const res = await
+          source: const res = await 
             scalekit.role.listOrganizationRoles("org_123");
         - label: Python SDK
           lang: python
-          source: res =
+          source: res = 
             scalekit_client.roles.list_organization_roles(org_id="org_123")
         - label: Go SDK
           lang: go
@@ -1644,15 +1714,15 @@ paths:
             _ = resp
         - label: Java SDK
           lang: java
-          source: ListOrganizationRolesResponse res =
+          source: ListOrganizationRolesResponse res = 
             scalekitClient.roles().listOrganizationRoles("org_123");
     post:
-      description: Creates a new role within the specified organization with
-        basic configuration including name, display name, description, and
-        permissions. Use this endpoint to define custom roles that can be
-        assigned to users within the organization. You can create hierarchical
-        roles by extending existing roles and assign specific permissions to
-        control access levels. The role will be scoped to the organization and
+      description: Creates a new role within the specified organization with 
+        basic configuration including name, display name, description, and 
+        permissions. Use this endpoint to define custom roles that can be 
+        assigned to users within the organization. You can create hierarchical 
+        roles by extending existing roles and assign specific permissions to 
+        control access levels. The role will be scoped to the organization and 
         can be used for organization-specific access control.
       tags:
         - Roles
@@ -1666,13 +1736,13 @@ paths:
           in: path
           required: true
       responses:
-        '201':
-          description: Organization role created successfully. Returns the
+        "201":
+          description: Organization role created successfully. Returns the 
             complete role object with system-generated ID and timestamps.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rolesCreateOrganizationRoleResponse'
+                $ref: "#/components/schemas/rolesCreateOrganizationRoleResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -1743,16 +1813,16 @@ paths:
           application/json:
             schema:
               description: Organization role details
-              $ref: '#/components/schemas/v1rolesCreateOrganizationRole'
+              $ref: "#/components/schemas/v1rolesCreateOrganizationRole"
         required: true
   /api/v1/organizations/{org_id}/roles/{role_name}:
     get:
-      description: Retrieves complete information for a specific organization
-        role including metadata, inheritance details, and optionally
-        permissions. Use this endpoint to audit role configuration and
-        understand the role's place in the organization's role hierarchy. You
-        can include permission details to see what capabilities the role
-        provides. This operation is useful for role management, user assignment
+      description: Retrieves complete information for a specific organization 
+        role including metadata, inheritance details, and optionally 
+        permissions. Use this endpoint to audit role configuration and 
+        understand the role's place in the organization's role hierarchy. You 
+        can include permission details to see what capabilities the role 
+        provides. This operation is useful for role management, user assignment 
         decisions, or understanding organization access controls.
       tags:
         - Roles
@@ -1778,15 +1848,15 @@ paths:
           name: include
           in: query
       responses:
-        '200':
+        "200":
           description: Successfully retrieved organization role details. Returns
-            the role object including metadata and inheritance details.
-            Permissions are included only when requested via the include
+            the role object including metadata and inheritance details. 
+            Permissions are included only when requested via the include 
             parameter.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rolesGetOrganizationRoleResponse'
+                $ref: "#/components/schemas/rolesGetOrganizationRoleResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -1810,14 +1880,14 @@ paths:
             _ = resp
         - label: Java SDK
           lang: java
-          source: GetOrganizationRoleResponse res =
+          source: GetOrganizationRoleResponse res = 
             scalekitClient.roles().getOrganizationRole("org_123", "org_admin");
     put:
       description: Modifies an existing organization role's properties including
-        display name, description, permissions, and inheritance settings. Use
+        display name, description, permissions, and inheritance settings. Use 
         this endpoint to update role metadata, change permission assignments, or
-        modify role hierarchy within the organization. Only the fields you
-        specify will be updated, leaving other properties unchanged. When
+        modify role hierarchy within the organization. Only the fields you 
+        specify will be updated, leaving other properties unchanged. When 
         updating permissions, the new list replaces all existing permissions for
         the role.
       tags:
@@ -1838,13 +1908,13 @@ paths:
           in: path
           required: true
       responses:
-        '200':
-          description: Organization role updated successfully. Returns the
+        "200":
+          description: Organization role updated successfully. Returns the 
             modified role object with updated timestamps.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rolesUpdateOrganizationRoleResponse'
+                $ref: "#/components/schemas/rolesUpdateOrganizationRoleResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -1899,15 +1969,15 @@ paths:
           application/json:
             schema:
               description: Organization role details
-              $ref: '#/components/schemas/v1rolesUpdateRole'
+              $ref: "#/components/schemas/v1rolesUpdateRole"
         required: true
     delete:
-      description: Permanently removes a role from the organization and
-        optionally reassigns users who had that role to a different role. Use
+      description: Permanently removes a role from the organization and 
+        optionally reassigns users who had that role to a different role. Use 
         this endpoint when you need to clean up unused roles or restructure your
-        organization's access control system. If users are assigned to the role
-        being deleted, you can provide a reassign_role_name to move those users
-        to a different role before deletion. This action cannot be undone, so
+        organization's access control system. If users are assigned to the role 
+        being deleted, you can provide a reassign_role_name to move those users 
+        to a different role before deletion. This action cannot be undone, so 
         ensure no critical users depend on the role before deletion.
       tags:
         - Roles
@@ -1932,8 +2002,8 @@ paths:
           name: reassign_role_name
           in: query
       responses:
-        '200':
-          description: Organization role successfully deleted and users
+        "200":
+          description: Organization role successfully deleted and users 
             reassigned if specified. No content returned.
           content:
             application/json:
@@ -1997,11 +2067,11 @@ paths:
             "org_role_admin", "org_role_member");
   /api/v1/organizations/{org_id}/roles:set_defaults:
     patch:
-      description: Updates the default member role for the specified
+      description: Updates the default member role for the specified 
         organization. Use this endpoint to configure which role is automatically
-        assigned to new users when they join the organization. The system will
-        validate that the specified role exists and update the organization
-        settings accordingly. This configuration affects all new user
+        assigned to new users when they join the organization. The system will 
+        validate that the specified role exists and update the organization 
+        settings accordingly. This configuration affects all new user 
         invitations and memberships within the organization.
       tags:
         - Roles
@@ -2015,14 +2085,14 @@ paths:
           in: path
           required: true
       responses:
-        '200':
-          description: Default organization roles updated successfully. Returns
-            the updated default member role object with complete role
+        "200":
+          description: Default organization roles updated successfully. Returns 
+            the updated default member role object with complete role 
             information.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rolesUpdateDefaultOrganizationRolesResponse'
+                $ref: "#/components/schemas/rolesUpdateDefaultOrganizationRolesResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -2068,12 +2138,12 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RolesServiceUpdateDefaultOrganizationRolesBody'
+              $ref: "#/components/schemas/RolesServiceUpdateDefaultOrganizationRolesBody"
         required: true
   /api/v1/organizations/{organization_id}/clients:
     get:
-      description: Retrieves a paginated list of API clients for a specific
-        organization. Returns client details including metadata, scopes, and
+      description: Retrieves a paginated list of API clients for a specific 
+        organization. Returns client details including metadata, scopes, and 
         secret information (without exposing actual secret values).
       tags:
         - API Auth
@@ -2082,7 +2152,7 @@ paths:
       parameters:
         - schema:
             type: string
-          description: Unique identifier of the organization whose clients to
+          description: Unique identifier of the organization whose clients to 
             list. Must start with 'org_' prefix.
           name: organization_id
           in: path
@@ -2109,13 +2179,13 @@ paths:
           name: page_token
           in: query
       responses:
-        '200':
-          description: List of organization API clients returned successfully.
+        "200":
+          description: List of organization API clients returned successfully. 
             Each client includes its configuration details and metadata.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/clientsListOrganizationClientsResponse'
+                $ref: "#/components/schemas/clientsListOrganizationClientsResponse"
       x-codeSamples:
         - label: Python SDK
           lang: python
@@ -2140,7 +2210,7 @@ paths:
             for client in clients:
                 print(f"Client ID: {scalekit_client.id}, Name: {scalekit_client.name}")
     post:
-      description: Creates a new API client for an organization. Returns the
+      description: Creates a new API client for an organization. Returns the 
         client details and a plain secret (available only once).
       tags:
         - API Auth
@@ -2154,15 +2224,15 @@ paths:
           in: path
           required: true
       responses:
-        '201':
-          description: API client created successfully. Returns the client ID
-            and plain secret (only available at creation time). The client can
-            be configured with scopes, audience values, and custom claims for
+        "201":
+          description: API client created successfully. Returns the client ID 
+            and plain secret (only available at creation time). The client can 
+            be configured with scopes, audience values, and custom claims for 
             fine-grained access control.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/clientsCreateOrganizationClientResponse'
+                $ref: "#/components/schemas/clientsCreateOrganizationClientResponse"
       x-codeSamples:
         - label: Python SDK
           lang: python
@@ -2193,11 +2263,11 @@ paths:
           application/json:
             schema:
               description: Details of the client to be created
-              $ref: '#/components/schemas/clientsOrganizationClient'
+              $ref: "#/components/schemas/clientsOrganizationClient"
         required: true
   /api/v1/organizations/{organization_id}/clients/{client_id}:
     get:
-      description: Retrieves details of a specific API client in an
+      description: Retrieves details of a specific API client in an 
         organization.
       tags:
         - API Auth
@@ -2217,14 +2287,14 @@ paths:
           in: path
           required: true
       responses:
-        '200':
-          description: Returns the complete API client configuration, including
-            all current settings and a list of active secrets. Note that secret
+        "200":
+          description: Returns the complete API client configuration, including 
+            all current settings and a list of active secrets. Note that secret 
             values are not included in the response for security reasons.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/clientsGetOrganizationClientResponse'
+                $ref: "#/components/schemas/clientsGetOrganizationClientResponse"
       x-codeSamples:
         - label: Python SDK
           lang: python
@@ -2239,9 +2309,9 @@ paths:
                 client_id=client_id
             )
     delete:
-      description: Permanently deletes an API client from an organization. This
-        operation cannot be undone and will revoke all access for the client.
-        All associated secrets will also be invalidated. Use this endpoint to
+      description: Permanently deletes an API client from an organization. This 
+        operation cannot be undone and will revoke all access for the client. 
+        All associated secrets will also be invalidated. Use this endpoint to 
         remove unused or compromised clients.
       tags:
         - API Auth
@@ -2250,21 +2320,21 @@ paths:
       parameters:
         - schema:
             type: string
-          description: Unique identifier of the organization that owns the
+          description: Unique identifier of the organization that owns the 
             client. Must start with 'org_' prefix.
           name: organization_id
           in: path
           required: true
         - schema:
             type: string
-          description: Unique identifier of the API client to permanently
+          description: Unique identifier of the API client to permanently 
             delete. Must start with 'm2morg_' prefix.
           name: client_id
           in: path
           required: true
       responses:
-        '200':
-          description: Organization API client successfully deleted and no
+        "200":
+          description: Organization API client successfully deleted and no 
             longer accessible
           content:
             application/json:
@@ -2283,7 +2353,7 @@ paths:
                 client_id=client_id
             )
     patch:
-      description: Updates an existing organization API client. Only specified
+      description: Updates an existing organization API client. Only specified 
         fields are modified.
       tags:
         - API Auth
@@ -2303,14 +2373,14 @@ paths:
           in: path
           required: true
       responses:
-        '200':
-          description: Returns the updated organization API client with all
-            current details reflected in the response, including modified
+        "200":
+          description: Returns the updated organization API client with all 
+            current details reflected in the response, including modified 
             scopes, audience values, and custom claims.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/clientsUpdateOrganizationClientResponse'
+                $ref: "#/components/schemas/clientsUpdateOrganizationClientResponse"
       x-codeSamples:
         - label: Python SDK
           lang: python
@@ -2343,11 +2413,11 @@ paths:
           application/json:
             schema:
               description: Updated details for the client
-              $ref: '#/components/schemas/clientsOrganizationClient'
+              $ref: "#/components/schemas/clientsOrganizationClient"
         required: true
   /api/v1/organizations/{organization_id}/clients/{client_id}/secrets:
     post:
-      description: Creates a new secret for an organization API client. Returns
+      description: Creates a new secret for an organization API client. Returns 
         the plain secret (available only once).
       tags:
         - API Auth
@@ -2367,14 +2437,14 @@ paths:
           in: path
           required: true
       responses:
-        '201':
-          description: Client secret created successfully. Returns the new
-            secret ID and the plain secret value (only available at creation
+        "201":
+          description: Client secret created successfully. Returns the new 
+            secret ID and the plain secret value (only available at creation 
             time). The secret can be used immediately for authentication.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/clientsCreateOrganizationClientSecretResponse'
+                $ref: "#/components/schemas/clientsCreateOrganizationClientSecretResponse"
       x-codeSamples:
         - label: Python SDK
           lang: python
@@ -2426,8 +2496,8 @@ paths:
           in: path
           required: true
       responses:
-        '200':
-          description: Client secret successfully deleted and no longer
+        "200":
+          description: Client secret successfully deleted and no longer 
             accessible
           content:
             application/json:
@@ -2456,8 +2526,8 @@ paths:
   /api/v1/organizations/{organization_id}/connections/{id}:
     get:
       description: Retrieves the complete configuration and status details for a
-        specific connection by its ID within an organization. Returns all
-        connection properties including provider settings, protocols, and
+        specific connection by its ID within an organization. Returns all 
+        connection properties including provider settings, protocols, and 
         current status.
       tags:
         - Connections
@@ -2466,26 +2536,26 @@ paths:
       parameters:
         - schema:
             type: string
-          description: Organization identifier (required). Specifies which
+          description: Organization identifier (required). Specifies which 
             organization owns the connection you want to retrieve.
           name: organization_id
           in: path
           required: true
         - schema:
             type: string
-          description: Connection identifier (required). Specifies which
+          description: Connection identifier (required). Specifies which 
             specific connection to retrieve from the organization.
           name: id
           in: path
           required: true
       responses:
-        '200':
-          description: Successfully retrieved connection details for the
+        "200":
+          description: Successfully retrieved connection details for the 
             specified organization
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/connectionsGetConnectionResponse'
+                $ref: "#/components/schemas/connectionsGetConnectionResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -2511,13 +2581,13 @@ paths:
             )
         - label: Java SDK
           lang: java
-          source: Connection connection =
-            scalekitClient.connections().getConnectionById(connectionId,
+          source: Connection connection = 
+            scalekitClient.connections().getConnectionById(connectionId, 
             organizationId);
     delete:
-      description: Deletes an SSO connection from the specified organization by
-        connection ID. Use this endpoint when an identity provider integration
-        is no longer needed for the organization. Returns an empty response
+      description: Deletes an SSO connection from the specified organization by 
+        connection ID. Use this endpoint when an identity provider integration 
+        is no longer needed for the organization. Returns an empty response 
         after the SSO connection is deleted successfully.
       tags:
         - Connections
@@ -2537,7 +2607,7 @@ paths:
           in: path
           required: true
       responses:
-        '200':
+        "200":
           description: SSO connection deleted successfully
           content:
             application/json:
@@ -2545,7 +2615,7 @@ paths:
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
-          source: await scalekit.connection.deleteConnection(organizationId,
+          source: await scalekit.connection.deleteConnection(organizationId, 
             connectionId);
         - label: Python SDK
           lang: python
@@ -2564,13 +2634,13 @@ paths:
             )
         - label: Java SDK
           lang: java
-          source: scalekitClient.connections().deleteConnection(connectionId,
+          source: scalekitClient.connections().deleteConnection(connectionId, 
             organizationId);
   /api/v1/organizations/{organization_id}/connections/{id}:disable:
     patch:
-      description: Deactivate an existing connection for the specified
-        organization. When disabled, users cannot authenticate using this
-        connection. This endpoint changes the connection state from enabled to
+      description: Deactivate an existing connection for the specified 
+        organization. When disabled, users cannot authenticate using this 
+        connection. This endpoint changes the connection state from enabled to 
         disabled without modifying other configuration settings
       tags:
         - Connections
@@ -2591,16 +2661,16 @@ paths:
           in: path
           required: true
       responses:
-        '200':
+        "200":
           description: Connection disabled successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/connectionsToggleConnectionResponse'
+                $ref: "#/components/schemas/connectionsToggleConnectionResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
-          source: await scalekit.connection.disableConnection(organizationId,
+          source: await scalekit.connection.disableConnection(organizationId, 
             connectionId);
         - label: Python SDK
           lang: python
@@ -2619,14 +2689,14 @@ paths:
             )
         - label: Java SDK
           lang: java
-          source: ToggleConnectionResponse response =
-            scalekitClient.connections().disableConnection(connectionId,
+          source: ToggleConnectionResponse response = 
+            scalekitClient.connections().disableConnection(connectionId, 
             organizationId);
   /api/v1/organizations/{organization_id}/connections/{id}:enable:
     patch:
-      description: Activate an existing connection for the specified
-        organization. When enabled, users can authenticate using this
-        connection. This endpoint changes the connection state from disabled to
+      description: Activate an existing connection for the specified 
+        organization. When enabled, users can authenticate using this 
+        connection. This endpoint changes the connection state from disabled to 
         enabled without modifying other configuration settings
       tags:
         - Connections
@@ -2647,16 +2717,16 @@ paths:
           in: path
           required: true
       responses:
-        '200':
+        "200":
           description: Connection enabled successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/connectionsToggleConnectionResponse'
+                $ref: "#/components/schemas/connectionsToggleConnectionResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
-          source: await scalekit.connection.enableConnection(organizationId,
+          source: await scalekit.connection.enableConnection(organizationId, 
             connectionId);
         - label: Python SDK
           lang: python
@@ -2675,8 +2745,8 @@ paths:
             )
         - label: Java SDK
           lang: java
-          source: ToggleConnectionResponse response =
-            scalekitClient.connections().enableConnection(connectionId,
+          source: ToggleConnectionResponse response = 
+            scalekitClient.connections().enableConnection(connectionId, 
             organizationId);
   /api/v1/organizations/{organization_id}/directories:
     get:
@@ -2692,13 +2762,13 @@ paths:
           in: path
           required: true
       responses:
-        '200':
-          description: Successfully retrieved the list of directories for the
+        "200":
+          description: Successfully retrieved the list of directories for the 
             organization
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/directoriesListDirectoriesResponse'
+                $ref: "#/components/schemas/directoriesListDirectoriesResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -2711,15 +2781,15 @@ paths:
             )
         - label: Go SDK
           lang: go
-          source: directories,err :=
+          source: directories,err := 
             scalekitClient.Directory().ListDirectories(ctx, organizationId)
         - label: Java SDK
           lang: java
-          source: ListDirectoriesResponse response =
+          source: ListDirectoriesResponse response = 
             scalekitClient.directories().listDirectories(organizationId);
   /api/v1/organizations/{organization_id}/directories/{directory_id}/groups:
     get:
-      description: Retrieves all groups from a specified directory. Use this
+      description: Retrieves all groups from a specified directory. Use this 
         endpoint to view group structures from your connected identity provider.
       tags:
         - Directory
@@ -2747,37 +2817,37 @@ paths:
           in: query
         - schema:
             type: string
-          description: Token for pagination. Use the value returned in the
+          description: Token for pagination. Use the value returned in the 
             'next_page_token' field of the previous response
           name: page_token
           in: query
         - schema:
             type: string
             format: date-time
-          description: Filter groups updated after this timestamp. Use ISO 8601
+          description: Filter groups updated after this timestamp. Use ISO 8601 
             format
           name: updated_after
           in: query
         - schema:
             type: boolean
-          description: If true, includes full group details. If false or not
+          description: If true, includes full group details. If false or not 
             specified, returns basic information only
           name: include_detail
           in: query
         - schema:
             type: boolean
-          description: 'If true, returns group and its details from external provider
-            (default: false)'
+          description: "If true, returns group and its details from external provider
+            (default: false)"
           name: include_external_groups
           in: query
       responses:
-        '200':
-          description: Successfully retrieved the list of groups from the
+        "200":
+          description: Successfully retrieved the list of groups from the 
             specified directory
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/directoriesListDirectoryGroupsResponse'
+                $ref: "#/components/schemas/directoriesListDirectoryGroupsResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -2821,8 +2891,8 @@ paths:
               .listDirectoryGroups(directory.getId(), organizationId, options);
   /api/v1/organizations/{organization_id}/directories/{directory_id}/users:
     get:
-      description: Retrieves a list of all users within a specified directory
-        for an organization. This endpoint allows you to view user accounts
+      description: Retrieves a list of all users within a specified directory 
+        for an organization. This endpoint allows you to view user accounts 
         associated with your connected Directory Providers.
       tags:
         - Directory
@@ -2837,7 +2907,7 @@ paths:
           required: true
         - schema:
             type: string
-          description: Unique identifier of the directory within the
+          description: Unique identifier of the directory within the 
             organization
           name: directory_id
           in: path
@@ -2845,45 +2915,45 @@ paths:
         - schema:
             type: integer
             format: int64
-          description: Number of users to return per page. Maximum value is 30.
+          description: Number of users to return per page. Maximum value is 30. 
             If not specified, defaults to 10
           name: page_size
           in: query
         - schema:
             type: string
-          description: Token for pagination. Use the value returned in the
-            'next_page_token' field of the previous response to retrieve the
+          description: Token for pagination. Use the value returned in the 
+            'next_page_token' field of the previous response to retrieve the 
             next page of results
           name: page_token
           in: query
         - schema:
             type: boolean
-          description: If set to true, the response will include the full user
-            payload with all available details. If false or not specified, only
+          description: If set to true, the response will include the full user 
+            payload with all available details. If false or not specified, only 
             essential user information will be returned
           name: include_detail
           in: query
         - schema:
             type: string
-          description: Filter users by their membership in a specific directory
+          description: Filter users by their membership in a specific directory 
             group
           name: directory_group_id
           in: query
         - schema:
             type: string
             format: date-time
-          description: Filter users that were updated after the specified
+          description: Filter users that were updated after the specified 
             timestamp. Use ISO 8601 format
           name: updated_after
           in: query
       responses:
-        '200':
-          description: Successfully retrieved the list of users from the
+        "200":
+          description: Successfully retrieved the list of users from the 
             specified directory
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/directoriesListDirectoryUsersResponse'
+                $ref: "#/components/schemas/directoriesListDirectoryUsersResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -2926,7 +2996,7 @@ paths:
               .listDirectoryUsers(directory.getId(), organizationId, options);
   /api/v1/organizations/{organization_id}/directories/{id}:
     get:
-      description: Retrieves detailed information about a specific directory
+      description: Retrieves detailed information about a specific directory 
         within an organization
       tags:
         - Directory
@@ -2946,12 +3016,12 @@ paths:
           in: path
           required: true
       responses:
-        '200':
+        "200":
           description: Successfully retrieved directory details
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/directoriesGetDirectoryResponse'
+                $ref: "#/components/schemas/directoriesGetDirectoryResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -2973,13 +3043,13 @@ paths:
             organizationId, directoryId)
         - label: Java SDK
           lang: java
-          source: Directory directory =
-            scalekitClient.directories().getDirectory(directoryId,
+          source: Directory directory = 
+            scalekitClient.directories().getDirectory(directoryId, 
             organizationId);
   /api/v1/organizations/{organization_id}/directories/{id}:disable:
     patch:
-      description: Stops synchronization of users and groups from a specified
-        directory within an organization. This operation prevents further
+      description: Stops synchronization of users and groups from a specified 
+        directory within an organization. This operation prevents further 
         updates from the connected Directory provider
       tags:
         - Directory
@@ -2988,26 +3058,26 @@ paths:
       parameters:
         - schema:
             type: string
-          description: A unique identifier for the organization. The value must
+          description: A unique identifier for the organization. The value must 
             begin with 'org_' and be between 1 and 32 characters long
           name: organization_id
           in: path
           required: true
         - schema:
             type: string
-          description: A unique identifier for a directory within the
-            organization. The value must begin with 'dir_' and be between 1 and
+          description: A unique identifier for a directory within the 
+            organization. The value must begin with 'dir_' and be between 1 and 
             32 characters long
           name: id
           in: path
           required: true
       responses:
-        '200':
+        "200":
           description: Successfully disabled the directory
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/directoriesToggleDirectoryResponse'
+                $ref: "#/components/schemas/directoriesToggleDirectoryResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -3024,8 +3094,8 @@ paths:
             )
         - label: Go SDK
           lang: go
-          source: disable,err :=
-            scalekitClient.Directory().DisableDirectory(ctx, organizationId,
+          source: disable,err := 
+            scalekitClient.Directory().DisableDirectory(ctx, organizationId, 
             directoryId)
         - label: Java SDK
           lang: java
@@ -3035,7 +3105,7 @@ paths:
               .disableDirectory(directoryId, organizationId);
   /api/v1/organizations/{organization_id}/directories/{id}:enable:
     patch:
-      description: Activates a directory within an organization, allowing it to
+      description: Activates a directory within an organization, allowing it to 
         synchronize users and groups with the connected Directory provider
       tags:
         - Directory
@@ -3044,30 +3114,30 @@ paths:
       parameters:
         - schema:
             type: string
-          description: A unique identifier for the organization. The value must
+          description: A unique identifier for the organization. The value must 
             begin with 'org_' and be between 1 and 32 characters long
           name: organization_id
           in: path
           required: true
         - schema:
             type: string
-          description: A unique identifier for a directory within the
-            organization. The value must begin with 'dir_' and be between 1 and
+          description: A unique identifier for a directory within the 
+            organization. The value must begin with 'dir_' and be between 1 and 
             32 characters long
           name: id
           in: path
           required: true
       responses:
-        '200':
+        "200":
           description: Success
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/directoriesToggleDirectoryResponse'
+                $ref: "#/components/schemas/directoriesToggleDirectoryResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
-          source: await scalekit.directory.enableDirectory('<organization_id>',
+          source: await scalekit.directory.enableDirectory('<organization_id>', 
             '<directory_id>');
         - label: Python SDK
           lang: python
@@ -3077,7 +3147,7 @@ paths:
             )
         - label: Go SDK
           lang: go
-          source: enable,err := scalekitClient.Directory().EnableDirectory(ctx,
+          source: enable,err := scalekitClient.Directory().EnableDirectory(ctx, 
             organizationId, directoryId)
         - label: Java SDK
           lang: java
@@ -3108,29 +3178,29 @@ paths:
       parameters:
         - schema:
             type: string
-          description: Scalekit-generated unique identifier for the
-            organization. Use either this or external_id to identify the
+          description: Scalekit-generated unique identifier for the 
+            organization. Use either this or external_id to identify the 
             organization.
           name: organization_id
           in: path
           required: true
         - schema:
             type: string
-          description: Optional comma-separated list of additional fields to
+          description: Optional comma-separated list of additional fields to 
             include in the response (e.g., 'verification_details').
           name: include
           in: query
         - schema:
             type: integer
             format: int32
-          description: Maximum number of domains to return per page. Default is
+          description: Maximum number of domains to return per page. Default is 
             30, maximum is 100.
           name: page_size
           in: query
         - schema:
             type: integer
             format: int32
-          description: Page number to retrieve (0-based). Use 0 for the first
+          description: Page number to retrieve (0-based). Use 0 for the first 
             page.
           name: page_number
           in: query
@@ -3150,12 +3220,12 @@ paths:
           name: domain_type
           in: query
       responses:
-        '200':
+        "200":
           description: Successfully retrieved the list of domains.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/domainsListDomainResponse'
+                $ref: "#/components/schemas/domainsListDomainResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -3191,8 +3261,8 @@ paths:
             })
         - label: Java SDK
           lang: java
-          source: List<Domain> domains =
-            scalekitClient.domains().listDomainsByOrganizationId("org_id",
+          source: List<Domain> domains = 
+            scalekitClient.domains().listDomainsByOrganizationId("org_id", 
             "ORGANIZATION_DOMAIN");
     post:
       description: >+
@@ -3220,26 +3290,26 @@ paths:
       parameters:
         - schema:
             type: string
-          description: Scalekit-generated unique identifier for the
-            organization. Use either this or external_id to identify the
+          description: Scalekit-generated unique identifier for the 
+            organization. Use either this or external_id to identify the 
             organization.
           name: organization_id
           in: path
           required: true
       responses:
-        '200':
+        "200":
           description: Successfully created the domain.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/domainsCreateDomainResponse'
-        '400':
-          description: Invalid request — common causes invalid domain format,
+                $ref: "#/components/schemas/domainsCreateDomainResponse"
+        "400":
+          description: Invalid request — common causes invalid domain format, 
             public or disposable domain, or domain already exists.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/errdetailsErrorInfo'
+                $ref: "#/components/schemas/errdetailsErrorInfo"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -3289,9 +3359,9 @@ paths:
         content:
           application/json:
             schema:
-              description: Domain configuration including the domain name and
+              description: Domain configuration including the domain name and 
                 type.
-              $ref: '#/components/schemas/v1domainsCreateDomain'
+              $ref: "#/components/schemas/v1domainsCreateDomain"
         required: true
   /api/v1/organizations/{organization_id}/domains/{id}:
     get:
@@ -3306,26 +3376,26 @@ paths:
       parameters:
         - schema:
             type: string
-          description: Scalekit-generated unique identifier for the
-            organization. Use either this or external_id to identify the
+          description: Scalekit-generated unique identifier for the 
+            organization. Use either this or external_id to identify the 
             organization.
           name: organization_id
           in: path
           required: true
         - schema:
             type: string
-          description: Scalekit-generated unique identifier of the domain to
+          description: Scalekit-generated unique identifier of the domain to 
             retrieve.
           name: id
           in: path
           required: true
       responses:
-        '200':
+        "200":
           description: Successfully retrieved the domain details.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/domainsGetDomainResponse'
+                $ref: "#/components/schemas/domainsGetDomainResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -3355,11 +3425,11 @@ paths:
             domain_id="dom_123")
         - label: Go SDK
           lang: go
-          source: domain, err := scalekitClient.Domain().GetDomain(ctx,
+          source: domain, err := scalekitClient.Domain().GetDomain(ctx, 
             "dom_123", "org_123")
         - label: Java SDK
           lang: java
-          source: Domain domain =
+          source: Domain domain = 
             scalekitClient.domains().getDomainById("org_123", "dom_123");
     delete:
       description: >+
@@ -3379,21 +3449,21 @@ paths:
       parameters:
         - schema:
             type: string
-          description: Scalekit-generated unique identifier for the
-            organization. Use either this or external_id to identify the
+          description: Scalekit-generated unique identifier for the 
+            organization. Use either this or external_id to identify the 
             organization.
           name: organization_id
           in: path
           required: true
         - schema:
             type: string
-          description: Scalekit-generated unique identifier of the domain to be
+          description: Scalekit-generated unique identifier of the domain to be 
             permanently deleted.
           name: id
           in: path
           required: true
       responses:
-        '200':
+        "200":
           description: Domain successfully deleted.
           content:
             application/json:
@@ -3419,12 +3489,77 @@ paths:
             )
         - label: Go SDK
           lang: go
-          source: err = scalekitClient.Domain().DeleteDomain(ctx, "dom_123",
+          source: err = scalekitClient.Domain().DeleteDomain(ctx, "dom_123", 
             "org_123")
         - label: Java SDK
           lang: java
-          source: scalekitClient.domains().deleteDomain(organization.getId(),
+          source: scalekitClient.domains().deleteDomain(organization.getId(), 
             domain.getId());
+  /api/v1/organizations/{organization_id}/session-policy:
+    get:
+      description: Retrieves the session policy for an organization. Returns 
+        session_policy='APPLICATION' if the organization inherits the 
+        application-level defaults, or session_policy='CUSTOM' with the 
+        configured values if a custom policy is active.
+      tags:
+        - Organizations
+      summary: Get organization session policy
+      operationId: OrganizationService_GetOrganizationSessionPolicy
+      parameters:
+        - schema:
+            type: string
+          description: The unique identifier of the organization whose session 
+            policy is being requested.
+          name: organization_id
+          in: path
+          required: true
+      responses:
+        "200":
+          description: Session policy retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/organizationsGetOrganizationSessionPolicyResponse"
+        "404":
+          description: Organization not found.
+          content:
+            application/json:
+              schema: {}
+    patch:
+      description: Sets a custom session policy for an organization or reverts 
+        to application-level settings. Send session_policy='APPLICATION' to 
+        revert to application defaults. Send session_policy='CUSTOM' with 
+        timeout values to activate a custom policy.
+      tags:
+        - Organizations
+      summary: Update organization session policy
+      operationId: OrganizationService_UpdateOrganizationSessionPolicy
+      parameters:
+        - schema:
+            type: string
+          description: The unique identifier of the organization whose session 
+            policy is being updated.
+          name: organization_id
+          in: path
+          required: true
+      responses:
+        "200":
+          description: Session policy updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/organizationsUpdateOrganizationSessionPolicyResponse"
+        "404":
+          description: Organization not found.
+          content:
+            application/json:
+              schema: {}
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OrganizationServiceUpdateOrganizationSessionPolicyBody"
+        required: true
   /api/v1/organizations/{organization_id}/settings/usermanagement:
     patch:
       description: Upsert user management settings for an organization
@@ -3440,23 +3575,23 @@ paths:
           in: path
           required: true
       responses:
-        '200':
+        "200":
           description: Returns the updated organization setting.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/organizationsUpsertUserManagementSettingsResponse'
+                $ref: "#/components/schemas/organizationsUpsertUserManagementSettingsResponse"
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/OrganizationServiceUpsertUserManagementSettingsBody'
+              $ref: "#/components/schemas/OrganizationServiceUpsertUserManagementSettingsBody"
         required: true
   /api/v1/organizations/{organization_id}/users:
     get:
-      description: Retrieves a paginated list of all users who are members of
-        the specified organization. Use this endpoint to view all users with
-        access to a particular organization, including their roles, metadata,
+      description: Retrieves a paginated list of all users who are members of 
+        the specified organization. Use this endpoint to view all users with 
+        access to a particular organization, including their roles, metadata, 
         and membership details. Supports pagination for large user lists.
       tags:
         - Users
@@ -3465,7 +3600,7 @@ paths:
       parameters:
         - schema:
             type: string
-          description: Unique identifier of the organization for which to list
+          description: Unique identifier of the organization for which to list 
             users. Must start with 'org_' and be 1-32 characters long.
           name: organization_id
           in: path
@@ -3473,25 +3608,25 @@ paths:
         - schema:
             type: integer
             format: int64
-          description: 'Maximum number of users to return in a single response. Valid
-            range: 1-100. Server may return fewer users than specified.'
+          description: "Maximum number of users to return in a single response. Valid
+            range: 1-100. Server may return fewer users than specified."
           name: page_size
           in: query
         - schema:
             type: string
-          description: Pagination token from a previous ListUserResponse. Used
-            to retrieve the next page of results. Leave empty for the first
+          description: Pagination token from a previous ListUserResponse. Used 
+            to retrieve the next page of results. Leave empty for the first 
             request.
           name: page_token
           in: query
       responses:
-        '200':
-          description: Successfully retrieved the list of users in the
+        "200":
+          description: Successfully retrieved the list of users in the 
             organization
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/usersListOrganizationUsersResponse'
+                $ref: "#/components/schemas/usersListOrganizationUsersResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -3503,8 +3638,8 @@ paths:
             console.log(response.users);
         - label: Python SDK
           lang: python
-          source: resp, _ =
-            scalekit_client.users.list_users(organization_id="org_123",
+          source: resp, _ = 
+            scalekit_client.users.list_users(organization_id="org_123", 
             page_size=50)
         - label: Go SDK
           lang: go
@@ -3525,11 +3660,11 @@ paths:
             ListOrganizationUsersResponse list = users.
               listOrganizationUsers("org_123", listReq);
     post:
-      description: Creates a new user account and immediately adds them to the
+      description: Creates a new user account and immediately adds them to the 
         specified organization. Use this endpoint when you want to create a user
-        and grant them access to an organization in a single operation. You can
+        and grant them access to an organization in a single operation. You can 
         provide user profile information, assign roles, and configure membership
-        metadata. The user receives an activation email unless this feature is
+        metadata. The user receives an activation email unless this feature is 
         disabled in the organization settings.
       tags:
         - Users
@@ -3543,18 +3678,18 @@ paths:
           required: true
         - schema:
             type: boolean
-          description: If true, sends an activation email to the user. Defaults
+          description: If true, sends an activation email to the user. Defaults 
             to true.
           name: send_invitation_email
           in: query
       responses:
-        '201':
-          description: User created successfully. Returns the created user
+        "201":
+          description: User created successfully. Returns the created user 
             object, including system-generated identifiers and timestamps
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/usersCreateUserAndMembershipResponse'
+                $ref: "#/components/schemas/usersCreateUserAndMembershipResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -3647,12 +3782,12 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/usersCreateUser'
+              $ref: "#/components/schemas/usersCreateUser"
         required: true
   /api/v1/organizations/{organization_id}/users/{user_id}/permissions:
     get:
-      description: Retrieves all permissions a user has access to within a
-        specific organization. This includes permissions from direct role
+      description: Retrieves all permissions a user has access to within a 
+        specific organization. This includes permissions from direct role 
         assignments and inherited permissions from role hierarchy.
       tags:
         - Users
@@ -3672,17 +3807,17 @@ paths:
           in: path
           required: true
       responses:
-        '200':
-          description: Successfully retrieved the list of permissions for the
+        "200":
+          description: Successfully retrieved the list of permissions for the 
             user
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/usersListUserPermissionsResponse'
+                $ref: "#/components/schemas/usersListUserPermissionsResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
-          source: const { permissions } = await
+          source: const { permissions } = await 
             scalekit.user.listUserPermissions("org_123", "usr_123");
         - label: Python SDK
           lang: python
@@ -3712,8 +3847,8 @@ paths:
             List<Permission> permissions = resp.getPermissionsList();
   /api/v1/organizations/{organization_id}/users/{user_id}/roles:
     get:
-      description: Retrieves all roles assigned to a user within a specific
-        organization. This includes both direct role assignments and inherited
+      description: Retrieves all roles assigned to a user within a specific 
+        organization. This includes both direct role assignments and inherited 
         roles from role hierarchy.
       tags:
         - Users
@@ -3733,13 +3868,13 @@ paths:
           in: path
           required: true
       responses:
-        '200':
-          description: Successfully retrieved the list of roles assigned to the
+        "200":
+          description: Successfully retrieved the list of roles assigned to the 
             user
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/usersListUserRolesResponse'
+                $ref: "#/components/schemas/usersListUserRolesResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -3773,11 +3908,11 @@ paths:
             List<Role> roles = resp.getRolesList();
   /api/v1/organizations/{organization_id}/users:search:
     get:
-      description: Searches for users within a specific organization by email
-        address, user ID, or external ID. The query must be at least 3
+      description: Searches for users within a specific organization by email 
+        address, user ID, or external ID. The query must be at least 3 
         characters and is case-insensitive. Scopes results strictly to the given
-        organization. Returns a paginated list of matching users with up to 30
-        results per page. Use the next_page_token from the response to retrieve
+        organization. Returns a paginated list of matching users with up to 30 
+        results per page. Use the next_page_token from the response to retrieve 
         subsequent pages.
       tags:
         - Users
@@ -3786,7 +3921,7 @@ paths:
       parameters:
         - schema:
             type: string
-          description: Unique identifier of the organization to search within.
+          description: Unique identifier of the organization to search within. 
             Must start with 'org_' and be 1-32 characters long.
           name: organization_id
           in: path
@@ -3811,34 +3946,38 @@ paths:
           in: query
         - schema:
             type: string
-          description: Token from a previous response for pagination. Provide
+          description: Token from a previous response for pagination. Provide 
             this to retrieve the next page of results.
           name: page_token
           in: query
       responses:
-        '200':
+        "200":
           description: Matching users within the organization returned; includes
             pagination cursors for navigating large result sets.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/usersSearchOrganizationUsersResponse'
-        '400':
-          description: Bad Request - query must be at least 3 characters and no
-            more than 100 characters, and organization_id must be a valid org_
+                $ref: "#/components/schemas/usersSearchOrganizationUsersResponse"
+        "400":
+          description: Bad Request - query must be at least 3 characters and no 
+            more than 100 characters, and organization_id must be a valid org_ 
             prefixed identifier.
           content:
             application/json:
               schema: {}
-        '404':
+        "404":
           description: Not Found - organization not found.
           content:
             application/json:
               schema: {}
   /api/v1/organizations:external/{external_id}:
     get:
-      description: Retrieves organization details by External ID, including
-        name, region, metadata, and settings
+      description: Retrieves organization details by external ID, including 
+        name, region, metadata, and settings. Only provide external_id in the 
+        path. If the id query parameter is also supplied, it silently takes 
+        precedence over external_id due to protobuf oneof semantics, which 
+        causes the request to fail with a 400 Bad Request ('ExternalId is 
+        required').
       tags:
         - Organizations
       summary: Get organization details by external Id
@@ -3846,54 +3985,58 @@ paths:
       parameters:
         - schema:
             type: string
-          description: Unique identifier that links an Organization Object to
-            your app's tenant, stored as an External ID
+          description: Unique identifier that links an organization to your 
+            app's tenant. Use this with the GetOrganizationByExternalId 
+            endpoint. Only one of id or external_id should be provided per 
+            request.
           name: external_id
           in: path
           required: true
         - schema:
             type: string
-          description: Unique scalekit-generated identifier that uniquely
-            references an organization
+          description: Unique Scalekit-generated identifier for an organization.
+            Use this with the GetOrganization endpoint. Do not pass this 
+            parameter when calling GetOrganizationByExternalId — use external_id
+            instead.
           name: id
           in: query
       responses:
-        '200':
+        "200":
           description: Returns the complete organization object with ID, display
             name, settings, external ID and metadata
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/organizationsGetOrganizationResponse'
-        '400':
-          description: Invalid request - external ID is empty or the caller's
+                $ref: "#/components/schemas/organizationsGetOrganizationResponse"
+        "400":
+          description: Invalid request - external ID is empty or the caller's 
             organization claim does not match
           content:
             application/json:
               schema: {}
-        '404':
-          description: Organization not found - no organization exists with the
+        "404":
+          description: Organization not found - no organization exists with the 
             specified external ID
           content:
             application/json:
               schema: {}
   /api/v1/passwordless/email/resend:
     post:
-      description: Resend a verification email if the user didn't receive it or
+      description: Resend a verification email if the user didn't receive it or 
         if the previous code/link has expired
       tags:
         - Magic link & OTP
       summary: Resend passwordless email
       operationId: PasswordlessService_ResendPasswordlessEmail
       responses:
-        '200':
-          description: Successfully resent the passwordless authentication
-            email. Returns updated authentication request details with new
+        "200":
+          description: Successfully resent the passwordless authentication 
+            email. Returns updated authentication request details with new 
             expiration time.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/passwordlessSendPasswordlessResponse'
+                $ref: "#/components/schemas/passwordlessSendPasswordlessResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -3934,31 +4077,31 @@ paths:
             }
         - label: Java SDK
           lang: java
-          source: SendPasswordlessResponse resendResponse =
+          source: SendPasswordlessResponse resendResponse = 
             passwordlessClient.resendPasswordlessEmail(authRequestId);
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/passwordlessResendPasswordlessRequest'
+              $ref: "#/components/schemas/passwordlessResendPasswordlessRequest"
         required: true
   /api/v1/passwordless/email/send:
     post:
-      description: Send a verification email containing either a verification
+      description: Send a verification email containing either a verification 
         code (OTP), magic link, or both to a user's email address
       tags:
         - Magic link & OTP
       summary: Send passwordless email
       operationId: PasswordlessService_SendPasswordlessEmail
       responses:
-        '200':
-          description: Successfully sent passwordless authentication email.
+        "200":
+          description: Successfully sent passwordless authentication email. 
             Returns the authentication request details including expiration time
             and auth request ID
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/passwordlessSendPasswordlessResponse'
+                $ref: "#/components/schemas/passwordlessSendPasswordlessResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -4059,24 +4202,24 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/passwordlessSendPasswordlessRequest'
+              $ref: "#/components/schemas/passwordlessSendPasswordlessRequest"
         required: true
   /api/v1/passwordless/email/verify:
     post:
-      description: Verify a user's identity using either a verification code or
+      description: Verify a user's identity using either a verification code or 
         magic link token
       tags:
         - Magic link & OTP
       summary: Verify passwordless email
       operationId: PasswordlessService_VerifyPasswordlessEmail
       responses:
-        '200':
-          description: Successfully verified the passwordless authentication.
+        "200":
+          description: Successfully verified the passwordless authentication. 
             Returns user email
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/passwordlessVerifyPasswordLessResponse'
+                $ref: "#/components/schemas/passwordlessVerifyPasswordLessResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -4202,19 +4345,19 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/passwordlessVerifyPasswordLessRequest'
+              $ref: "#/components/schemas/passwordlessVerifyPasswordLessRequest"
         required: true
   /api/v1/permissions:
     get:
-      description: Retrieves a comprehensive, paginated list of all permissions
-        available within the environment. Use this endpoint to view all
-        permission definitions for auditing, role management, or understanding
-        the complete set of available access controls. The response includes
-        pagination tokens to navigate through large sets of permissions
-        efficiently. Each permission object contains the permission name,
-        description, creation time, and last update time. This operation is
+      description: Retrieves a comprehensive, paginated list of all permissions 
+        available within the environment. Use this endpoint to view all 
+        permission definitions for auditing, role management, or understanding 
+        the complete set of available access controls. The response includes 
+        pagination tokens to navigate through large sets of permissions 
+        efficiently. Each permission object contains the permission name, 
+        description, creation time, and last update time. This operation is 
         useful for building permission selection interfaces, auditing permission
-        usage, or understanding the scope of available access controls in your
+        usage, or understanding the scope of available access controls in your 
         RBAC system.
       tags:
         - Permissions
@@ -4237,20 +4380,20 @@ paths:
             enum:
               - SCALEKIT
               - ENVIRONMENT
-          description: 'Filter permissions by type: ALL, SCALEKIT, or ENVIRONMENT,
+          description: "Filter permissions by type: ALL, SCALEKIT, or ENVIRONMENT,
             where SCALEKIT are predefined Scalekit permissions and ENVIRONMENT are
-            custom permissions created in the environment, default is ALL'
+            custom permissions created in the environment, default is ALL"
           name: type
           in: query
       responses:
-        '200':
+        "200":
           description: Successfully retrieved the list of permissions. Returns a
-            paginated list of permission objects with metadata and pagination
+            paginated list of permission objects with metadata and pagination 
             tokens for navigation.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rolesListPermissionsResponse'
+                $ref: "#/components/schemas/rolesListPermissionsResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -4266,31 +4409,31 @@ paths:
             _ = resp
         - label: Java SDK
           lang: java
-          source: ListPermissionsResponse res =
+          source: ListPermissionsResponse res = 
             scalekitClient.permissions().listPermissions();
     post:
-      description: Creates a new permission that represents a specific action
-        users can perform within the environment. Use this endpoint to define
-        granular access controls for your RBAC system. You can provide a unique
-        permission name following the format 'action:resource' (for example,
-        'read:documents', 'write:users') and an optional description explaining
-        the permission's purpose. The permission name must be unique across the
-        environment and follows alphanumeric naming conventions with colons and
-        underscores. Returns the created permission object including
+      description: Creates a new permission that represents a specific action 
+        users can perform within the environment. Use this endpoint to define 
+        granular access controls for your RBAC system. You can provide a unique 
+        permission name following the format 'action:resource' (for example, 
+        'read:documents', 'write:users') and an optional description explaining 
+        the permission's purpose. The permission name must be unique across the 
+        environment and follows alphanumeric naming conventions with colons and 
+        underscores. Returns the created permission object including 
         system-generated ID and timestamps.
       tags:
         - Permissions
       summary: Create new permission
       operationId: RolesService_CreatePermission
       responses:
-        '201':
-          description: Permission created successfully. Returns the complete
-            permission object with system-generated ID, name, description, and
+        "201":
+          description: Permission created successfully. Returns the complete 
+            permission object with system-generated ID, name, description, and 
             timestamps.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rolesCreatePermissionResponse'
+                $ref: "#/components/schemas/rolesCreatePermissionResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -4343,18 +4486,18 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/v1rolesCreatePermission'
+              $ref: "#/components/schemas/v1rolesCreatePermission"
         required: true
   /api/v1/permissions/{permission_name}:
     get:
-      description: Retrieves complete information for a specific permission by
+      description: Retrieves complete information for a specific permission by 
         its unique name identifier. Use this endpoint to view permission details
-        including description, creation time, and last update time. Provide the
-        permission name in the path parameter following the format
-        'action:resource' (for example, 'read:documents'). This operation is
-        useful for auditing permission definitions, understanding permission
-        purposes, or verifying permission existence before assignment. Returns
-        the complete permission object with all metadata and system-generated
+        including description, creation time, and last update time. Provide the 
+        permission name in the path parameter following the format 
+        'action:resource' (for example, 'read:documents'). This operation is 
+        useful for auditing permission definitions, understanding permission 
+        purposes, or verifying permission existence before assignment. Returns 
+        the complete permission object with all metadata and system-generated 
         timestamps.
       tags:
         - Permissions
@@ -4368,18 +4511,18 @@ paths:
           in: path
           required: true
       responses:
-        '200':
-          description: Successfully retrieved permission details. Returns the
-            complete permission object including name, description, creation
+        "200":
+          description: Successfully retrieved permission details. Returns the 
+            complete permission object including name, description, creation 
             time, and update time.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rolesGetPermissionResponse'
+                $ref: "#/components/schemas/rolesGetPermissionResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
-          source: const res = await
+          source: const res = await 
             scalekit.permission.getPermission("read:users");
         - label: Python SDK
           lang: python
@@ -4398,18 +4541,18 @@ paths:
             _ = resp
         - label: Java SDK
           lang: java
-          source: GetPermissionResponse res =
+          source: GetPermissionResponse res = 
             scalekitClient.permissions().getPermission("read:users");
     put:
-      description: Modifies an existing permission's attributes including
-        description and metadata. Use this endpoint to update permission
-        descriptions or clarify permission purposes after creation. The
-        permission is identified by its unique name in the path parameter, and
-        only the fields you specify in the request body will be updated. Note
-        that the permission name itself cannot be changed as it serves as the
-        immutable identifier. This operation is useful for maintaining clear
+      description: Modifies an existing permission's attributes including 
+        description and metadata. Use this endpoint to update permission 
+        descriptions or clarify permission purposes after creation. The 
+        permission is identified by its unique name in the path parameter, and 
+        only the fields you specify in the request body will be updated. Note 
+        that the permission name itself cannot be changed as it serves as the 
+        immutable identifier. This operation is useful for maintaining clear 
         documentation of permission purposes or updating descriptions to reflect
-        changes in system functionality. Returns the updated permission object
+        changes in system functionality. Returns the updated permission object 
         with modified timestamps.
       tags:
         - Permissions
@@ -4423,13 +4566,13 @@ paths:
           in: path
           required: true
       responses:
-        '200':
-          description: Permission updated successfully. Returns the modified
+        "200":
+          description: Permission updated successfully. Returns the modified 
             permission object with updated description and timestamps.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rolesUpdatePermissionResponse'
+                $ref: "#/components/schemas/rolesUpdatePermissionResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -4481,17 +4624,17 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/v1rolesCreatePermission'
+              $ref: "#/components/schemas/v1rolesCreatePermission"
         required: true
     delete:
-      description: Permanently removes a permission from the environment using
-        its unique name identifier. Use this endpoint when you need to clean up
-        unused permissions or remove access controls that are no longer
+      description: Permanently removes a permission from the environment using 
+        its unique name identifier. Use this endpoint when you need to clean up 
+        unused permissions or remove access controls that are no longer 
         relevant. The permission is identified by its name in the path parameter
         following the format 'action:resource'. This operation cannot be undone,
-        so ensure no active roles depend on the permission before deletion. If
-        the permission is currently assigned to any roles, you may need to
-        remove those assignments first or update the roles to use alternative
+        so ensure no active roles depend on the permission before deletion. If 
+        the permission is currently assigned to any roles, you may need to 
+        remove those assignments first or update the roles to use alternative 
         permissions. Returns no content on successful deletion.
       tags:
         - Permissions
@@ -4505,7 +4648,7 @@ paths:
           in: path
           required: true
       responses:
-        '200':
+        "200":
           description: Permission successfully deleted. No content returned.
           content:
             application/json:
@@ -4532,12 +4675,12 @@ paths:
           source: scalekitClient.permissions().deletePermission("read:users");
   /api/v1/roles:
     get:
-      description: Retrieves a comprehensive list of all roles available within
-        the specified environment including organization roles. Use this
-        endpoint to view all role definitions, including custom roles and their
-        configurations. You can optionally include permission details for each
-        role to understand their capabilities. This is useful for role
-        management, auditing organization access controls, or understanding the
+      description: Retrieves a comprehensive list of all roles available within 
+        the specified environment including organization roles. Use this 
+        endpoint to view all role definitions, including custom roles and their 
+        configurations. You can optionally include permission details for each 
+        role to understand their capabilities. This is useful for role 
+        management, auditing organization access controls, or understanding the 
         available access levels within the organization.
       tags:
         - Roles
@@ -4552,13 +4695,13 @@ paths:
           name: include
           in: query
       responses:
-        '200':
-          description: Successfully retrieved list of roles. Returns all roles
+        "200":
+          description: Successfully retrieved list of roles. Returns all roles 
             with their metadata and optionally their permissions.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rolesListRolesResponse'
+                $ref: "#/components/schemas/rolesListRolesResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -4576,24 +4719,24 @@ paths:
           lang: java
           source: ListRolesResponse res = scalekitClient.roles().listRoles();
     post:
-      description: Creates a new role within the environment with specified
-        permissions and metadata. Use this endpoint to define custom roles that
+      description: Creates a new role within the environment with specified 
+        permissions and metadata. Use this endpoint to define custom roles that 
         can be assigned to users or groups. You can create hierarchical roles by
-        extending existing roles, assign specific permissions, and configure
-        display information. Roles are the foundation of your access control
+        extending existing roles, assign specific permissions, and configure 
+        display information. Roles are the foundation of your access control 
         system and determine what actions users can perform.
       tags:
         - Roles
       summary: Create new role in environment
       operationId: RolesService_CreateRole
       responses:
-        '201':
-          description: Role created successfully. Returns the complete role
+        "201":
+          description: Role created successfully. Returns the complete role 
             object with system-generated ID and timestamps.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rolesCreateRoleResponse'
+                $ref: "#/components/schemas/rolesCreateRoleResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -4656,9 +4799,9 @@ paths:
         content:
           application/json:
             schema:
-              description: Role configuration details including name, display
+              description: Role configuration details including name, display 
                 name, description, permissions, and inheritance settings.
-              $ref: '#/components/schemas/v1rolesCreateRole'
+              $ref: "#/components/schemas/v1rolesCreateRole"
               examples:
                 - description: Can edit content
                   display_name: Content Editor
@@ -4669,36 +4812,36 @@ paths:
         required: true
   /api/v1/roles/default:
     patch:
-      description: Updates the default creator and member roles for the current
-        environment. Use this endpoint to configure which roles are
-        automatically assigned to new users when they join the environment. You
-        can specify role names for both creator and member default roles. The
-        system will validate that the specified roles exist and update the
-        environment settings accordingly. Returns the updated default role
+      description: Updates the default creator and member roles for the current 
+        environment. Use this endpoint to configure which roles are 
+        automatically assigned to new users when they join the environment. You 
+        can specify role names for both creator and member default roles. The 
+        system will validate that the specified roles exist and update the 
+        environment settings accordingly. Returns the updated default role 
         objects including their complete role information and permissions.
       tags:
         - Roles
       summary: Set default creator and member roles
       operationId: RolesService_UpdateDefaultRoles2
       responses:
-        '200':
+        "200":
           description: Default roles updated successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rolesUpdateDefaultRolesResponse'
+                $ref: "#/components/schemas/rolesUpdateDefaultRolesResponse"
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/rolesUpdateDefaultRolesRequest'
+              $ref: "#/components/schemas/rolesUpdateDefaultRolesRequest"
         required: true
   /api/v1/roles/{role_name}:
     get:
-      description: Retrieves complete information for a specific role including
-        metadata and inheritance details (base role and dependent role count).
-        Use this endpoint to audit role configuration and understand the role's
-        place in the hierarchy. To view the role's permissions, use the
+      description: Retrieves complete information for a specific role including 
+        metadata and inheritance details (base role and dependent role count). 
+        Use this endpoint to audit role configuration and understand the role's 
+        place in the hierarchy. To view the role's permissions, use the 
         ListRolePermissions endpoint.
       tags:
         - Roles
@@ -4707,7 +4850,7 @@ paths:
       parameters:
         - schema:
             type: string
-          description: Unique name identifier of the role to retrieve. Must be
+          description: Unique name identifier of the role to retrieve. Must be 
             alphanumeric with underscores, 1-64 characters.
           name: role_name
           in: path
@@ -4720,14 +4863,14 @@ paths:
           name: include
           in: query
       responses:
-        '200':
-          description: Successfully retrieved role details. Returns the role
-            object including metadata and inheritance details. Permissions are
+        "200":
+          description: Successfully retrieved role details. Returns the role 
+            object including metadata and inheritance details. Permissions are 
             not included.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rolesGetRoleResponse'
+                $ref: "#/components/schemas/rolesGetRoleResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -4745,11 +4888,11 @@ paths:
           lang: java
           source: GetRoleResponse res = scalekitClient.roles().getRole("admin");
     put:
-      description: Modifies an existing role's properties including display
-        name, description, permissions, and inheritance. Use this endpoint to
-        update role metadata, change permission assignments, or modify role
-        hierarchy. Only the fields you specify will be updated, leaving other
-        properties unchanged. When updating permissions, the new list replaces
+      description: Modifies an existing role's properties including display 
+        name, description, permissions, and inheritance. Use this endpoint to 
+        update role metadata, change permission assignments, or modify role 
+        hierarchy. Only the fields you specify will be updated, leaving other 
+        properties unchanged. When updating permissions, the new list replaces 
         all existing permissions for the role.
       tags:
         - Roles
@@ -4758,19 +4901,19 @@ paths:
       parameters:
         - schema:
             type: string
-          description: Unique name identifier of the role to update. Must be
+          description: Unique name identifier of the role to update. Must be 
             alphanumeric with underscores, 1-64 characters.
           name: role_name
           in: path
           required: true
       responses:
-        '200':
-          description: Role updated successfully. Returns the modified role
+        "200":
+          description: Role updated successfully. Returns the modified role 
             object with updated timestamps.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rolesUpdateRoleResponse'
+                $ref: "#/components/schemas/rolesUpdateRoleResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -4821,22 +4964,22 @@ paths:
         content:
           application/json:
             schema:
-              description: Role fields to update. Only specified fields will be
+              description: Role fields to update. Only specified fields will be 
                 modified.
-              $ref: '#/components/schemas/v1rolesUpdateRole'
+              $ref: "#/components/schemas/v1rolesUpdateRole"
               examples:
                 - description: Can edit and approve content
                   display_name: Senior Editor
         required: true
     delete:
       description: Permanently removes a role from the environment and reassigns
-        users who had that role to a different role. Use this endpoint when you
+        users who had that role to a different role. Use this endpoint when you 
         need to clean up unused roles or restructure your access control system.
-        The role cannot be deleted if it has dependent roles (roles that extend
-        it) unless you specify a replacement role. If users are assigned to the
-        role being deleted, you must provide a reassign_role_name to move those
-        users to a different role before deletion can proceed. This action
-        cannot be undone, so ensure no critical users depend on the role before
+        The role cannot be deleted if it has dependent roles (roles that extend 
+        it) unless you specify a replacement role. If users are assigned to the 
+        role being deleted, you must provide a reassign_role_name to move those 
+        users to a different role before deletion can proceed. This action 
+        cannot be undone, so ensure no critical users depend on the role before 
         deletion.
       tags:
         - Roles
@@ -4845,7 +4988,7 @@ paths:
       parameters:
         - schema:
             type: string
-          description: Unique name identifier of the role to delete. Must be
+          description: Unique name identifier of the role to delete. Must be 
             alphanumeric with underscores, 1-64 characters.
           name: role_name
           in: path
@@ -4861,8 +5004,8 @@ paths:
           name: reassign_role_name
           in: query
       responses:
-        '200':
-          description: Role successfully deleted and users reassigned. No
+        "200":
+          description: Role successfully deleted and users reassigned. No 
             content returned.
           content:
             application/json:
@@ -4904,64 +5047,17 @@ paths:
 
             // With reassignment
             scalekitClient.roles().deleteRole("admin", "member");
-  /api/v1/roles/{role_name}/base:
-    delete:
-      description: Removes the base role inheritance relationship for a
-        specified role, effectively eliminating all inherited permissions from
-        the base role. Use this endpoint when you want to break the hierarchical
-        relationship between roles and remove inherited permissions. The role
-        will retain only its directly assigned permissions after this operation.
-        This action cannot be undone, so ensure the role has sufficient direct
-        permissions before removing inheritance. Returns no content on
-        successful removal of the base relationship.
-      tags:
-        - Roles
-      summary: Delete role inheritance relationship
-      operationId: RolesService_DeleteRoleBase
-      parameters:
-        - schema:
-            type: string
-          description: Unique name identifier of the role whose base inheritance
-            relationship should be removed. Must be alphanumeric with
-            underscores, 1-64 characters.
-          name: role_name
-          in: path
-          required: true
-      responses:
-        '200':
-          description: Base role inheritance relationship successfully removed.
-            The role now has only its directly assigned permissions.
-          content:
-            application/json:
-              schema: {}
-      x-codeSamples:
-        - label: Node.js SDK
-          lang: javascript
-          source: await scalekit.role.deleteRoleBase("senior_editor");
-        - label: Python SDK
-          lang: python
-          source: scalekit_client.roles.delete_role_base(role_name="senior_editor")
-        - label: Go SDK
-          lang: go
-          source: |-
-            err := scalekitClient.Role().DeleteRoleBase(ctx, "senior_editor")
-            if err != nil {
-                // handle error
-            }
-        - label: Java SDK
-          lang: java
-          source: scalekitClient.roles().deleteRoleBase("senior_editor");
   /api/v1/roles/{role_name}/dependents:
     get:
-      description: Retrieves all roles that directly extend the specified base
-        role through inheritance. Use this endpoint to understand the role
+      description: Retrieves all roles that directly extend the specified base 
+        role through inheritance. Use this endpoint to understand the role 
         hierarchy and identify which roles inherit permissions from a particular
-        base role. Provide the base role name as a path parameter, and the
-        response will include all dependent roles with their metadata and
-        permission information. This operation is useful for auditing role
-        inheritance relationships, understanding the impact of changes to base
-        roles, or managing role hierarchies effectively. Returns a list of
-        dependent role objects including their names, display names,
+        base role. Provide the base role name as a path parameter, and the 
+        response will include all dependent roles with their metadata and 
+        permission information. This operation is useful for auditing role 
+        inheritance relationships, understanding the impact of changes to base 
+        roles, or managing role hierarchies effectively. Returns a list of 
+        dependent role objects including their names, display names, 
         descriptions, and permission details.
       tags:
         - Roles
@@ -4975,21 +5071,21 @@ paths:
           in: path
           required: true
       responses:
-        '200':
+        "200":
           description: Successfully retrieved dependent roles. Returns a list of
-            all roles that extend the specified base role, including their
+            all roles that extend the specified base role, including their 
             metadata and permission information.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rolesListDependentRolesResponse'
+                $ref: "#/components/schemas/rolesListDependentRolesResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
           source: const res = await scalekit.role.listDependentRoles("admin");
         - label: Python SDK
           lang: python
-          source: res =
+          source: res = 
             scalekit_client.roles.list_dependent_roles(role_name="admin")
         - label: Go SDK
           lang: go
@@ -4999,20 +5095,20 @@ paths:
             _ = resp
         - label: Java SDK
           lang: java
-          source: ListDependentRolesResponse res =
+          source: ListDependentRolesResponse res = 
             scalekitClient.roles().listDependentRoles("admin");
   /api/v1/roles/{role_name}/permissions:
     get:
-      description: Retrieves all permissions directly assigned to the specified
+      description: Retrieves all permissions directly assigned to the specified 
         role, excluding permissions inherited from base roles. Use this endpoint
-        to view the explicit permission assignments for a role, which is useful
-        for understanding direct role capabilities, auditing permission
+        to view the explicit permission assignments for a role, which is useful 
+        for understanding direct role capabilities, auditing permission 
         assignments, or managing role-permission relationships. Provide the role
-        name as a path parameter, and the response will include only the
+        name as a path parameter, and the response will include only the 
         permissions that are directly assigned to that role. This operation does
-        not include inherited permissions from role hierarchies - use
-        ListEffectiveRolePermissions to see the complete set of permissions
-        including inheritance. Returns a list of permission objects with their
+        not include inherited permissions from role hierarchies - use 
+        ListEffectiveRolePermissions to see the complete set of permissions 
+        including inheritance. Returns a list of permission objects with their 
         names, descriptions, and assignment metadata.
       tags:
         - Roles
@@ -5026,22 +5122,22 @@ paths:
           in: path
           required: true
       responses:
-        '200':
-          description: Successfully retrieved role permissions. Returns a list
-            of all permissions directly assigned to the specified role,
+        "200":
+          description: Successfully retrieved role permissions. Returns a list 
+            of all permissions directly assigned to the specified role, 
             excluding inherited permissions.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rolesListRolePermissionsResponse'
+                $ref: "#/components/schemas/rolesListRolePermissionsResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
-          source: const res = await
+          source: const res = await 
             scalekit.permission.listRolePermissions("admin");
         - label: Python SDK
           lang: python
-          source: res =
+          source: res = 
             scalekit_client.permissions.list_role_permissions(role_name="admin")
         - label: Go SDK
           lang: go
@@ -5054,18 +5150,18 @@ paths:
             _ = resp
         - label: Java SDK
           lang: java
-          source: ListRolePermissionsResponse res =
+          source: ListRolePermissionsResponse res = 
             scalekitClient.permissions().listRolePermissions("admin");
     post:
-      description: Adds one or more permissions to the specified role while
-        preserving existing permission assignments. Use this endpoint to grant
-        additional capabilities to a role without affecting its current
-        permission set. Provide the role name as a path parameter and a list of
-        permission names in the request body. The system will validate that all
+      description: Adds one or more permissions to the specified role while 
+        preserving existing permission assignments. Use this endpoint to grant 
+        additional capabilities to a role without affecting its current 
+        permission set. Provide the role name as a path parameter and a list of 
+        permission names in the request body. The system will validate that all 
         specified permissions exist in the environment and add them to the role.
-        Existing permission assignments remain unchanged, making this operation
+        Existing permission assignments remain unchanged, making this operation 
         safe for incremental permission management. This is useful for gradually
-        expanding role capabilities or adding new permissions as your system
+        expanding role capabilities or adding new permissions as your system 
         evolves. Returns the updated list of all permissions now assigned to the
         role.
       tags:
@@ -5080,18 +5176,18 @@ paths:
           in: path
           required: true
       responses:
-        '200':
-          description: Permissions added to role successfully. Returns the
+        "200":
+          description: Permissions added to role successfully. Returns the 
             complete list of all permissions now assigned to the role, including
             both existing and newly added permissions.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rolesAddPermissionsToRoleResponse'
+                $ref: "#/components/schemas/rolesAddPermissionsToRoleResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
-          source: await scalekit.permission.addPermissionsToRole("role_admin",
+          source: await scalekit.permission.addPermissionsToRole("role_admin", 
             ["perm.read", "perm.write"]);
         - label: Python SDK
           lang: python
@@ -5102,8 +5198,8 @@ paths:
             )
         - label: Go SDK
           lang: go
-          source: resp, err :=
-            scalekitClient.Permission().AddPermissionsToRole(ctx, "role_admin",
+          source: resp, err := 
+            scalekitClient.Permission().AddPermissionsToRole(ctx, "role_admin", 
             []string{"perm.read", "perm.write"})
         - label: Java SDK
           lang: java
@@ -5120,19 +5216,19 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RolesServiceAddPermissionsToRoleBody'
+              $ref: "#/components/schemas/RolesServiceAddPermissionsToRoleBody"
         required: true
   /api/v1/roles/{role_name}/permissions/{permission_name}:
     delete:
-      description: Removes a specific permission from the specified role,
-        revoking that capability from all users assigned to the role. Use this
-        endpoint to restrict role capabilities or remove unnecessary
-        permissions. Provide both the role name and permission name as path
+      description: Removes a specific permission from the specified role, 
+        revoking that capability from all users assigned to the role. Use this 
+        endpoint to restrict role capabilities or remove unnecessary 
+        permissions. Provide both the role name and permission name as path 
         parameters. This operation only affects the direct permission assignment
-        and does not impact permissions inherited from base roles. If the
-        permission is inherited through role hierarchy, you may need to modify
-        the base role instead. This is useful for fine-tuning role permissions,
-        implementing least-privilege access controls, or removing deprecated
+        and does not impact permissions inherited from base roles. If the 
+        permission is inherited through role hierarchy, you may need to modify 
+        the base role instead. This is useful for fine-tuning role permissions, 
+        implementing least-privilege access controls, or removing deprecated 
         permissions. Returns no content on successful removal.
       tags:
         - Roles
@@ -5152,8 +5248,8 @@ paths:
           in: path
           required: true
       responses:
-        '200':
-          description: Permission removed from role successfully. No content
+        "200":
+          description: Permission removed from role successfully. No content 
             returned.
           content:
             application/json:
@@ -5161,7 +5257,7 @@ paths:
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
-          source: await scalekit.permission.removePermissionFromRole("admin",
+          source: await scalekit.permission.removePermissionFromRole("admin", 
             "read:users");
         - label: Python SDK
           lang: python
@@ -5183,16 +5279,16 @@ paths:
             "read:users");
   /api/v1/roles/{role_name}/permissions:all:
     get:
-      description: Retrieves the complete set of effective permissions for a
-        role, including both directly assigned permissions and permissions
-        inherited from base roles through the role hierarchy. Use this endpoint
+      description: Retrieves the complete set of effective permissions for a 
+        role, including both directly assigned permissions and permissions 
+        inherited from base roles through the role hierarchy. Use this endpoint 
         to understand the full scope of capabilities available to users assigned
-        to a specific role. Provide the role name as a path parameter, and the
+        to a specific role. Provide the role name as a path parameter, and the 
         response will include all permissions that apply to the role, accounting
-        for inheritance relationships. This operation is essential for auditing
-        role capabilities, understanding permission inheritance, or verifying
-        the complete access scope before role assignment. Returns a
-        comprehensive list of permission names representing the full set of
+        for inheritance relationships. This operation is essential for auditing 
+        role capabilities, understanding permission inheritance, or verifying 
+        the complete access scope before role assignment. Returns a 
+        comprehensive list of permission names representing the full set of 
         effective permissions for the specified role.
       tags:
         - Roles
@@ -5206,51 +5302,24 @@ paths:
           in: path
           required: true
       responses:
-        '200':
+        "200":
           description: Successfully retrieved effective permissions. Returns the
-            complete list of all permissions that apply to the role, including
+            complete list of all permissions that apply to the role, including 
             both direct assignments and inherited permissions from base roles.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rolesListEffectiveRolePermissionsResponse'
-      x-codeSamples:
-        - label: Node.js SDK
-          lang: javascript
-          source: const { permissions } = await
-            scalekit.permission.listEffectiveRolePermissions("senior_editor");
-        - label: Python SDK
-          lang: python
-          source: |-
-            response = scalekit_client.permissions.list_effective_role_permissions(role_name="senior_editor")
-            permissions = response.permissions
-        - label: Go SDK
-          lang: go
-          source: >-
-            resp, err :=
-            scalekitClient.Permission().ListEffectiveRolePermissions(ctx,
-            "senior_editor")
-
-            if err != nil {
-                // handle error
-            }
-
-            permissions := resp.Permissions
-        - label: Java SDK
-          lang: java
-          source: |-
-            ListEffectiveRolePermissionsResponse response = scalekitClient.permissions().listEffectiveRolePermissions("senior_editor");
-            List<Permission> permissions = response.getPermissionsList();
+                $ref: "#/components/schemas/rolesListEffectiveRolePermissionsResponse"
   /api/v1/roles/{role_name}/users:count:
     get:
       description: Retrieves the total number of users currently assigned to the
         specified role within the environment. Use this endpoint to monitor role
         usage, enforce user limits, or understand the scope of role assignments.
-        Provide the role's unique name as a path parameter, and the response
-        will include the current user count for that role. This operation is
-        read-only and does not modify any data or user assignments. The count
-        reflects all users who have the role either directly assigned or
-        inherited through organization membership. This information is useful
+        Provide the role's unique name as a path parameter, and the response 
+        will include the current user count for that role. This operation is 
+        read-only and does not modify any data or user assignments. The count 
+        reflects all users who have the role either directly assigned or 
+        inherited through organization membership. This information is useful 
         for capacity planning, security auditing, or understanding the impact of
         role changes across your user base.
       tags:
@@ -5265,21 +5334,21 @@ paths:
           in: path
           required: true
       responses:
-        '200':
+        "200":
           description: Successfully retrieved user count for the specified role.
-            Returns the total number of users currently assigned to the role,
+            Returns the total number of users currently assigned to the role, 
             including both direct assignments and inherited assignments.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rolesGetRoleUsersCountResponse'
+                $ref: "#/components/schemas/rolesGetRoleUsersCountResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
           source: const res = await scalekit.role.getRoleUsersCount("admin");
         - label: Python SDK
           lang: python
-          source: res =
+          source: res = 
             scalekit_client.roles.get_role_users_count(role_name="admin")
         - label: Go SDK
           lang: go
@@ -5289,28 +5358,28 @@ paths:
             _ = resp
         - label: Java SDK
           lang: java
-          source: GetRoleUsersCountResponse res =
+          source: GetRoleUsersCountResponse res = 
             scalekitClient.roles().getRoleUsersCount("admin");
   /api/v1/roles:set_defaults:
     patch:
-      description: Updates the default creator and member roles for the current
-        environment. Use this endpoint to configure which roles are
-        automatically assigned to new users when they join the environment. You
-        can specify role names for both creator and member default roles. The
-        system will validate that the specified roles exist and update the
-        environment settings accordingly. Returns the updated default role
+      description: Updates the default creator and member roles for the current 
+        environment. Use this endpoint to configure which roles are 
+        automatically assigned to new users when they join the environment. You 
+        can specify role names for both creator and member default roles. The 
+        system will validate that the specified roles exist and update the 
+        environment settings accordingly. Returns the updated default role 
         objects including their complete role information and permissions.
       tags:
         - Roles
       summary: Set default creator and member roles
       operationId: RolesService_UpdateDefaultRoles
       responses:
-        '200':
+        "200":
           description: Default roles updated successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rolesUpdateDefaultRolesResponse'
+                $ref: "#/components/schemas/rolesUpdateDefaultRolesResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -5347,18 +5416,18 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/rolesUpdateDefaultRolesRequest'
+              $ref: "#/components/schemas/rolesUpdateDefaultRolesRequest"
         required: true
   /api/v1/sessions/{session_id}:
     get:
-      description: Retrieves comprehensive details for a specific user session
-        including authentication status, device information, and expiration
-        timelines. Use this endpoint to fetch current session metadata for
-        security audits, session validation, or to display session information
-        in user account management interfaces. Returns all session properties
-        including the user ID, authenticated organizations, device details with
-        browser/OS information, IP address and geolocation, and all relevant
-        timestamps (creation, last activity, idle expiration, absolute
+      description: Retrieves comprehensive details for a specific user session 
+        including authentication status, device information, and expiration 
+        timelines. Use this endpoint to fetch current session metadata for 
+        security audits, session validation, or to display session information 
+        in user account management interfaces. Returns all session properties 
+        including the user ID, authenticated organizations, device details with 
+        browser/OS information, IP address and geolocation, and all relevant 
+        timestamps (creation, last activity, idle expiration, absolute 
         expiration, and actual expiration if applicable).
       tags:
         - Sessions
@@ -5373,20 +5442,20 @@ paths:
           in: path
           required: true
       responses:
-        '200':
+        "200":
           description: Successfully retrieved session details
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/sessionsSessionDetails'
+                $ref: "#/components/schemas/sessionsSessionDetails"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
-          source: const res = await
+          source: const res = await 
             scalekit.session.getSession("ses_123456789");
         - label: Python SDK
           lang: python
-          source: res =
+          source: res = 
             scalekit_client.sessions.get_session(session_id="ses_123456789")
         - label: Go SDK
           lang: go
@@ -5399,17 +5468,17 @@ paths:
             _ = resp
         - label: Java SDK
           lang: java
-          source: SessionDetails res =
+          source: SessionDetails res = 
             scalekitClient.sessions().getSession("ses_123456789");
   /api/v1/sessions/{session_id}/revoke:
     post:
-      description: Immediately invalidates a specific user session by session
+      description: Immediately invalidates a specific user session by session 
         ID, setting its status to 'revoked'. Once revoked, the session cannot be
-        used for any future API requests or application access. Use this
-        endpoint to implement session-level logout, force a user to
-        reauthenticate on a specific device, or terminate suspicious sessions.
-        The revocation is instantaneous and irreversible. Returns the revoked
-        session details including the session ID, user ID, and the revocation
+        used for any future API requests or application access. Use this 
+        endpoint to implement session-level logout, force a user to 
+        reauthenticate on a specific device, or terminate suspicious sessions. 
+        The revocation is instantaneous and irreversible. Returns the revoked 
+        session details including the session ID, user ID, and the revocation 
         timestamp.
       tags:
         - Sessions
@@ -5418,27 +5487,27 @@ paths:
       parameters:
         - schema:
             type: string
-          description: Unique identifier for the session to revoke. Must start
+          description: Unique identifier for the session to revoke. Must start 
             with 'ses_' prefix.
           name: session_id
           in: path
           required: true
       responses:
-        '200':
-          description: Successfully revoked the session. Returns the revoked
+        "200":
+          description: Successfully revoked the session. Returns the revoked 
             session details
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/sessionsRevokeSessionResponse'
+                $ref: "#/components/schemas/sessionsRevokeSessionResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
-          source: const res = await
+          source: const res = await 
             scalekit.session.revokeSession("ses_123456789");
         - label: Python SDK
           lang: python
-          source: res =
+          source: res = 
             scalekit_client.sessions.revoke_session(session_id="ses_123456789")
         - label: Go SDK
           lang: go
@@ -5451,14 +5520,14 @@ paths:
             _ = resp
         - label: Java SDK
           lang: java
-          source: RevokeSessionResponse res =
+          source: RevokeSessionResponse res = 
             scalekitClient.sessions().revokeSession("ses_123456789");
   /api/v1/users:
     get:
-      description: Retrieves a paginated list of all users across your entire
-        environment. Use this endpoint to view all users regardless of their
-        organization memberships. This is useful for administrative purposes,
-        user audits, or when you need to see all users in your Scalekit
+      description: Retrieves a paginated list of all users across your entire 
+        environment. Use this endpoint to view all users regardless of their 
+        organization memberships. This is useful for administrative purposes, 
+        user audits, or when you need to see all users in your Scalekit 
         environment. Supports pagination for large user bases.
       tags:
         - Users
@@ -5468,23 +5537,23 @@ paths:
         - schema:
             type: integer
             format: int64
-          description: Maximum number of organizations to return per page. Must
+          description: Maximum number of organizations to return per page. Must 
             be between 10 and 100
           name: page_size
           in: query
         - schema:
             type: string
-          description: Pagination token from the previous response. Use to
+          description: Pagination token from the previous response. Use to 
             retrieve the next page of organizations
           name: page_token
           in: query
       responses:
-        '200':
+        "200":
           description: List of users.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/usersListUsersResponse'
+                $ref: "#/components/schemas/usersListUsersResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -5500,9 +5569,8 @@ paths:
             page_size=100)
         - label: Go SDK
           lang: go
-          source:
-            'all, err := scalekitClient.User().ListUsers(ctx, &scalekit.ListUsersOptions{PageSize:
-            100})'
+          source: "all, err := scalekitClient.User().ListUsers(ctx, &scalekit.ListUsersOptions{PageSize:
+            100})"
         - label: Java SDK
           lang: java
           source: |-
@@ -5511,8 +5579,8 @@ paths:
             ListUsersResponse allUsers = users.listUsers(lur);
   /api/v1/users/{id}:
     get:
-      description: Retrieves all details for a user by system-generated user ID
-        or external ID. The response includes organization memberships and user
+      description: Retrieves all details for a user by system-generated user ID 
+        or external ID. The response includes organization memberships and user 
         metadata.
       tags:
         - Users
@@ -5527,18 +5595,18 @@ paths:
           required: true
         - schema:
             type: string
-          description: Your application's unique identifier for this
+          description: Your application's unique identifier for this 
             organization, used to link Scalekit with your system.
           name: external_id
           in: query
       responses:
-        '200':
-          description: User details retrieved successfully. Returns full user
+        "200":
+          description: User details retrieved successfully. Returns full user 
             object with system-generated fields and timestamps.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/usersGetUserResponse'
+                $ref: "#/components/schemas/usersGetUserResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -5562,10 +5630,10 @@ paths:
             GetUserResponse resp = scalekitClient.users().getUser("usr_123456");
             User user = resp.getUser();
     delete:
-      description: Permanently removes a user from your environment and deletes
-        all associated data. Use this endpoint when you need to completely
-        remove a user account. This action deletes the user's profile,
-        memberships, and all related data across all organizations. This
+      description: Permanently removes a user from your environment and deletes 
+        all associated data. Use this endpoint when you need to completely 
+        remove a user account. This action deletes the user's profile, 
+        memberships, and all related data across all organizations. This 
         operation cannot be undone, so use with caution.
       tags:
         - Users
@@ -5574,19 +5642,19 @@ paths:
       parameters:
         - schema:
             type: string
-          description: System-generated user ID. Must start with 'usr_' (19-25
+          description: System-generated user ID. Must start with 'usr_' (19-25 
             characters)
           name: id
           in: path
           required: true
         - schema:
             type: string
-          description: External system identifier from connected directories.
+          description: External system identifier from connected directories. 
             Must match existing records
           name: external_id
           in: query
       responses:
-        '200':
+        "200":
           description: User successfully deleted. No content returned
           content:
             application/json:
@@ -5611,11 +5679,11 @@ paths:
           lang: java
           source: users.deleteUser("usr_123");
     patch:
-      description: Modifies user account information including profile details,
+      description: Modifies user account information including profile details, 
         metadata, and external ID. Use this endpoint to update a user's personal
-        information, contact details, or custom metadata. You can update the
+        information, contact details, or custom metadata. You can update the 
         user's profile, phone number, and metadata fields. Note that fields like
-        user ID, email address, environment ID, and creation time cannot be
+        user ID, email address, environment ID, and creation time cannot be 
         modified.
       tags:
         - Users
@@ -5624,25 +5692,25 @@ paths:
       parameters:
         - schema:
             type: string
-          description: System-generated user ID. Must start with 'usr_' and be
+          description: System-generated user ID. Must start with 'usr_' and be 
             19-25 characters long.
           name: id
           in: path
           required: true
         - schema:
             type: string
-          description: Your application's unique identifier for this
+          description: Your application's unique identifier for this 
             organization, used to link Scalekit with your system.
           name: external_id
           in: query
       responses:
-        '200':
-          description: User updated successfully. Returns the modified user
+        "200":
+          description: User updated successfully. Returns the modified user 
             object with updated timestamps.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/usersUpdateUserResponse'
+                $ref: "#/components/schemas/usersUpdateUserResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -5708,22 +5776,22 @@ paths:
         content:
           application/json:
             schema:
-              description: User fields to update. Only specified fields will be
+              description: User fields to update. Only specified fields will be 
                 modified. Required fields must be provided if being changed.
-              $ref: '#/components/schemas/v1usersUpdateUser'
+              $ref: "#/components/schemas/v1usersUpdateUser"
               examples:
                 - firstName: John
                   lastName: Doe
         required: true
   /api/v1/users/{user_id}/sessions:
     get:
-      description: Retrieves a paginated list of all sessions associated with a
-        specific user across all devices and browsers. Use this endpoint to
-        audit user activity, display all active sessions in account management
-        interfaces, or verify user authentication status across devices.
-        Supports filtering by session status (active, expired, revoked, logout)
+      description: Retrieves a paginated list of all sessions associated with a 
+        specific user across all devices and browsers. Use this endpoint to 
+        audit user activity, display all active sessions in account management 
+        interfaces, or verify user authentication status across devices. 
+        Supports filtering by session status (active, expired, revoked, logout) 
         and time range (creation date). Returns session details for each session
-        including device information, IP address, geolocation, and current
+        including device information, IP address, geolocation, and current 
         status. The response includes pagination metadata (page tokens and total
         count) to handle large session lists efficiently.
       tags:
@@ -5733,7 +5801,7 @@ paths:
       parameters:
         - schema:
             type: string
-          description: Unique identifier for the user whose sessions to
+          description: Unique identifier for the user whose sessions to 
             retrieve. Must start with 'usr_' prefix.
           name: user_id
           in: path
@@ -5741,15 +5809,15 @@ paths:
         - schema:
             type: integer
             format: int64
-          description: Maximum number of sessions to return in a single page.
-            Optional parameter. If not specified, defaults to a server-defined
-            limit. Use smaller values for faster responses, larger values for
+          description: Maximum number of sessions to return in a single page. 
+            Optional parameter. If not specified, defaults to a server-defined 
+            limit. Use smaller values for faster responses, larger values for 
             fewer requests.
           name: page_size
           in: query
         - schema:
             type: string
-          description: Pagination token from the previous response for
+          description: Pagination token from the previous response for 
             retrieving the next page of results. Leave empty for the first page.
             Use the next_page_token from a previous response to fetch subsequent
             pages.
@@ -5770,8 +5838,8 @@ paths:
         - schema:
             type: string
             format: date-time
-          description: Filter to include only sessions created on or after this
-            timestamp. Optional. Uses RFC 3339 format. Useful for querying
+          description: Filter to include only sessions created on or after this 
+            timestamp. Optional. Uses RFC 3339 format. Useful for querying 
             sessions within a specific time window.
           name: filter.start_time
           in: query
@@ -5779,18 +5847,18 @@ paths:
             type: string
             format: date-time
           description: Filter to include only sessions created on or before this
-            timestamp. Optional. Uses RFC 3339 format. Must be after start_time
+            timestamp. Optional. Uses RFC 3339 format. Must be after start_time 
             if both are specified.
           name: filter.end_time
           in: query
       responses:
-        '200':
-          description: Successfully retrieved user sessions. Returns a list of
+        "200":
+          description: Successfully retrieved user sessions. Returns a list of 
             sessions with pagination information
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/sessionsUserSessionDetails'
+                $ref: "#/components/schemas/sessionsUserSessionDetails"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -5893,14 +5961,14 @@ paths:
             "next_page_token", filter);
   /api/v1/users/{user_id}/sessions/revoke:
     post:
-      description: Immediately invalidates all active sessions for a specific
+      description: Immediately invalidates all active sessions for a specific 
         user across all devices and browsers, setting their status to 'revoked'.
-        Use this endpoint to implement global logout functionality, force
-        re-authentication after security incidents, or terminate all sessions
-        following a password reset or credential compromise. Only active
-        sessions are revoked; already expired, logout, or previously revoked
-        sessions remain unchanged. The revocation is atomic and instantaneous.
-        Returns a list of all revoked sessions with their details and a total
+        Use this endpoint to implement global logout functionality, force 
+        re-authentication after security incidents, or terminate all sessions 
+        following a password reset or credential compromise. Only active 
+        sessions are revoked; already expired, logout, or previously revoked 
+        sessions remain unchanged. The revocation is atomic and instantaneous. 
+        Returns a list of all revoked sessions with their details and a total 
         count of sessions revoked.
       tags:
         - Sessions
@@ -5915,21 +5983,21 @@ paths:
           in: path
           required: true
       responses:
-        '200':
-          description: Successfully revoked all user sessions. Returns the list
+        "200":
+          description: Successfully revoked all user sessions. Returns the list 
             of revoked sessions and total count
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/sessionsRevokeAllUserSessionsResponse'
+                $ref: "#/components/schemas/sessionsRevokeAllUserSessionsResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
-          source: const res = await
+          source: const res = await 
             scalekit.session.revokeAllUserSessions("user_123");
         - label: Python SDK
           lang: python
-          source: res =
+          source: res = 
             scalekit_client.sessions.revoke_all_user_sessions(user_id="user_123")
         - label: Go SDK
           lang: go
@@ -5942,14 +6010,14 @@ paths:
             _ = resp
         - label: Java SDK
           lang: java
-          source: RevokeAllUserSessionsResponse res =
+          source: RevokeAllUserSessionsResponse res = 
             scalekitClient.sessions().revokeAllUserSessions("user_123");
   /api/v1/users:search:
     get:
-      description: Searches for users across the entire environment by email
-        address, user ID, or external ID. The query must be at least 3
+      description: Searches for users across the entire environment by email 
+        address, user ID, or external ID. The query must be at least 3 
         characters and is case-insensitive. Returns a paginated list of matching
-        users with up to 30 results per page. Use the next_page_token from the
+        users with up to 30 results per page. Use the next_page_token from the 
         response to retrieve subsequent pages.
       tags:
         - Users
@@ -5976,28 +6044,28 @@ paths:
           in: query
         - schema:
             type: string
-          description: Token from a previous response for pagination. Provide
+          description: Token from a previous response for pagination. Provide 
             this to retrieve the next page of results.
           name: page_token
           in: query
       responses:
-        '200':
-          description: Matching users returned; includes pagination cursors for
+        "200":
+          description: Matching users returned; includes pagination cursors for 
             navigating large result sets.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/usersSearchUsersResponse'
-        '400':
-          description: Bad Request - query must be at least 3 characters and no
+                $ref: "#/components/schemas/usersSearchUsersResponse"
+        "400":
+          description: Bad Request - query must be at least 3 characters and no 
             more than 100 characters.
           content:
             application/json:
               schema: {}
   /api/v1/webauthn/credentials:
     get:
-      description: Retrieves all registered passkeys for the current user,
-        including device information, creation timestamps, and display names.
+      description: Retrieves all registered passkeys for the current user, 
+        including device information, creation timestamps, and display names. 
         Use this to show users their registered authenticators.
       tags:
         - Passkeys
@@ -6006,25 +6074,25 @@ paths:
       parameters:
         - schema:
             type: string
-          description: User ID to list credentials for (optional, current user
+          description: User ID to list credentials for (optional, current user 
             if not provided)
           name: user_id
           in: query
       responses:
-        '200':
+        "200":
           description: List of passkeys with metadata
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/webauthnListCredentialsResponse'
+                $ref: "#/components/schemas/webauthnListCredentialsResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
-          source: const res = await
+          source: const res = await 
             scalekit.webauthn.listCredentials("user_123");
         - label: Python SDK
           lang: python
-          source: res =
+          source: res = 
             scalekit_client.webauthn.list_credentials(user_id="user_123")
         - label: Go SDK
           lang: go
@@ -6037,12 +6105,12 @@ paths:
             _ = resp
         - label: Java SDK
           lang: java
-          source: ListCredentialsResponse res =
+          source: ListCredentialsResponse res = 
             scalekitClient.webauthn().listCredentials("user_123");
   /api/v1/webauthn/credentials/{credential_id}:
     delete:
-      description: Deletes a specific passkey credential for the current user.
-        After removal, the authenticator can no longer be used for
+      description: Deletes a specific passkey credential for the current user. 
+        After removal, the authenticator can no longer be used for 
         authentication.
       tags:
         - Passkeys
@@ -6056,20 +6124,20 @@ paths:
           in: path
           required: true
       responses:
-        '200':
+        "200":
           description: Passkey successfully deleted
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/webauthnDeleteCredentialResponse'
+                $ref: "#/components/schemas/webauthnDeleteCredentialResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
-          source: const res = await
+          source: const res = await 
             scalekit.webauthn.deleteCredential("wac_123");
         - label: Python SDK
           lang: python
-          source: res =
+          source: res = 
             scalekit_client.webauthn.delete_credential(credential_id="wac_123")
         - label: Go SDK
           lang: go
@@ -6082,11 +6150,11 @@ paths:
             _ = resp
         - label: Java SDK
           lang: java
-          source: DeleteCredentialResponse res =
+          source: DeleteCredentialResponse res = 
             scalekitClient.webauthn().deleteCredential("wac_123");
     patch:
-      description: Updates the display name of a passkey credential to help
-        users identify their authenticators. Only the display name can be
+      description: Updates the display name of a passkey credential to help 
+        users identify their authenticators. Only the display name can be 
         modified.
       tags:
         - Passkeys
@@ -6100,12 +6168,12 @@ paths:
           in: path
           required: true
       responses:
-        '200':
+        "200":
           description: Passkey successfully updated with new name
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/webauthnUpdateCredentialResponse'
+                $ref: "#/components/schemas/webauthnUpdateCredentialResponse"
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
@@ -6140,7 +6208,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/WebAuthnServiceUpdateCredentialBody'
+              $ref: "#/components/schemas/WebAuthnServiceUpdateCredentialBody"
         required: true
 tags:
   - description: |
@@ -6158,43 +6226,43 @@ tags:
       | `metadata`<br>_object_     | Additional organization information stored as JSON.<br>Example: `{"key":"value"}`                                                            |
       | `region_code`<br>_string_  | Data center region where organization data is stored. Currently always returns `US`.                                                         | -->
     name: Organizations
-  - description: Permission management for defining and controlling access to
-      system resources. Create, retrieve, update, and delete granular
+  - description: Permission management for defining and controlling access to 
+      system resources. Create, retrieve, update, and delete granular 
       permissions that represent specific actions users can perform. Permissions
-      are the building blocks of role-based access control (RBAC) and can be
-      assigned to roles to grant users the ability to perform specific
-      operations. Use this service to define custom permissions for your
+      are the building blocks of role-based access control (RBAC) and can be 
+      assigned to roles to grant users the ability to perform specific 
+      operations. Use this service to define custom permissions for your 
       application's unique access control requirements.
     name: Permissions
-  - description: Comprehensive user management operations including user
-      lifecycle, organization memberships, and invitation workflows. This
-      service provides endpoints for creating, retrieving, updating, and
-      deleting user accounts across your Scalekit environment. It supports both
-      individual user operations and bulk operations for user administration,
-      including user search, pagination, and metadata management. The service
+  - description: Comprehensive user management operations including user 
+      lifecycle, organization memberships, and invitation workflows. This 
+      service provides endpoints for creating, retrieving, updating, and 
+      deleting user accounts across your Scalekit environment. It supports both 
+      individual user operations and bulk operations for user administration, 
+      including user search, pagination, and metadata management. The service 
       also handles user invitations and organization membership management.
     name: Users
-  - description: Manage enterprise connections for your Scalekit environment.
+  - description: Manage enterprise connections for your Scalekit environment. 
       This service provides endpoints for retrieving, and updating connections.
     name: Connections
-  - description: Directory management for viewing and controlling external
-      identity provider connections in your Scalekit environment. This service
-      provides endpoints for retrieving directory information, listing
-      directories and their contents, and enabling or disabling directory
+  - description: Directory management for viewing and controlling external 
+      identity provider connections in your Scalekit environment. This service 
+      provides endpoints for retrieving directory information, listing 
+      directories and their contents, and enabling or disabling directory 
       synchronization.
     name: Directory
-  - description: Role-based access control (RBAC) for defining and managing
-      permissions in an environment. Create and update custom roles with
-      explicit permissions, model role hierarchies through inheritance, view
-      dependent roles, manage role-permission assignments, and list roles and
+  - description: Role-based access control (RBAC) for defining and managing 
+      permissions in an environment. Create and update custom roles with 
+      explicit permissions, model role hierarchies through inheritance, view 
+      dependent roles, manage role-permission assignments, and list roles and 
       permissions. Also provides a utility to count users assigned to a role.
     name: Roles
-  - description: Comprehensive session management for user authentication and
-      authorization. This service provides endpoints for retrieving session
-      details, managing user sessions across devices, revoking individual
-      sessions, and terminating all active sessions for a user. It supports
-      session auditing, device tracking, and security monitoring with detailed
-      session metadata including device information, IP geolocation, and
+  - description: Comprehensive session management for user authentication and 
+      authorization. This service provides endpoints for retrieving session 
+      details, managing user sessions across devices, revoking individual 
+      sessions, and terminating all active sessions for a user. It supports 
+      session auditing, device tracking, and security monitoring with detailed 
+      session metadata including device information, IP geolocation, and 
       activity timestamps.
     name: Sessions
   - description: >
@@ -6210,24 +6278,24 @@ tags:
       Scalekit suggests the organization in the organization switcher
       (authentication-method agnostic).
     name: Domains
-  - description: Endpoints for managing API client applications. API clients
-      enable secure, automated interactions between software systems without
-      human intervention. Each client is uniquely identified by a `client_id`
-      and can be configured with authentication settings, redirect URIs, and
-      security parameters. Use these endpoints to create, manage, and configure
+  - description: Endpoints for managing API client applications. API clients 
+      enable secure, automated interactions between software systems without 
+      human intervention. Each client is uniquely identified by a `client_id` 
+      and can be configured with authentication settings, redirect URIs, and 
+      security parameters. Use these endpoints to create, manage, and configure 
       API clients for your API clients.
     name: API Auth
     externalDocs:
       url: https://docs.scalekit.com/m2m/overview
   - description: Endpoints for sending and verifying passwordless authentication
-      emails. These APIs allow users to authenticate without passwords by
+      emails. These APIs allow users to authenticate without passwords by 
       receiving a verification code or magic link in their email.
     name: Magic link & OTP
   - description: Endpoints for passkey-based authentication using WebAuthn/FIDO2
       standards.
     name: Passkeys
-  - description: Manage connected accounts for third-party integrations and
-      OAuth connections. Connected accounts represent authenticated access to
+  - description: Manage connected accounts for third-party integrations and 
+      OAuth connections. Connected accounts represent authenticated access to 
       external services like Google, Notion, Slack, and other applications.
     name: Connected Accounts
 externalDocs:
@@ -6243,19 +6311,63 @@ components:
       type: object
       properties:
         description:
-          description: Human-readable label for the link (e.g. "User
+          description: Human-readable label for the link (e.g. "User 
             verification flow").
           type: string
         url:
-          description: Absolute URL to the documentation page (e.g.
+          description: Absolute URL to the documentation page (e.g. 
             "https://docs.scalekit.com/...").
           type: string
+    OrganizationServiceUpdateOrganizationSessionPolicyBody:
+      type: object
+      properties:
+        absolute_session_timeout:
+          description: The absolute session timeout value. The unit is specified
+            by absolute_session_timeout_unit. Omit when policy_source is 
+            APPLICATION.
+          type: integer
+          format: int32
+          examples:
+            - 360
+        absolute_session_timeout_unit:
+          description: "Unit for absolute_session_timeout. Accepted values: 'MINUTES',
+            'HOURS', 'DAYS'. Defaults to MINUTES."
+          $ref: "#/components/schemas/commonsTimeUnit"
+          examples:
+            - MINUTES
+        idle_session_timeout:
+          description: The idle session timeout value. The unit is specified by 
+            idle_session_timeout_unit. Omit when idle_session_timeout_enabled is
+            false.
+          type: integer
+          format: int32
+          examples:
+            - 84
+        idle_session_timeout_enabled:
+          description: Whether idle session timeout is enabled. Omit when 
+            policy_source is APPLICATION.
+          type: boolean
+          examples:
+            - true
+        idle_session_timeout_unit:
+          description: "Unit for idle_session_timeout. Accepted values: 'MINUTES',
+            'HOURS', 'DAYS'. Defaults to MINUTES."
+          $ref: "#/components/schemas/commonsTimeUnit"
+          examples:
+            - MINUTES
+        policy_source:
+          description: Policy source. Send 'APPLICATION' to revert to 
+            application defaults. Send 'CUSTOM' with timeout values to activate 
+            a custom policy.
+          $ref: "#/components/schemas/organizationsSessionPolicyType"
+          examples:
+            - CUSTOM
     OrganizationServiceUpsertUserManagementSettingsBody:
       type: object
       properties:
         settings:
           description: The new values for the setting fields to patch.
-          $ref: '#/components/schemas/organizationsOrganizationUserManagementSettings'
+          $ref: "#/components/schemas/organizationsOrganizationUserManagementSettings"
     RolesServiceAddPermissionsToRoleBody:
       type: object
       properties:
@@ -6294,7 +6406,7 @@ components:
           title: Conveyance preference
         enterprise_approved_ids:
           type: array
-          title: Enterprise-approved IDs (optional allowlist when enterprise
+          title: Enterprise-approved IDs (optional allowlist when enterprise 
             attestation is used)
           items:
             type: string
@@ -6310,48 +6422,47 @@ components:
       type: object
       properties:
         desired_authenticator_status:
-          description: provides the list of statuses which are considered
-            undesirable for status report validation purposes. Should be used
+          description: provides the list of statuses which are considered 
+            undesirable for status report validation purposes. Should be used 
             with validate_status set to true.
           type: array
           items:
             type: string
-            default: '[]'
+            default: "[]"
         undesired_authenticator_status:
-          description: provides the list of statuses which are considered
-            undesirable for status report validation purposes. Should be used
+          description: provides the list of statuses which are considered 
+            undesirable for status report validation purposes. Should be used 
             with validate_status set to true.
           type: array
           items:
             type: string
-            default:
-              "['ATTESTATION_KEY_COMPROMISE', 'USER_VERIFICATION_BYPASS', 'USER_KEY_REMOTE_COMPROMISE',
+            default: "['ATTESTATION_KEY_COMPROMISE', 'USER_VERIFICATION_BYPASS', 'USER_KEY_REMOTE_COMPROMISE',
               'USER_KEY_PHYSICAL_COMPROMISE', 'REVOKED']"
         validate_anchors:
-          description: when set to true enables the validation of the
-            attestation statement against the trust anchor from the metadata
+          description: when set to true enables the validation of the 
+            attestation statement against the trust anchor from the metadata 
             statement.
           type: boolean
         validate_attestation_type:
-          description: when set to true enables the validation of the
-            attestation statements type against the known types the
+          description: when set to true enables the validation of the 
+            attestation statements type against the known types the 
             authenticator can produce.
           type: boolean
         validate_entry:
-          description: requires that the provided metadata has an entry for the
-            given authenticator to be considered valid. By default an AAGUID
-            which has a zero value should fail validation if
-            validate_entry_permit_zero_aaguid is not provided with the value of
+          description: requires that the provided metadata has an entry for the 
+            given authenticator to be considered valid. By default an AAGUID 
+            which has a zero value should fail validation if 
+            validate_entry_permit_zero_aaguid is not provided with the value of 
             true.
           type: boolean
         validate_entry_permit_zero_aaguid:
-          description: is an option that permits a zero'd AAGUID from an
-            attestation statement to automatically pass metadata validations.
+          description: is an option that permits a zero'd AAGUID from an 
+            attestation statement to automatically pass metadata validations. 
             Generally helpful to use with validate_entry.
           type: boolean
         validate_status:
-          description: when set to true enables the validation of the
-            attestation statements AAGUID against the desired and undesired
+          description: when set to true enables the validation of the 
+            attestation statements AAGUID against the desired and undesired 
             lists
           type: boolean
     WebAuthConfigurationRp:
@@ -6382,7 +6493,7 @@ components:
           type: string
           default: '"300s"'
         login_uvd:
-          description: Login timeout duration when user verification is
+          description: Login timeout duration when user verification is 
             discouraged
           type: string
           default: '"300s"'
@@ -6391,7 +6502,7 @@ components:
           type: string
           default: '"300s"'
         registration_uvd:
-          description: Registration timeout duration when user verification is
+          description: Registration timeout duration when user verification is 
             discouraged
           type: string
           default: '"300s"'
@@ -6399,7 +6510,7 @@ components:
       type: object
       properties:
         aaguid:
-          description: Authenticator Attestation GUID (AAGUID) identifying the
+          description: Authenticator Attestation GUID (AAGUID) identifying the 
             device model
           type: string
         attachment:
@@ -6422,7 +6533,7 @@ components:
       type: object
       properties:
         backup_eligible:
-          description: Whether this credential can be backed up to another
+          description: Whether this credential can be backed up to another 
             device
           type: boolean
         backup_state:
@@ -6489,7 +6600,7 @@ components:
           description: Operating system version
           type: string
           examples:
-            - '14.2'
+            - "14.2"
         raw:
           description: Raw user agent string from the browser
           type: string
@@ -6500,7 +6611,7 @@ components:
       type: object
       properties:
         display_name:
-          description: Human-friendly name for this credential (1-120
+          description: Human-friendly name for this credential (1-120 
             characters)
           type: string
           examples:
@@ -6512,7 +6623,7 @@ components:
         - LINK
         - LINK_OTP
     clientsClientSecret:
-      description: A secure credential used for authenticating an API client.
+      description: A secure credential used for authenticating an API client. 
         Each client can have multiple secrets for key rotation purposes.
       type: object
       title: Client Secret
@@ -6525,14 +6636,14 @@ components:
           examples:
             - 2024-01-05T14:48:00Z
         created_by:
-          description: The identifier of the user or system that created this
-            secret. This field helps track who created the secret for audit and
+          description: The identifier of the user or system that created this 
+            secret. This field helps track who created the secret for audit and 
             compliance purposes.
           type: string
           examples:
             - user_12345
         expire_time:
-          description: The timestamp when this secret will expire. After this
+          description: The timestamp when this secret will expire. After this 
             time, the secret cannot be used for authentication regardless of its
             status. If not set, the secret does not expire.
           type: string
@@ -6540,15 +6651,15 @@ components:
           examples:
             - 2025-01-05T14:48:00Z
         id:
-          description: The unique identifier for this client secret. This ID is
-            used to reference the secret in API requests for management
+          description: The unique identifier for this client secret. This ID is 
+            used to reference the secret in API requests for management 
             operations like updating or deleting the secret.
           type: string
           examples:
             - sec_1234abcd5678efgh
         last_used_time:
-          description: The timestamp when this secret was last used for
-            authentication. This field helps track secret usage for security
+          description: The timestamp when this secret was last used for 
+            authentication. This field helps track secret usage for security 
             monitoring and identifying unused secrets that may be candidates for
             rotation.
           type: string
@@ -6556,31 +6667,31 @@ components:
           examples:
             - 2024-02-15T10:30:00Z
         plain_secret:
-          description: The full plaintext secret value. This field is only
-            populated when the secret is first created and is never stored by
-            the server. It must be securely stored by the client application as
+          description: The full plaintext secret value. This field is only 
+            populated when the secret is first created and is never stored by 
+            the server. It must be securely stored by the client application as 
             it cannot be retrieved again.
           type: string
           examples:
             - sec_1234567890abcdefghijklmnopqrstuvwxyz
         secret_suffix:
-          description: A suffix that helps identify this secret. This is the
-            last few characters of the full secret value but is not sufficient
-            for authentication. Helps identify which secret is being used in
+          description: A suffix that helps identify this secret. This is the 
+            last few characters of the full secret value but is not sufficient 
+            for authentication. Helps identify which secret is being used in 
             logs and debugging.
           type: string
           examples:
             - xyzw
         status:
-          description: The current status of this secret. A secret must be
-            ACTIVE to be used for authentication. INACTIVE secrets cannot be
+          description: The current status of this secret. A secret must be 
+            ACTIVE to be used for authentication. INACTIVE secrets cannot be 
             used for authentication but are retained for audit purposes.
-          $ref: '#/components/schemas/clientsClientSecretStatus'
+          $ref: "#/components/schemas/clientsClientSecretStatus"
           examples:
             - INACTIVE
         update_time:
-          description: The timestamp when this secret was last updated. This
-            field is automatically updated by the server when the secret's
+          description: The timestamp when this secret was last updated. This 
+            field is automatically updated by the server when the secret's 
             status changes or other properties are modified.
           type: string
           format: date-time
@@ -6603,7 +6714,7 @@ components:
       properties:
         client:
           description: Details of the created client
-          $ref: '#/components/schemas/clientsM2MClient'
+          $ref: "#/components/schemas/clientsM2MClient"
         plain_secret:
           description: Client secret value (only returned once at creation)
           type: string
@@ -6619,19 +6730,19 @@ components:
             - m2morg_client_secret_xyz123
         secret:
           description: Details of the created client secret
-          $ref: '#/components/schemas/clientsClientSecret'
+          $ref: "#/components/schemas/clientsClientSecret"
     clientsCustomClaim:
       type: object
       properties:
         key:
-          description: The name of the custom claim. Must be between 1 and 128
-            characters. Use descriptive names that clearly indicate the claim's
+          description: The name of the custom claim. Must be between 1 and 128 
+            characters. Use descriptive names that clearly indicate the claim's 
             purpose.
           type: string
           examples:
             - environment
         value:
-          description: The value of the custom claim. This value will be
+          description: The value of the custom claim. This value will be 
             included in access tokens issued to the client.
           type: string
           examples:
@@ -6641,31 +6752,31 @@ components:
       properties:
         client:
           description: Details of the requested client
-          $ref: '#/components/schemas/clientsM2MClient'
+          $ref: "#/components/schemas/clientsM2MClient"
     clientsListOrganizationClientsResponse:
-      description: Response message containing a paginated list of API clients
+      description: Response message containing a paginated list of API clients 
         for the specified organization.
       type: object
       title: List Organization Clients Response
       properties:
         clients:
-          description: List of API client objects for the organization. Each
-            client includes its configuration, metadata, and active secrets
+          description: List of API client objects for the organization. Each 
+            client includes its configuration, metadata, and active secrets 
             (without exposing actual secret values).
           type: array
           title: List of organization API clients
           items:
             type: object
-            $ref: '#/components/schemas/clientsM2MClient'
+            $ref: "#/components/schemas/clientsM2MClient"
         next_page_token:
-          description: Pagination token for the next page of results. Use this
+          description: Pagination token for the next page of results. Use this 
             token to fetch the next page.
           type: string
           title: Pagination token for the next page of results
           examples:
             - <next_page_token>
         prev_page_token:
-          description: Pagination token for the previous page of results. Use
+          description: Pagination token for the previous page of results. Use 
             this token to fetch the previous page.
           type: string
           title: Pagination token for the previous page of results
@@ -6682,37 +6793,37 @@ components:
       type: object
       properties:
         audience:
-          description: The intended recipients of access tokens issued to this
-            client. Each audience value should be a URI that identifies an API
+          description: The intended recipients of access tokens issued to this 
+            client. Each audience value should be a URI that identifies an API 
             or service.
           type: array
           items:
             type: string
           examples:
-            - - https://api.example.com
+            -   - https://api.example.com
         client_id:
-          description: The unique identifier for this API client. This ID is
-            used to identify the client in API requests and logs. It is
-            automatically generated when the client is created and cannot be
+          description: The unique identifier for this API client. This ID is 
+            used to identify the client in API requests and logs. It is 
+            automatically generated when the client is created and cannot be 
             modified.
           type: string
           examples:
             - m2morg_1231234233424344
         create_time:
-          description: The timestamp when this API client was created. This
+          description: The timestamp when this API client was created. This 
             field is automatically set by the server and cannot be modified.
           type: string
           format: date-time
           examples:
             - 2024-01-05T14:48:00Z
         custom_claims:
-          description: Additional claims included in access tokens issued to
-            this client. These claims provide context about the client and can
+          description: Additional claims included in access tokens issued to 
+            this client. These claims provide context about the client and can 
             be used for authorization decisions.
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/clientsCustomClaim'
+            $ref: "#/components/schemas/clientsCustomClaim"
         description:
           description: A detailed description of the client's purpose and usage.
             This helps administrators understand what the client is used for.
@@ -6720,58 +6831,58 @@ components:
           examples:
             - Service account for automated deployment processes
         expiry:
-          description: Expiry time in seconds for the token generated by the
+          description: Expiry time in seconds for the token generated by the 
             client
           type: string
           format: int64
           examples:
             - 3600
         is_cimd:
-          description: Indicates if the client was created via Client ID
-            Metadata Document (CIMD). CIMD clients can update their own
+          description: Indicates if the client was created via Client ID 
+            Metadata Document (CIMD). CIMD clients can update their own 
             configuration according to the CIMD specification.
           type: boolean
           examples:
             - false
         is_dcr:
-          description: Indicates if the client was created via Dynamic Client
-            Registration (DCR). Clients created through DCR may have different
-            management and lifecycle policies compared to those created
+          description: Indicates if the client was created via Dynamic Client 
+            Registration (DCR). Clients created through DCR may have different 
+            management and lifecycle policies compared to those created 
             manually.
           type: boolean
           examples:
             - false
         metadata_uri:
-          description: The URI to the client's metadata, which is utilized to
+          description: The URI to the client's metadata, which is utilized to 
             obtain the client's configuration details
           type: string
           examples:
             - https://example.com/client-metadata.json
         name:
-          description: The display name of the API client. This name helps
+          description: The display name of the API client. This name helps 
             identify the client in the dashboard and logs.
           type: string
           examples:
             - GitHub Actions Deployment Service
         organization_id:
-          description: The ID of the organization that owns this API client.
-            This ID is used to associate the client with the correct
+          description: The ID of the organization that owns this API client. 
+            This ID is used to associate the client with the correct 
             organization and enforce organization-specific access controls.
           type: string
           examples:
             - org_1231234233424344
         redirect_uris:
           description: The redirect URI for this API client. This URI is used in
-            the OAuth 2.0 authorization flow to redirect users after
+            the OAuth 2.0 authorization flow to redirect users after 
             authentication.
           type: array
           items:
             type: string
           examples:
-            - - https://example.com/callback
+            -   - https://example.com/callback
         resource_id:
-          description: The ID of the resource associated with this M2M client.
-            This field is used to link the client to a specific resource in the
+          description: The ID of the resource associated with this M2M client. 
+            This field is used to link the client to a specific resource in the 
             system.
           type: string
           examples:
@@ -6783,20 +6894,20 @@ components:
           items:
             type: string
           examples:
-            - - deploy:resources
-              - read:deployments
+            -   - deploy:resources
+                - read:deployments
         secrets:
-          description: List of client secrets associated with this client. Each
-            secret can be used for authentication, but only the most recently
-            created secret is typically active. Secrets are stored securely and
+          description: List of client secrets associated with this client. Each 
+            secret can be used for authentication, but only the most recently 
+            created secret is typically active. Secrets are stored securely and 
             their values are never returned after creation.
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/clientsClientSecret'
+            $ref: "#/components/schemas/clientsClientSecret"
         update_time:
           description: The timestamp when this API client was last updated. This
-            field is automatically updated by the server whenever the client's
+            field is automatically updated by the server whenever the client's 
             configuration changes.
           type: string
           format: date-time
@@ -6806,39 +6917,39 @@ components:
       type: object
       properties:
         audience:
-          description: The intended recipients of the access tokens issued to
+          description: The intended recipients of the access tokens issued to 
             this client. Each audience value should be a URI that identifies the
             API or service that will validate the token.
           type: array
           items:
             type: string
           examples:
-            - - https://api.example.com/api/analytics
-              - https://deployment-api.acmecorp.com
+            -   - https://api.example.com/api/analytics
+                - https://deployment-api.acmecorp.com
         custom_claims:
-          description: Additional claims to be included in access tokens issued
-            to this client. These claims provide context about the client and
-            can be used for authorization decisions. Keep claims minimal to
+          description: Additional claims to be included in access tokens issued 
+            to this client. These claims provide context about the client and 
+            can be used for authorization decisions. Keep claims minimal to 
             avoid increasing token size.
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/clientsCustomClaim'
+            $ref: "#/components/schemas/clientsCustomClaim"
           examples:
-            - - key: environment
-                value: production
-              - key: service
-                value: deployment
+            -   - key: environment
+                  value: production
+                - key: service
+                  value: deployment
         description:
           description: A detailed explanation of the client's purpose and usage.
             This helps administrators understand what the client is used for and
             who manages it.
           type: string
           examples:
-            - Service account for GitHub Actions to deploy resources to
+            - Service account for GitHub Actions to deploy resources to 
               production
         expiry:
-          description: Expiry time in seconds for the token generated by the
+          description: Expiry time in seconds for the token generated by the 
             client
           type: string
           format: int64
@@ -6846,33 +6957,33 @@ components:
             - 3600
         name:
           description: A descriptive name for the API client that helps identify
-            its purpose. This name is displayed in the dashboard and logs. Must
+            its purpose. This name is displayed in the dashboard and logs. Must 
             be between 1 and 128 characters.
           type: string
           examples:
             - GitHub Actions Deployment Service
         scopes:
-          description: OAuth 2.0 scopes that define the permissions granted to
-            this client. Each scope represents a specific permission or set of
-            permissions. The client can only access resources that match its
+          description: OAuth 2.0 scopes that define the permissions granted to 
+            this client. Each scope represents a specific permission or set of 
+            permissions. The client can only access resources that match its 
             granted scopes.
           type: array
           items:
             type: string
           examples:
-            - - deploy:resources
-              - read:deployments
+            -   - deploy:resources
+                - read:deployments
     clientsUpdateOrganizationClientResponse:
       type: object
       properties:
         client:
           description: Updated details of the client
-          $ref: '#/components/schemas/clientsM2MClient'
+          $ref: "#/components/schemas/clientsM2MClient"
     commonsExternalIdentity:
       type: object
       properties:
         connection_id:
-          description: Unique identifier for the external identity connection.
+          description: Unique identifier for the external identity connection. 
             Immutable and read-only.
           type: string
           readOnly: true
@@ -6880,7 +6991,7 @@ components:
             - conn_1234abcd5678efgh
         connection_provider:
           description: Type of the identity provider.
-          $ref: '#/components/schemas/commonsIdentityProviderType'
+          $ref: "#/components/schemas/commonsIdentityProviderType"
           readOnly: true
           examples:
             - GOOGLE
@@ -6891,34 +7002,34 @@ components:
           examples:
             - OAUTH
         connection_user_id:
-          description: Unique identifier for the user in the external identity
+          description: Unique identifier for the user in the external identity 
             provider system. Immutable and read-only.
           type: string
           readOnly: true
           examples:
             - ext_user_12345
         created_time:
-          description: Timestamp when this external identity connection was
+          description: Timestamp when this external identity connection was 
             first created. Immutable and read-only.
           type: string
           format: date-time
           readOnly: true
         is_social:
-          description: Indicates if the identity provider is a social provider
+          description: Indicates if the identity provider is a social provider 
             (true) or enterprise/custom provider (false). Read-only.
           type: boolean
           readOnly: true
           examples:
             - true
         last_login_time:
-          description: Timestamp of the user's last successful login via this
+          description: Timestamp of the user's last successful login via this 
             external identity provider. Automatically updated by the system.
           type: string
           format: date-time
           readOnly: true
         last_synced_time:
-          description: Timestamp of the last data synchronization for this
-            external identity from the provider. Automatically updated by the
+          description: Timestamp of the last data synchronization for this 
+            external identity from the provider. Automatically updated by the 
             system.
           type: string
           format: date-time
@@ -6961,8 +7072,8 @@ components:
           type: string
           format: date-time
         display_name:
-          description: Organization display name. This field stores a
-            user-friendly name for the organization that may be different from
+          description: Organization display name. This field stores a 
+            user-friendly name for the organization that may be different from 
             the formal name, often used for UI display purposes.
           type: string
           examples:
@@ -6975,14 +7086,14 @@ components:
           description: ID of the user who invited this user.
           type: string
         join_time:
-          description: Timestamp when the membership was created. Automatically
+          description: Timestamp when the membership was created. Automatically 
             set by the server.
           type: string
           format: date-time
         membership_status:
-          $ref: '#/components/schemas/commonsMembershipStatus'
+          $ref: "#/components/schemas/commonsMembershipStatus"
         metadata:
-          description: Custom key-value pairs for storing additional user
+          description: Custom key-value pairs for storing additional user 
             context. Keys (3-25 chars), values (1-256 chars).
           type: object
           additionalProperties:
@@ -6991,28 +7102,28 @@ components:
             - department: engineering
               location: nyc-office
         name:
-          description: Organization name. This field stores the formal
+          description: Organization name. This field stores the formal 
             organization name used for identification and display purposes.
           type: string
           examples:
             - AcmeCorp
         organization_id:
-          description: Unique identifier for the organization. Immutable and
+          description: Unique identifier for the organization. Immutable and 
             read-only.
           type: string
           examples:
             - org_1234abcd5678efgh
         permissions:
-          description: Effective permissions granted to the user within the
-            organization (including inherited permissions from assigned roles).
+          description: Effective permissions granted to the user within the 
+            organization (including inherited permissions from assigned roles). 
             Lists the specific actions and access rights the user can perform.
           type: array
           items:
             type: string
           examples:
-            - - read_projects
-              - write_tasks
-              - manage_users
+            -   - read_projects
+                - write_tasks
+                - manage_users
         provisioning_method:
           description: >-
             How the user was provisioned. 
@@ -7034,7 +7145,7 @@ components:
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/commonsRole'
+            $ref: "#/components/schemas/commonsRole"
     commonsRegionCode:
       type: string
       enum:
@@ -7055,24 +7166,30 @@ components:
           examples:
             - role_79643236410327240
         name:
-          description: Attribute name/identifier for the role used in system
-            operations and API calls. This should be a machine-readable
+          description: Attribute name/identifier for the role used in system 
+            operations and API calls. This should be a machine-readable 
             identifier that follows naming conventions.
           type: string
           examples:
             - team_dev
+    commonsTimeUnit:
+      type: string
+      enum:
+        - MINUTES
+        - HOURS
+        - DAYS
     commonsUserProfile:
       type: object
       properties:
         custom_attributes:
-          description: Custom attributes for extended user profile data and
-            application-specific information. This field stores
-            business-specific user data like department, job title, security
-            clearances, project assignments, or any other organizational
-            attributes your application requires. Unlike system metadata, these
-            attributes are typically managed by administrators or applications
+          description: Custom attributes for extended user profile data and 
+            application-specific information. This field stores 
+            business-specific user data like department, job title, security 
+            clearances, project assignments, or any other organizational 
+            attributes your application requires. Unlike system metadata, these 
+            attributes are typically managed by administrators or applications 
             and are visible to end users for personalization and business logic.
-            Keys must be 3-25 characters, values must be 1-256 characters, with
+            Keys must be 3-25 characters, values must be 1-256 characters, with 
             a maximum of 20 key-value pairs.
           type: object
           additionalProperties:
@@ -7081,7 +7198,7 @@ components:
             - department: engineering
               security_clearance: level2
         email_verified:
-          description: Indicates if the user's email address has been verified.
+          description: Indicates if the user's email address has been verified. 
             Automatically updated by the system.
           type: boolean
           readOnly: true
@@ -7093,20 +7210,20 @@ components:
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/commonsExternalIdentity'
+            $ref: "#/components/schemas/commonsExternalIdentity"
           readOnly: true
         family_name:
           description: The user's family name (last name or surname). This field
-            stores the user's last name and is combined with the given name to
-            create the full display name. The family name is used in formal
-            communications, user listings, and organizational directories
+            stores the user's last name and is combined with the given name to 
+            create the full display name. The family name is used in formal 
+            communications, user listings, and organizational directories 
             throughout the system. Maximum 255 characters allowed.
           type: string
           examples:
             - Doe
         gender:
           description: The user's gender identity information. This field stores
-            the user's gender identity for personalization, compliance
+            the user's gender identity for personalization, compliance 
             reporting, or organizational analytics purposes. This field supports
             any string value to accommodate diverse gender identities and should
             be handled with appropriate privacy considerations according to your
@@ -7124,44 +7241,44 @@ components:
           examples:
             - John
         groups:
-          description: The list of group names the user belongs to within the
-            organization. This field stores the user's group memberships for
-            role-based access control, team assignments, and organizational
-            structure. Groups are typically used for permission management,
-            collaborative access, and organizational hierarchy. Each group name
-            represents a distinct organizational unit or team that the user is
+          description: The list of group names the user belongs to within the 
+            organization. This field stores the user's group memberships for 
+            role-based access control, team assignments, and organizational 
+            structure. Groups are typically used for permission management, 
+            collaborative access, and organizational hierarchy. Each group name 
+            represents a distinct organizational unit or team that the user is 
             associated with.
           type: array
           items:
             type: string
           examples:
-            - - admin
-              - developer
+            -   - admin
+                - developer
         id:
-          description: Unique system-generated identifier for the user profile.
+          description: Unique system-generated identifier for the user profile. 
             Immutable and read-only.
           type: string
           readOnly: true
           examples:
             - usr_profile_1234abcd5678efgh
         locale:
-          description: The user's preferred language and region settings using
-            BCP-47 format codes. This field customizes the user's experience
-            with localized content, date formats, number formatting, and UI
-            language throughout the system. When not specified, the user
-            inherits the organization's default locale settings. Common values
+          description: The user's preferred language and region settings using 
+            BCP-47 format codes. This field customizes the user's experience 
+            with localized content, date formats, number formatting, and UI 
+            language throughout the system. When not specified, the user 
+            inherits the organization's default locale settings. Common values 
             include `en-US`, `en-GB`, `fr-FR`, `de-DE`, and `es-ES`.
           type: string
           examples:
             - en-US
         metadata:
-          description: Raw attributes received from identity providers during
-            authentication. This field stores the original user profile data as
-            received from external IdP systems (SAML, OIDC, etc.) including
-            provider-specific claims and attributes. These fields preserve the
+          description: Raw attributes received from identity providers during 
+            authentication. This field stores the original user profile data as 
+            received from external IdP systems (SAML, OIDC, etc.) including 
+            provider-specific claims and attributes. These fields preserve the 
             complete set of attributes received from the identity source and are
-            used for mapping, synchronization, and audit purposes. Keys must be
-            3-25 characters, values must be 1-256 characters, with a maximum of
+            used for mapping, synchronization, and audit purposes. Keys must be 
+            3-25 characters, values must be 1-256 characters, with a maximum of 
             20 key-value pairs.
           type: object
           additionalProperties:
@@ -7169,51 +7286,51 @@ components:
           examples:
             - department: engineering
               employee_type: full-time
-              idp_user_id: '12345'
+              idp_user_id: "12345"
         name:
-          description: The user's complete display name in formatted form. This
-            field stores the full name as a single string and is typically used
-            when you want to set the complete name rather than using separate
-            given and family names. This name appears in user interfaces,
-            reports, directory listings, and anywhere a formatted display name
-            is needed. This field serves as a formatted display name that
+          description: The user's complete display name in formatted form. This 
+            field stores the full name as a single string and is typically used 
+            when you want to set the complete name rather than using separate 
+            given and family names. This name appears in user interfaces, 
+            reports, directory listings, and anywhere a formatted display name 
+            is needed. This field serves as a formatted display name that 
             complements the individual given_name and family_name fields.
           type: string
           examples:
             - John Michael Doe
         phone_number:
-          description: The user's phone number in E.164 international format.
-            This field stores the phone number for user contact and
-            identification purposes. The phone number must include the country
-            code and be formatted according to E.164 standards (e.g., `+1` for
+          description: The user's phone number in E.164 international format. 
+            This field stores the phone number for user contact and 
+            identification purposes. The phone number must include the country 
+            code and be formatted according to E.164 standards (e.g., `+1` for 
             US numbers). This field is optional.
           type: string
           examples:
-            - '+14155552671'
+            - "+14155552671"
         phone_number_verified:
-          description: Indicates if the user's phone number has been verified.
+          description: Indicates if the user's phone number has been verified. 
             Automatically updated by the system.
           type: boolean
           readOnly: true
           examples:
             - true
         picture:
-          description: The URL to the user's profile picture or avatar image.
-            This field stores the location of the user's profile photo that
-            appears in user interfaces, directory listings, and collaborative
-            features throughout the system. The URL should point to a publicly
-            accessible image file. Supported formats typically include JPEG,
-            PNG, and GIF. This image is used for visual identification and
+          description: The URL to the user's profile picture or avatar image. 
+            This field stores the location of the user's profile photo that 
+            appears in user interfaces, directory listings, and collaborative 
+            features throughout the system. The URL should point to a publicly 
+            accessible image file. Supported formats typically include JPEG, 
+            PNG, and GIF. This image is used for visual identification and 
             personalization across the platform.
           type: string
           examples:
             - https://example.com/avatar.jpg
         preferred_username:
-          description: The user's preferred username for display and
-            identification purposes. This field stores a custom username that
-            the user prefers to be known by, which may differ from their email
-            or formal name. This username appears in user interfaces, mentions,
-            informal communications, and collaborative features throughout the
+          description: The user's preferred username for display and 
+            identification purposes. This field stores a custom username that 
+            the user prefers to be known by, which may differ from their email 
+            or formal name. This username appears in user interfaces, mentions, 
+            informal communications, and collaborative features throughout the 
             system. Maximum 512 characters allowed.
           type: string
           examples:
@@ -7222,17 +7339,20 @@ components:
       type: object
       title: Authentication credentials container supporting multiple auth types
       properties:
+        google_dwd:
+          title: Google Domain-Wide Delegation credentials
+          $ref: "#/components/schemas/connected_accountsGoogleDWDAuth"
         oauth_token:
           title: OAuth 2.0 credentials
-          $ref: '#/components/schemas/connected_accountsOauthToken'
+          $ref: "#/components/schemas/connected_accountsOauthToken"
         static_auth:
           title: Static authentication credentials
-          $ref: '#/components/schemas/connected_accountsStaticAuth'
+          $ref: "#/components/schemas/connected_accountsStaticAuth"
     connected_accountsConnectedAccount:
       type: object
       properties:
         api_config:
-          description: Optional JSON configuration for connector-specific API
+          description: Optional JSON configuration for connector-specific API 
             settings such as rate limits, custom endpoints, or feature flags.
           type: object
           examples:
@@ -7240,69 +7360,69 @@ components:
               rate_limit: 1000
               timeout: 30
         authorization_details:
-          description: Sensitive authentication credentials including access
-            tokens, refresh tokens, and scopes. Contains either OAuth tokens or
+          description: Sensitive authentication credentials including access 
+            tokens, refresh tokens, and scopes. Contains either OAuth tokens or 
             static auth details.
-          $ref: '#/components/schemas/connected_accountsAuthorizationDetails'
+          $ref: "#/components/schemas/connected_accountsAuthorizationDetails"
         authorization_type:
-          description: Type of authorization mechanism used. Specifies whether
-            this connection uses OAuth, API keys, bearer tokens, or other auth
+          description: Type of authorization mechanism used. Specifies whether 
+            this connection uses OAuth, API keys, bearer tokens, or other auth 
             methods.
-          $ref: '#/components/schemas/connected_accountsConnectorType'
+          $ref: "#/components/schemas/connected_accountsConnectorType"
         connection_id:
-          description: Reference to the parent connection configuration. Links
+          description: Reference to the parent connection configuration. Links 
             this account to a specific connector setup in your environment.
           type: string
           examples:
             - conn_24834495392086178
         connector:
-          description: Connector identifier (e.g., 'notion', 'slack',
-            'salesforce'). Indicates which third-party application this account
+          description: Connector identifier (e.g., 'notion', 'slack', 
+            'salesforce'). Indicates which third-party application this account 
             connects to.
           type: string
           examples:
             - notion
         id:
-          description: Unique Scalekit-generated identifier for this connected
+          description: Unique Scalekit-generated identifier for this connected 
             account. Always prefixed with 'ca_'.
           type: string
           examples:
             - ca_24834495392086178
         identifier:
           description: The unique identifier for this account in the third-party
-            service. Typically an email address, user ID, or workspace
+            service. Typically an email address, user ID, or workspace 
             identifier.
           type: string
           examples:
             - user@example.com
         last_used_at:
-          description: Timestamp when this connected account was last used to
+          description: Timestamp when this connected account was last used to 
             make an API call. Useful for tracking active connections.
           type: string
           format: date-time
           examples:
             - 2024-03-20T14:30:00Z
         provider:
-          description: OAuth provider name (e.g., 'google', 'microsoft',
-            'github'). Identifies which authentication service manages this
+          description: OAuth provider name (e.g., 'google', 'microsoft', 
+            'github'). Identifies which authentication service manages this 
             connection.
           type: string
           examples:
             - google
         status:
           description: Current status of the connected account. Indicates if the
-            account is active, expired, pending authorization, or pending user
+            account is active, expired, pending authorization, or pending user 
             identity verification.
-          $ref: '#/components/schemas/connected_accountsConnectorStatus'
+          $ref: "#/components/schemas/connected_accountsConnectorStatus"
         token_expires_at:
-          description: Expiration timestamp for the access token. After this
+          description: Expiration timestamp for the access token. After this 
             time, the token must be refreshed or re-authorized.
           type: string
           format: date-time
           examples:
             - 2024-12-31T23:59:59Z
         updated_at:
-          description: Timestamp when this connected account was last modified.
+          description: Timestamp when this connected account was last modified. 
             Updated whenever credentials or configuration changes.
           type: string
           format: date-time
@@ -7310,12 +7430,12 @@ components:
             - 2024-03-20T15:04:05Z
     connected_accountsConnectedAccountForList:
       type: object
-      title: Connected account summary for list operations - excludes sensitive
+      title: Connected account summary for list operations - excludes sensitive 
         authorization details
       properties:
         authorization_type:
           description: Authorization mechanism type.
-          $ref: '#/components/schemas/connected_accountsConnectorType'
+          $ref: "#/components/schemas/connected_accountsConnectorType"
         connection_id:
           description: Parent connection configuration reference.
           type: string
@@ -7350,7 +7470,7 @@ components:
             - google
         status:
           description: Current connection status.
-          $ref: '#/components/schemas/connected_accountsConnectorStatus'
+          $ref: "#/components/schemas/connected_accountsConnectorStatus"
         token_expires_at:
           description: Token expiration timestamp.
           type: string
@@ -7370,6 +7490,7 @@ components:
          - PENDING_AUTH: Account awaiting user authorization (re-auth initiated)
          - PENDING_VERIFICATION: OAuth complete; awaiting user identity verification
         before activation
+         - DISCONNECTED: Account has been manually disconnected
       type: string
       title: Status of a connected account indicating its current state
       enum:
@@ -7377,6 +7498,7 @@ components:
         - EXPIRED
         - PENDING_AUTH
         - PENDING_VERIFICATION
+        - DISCONNECTED
     connected_accountsConnectorType:
       description: |-
         - OAUTH: OAuth 2.0 authorization with access and refresh tokens
@@ -7385,6 +7507,9 @@ components:
          - BEARER_TOKEN: Bearer token authentication
          - CUSTOM: Custom authentication mechanism
          - BASIC: Basic authentication (alias)
+         - OAUTH_M2M: OAuth 2.0 client credentials (machine-to-machine)
+         - TRELLO_OAUTH1: Trello token-based OAuth1-style browser authorization
+         - GOOGLE_DWD: Google Domain-Wide Delegation
       type: string
       title: Type of authentication mechanism used for the connected account
       enum:
@@ -7394,12 +7519,15 @@ components:
         - BEARER_TOKEN
         - CUSTOM
         - BASIC
+        - OAUTH_M2M
+        - TRELLO_OAUTH1
+        - GOOGLE_DWD
     connected_accountsCreateConnectedAccountRequest:
       type: object
       properties:
         connected_account:
           description: Details of the connected account to create
-          $ref: '#/components/schemas/v1connected_accountsCreateConnectedAccount'
+          $ref: "#/components/schemas/v1connected_accountsCreateConnectedAccount"
           examples:
             - authorization_details:
                 oauth_token:
@@ -7410,13 +7538,15 @@ components:
                     - write
               authorization_type: OAUTH2
         connector:
-          description: Connector identifier
+          description: Connector identifier (e.g., 'notion', 'slack', 'google').
+            Alphanumeric characters, spaces, hyphens, underscores, and colons 
+            are allowed.
           type: string
           examples:
             - notion
         identifier:
-          description: The unique identifier for the connected account within
-            the third-party service (e.g., email address, user ID, workspace
+          description: The unique identifier for the connected account within 
+            the third-party service (e.g., email address, user ID, workspace 
             identifier).
           type: string
           examples:
@@ -7435,15 +7565,17 @@ components:
       type: object
       properties:
         connected_account:
-          description: The newly created connected account with its unique
-            identifier, status, and complete authorization details including
+          description: The newly created connected account with its unique 
+            identifier, status, and complete authorization details including 
             access tokens.
-          $ref: '#/components/schemas/connected_accountsConnectedAccount'
+          $ref: "#/components/schemas/connected_accountsConnectedAccount"
     connected_accountsDeleteConnectedAccountRequest:
       type: object
       properties:
         connector:
-          description: Connector identifier
+          description: Connector identifier (e.g., 'notion', 'slack', 'google').
+            Alphanumeric characters, spaces, hyphens, underscores, and colons 
+            are allowed.
           type: string
           examples:
             - notion
@@ -7453,8 +7585,8 @@ components:
           examples:
             - ca_123
         identifier:
-          description: The unique identifier for the connected account within
-            the third-party service (e.g., email address, user ID, workspace
+          description: The unique identifier for the connected account within 
+            the third-party service (e.g., email address, user ID, workspace 
             identifier).
           type: string
           examples:
@@ -7475,15 +7607,17 @@ components:
       type: object
       properties:
         connected_account:
-          description: The connected account with complete details including
-            sensitive authorization credentials (access tokens, refresh tokens,
+          description: The connected account with complete details including 
+            sensitive authorization credentials (access tokens, refresh tokens, 
             scopes). Handle with appropriate access controls.
-          $ref: '#/components/schemas/connected_accountsConnectedAccount'
+          $ref: "#/components/schemas/connected_accountsConnectedAccount"
     connected_accountsGetMagicLinkForConnectedAccountRequest:
       type: object
       properties:
         connector:
-          description: Connector identifier
+          description: Connector identifier (e.g., 'notion', 'slack', 'google').
+            Alphanumeric characters, spaces, hyphens, underscores, and colons 
+            are allowed.
           type: string
           examples:
             - notion
@@ -7493,8 +7627,8 @@ components:
           examples:
             - ca_123
         identifier:
-          description: The unique identifier for the connected account within
-            the third-party service (e.g., email address, user ID, workspace
+          description: The unique identifier for the connected account within 
+            the third-party service (e.g., email address, user ID, workspace 
             identifier).
           type: string
           examples:
@@ -7505,7 +7639,7 @@ components:
           examples:
             - org_121312434123312
         state:
-          description: Optional opaque state value. State added to the user
+          description: Optional opaque state value. State added to the user 
             verify redirect URL query params to validate the user verification
           type: string
           examples:
@@ -7534,31 +7668,68 @@ components:
           type: string
           examples:
             - https://notion.com/oauth/authorize?client_id=...
+    connected_accountsGoogleDWDAuth:
+      description: >-
+        Google Domain-Wide Delegation authentication — used for GOOGLE_DWD
+        connections.
+
+        Send only subject in requests; access_token, scopes, and
+        token_expires_at are response-only.
+      type: object
+      properties:
+        access_token:
+          description: OAuth access token acquired via the jwt-bearer grant. 
+            Present in responses only.
+          type: string
+          readOnly: true
+          examples:
+            - ya29.a0AfH6SMBx...
+        scopes:
+          description: OAuth scopes granted to this token. Present in responses 
+            only.
+          type: array
+          items:
+            type: string
+          readOnly: true
+          examples:
+            -   - openid
+                - https://www.googleapis.com/auth/userinfo.email
+        subject:
+          description: Email address of the Google Workspace user to impersonate
+            via Domain-Wide Delegation.
+          type: string
+          examples:
+            - user@example.com
+        token_expires_at:
+          description: When the access token expires. Present in responses only.
+          type: string
+          format: date-time
+          readOnly: true
     connected_accountsListConnectedAccountsResponse:
       type: object
       properties:
         connected_accounts:
-          description: List of connected accounts matching the filter criteria.
+          description: List of connected accounts matching the filter criteria. 
             Excludes sensitive authorization details for security.
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/connected_accountsConnectedAccountForList'
+            $ref: "#/components/schemas/connected_accountsConnectedAccountForList"
         next_page_token:
-          description: Pagination token for retrieving the next page. Empty if
-            this is the last page. Pass this value to page_token in the next
+          description: Pagination token for retrieving the next page. Empty if 
+            this is the last page. Pass this value to page_token in the next 
             request.
           type: string
           examples:
             - eyJvZmZzZXQiOjIwfQ==
         prev_page_token:
-          description: Pagination token for retrieving the previous page. Empty
+          description: Pagination token for retrieving the previous page. Empty 
             if this is the first page. Pass this value to page_token to go back.
           type: string
           examples:
             - eyJvZmZzZXQiOjB9
         total_size:
-          description: Total count of connected accounts matching the filter
+          description: Total count of connected accounts matching the filter 
             criteria across all pages. Use for calculating pagination.
           type: integer
           format: int64
@@ -7569,19 +7740,19 @@ components:
       title: OAuth 2.0 access and refresh tokens with scopes
       properties:
         access_token:
-          description: OAuth access token for API requests. Typically
+          description: OAuth access token for API requests. Typically 
             short-lived and must be refreshed after expiration.
           type: string
           examples:
             - ya29.a0AfH6SMBx...
         domain:
-          description: Associated domain for workspace or organization-scoped
+          description: Associated domain for workspace or organization-scoped 
             OAuth connections (e.g., Google Workspace domain).
           type: string
           examples:
             - example.com
         refresh_token:
-          description: OAuth refresh token for obtaining new access tokens.
+          description: OAuth refresh token for obtaining new access tokens. 
             Long-lived and used to maintain persistent authorization.
           type: string
           examples:
@@ -7593,32 +7764,32 @@ components:
           items:
             type: string
           examples:
-            - - https://www.googleapis.com/auth/drive.readonly
-              - https://www.googleapis.com/auth/userinfo.email
+            -   - https://www.googleapis.com/auth/drive.readonly
+                - https://www.googleapis.com/auth/userinfo.email
     connected_accountsSearchConnectedAccountsResponse:
       type: object
       properties:
         connected_accounts:
-          description: List of connected accounts matching the search query.
+          description: List of connected accounts matching the search query. 
             Excludes sensitive authorization details.
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/connected_accountsConnectedAccountForList'
+            $ref: "#/components/schemas/connected_accountsConnectedAccountForList"
         next_page_token:
-          description: Pagination token for the next page. Empty if this is the
+          description: Pagination token for the next page. Empty if this is the 
             last page.
           type: string
           examples:
             - eyJvZmZzZXQiOjMwfQ==
         prev_page_token:
-          description: Pagination token for the previous page. Empty if this is
+          description: Pagination token for the previous page. Empty if this is 
             the first page.
           type: string
           examples:
             - eyJvZmZzZXQiOjB9
         total_size:
-          description: Total count of accounts matching the search query across
+          description: Total count of accounts matching the search query across 
             all pages.
           type: integer
           format: int64
@@ -7626,11 +7797,11 @@ components:
             - 100
     connected_accountsStaticAuth:
       type: object
-      title: Static authentication credentials for API keys, bearer tokens, or
+      title: Static authentication credentials for API keys, bearer tokens, or 
         basic auth
       properties:
         details:
-          description: Flexible JSON structure containing static credentials.
+          description: Flexible JSON structure containing static credentials. 
             Format varies by connector type (API key, username/password, etc.).
           type: object
           examples:
@@ -7641,7 +7812,7 @@ components:
       properties:
         connected_account:
           description: Details of the connected account to update
-          $ref: '#/components/schemas/v1connected_accountsUpdateConnectedAccount'
+          $ref: "#/components/schemas/v1connected_accountsUpdateConnectedAccount"
           examples:
             - authorization_details:
                 oauth_token:
@@ -7652,7 +7823,9 @@ components:
                     - write
               authorization_type: OAUTH2
         connector:
-          description: Connector identifier
+          description: Connector identifier (e.g., 'notion', 'slack', 'google').
+            Alphanumeric characters, spaces, hyphens, underscores, and colons 
+            are allowed.
           type: string
           examples:
             - notion
@@ -7662,8 +7835,8 @@ components:
           examples:
             - ca_123
         identifier:
-          description: The unique identifier for the connected account within
-            the third-party service (e.g., email address, user ID, workspace
+          description: The unique identifier for the connected account within 
+            the third-party service (e.g., email address, user ID, workspace 
             identifier).
           type: string
           examples:
@@ -7684,7 +7857,7 @@ components:
         connected_account:
           description: The updated connected account with refreshed credentials,
             new token expiry, and modified configuration settings.
-          $ref: '#/components/schemas/connected_accountsConnectedAccount'
+          $ref: "#/components/schemas/connected_accountsConnectedAccount"
     connected_accountsVerifyConnectedAccountUserRequest:
       type: object
       required:
@@ -7692,7 +7865,7 @@ components:
         - identifier
       properties:
         auth_request_id:
-          description: Auth request ID as base64url-encoded opaque token from
+          description: Auth request ID as base64url-encoded opaque token from 
             the user verify redirect URL query params
           type: string
           examples:
@@ -7730,52 +7903,56 @@ components:
           additionalProperties:
             type: string
         configuration_type:
-          description: 'How the connection was configured: DISCOVERY (automatic configuration)
-            or MANUAL (administrator configured)'
-          $ref: '#/components/schemas/connectionsConfigurationType'
+          description: "How the connection was configured: DISCOVERY (automatic configuration)
+            or MANUAL (administrator configured)"
+          $ref: "#/components/schemas/connectionsConfigurationType"
           examples:
             - MANUAL
         debug_enabled:
-          description: Enables testing mode that allows non-HTTPS endpoints.
-            Should only be enabled in development environments, never in
+          description: Enables testing mode that allows non-HTTPS endpoints. 
+            Should only be enabled in development environments, never in 
             production.
           type: boolean
           examples:
             - true
         domains:
-          description: Domain associated with this connection, used for
+          description: Domain associated with this connection, used for 
             domain-based authentication flows.
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/domainsDomain'
+            $ref: "#/components/schemas/domainsDomain"
           examples:
-            - - name: example.com
+            -   - name: example.com
         enabled:
           description: Controls whether users can sign in using this connection.
-            When false, the connection exists but cannot be used for
+            When false, the connection exists but cannot be used for 
             authentication.
           type: boolean
           examples:
             - false
+        google_dwd_config:
+          description: Configuration details for Google Domain-Wide Delegation. 
+            Present only when type is GOOGLE_DWD.
+          $ref: "#/components/schemas/connectionsGoogleDWDConfig"
         id:
-          description: Unique identifier for this connection. Used in API calls
+          description: Unique identifier for this connection. Used in API calls 
             to reference this specific connection.
           type: string
           examples:
             - conn_2123312131125533
         key_id:
-          description: Alternative identifier for this connection, typically
+          description: Alternative identifier for this connection, typically 
             used in frontend applications or URLs.
           type: string
         oauth_config:
           description: Configuration details for OAuth connections. Present only
             when type is OAUTH.
-          $ref: '#/components/schemas/connectionsOAuthConnectionConfig'
+          $ref: "#/components/schemas/connectionsOAuthConnectionConfig"
         oidc_config:
-          description: Configuration details for OpenID Connect (OIDC)
+          description: Configuration details for OpenID Connect (OIDC) 
             connections. Present only when type is OIDC.
-          $ref: '#/components/schemas/connectionsOIDCConnectionConfig'
+          $ref: "#/components/schemas/connectionsOIDCConnectionConfig"
         organization_id:
           description: Identifier of the organization that owns this connection.
             Connections are typically scoped to a single organization.
@@ -7783,52 +7960,52 @@ components:
           examples:
             - org_2123312131125533
         passwordless_config:
-          description: Configuration details for Magic Link authentication.
+          description: Configuration details for Magic Link authentication. 
             Present only when type is MAGIC_LINK.
-          $ref: '#/components/schemas/connectionsPasswordLessConfig'
+          $ref: "#/components/schemas/connectionsPasswordLessConfig"
         provider:
-          description: Identity provider service that handles authentication
+          description: Identity provider service that handles authentication 
             (such as OKTA, Google, Azure AD, or a custom provider)
-          $ref: '#/components/schemas/connectionsConnectionProvider'
+          $ref: "#/components/schemas/connectionsConnectionProvider"
           examples:
             - OKTA
         provider_key:
-          description: Key ID of the identity provider service that handles
+          description: Key ID of the identity provider service that handles 
             authentication
           type: string
           examples:
             - google
         saml_config:
-          description: Configuration details for SAML connections. Present only
+          description: Configuration details for SAML connections. Present only 
             when type is SAML.
-          $ref: '#/components/schemas/connectionsSAMLConnectionConfigResponse'
+          $ref: "#/components/schemas/connectionsSAMLConnectionConfigResponse"
         static_config:
           description: Static configuration for custom connections. Present only
             when type is BASIC, BEARER, API_KEY, or custom.
-          $ref: '#/components/schemas/connectionsStaticAuthConfig'
+          $ref: "#/components/schemas/connectionsStaticAuthConfig"
         status:
-          description: Current configuration status of the connection. Possible
+          description: Current configuration status of the connection. Possible 
             values include IN_PROGRESS, CONFIGURED, and ERROR.
-          $ref: '#/components/schemas/connectionsConnectionStatus'
+          $ref: "#/components/schemas/connectionsConnectionStatus"
           readOnly: true
           examples:
             - IN_PROGRESS
         test_connection_uri:
-          description: URI that can be used to test this connection. Visit this
+          description: URI that can be used to test this connection. Visit this 
             URL to verify the connection works correctly.
           type: string
           examples:
             - https://auth.example.com/test-connection/conn_2123312131125533
         type:
-          description: Authentication protocol used by this connection. Can be
+          description: Authentication protocol used by this connection. Can be 
             OIDC (OpenID Connect), SAML, OAUTH, or MAGIC_LINK.
-          $ref: '#/components/schemas/connectionsConnectionType'
+          $ref: "#/components/schemas/connectionsConnectionType"
           examples:
             - OIDC
         webauthn_config:
-          description: Configuration details for WebAuthn (passkeys). Present
+          description: Configuration details for WebAuthn (passkeys). Present 
             only when type is WEBAUTHN.
-          $ref: '#/components/schemas/connectionsWebAuthConfiguration'
+          $ref: "#/components/schemas/connectionsWebAuthConfiguration"
     connectionsConnectionProvider:
       type: string
       enum:
@@ -7866,14 +8043,33 @@ components:
         - BEARER
         - API_KEY
         - WEBAUTHN
+        - OAUTH_M2M
+        - TRELLO_OAUTH1
+        - GOOGLE_DWD
     connectionsGetConnectionResponse:
       type: object
       properties:
         connection:
-          description: Complete connection details including provider
+          description: Complete connection details including provider 
             configuration, protocol settings, status, and all metadata. Contains
             everything needed to understand the connection's current state.
-          $ref: '#/components/schemas/connectionsConnection'
+          $ref: "#/components/schemas/connectionsConnection"
+    connectionsGoogleDWDConfig:
+      type: object
+      properties:
+        scopes:
+          description: OAuth 2.0 scopes to request.
+          type: array
+          items:
+            type: string
+        service_account_json:
+          description: "Google Cloud service account JSON key. Write-only: reads return
+            a masked value."
+          type: string
+        token_uri:
+          description: Google token endpoint. Defaults to 
+            https://oauth2.googleapis.com/token.
+          type: string
     connectionsIDPCertificate:
       type: object
       properties:
@@ -7911,10 +8107,10 @@ components:
           items:
             type: string
           examples:
-            - - yourapp.com
-              - yourworkspace.com
+            -   - yourapp.com
+                - yourworkspace.com
         enabled:
-          description: Whether the connection is currently active for
+          description: Whether the connection is currently active for 
             organization users
           type: boolean
           examples:
@@ -7925,13 +8121,13 @@ components:
           examples:
             - conn_2123312131125533
         key_id:
-          description: Alternative identifier for this connection, typically
+          description: Alternative identifier for this connection, typically 
             used in frontend applications or URLs
           type: string
           examples:
             - conn_2123312131125533
         organization_id:
-          description: Unique identifier of the organization that owns this
+          description: Unique identifier of the organization that owns this 
             connection
           type: string
           examples:
@@ -7943,24 +8139,24 @@ components:
             - Your Organization
         provider:
           description: Identity provider type (e.g., OKTA, Google, Azure AD)
-          $ref: '#/components/schemas/connectionsConnectionProvider'
+          $ref: "#/components/schemas/connectionsConnectionProvider"
           examples:
             - CUSTOM
         provider_key:
-          description: Key ID of the identity provider service that handles
+          description: Key ID of the identity provider service that handles 
             authentication
           type: string
           examples:
             - google
         status:
           description: Current configuration status of the connection
-          $ref: '#/components/schemas/connectionsConnectionStatus'
+          $ref: "#/components/schemas/connectionsConnectionStatus"
           readOnly: true
           examples:
             - IN_PROGRESS
         type:
           description: Authentication protocol used by the connection
-          $ref: '#/components/schemas/connectionsConnectionType'
+          $ref: "#/components/schemas/connectionsConnectionType"
           examples:
             - OIDC
     connectionsListConnectionsResponse:
@@ -7971,7 +8167,7 @@ components:
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/connectionsListConnection'
+            $ref: "#/components/schemas/connectionsListConnection"
     connectionsNameIdFormat:
       type: string
       enum:
@@ -7987,6 +8183,12 @@ components:
           type: string
           examples:
             - offline
+        app_name:
+          description: Application name used by providers that require it as an 
+            authorize query parameter (e.g., Trello's app_name).
+          type: string
+          examples:
+            - My Trello App
         authorize_uri:
           description: Authorize URI
           type: string
@@ -8007,6 +8209,19 @@ components:
           type: string
           examples:
             - user_scope
+        is_cimd:
+          description: Indicates whether this connection was registered using 
+            Client ID Metadata Document (CIMD) instead of Dynamic Client 
+            Registration.
+          type: boolean
+          readOnly: true
+          examples:
+            - true
+        optional_scopes:
+          description: Optional scopes configuration for identity providers that
+            support or require additional scopes to be sent in a custom field 
+            during authentication requests.
+          $ref: "#/components/schemas/connectionsOptionalScopes"
         pkce_enabled:
           description: PKCE Enabled
           type: boolean
@@ -8028,17 +8243,17 @@ components:
           items:
             type: string
           examples:
-            - - openid
-              - profile
+            -   - openid
+                - profile
         sync_user_profile_on_login:
-          description: Indicates whether user profiles should be synchronized
+          description: Indicates whether user profiles should be synchronized 
             with the identity provider upon each log-in.
           type: boolean
           examples:
             - true
         tenant_id:
-          description: Microsoft Entra tenant ID. Required when using a
-            single-tenant or multi-tenant app registered in Microsoft Entra.
+          description: Microsoft Entra tenant ID. Required when using a 
+            single-tenant or multi-tenant app registered in Microsoft Entra. 
             Leave empty to use the common endpoint.
           type: string
           examples:
@@ -8072,7 +8287,7 @@ components:
           examples:
             - https://youridp.com/service/oauth/authorize
         backchannel_logout_redirect_uri:
-          description: backchannel logout redirect uri where idp sends
+          description: backchannel logout redirect uri where idp sends 
             logout_token
           type: string
           readOnly: true
@@ -8104,7 +8319,7 @@ components:
           examples:
             - https://youridp.com/service/oauth
         jit_provisioning_with_sso_enabled:
-          description: Indicates if Just In Time user provisioning is enabled
+          description: Indicates if Just In Time user provisioning is enabled 
             for the connection
           type: boolean
           examples:
@@ -8134,19 +8349,19 @@ components:
           description: OIDC Scopes
           type: array
           items:
-            $ref: '#/components/schemas/connectionsOIDCScope'
+            $ref: "#/components/schemas/connectionsOIDCScope"
           examples:
-            - - openid
-              - profile
+            -   - openid
+                - profile
         sync_user_profile_on_login:
-          description: Indicates whether user profiles should be synchronized
+          description: Indicates whether user profiles should be synchronized 
             with the identity provider upon each log-in.
           type: boolean
           examples:
             - true
         token_auth_type:
           description: Token Auth Type
-          $ref: '#/components/schemas/connectionsTokenAuthType'
+          $ref: "#/components/schemas/connectionsTokenAuthType"
           examples:
             - URL_PARAMS
         token_uri:
@@ -8167,6 +8382,26 @@ components:
         - email
         - address
         - phone
+    connectionsOptionalScopes:
+      type: object
+      properties:
+        field_name:
+          description: Name of the field in which scope should be sent in the 
+            authentication request. This is required by some identity providers 
+            that expect scopes to be sent in a custom field instead of the 
+            standard 'scope' parameter.
+          type: string
+          examples:
+            - optional_scope or bot_scope
+        scopes:
+          description: List of optional scopes that can be requested during 
+            authentication
+          type: array
+          items:
+            type: string
+          examples:
+            -   - scope1
+                - scope2
     connectionsPasswordLessConfig:
       type: object
       properties:
@@ -8178,7 +8413,7 @@ components:
             - 6
         code_challenge_type:
           description: Code Challenge Type
-          $ref: '#/components/schemas/connectionsCodeChallengeType'
+          $ref: "#/components/schemas/connectionsCodeChallengeType"
           examples:
             - NUMERIC
         enforce_same_browser_origin:
@@ -8193,13 +8428,13 @@ components:
           examples:
             - 1
         regenerate_passwordless_credentials_on_resend:
-          description: 'Regenerate the '
+          description: "Regenerate the "
           type: boolean
           examples:
             - true
         type:
           description: Passwordless Type
-          $ref: '#/components/schemas/connectionsPasswordlessType'
+          $ref: "#/components/schemas/connectionsPasswordlessType"
           examples:
             - LINK
         validity:
@@ -8252,7 +8487,7 @@ components:
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/connectionsIDPCertificate'
+            $ref: "#/components/schemas/connectionsIDPCertificate"
         idp_entity_id:
           description: IDP Entity ID
           type: string
@@ -8265,12 +8500,12 @@ components:
             - https://youridp.com/service/saml/metadata
         idp_name_id_format:
           description: IDP Name ID Format
-          $ref: '#/components/schemas/connectionsNameIdFormat'
+          $ref: "#/components/schemas/connectionsNameIdFormat"
           examples:
             - EMAIL
         idp_slo_request_binding:
           description: IDP SLO Request Binding
-          $ref: '#/components/schemas/connectionsRequestBinding'
+          $ref: "#/components/schemas/connectionsRequestBinding"
           examples:
             - HTTP_POST
         idp_slo_required:
@@ -8285,7 +8520,7 @@ components:
             - https://youridp.com/service/saml/slo
         idp_sso_request_binding:
           description: IDP SSO Request Binding
-          $ref: '#/components/schemas/connectionsRequestBinding'
+          $ref: "#/components/schemas/connectionsRequestBinding"
           examples:
             - HTTP_POST
         idp_sso_url:
@@ -8294,14 +8529,14 @@ components:
           examples:
             - https://youridp.com/service/saml/sso
         jit_provisioning_with_sso_enabled:
-          description: Indicates if Just In Time user provisioning is enabled
+          description: Indicates if Just In Time user provisioning is enabled 
             for the connection
           type: boolean
           examples:
             - true
         saml_signing_option:
           description: SAML Signing Option
-          $ref: '#/components/schemas/connectionsSAMLSigningOptions'
+          $ref: "#/components/schemas/connectionsSAMLSigningOptions"
           examples:
             - SAML_ONLY_RESPONSE_SIGNING
         sp_assertion_url:
@@ -8326,7 +8561,7 @@ components:
           examples:
             - https://yourapp.com/sso/v1/saml/conn_1234/slo/callback
         sync_user_profile_on_login:
-          description: Indicates whether user profiles should be synchronized
+          description: Indicates whether user profiles should be synchronized 
             with the identity provider upon each log-in.
           type: boolean
           examples:
@@ -8360,7 +8595,7 @@ components:
       properties:
         enabled:
           description: Current state of the connection after the operation. True
-            means the connection is now enabled and can be used for
+            means the connection is now enabled and can be used for 
             authentication.
           type: boolean
           examples:
@@ -8377,15 +8612,15 @@ components:
         - BASIC_AUTH
     connectionsWebAuthConfiguration:
       type: object
-      title: WebAuthConfiguration defines WebAuthn (passkeys) configuration
+      title: WebAuthConfiguration defines WebAuthn (passkeys) configuration 
         limited to RP and Attestation
       properties:
         attestation:
-          $ref: '#/components/schemas/WebAuthConfigurationAttestation'
+          $ref: "#/components/schemas/WebAuthConfigurationAttestation"
         authenticator_selection:
-          $ref: '#/components/schemas/WebAuthConfigurationAuthenticatorSelection'
+          $ref: "#/components/schemas/WebAuthConfigurationAuthenticatorSelection"
         authenticators:
-          $ref: '#/components/schemas/WebAuthConfigurationAuthenticators'
+          $ref: "#/components/schemas/WebAuthConfigurationAuthenticators"
         enable_auto_registration:
           description: Enable auto registration for WebAuthn
           type: boolean
@@ -8393,12 +8628,12 @@ components:
           description: Allow autofill of passkeys in login page
           type: boolean
         rp:
-          $ref: '#/components/schemas/WebAuthConfigurationRp'
+          $ref: "#/components/schemas/WebAuthConfigurationRp"
         show_passkey_button:
           description: Show passkey button on login screen
           type: boolean
         timeout:
-          $ref: '#/components/schemas/WebAuthConfigurationTimeout'
+          $ref: "#/components/schemas/WebAuthConfigurationTimeout"
     directoriesAttributeMapping:
       type: object
       properties:
@@ -8413,45 +8648,45 @@ components:
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/directoriesAttributeMapping'
+            $ref: "#/components/schemas/directoriesAttributeMapping"
     directoriesDirectory:
       type: object
       properties:
         attribute_mappings:
-          description: Mappings between directory attributes and Scalekit user
+          description: Mappings between directory attributes and Scalekit user 
             and group attributes
-          $ref: '#/components/schemas/directoriesAttributeMappings'
+          $ref: "#/components/schemas/directoriesAttributeMappings"
         directory_endpoint:
-          description: The endpoint URL generated by Scalekit for synchronizing
+          description: The endpoint URL generated by Scalekit for synchronizing 
             users and groups from the Directory Provider
           type: string
           examples:
             - https://yourapp.scalekit.com/api/v1/directoies/dir_123212312/scim/v2
         directory_provider:
           description: Identity provider connected to this directory
-          $ref: '#/components/schemas/directoriesDirectoryProvider'
+          $ref: "#/components/schemas/directoriesDirectoryProvider"
           examples:
             - OKTA
         directory_type:
-          description: Type of the directory, indicating the protocol or
+          description: Type of the directory, indicating the protocol or 
             standard used for synchronization
-          $ref: '#/components/schemas/directoriesDirectoryType'
+          $ref: "#/components/schemas/directoriesDirectoryType"
           examples:
             - SCIM
         email:
-          description: Email Id associated with Directory whose access will be
+          description: Email Id associated with Directory whose access will be 
             used for polling
           type: string
           examples:
             - john.doe@scalekit.cloud
         enabled:
-          description: Indicates whether the directory is currently enabled and
+          description: Indicates whether the directory is currently enabled and 
             actively synchronizing users and groups
           type: boolean
           examples:
             - true
         groups_tracked:
-          description: It indicates if all groups are tracked or select groups
+          description: It indicates if all groups are tracked or select groups 
             are tracked
           type: string
           examples:
@@ -8469,32 +8704,32 @@ components:
           examples:
             - 2024-10-01T00:00:00Z
         name:
-          description: Name of the directory, typically representing the
+          description: Name of the directory, typically representing the 
             connected Directory provider
           type: string
           examples:
             - Azure AD
         organization_id:
-          description: Unique identifier of the organization to which the
+          description: Unique identifier of the organization to which the 
             directory belongs
           type: string
           examples:
             - org_121312434123312
         role_assignments:
-          description: Role assignments associated with the directory, defining
+          description: Role assignments associated with the directory, defining 
             group based role assignments
-          $ref: '#/components/schemas/directoriesRoleAssignments'
+          $ref: "#/components/schemas/directoriesRoleAssignments"
         secrets:
           description: List of secrets used for authenticating and synchronizing
             with the Directory Provider
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/directoriesSecret'
+            $ref: "#/components/schemas/directoriesSecret"
         stats:
-          description: Statistics and metrics related to the directory, such as
+          description: Statistics and metrics related to the directory, such as 
             synchronization status and error counts
-          $ref: '#/components/schemas/directoriesStats'
+          $ref: "#/components/schemas/directoriesStats"
         status:
           description: Directory Status
           type: string
@@ -8584,7 +8819,7 @@ components:
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/directoriesDirectoryGroup'
+            $ref: "#/components/schemas/directoriesDirectoryGroup"
         id:
           description: User ID
           type: string
@@ -8609,7 +8844,7 @@ components:
       properties:
         directory:
           description: Detailed information about the requested directory
-          $ref: '#/components/schemas/directoriesDirectory'
+          $ref: "#/components/schemas/directoriesDirectory"
     directoriesListDirectoriesResponse:
       type: object
       properties:
@@ -8618,27 +8853,27 @@ components:
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/directoriesDirectory'
+            $ref: "#/components/schemas/directoriesDirectory"
     directoriesListDirectoryGroupsResponse:
       type: object
       properties:
         groups:
-          description: List of directory groups retrieved from the specified
+          description: List of directory groups retrieved from the specified 
             directory
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/directoriesDirectoryGroup'
+            $ref: "#/components/schemas/directoriesDirectoryGroup"
         next_page_token:
-          description: Token to retrieve the next page of results. Use this
+          description: Token to retrieve the next page of results. Use this 
             token in the 'page_token' field of the next request
           type: string
         prev_page_token:
-          description: Token to retrieve the previous page of results. Use this
+          description: Token to retrieve the previous page of results. Use this 
             token in the 'page_token' field of the next request
           type: string
         total_size:
-          description: Total number of groups matching the request criteria,
+          description: Total number of groups matching the request criteria, 
             regardless of pagination
           type: integer
           format: int64
@@ -8646,25 +8881,25 @@ components:
       type: object
       properties:
         next_page_token:
-          description: Token for pagination. Use this token in the 'page_token'
+          description: Token for pagination. Use this token in the 'page_token' 
             field of the next request to fetch the subsequent page of users
           type: string
         prev_page_token:
-          description: Token for pagination. Use this token in the 'page_token'
+          description: Token for pagination. Use this token in the 'page_token' 
             field of the next request to fetch the prior page of users
           type: string
         total_size:
-          description: Total number of users available in the directory that
+          description: Total number of users available in the directory that 
             match the request criteria
           type: integer
           format: int64
         users:
-          description: List of directory users retrieved from the specified
+          description: List of directory users retrieved from the specified 
             directory
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/directoriesDirectoryUser'
+            $ref: "#/components/schemas/directoriesDirectoryUser"
     directoriesRoleAssignment:
       type: object
       properties:
@@ -8682,7 +8917,7 @@ components:
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/directoriesRoleAssignment'
+            $ref: "#/components/schemas/directoriesRoleAssignment"
     directoriesSecret:
       type: object
       properties:
@@ -8718,7 +8953,7 @@ components:
             - Nzg5
         status:
           description: Secret Status
-          $ref: '#/components/schemas/directoriesSecretStatus'
+          $ref: "#/components/schemas/directoriesSecretStatus"
           examples:
             - INACTIVE
     directoriesSecretStatus:
@@ -8756,16 +8991,16 @@ components:
       type: object
       properties:
         enabled:
-          description: Specifies the directory's state after the toggle
+          description: Specifies the directory's state after the toggle 
             operation. A value of `true` indicates that the directory is enabled
-            and actively synchronizing users and groups. A value of `false`
+            and actively synchronizing users and groups. A value of `false` 
             means the directory is disabled, halting synchronization
           type: boolean
           examples:
             - true
         error_message:
-          description: Contains a human-readable error message if the toggle
-            operation encountered an issue. If the operation was successful,
+          description: Contains a human-readable error message if the toggle 
+            operation encountered an issue. If the operation was successful, 
             this field will be empty
           type: string
           examples:
@@ -8774,9 +9009,9 @@ components:
       type: object
       properties:
         domain:
-          description: The newly created domain object with all configuration
+          description: The newly created domain object with all configuration 
             details and system-generated identifiers.
-          $ref: '#/components/schemas/domainsDomain'
+          $ref: "#/components/schemas/domainsDomain"
     domainsDomain:
       type: object
       properties:
@@ -8787,21 +9022,21 @@ components:
           examples:
             - 2025-09-01T12:14:43.100000Z
         domain:
-          description: The business domain name that was configured for allowed
-            email domain functionality (e.g., company.com,
+          description: The business domain name that was configured for allowed 
+            email domain functionality (e.g., company.com, 
             subdomain.company.com).
           type: string
           examples:
             - customerdomain.com
         domain_type:
-          example: 'ORGANIZATION_DOMAIN'
+          example: "ORGANIZATION_DOMAIN"
         environment_id:
           description: The environment ID where this domain is configured.
           type: string
           examples:
             - env_58345499215790610
         id:
-          description: Scalekit-generated unique identifier for this domain
+          description: Scalekit-generated unique identifier for this domain 
             record.
           type: string
           examples:
@@ -8828,7 +9063,7 @@ components:
             configuration.
 
             - NOT_APPLICABLE: verification does not apply to this domain type.
-          $ref: '#/components/schemas/domainsVerificationMethod'
+          $ref: "#/components/schemas/domainsVerificationMethod"
           examples:
             - ADMIN
         verification_status:
@@ -8844,7 +9079,7 @@ components:
 
             - FAILED: DNS TXT record was not validated within the verification
             window.
-          $ref: '#/components/schemas/domainsVerificationStatus'
+          $ref: "#/components/schemas/domainsVerificationStatus"
           examples:
             - AUTO_VERIFIED
     domainsDomainType:
@@ -8853,25 +9088,25 @@ components:
         - ALLOWED_EMAIL_DOMAIN
         - ORGANIZATION_DOMAIN
       x-enum-varnames:
-        - 'ORGANIZATION_DOMAIN'
-        - 'ALLOWED_EMAIL_DOMAIN'
+        - "ORGANIZATION_DOMAIN"
+        - "ALLOWED_EMAIL_DOMAIN"
     domainsGetDomainResponse:
       type: object
       properties:
         domain:
-          description: The requested domain object with complete details
+          description: The requested domain object with complete details 
             including domain type, timestamps and configuration.
-          $ref: '#/components/schemas/domainsDomain'
+          $ref: "#/components/schemas/domainsDomain"
     domainsListDomainResponse:
       type: object
       properties:
         domains:
-          description: Array of domain objects containing all domain details
+          description: Array of domain objects containing all domain details 
             including verification status and configuration.
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/domainsDomain'
+            $ref: "#/components/schemas/domainsDomain"
         page_number:
           description: Current page number in the pagination sequence.
           type: integer
@@ -8905,7 +9140,7 @@ components:
           description: Additional debugging information provided by the server.
           type: string
         stack_entries:
-          description: The stack trace entries indicating where the error
+          description: The stack trace entries indicating where the error 
             occurred.
           type: array
           items:
@@ -8914,21 +9149,21 @@ components:
       type: object
       properties:
         debug_info:
-          $ref: '#/components/schemas/errdetailsDebugInfo'
+          $ref: "#/components/schemas/errdetailsDebugInfo"
         error_code:
           type: string
         help_info:
-          $ref: '#/components/schemas/errdetailsHelpInfo'
+          $ref: "#/components/schemas/errdetailsHelpInfo"
         localized_message_info:
-          $ref: '#/components/schemas/errdetailsLocalizedMessageInfo'
+          $ref: "#/components/schemas/errdetailsLocalizedMessageInfo"
         request_info:
-          $ref: '#/components/schemas/errdetailsRequestInfo'
+          $ref: "#/components/schemas/errdetailsRequestInfo"
         resource_info:
-          $ref: '#/components/schemas/errdetailsResourceInfo'
+          $ref: "#/components/schemas/errdetailsResourceInfo"
         tool_error_info:
-          $ref: '#/components/schemas/errdetailsToolErrorInfo'
+          $ref: "#/components/schemas/errdetailsToolErrorInfo"
         validation_error_info:
-          $ref: '#/components/schemas/errdetailsValidationErrorInfo'
+          $ref: "#/components/schemas/errdetailsValidationErrorInfo"
     errdetailsHelpInfo:
       description: >-
         HelpInfo provides documentation links attached to an error response.
@@ -8946,7 +9181,7 @@ components:
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/HelpInfoLink'
+            $ref: "#/components/schemas/HelpInfoLink"
     errdetailsLocalizedMessageInfo:
       type: object
       properties:
@@ -9022,21 +9257,21 @@ components:
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/ValidationErrorInfoFieldViolation'
+            $ref: "#/components/schemas/ValidationErrorInfoFieldViolation"
     organizationsCreateOrganizationResponse:
       type: object
       properties:
         organization:
-          description: The newly created organization containing its ID,
+          description: The newly created organization containing its ID, 
             settings, and metadata
-          $ref: '#/components/schemas/organizationsOrganization'
+          $ref: "#/components/schemas/organizationsOrganization"
     organizationsFeature:
       description: >-
         - dir_sync: Enables directory synchronization configuration in the
         portal
          - sso: Enables Single Sign-On (SSO) configuration in the portal
       type: string
-      title: Feature represents the available features that can be enabled for
+      title: Feature represents the available features that can be enabled for 
         an organization's portal link
       enum:
         - dir_sync
@@ -9045,16 +9280,22 @@ components:
       type: object
       properties:
         link:
-          description: 'Contains the generated admin portal link details. The link
+          description: "Contains the generated admin portal link details. The link
             URL can be shared with organization administrators to set up: Single Sign-On
-            (SSO) authentication and directory synchronization'
-          $ref: '#/components/schemas/organizationsLink'
+            (SSO) authentication and directory synchronization"
+          $ref: "#/components/schemas/organizationsLink"
     organizationsGetOrganizationResponse:
       type: object
       properties:
         organization:
           description: The newly created organization
-          $ref: '#/components/schemas/organizationsOrganization'
+          $ref: "#/components/schemas/organizationsOrganization"
+    organizationsGetOrganizationSessionPolicyResponse:
+      type: object
+      properties:
+        policy:
+          description: The session policy for the organization.
+          $ref: "#/components/schemas/organizationsOrganizationSessionPolicySettings"
     organizationsLink:
       type: object
       properties:
@@ -9079,7 +9320,7 @@ components:
       type: object
       properties:
         next_page_token:
-          description: Pagination token for the next page of results. Use this
+          description: Pagination token for the next page of results. Use this 
             token to fetch the next page.
           type: string
           examples:
@@ -9089,9 +9330,9 @@ components:
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/organizationsOrganization'
+            $ref: "#/components/schemas/organizationsOrganization"
         prev_page_token:
-          description: Pagination token for the previous page of results. Use
+          description: Pagination token for the previous page of results. Use 
             this token to fetch the previous page.
           type: string
           examples:
@@ -9115,43 +9356,62 @@ components:
           examples:
             - 2025-02-15T06:23:44.560000Z
         display_name:
-          description: Name of the organization. Must be between 1 and 200
+          description: Name of the organization. Must be between 1 and 200 
             characters
           type: string
           title: Name of the org to be used in display
           examples:
             - Megasoft
         external_id:
-          description: Your application's unique identifier for this
+          description: Your application's unique identifier for this 
             organization, used to link Scalekit with your system.
           type: string
-          title: External Id is useful to store a unique identifier for a given
-            Org that. The unique Identifier can be the id of your tenant / org
+          title: External Id is useful to store a unique identifier for a given 
+            Org that. The unique Identifier can be the id of your tenant / org 
             in your SaaSApp
           examples:
             - my_unique_id
         id:
-          description: Unique scalekit-generated identifier that uniquely
+          description: Unique scalekit-generated identifier that uniquely 
             references an organization
           type: string
           title: Id
           examples:
             - org_59615193906282635
+        logo_url:
+          description: HTTPS URL of the organization's logo image. Maximum 2048 
+            characters. Must use the https scheme.
+          type: string
+          format: uri
+          maxLength: 2048
+          pattern: ^https://
+          examples:
+            - https://cdn.example.com/acme-logo.png
         metadata:
           description: Key value pairs extension attributes.
           type: object
           additionalProperties:
             type: string
         region_code:
-          description: Geographic region code for the organization. Currently
+          description: Geographic region code for the organization. Currently 
             limited to US.
           title: Optional regioncode
-          $ref: '#/components/schemas/commonsRegionCode'
+          $ref: "#/components/schemas/commonsRegionCode"
           examples:
             - US
         settings:
           title: Organization Settings
-          $ref: '#/components/schemas/organizationsOrganizationSettings'
+          $ref: "#/components/schemas/organizationsOrganizationSettings"
+        slug:
+          description: DNS-safe slug for dynamic redirect URI resolution. Must 
+            be 1-63 chars, lowercase alphanumeric and hyphens, must start and 
+            end with an alphanumeric character. Unique per environment.
+          type: string
+          maxLength: 63
+          minLength: 1
+          pattern: ^[a-z0-9]([a-z0-9]|-[a-z0-9])*$
+          examples:
+            - acme
         update_time:
           description: Timestamp when the organization was last updated
           type: string
@@ -9159,25 +9419,69 @@ components:
           title: Updated time
           examples:
             - 2025-02-15T06:23:44.560000Z
+    organizationsOrganizationSessionPolicySettings:
+      type: object
+      properties:
+        absolute_session_timeout:
+          description: The absolute session timeout value. The unit is specified
+            by absolute_session_timeout_unit. Omitted when policy_source is 
+            'environment'.
+          type: integer
+          format: int32
+          examples:
+            - 360
+        absolute_session_timeout_unit:
+          description: "Unit for absolute_session_timeout. Accepted values: 'minutes',
+            'hours', 'days'. Responses always return 'minutes'."
+          $ref: "#/components/schemas/commonsTimeUnit"
+          examples:
+            - minutes
+        idle_session_timeout:
+          description: The idle session timeout value. The unit is specified by 
+            idle_session_timeout_unit. Omitted when idle_session_timeout_enabled
+            is false or policy_source is 'environment'.
+          type: integer
+          format: int32
+          examples:
+            - 84
+        idle_session_timeout_enabled:
+          description: Whether idle session timeout is enabled for this 
+            organization. Omitted when policy_source is 'environment'.
+          type: boolean
+          examples:
+            - true
+        idle_session_timeout_unit:
+          description: "Unit for idle_session_timeout. Accepted values: 'minutes',
+            'hours', 'days'. Responses always return 'minutes'."
+          $ref: "#/components/schemas/commonsTimeUnit"
+          examples:
+            - minutes
+        policy_source:
+          description: Policy source. 'APPLICATION' means the organization 
+            inherits the application-level session policy. 'CUSTOM' means 
+            organization-specific timeout values are active.
+          $ref: "#/components/schemas/organizationsSessionPolicyType"
+          examples:
+            - CUSTOM
     organizationsOrganizationSettings:
-      description: Configuration options that control organization-level
+      description: Configuration options that control organization-level 
         features and capabilities
       type: object
       title: Organization Settings
       properties:
         features:
-          description: List of feature toggles that control organization
-            capabilities such as SSO authentication and directory
+          description: List of feature toggles that control organization 
+            capabilities such as SSO authentication and directory 
             synchronization
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/organizationsOrganizationSettingsFeature'
+            $ref: "#/components/schemas/organizationsOrganizationSettingsFeature"
           examples:
-            - - enabled: true
-                name: sso
-              - enabled: false
-                name: directory_sync
+            -   - enabled: true
+                  name: sso
+                - enabled: false
+                  name: directory_sync
       examples:
         - features:
             - enabled: true
@@ -9185,7 +9489,7 @@ components:
             - enabled: false
               name: directory_sync
     organizationsOrganizationSettingsFeature:
-      description: Controls the activation state of a specific organization
+      description: Controls the activation state of a specific organization 
         feature
       type: object
       title: Organization Feature Toggle
@@ -9202,7 +9506,8 @@ components:
         name:
           description: 'Feature identifier. Supported values include: "sso" (Single
             Sign-On), "directory_sync" (Directory Synchronization), "domain_verification"
-            (Domain Verification)'
+            (Domain Verification), "session_policy" (Organization-level session policy
+            override)'
           type: string
           examples:
             - sso
@@ -9211,30 +9516,41 @@ components:
       properties:
         max_allowed_users:
           description: Maximum number of users allowed in the organization. When
-            nil (not set), there feature is not enabled. When explicitly set to
-            zero, it also means no limit. When set to a positive integer, it
+            nil (not set), there feature is not enabled. When explicitly set to 
+            zero, it also means no limit. When set to a positive integer, it 
             enforces the maximum user limit.
           type: integer
           format: int32
           examples:
             - 100
+    organizationsSessionPolicyType:
+      type: string
+      enum:
+        - APPLICATION
+        - CUSTOM
     organizationsUpdateOrganizationResponse:
       type: object
       properties:
         organization:
           description: Updated organization details
-          $ref: '#/components/schemas/organizationsOrganization'
+          $ref: "#/components/schemas/organizationsOrganization"
+    organizationsUpdateOrganizationSessionPolicyResponse:
+      type: object
+      properties:
+        policy:
+          description: The updated session policy for the organization.
+          $ref: "#/components/schemas/organizationsOrganizationSessionPolicySettings"
     organizationsUpsertUserManagementSettingsResponse:
       type: object
       properties:
         settings:
           description: The updated setting.
-          $ref: '#/components/schemas/organizationsOrganizationUserManagementSettings'
+          $ref: "#/components/schemas/organizationsOrganizationUserManagementSettings"
     passwordlessResendPasswordlessRequest:
       type: object
       properties:
         auth_request_id:
-          description: The authentication request identifier from the original
+          description: The authentication request identifier from the original 
             send passwordless email request. Use this to resend the Verification
             Code (OTP) or Magic Link to the same email address.
           type: string
@@ -9244,39 +9560,39 @@ components:
       type: object
       properties:
         email:
-          description: Email address where the passwordless authentication
+          description: Email address where the passwordless authentication 
             credentials will be sent. Must be a valid email format.
           type: string
           examples:
             - john.doe@example.com
         expires_in:
-          description: Time in seconds until the passwordless authentication
+          description: Time in seconds until the passwordless authentication 
             expires. If not specified, defaults to 300 seconds (5 minutes)
           type: integer
           format: int64
           examples:
             - 300
         magiclink_auth_uri:
-          description: Your application's callback URL where users will be
-            redirected after clicking the magic link in their email. The link
+          description: Your application's callback URL where users will be 
+            redirected after clicking the magic link in their email. The link 
             token will be appended as a query parameter as link_token
           type: string
           examples:
             - https://yourapp.com/auth/passwordless/callback
         state:
           description: Custom state parameter that will be returned unchanged in
-            the verification response. Use this to maintain application state
-            between the authentication request and callback, such as the
+            the verification response. Use this to maintain application state 
+            between the authentication request and callback, such as the 
             intended destination after login
           type: string
           examples:
             - d62ivasry29lso
         template:
-          description: Specifies the authentication intent for the passwordless
-            request. Use SIGNIN for existing users or SIGNUP for new user
-            registration. This affects the email template and user experience
+          description: Specifies the authentication intent for the passwordless 
+            request. Use SIGNIN for existing users or SIGNUP for new user 
+            registration. This affects the email template and user experience 
             flow.
-          $ref: '#/components/schemas/passwordlessTemplateType'
+          $ref: "#/components/schemas/passwordlessTemplateType"
           examples:
             - SIGNIN
         template_variables:
@@ -9306,14 +9622,14 @@ components:
       type: object
       properties:
         auth_request_id:
-          description: Unique identifier for this passwordless authentication
+          description: Unique identifier for this passwordless authentication 
             request. Use this ID to resend emails.
           type: string
           readOnly: true
           examples:
             - h5Y8kT5RVwaea5WEgW4n-6C-aO_-fuTUW7Vb9-Rh3AcY9qxZqQ
         expires_at:
-          description: Unix timestamp (seconds since epoch) when the
+          description: Unix timestamp (seconds since epoch) when the 
             passwordless authentication will expire. After this time, the OTP or
             magic link will no longer be valid.
           type: string
@@ -9322,8 +9638,8 @@ components:
           examples:
             - 1748696575
         expires_in:
-          description: Number of seconds from now until the passwordless
-            authentication expires. This is a convenience field calculated from
+          description: Number of seconds from now until the passwordless 
+            authentication expires. This is a convenience field calculated from 
             the expires_at timestamp.
           type: integer
           format: int64
@@ -9331,10 +9647,10 @@ components:
           examples:
             - 300
         passwordless_type:
-          description: Type of passwordless authentication that was sent via
-            email. OTP sends a numeric code, LINK sends a clickable magic link,
+          description: Type of passwordless authentication that was sent via 
+            email. OTP sends a numeric code, LINK sends a clickable magic link, 
             and LINK_OTP provides both options for user convenience.
-          $ref: '#/components/schemas/authpasswordlessPasswordlessType'
+          $ref: "#/components/schemas/authpasswordlessPasswordlessType"
           examples:
             - OTP
     passwordlessTemplateType:
@@ -9346,22 +9662,22 @@ components:
       type: object
       properties:
         auth_request_id:
-          description: The authentication request identifier returned from the
-            send passwordless email endpoint. Required when verifying OTP codes
+          description: The authentication request identifier returned from the 
+            send passwordless email endpoint. Required when verifying OTP codes 
             to link the verification with the original request.
           type: string
           examples:
             - h5Y8kT5RVwaea5WEgW4n-6C-aO_-fuTUW7Vb9-Rh3AcY9qxZqQ
         code:
-          description: The Verification Code (OTP) received via email. This is
+          description: The Verification Code (OTP) received via email. This is 
             typically a 6-digit numeric code that users enter manually to verify
             their identity.
           type: string
           examples:
-            - '123456'
+            - "123456"
         link_token:
-          description: The unique token from the magic link URL received via
-            email. Extract this token when users click the magic link and are
+          description: The unique token from the magic link URL received via 
+            email. Extract this token when users click the magic link and are 
             redirected to your application to later verify the user.
           type: string
           examples:
@@ -9370,22 +9686,22 @@ components:
       type: object
       properties:
         email:
-          description: Email address of the successfully authenticated user.
-            This confirms which email account was verified through the
+          description: Email address of the successfully authenticated user. 
+            This confirms which email account was verified through the 
             passwordless flow.
           type: string
           readOnly: true
           examples:
             - john.doe@example.com
         passwordless_type:
-          description: The type of passwordless authentication that was
+          description: The type of passwordless authentication that was 
             successfully verified, confirming which method the user completed.
-          $ref: '#/components/schemas/authpasswordlessPasswordlessType'
+          $ref: "#/components/schemas/authpasswordlessPasswordlessType"
           examples:
             - OTP
         state:
-          description: The custom state parameter that was provided in the
-            original authentication request, returned unchanged. Use this to
+          description: The custom state parameter that was provided in the 
+            original authentication request, returned unchanged. Use this to 
             restore your application's context after authentication.
           type: string
           readOnly: true
@@ -9394,7 +9710,7 @@ components:
         template:
           description: Specifies which email template to choose. For User Signin
             choose SIGNIN and for User Signup use SIGNUP
-          $ref: '#/components/schemas/passwordlessTemplateType'
+          $ref: "#/components/schemas/passwordlessTemplateType"
           examples:
             - SIGNIN
     protobufNullValue:
@@ -9411,29 +9727,29 @@ components:
       type: object
       properties:
         permissions:
-          description: List of all permissions belonging to the role after
+          description: List of all permissions belonging to the role after 
             addition
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/rolesPermission'
+            $ref: "#/components/schemas/rolesPermission"
     rolesCreateOrganizationRoleResponse:
       type: object
       properties:
         role:
-          $ref: '#/components/schemas/v1rolesRole'
+          $ref: "#/components/schemas/v1rolesRole"
     rolesCreatePermissionResponse:
       type: object
       properties:
         permission:
-          $ref: '#/components/schemas/rolesPermission'
+          $ref: "#/components/schemas/rolesPermission"
     rolesCreateRoleResponse:
       type: object
       properties:
         role:
-          description: The created role object with system-generated ID and all
+          description: The created role object with system-generated ID and all 
             configuration details.
-          $ref: '#/components/schemas/v1rolesRole'
+          $ref: "#/components/schemas/v1rolesRole"
           examples:
             - description: Can edit content
               display_name: Content Editor
@@ -9443,19 +9759,19 @@ components:
       type: object
       properties:
         role:
-          $ref: '#/components/schemas/v1rolesRole'
+          $ref: "#/components/schemas/v1rolesRole"
     rolesGetPermissionResponse:
       type: object
       properties:
         permission:
-          $ref: '#/components/schemas/rolesPermission'
+          $ref: "#/components/schemas/rolesPermission"
     rolesGetRoleResponse:
       type: object
       properties:
         role:
-          description: The complete role object with all metadata, permissions,
+          description: The complete role object with all metadata, permissions, 
             and inheritance details.
-          $ref: '#/components/schemas/v1rolesRole'
+          $ref: "#/components/schemas/v1rolesRole"
           examples:
             - dependent_roles_count: 2
               display_name: Content Editor
@@ -9480,17 +9796,17 @@ components:
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/v1rolesRole'
+            $ref: "#/components/schemas/v1rolesRole"
     rolesListEffectiveRolePermissionsResponse:
       type: object
       properties:
         permissions:
-          description: List of all effective permissions including those
+          description: List of all effective permissions including those 
             inherited from base roles
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/rolesPermission'
+            $ref: "#/components/schemas/rolesPermission"
     rolesListOrganizationRolesResponse:
       type: object
       properties:
@@ -9499,7 +9815,7 @@ components:
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/v1rolesRole'
+            $ref: "#/components/schemas/v1rolesRole"
     rolesListPermissionsResponse:
       type: object
       properties:
@@ -9512,7 +9828,7 @@ components:
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/rolesPermission'
+            $ref: "#/components/schemas/rolesPermission"
         prev_page_token:
           description: Token to retrieve previous page of results
           type: string
@@ -9532,24 +9848,24 @@ components:
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/rolesPermission'
+            $ref: "#/components/schemas/rolesPermission"
     rolesListRolesResponse:
       type: object
       properties:
         roles:
-          description: List of all roles in the environment with their metadata
+          description: List of all roles in the environment with their metadata 
             and optionally their permissions.
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/v1rolesRole'
+            $ref: "#/components/schemas/v1rolesRole"
           examples:
-            - - display_name: Administrator
-                id: role_1234abcd5678efgh
-                name: admin
-              - display_name: Viewer
-                id: role_9876zyxw5432vuts
-                name: viewer
+            -   - display_name: Administrator
+                  id: role_1234abcd5678efgh
+                  name: admin
+                - display_name: Viewer
+                  id: role_9876zyxw5432vuts
+                  name: viewer
     rolesPermission:
       type: object
       title: Permission Entity
@@ -9562,7 +9878,7 @@ components:
         id:
           type: string
         is_scalekit_permission:
-          description: Indicates whether this permission is predefined by
+          description: Indicates whether this permission is predefined by 
             Scalekit
           type: boolean
           examples:
@@ -9579,7 +9895,7 @@ components:
         - ENVIRONMENT
     rolesRolePermission:
       type: object
-      title: RolePermissions represents a permission with role source
+      title: RolePermissions represents a permission with role source 
         information
       properties:
         create_time:
@@ -9604,7 +9920,7 @@ components:
       properties:
         default_member:
           description: Updated default member role
-          $ref: '#/components/schemas/v1rolesRole'
+          $ref: "#/components/schemas/v1rolesRole"
           examples:
             - description: Role for regular members
               display_name: Member Role
@@ -9624,9 +9940,9 @@ components:
       type: object
       properties:
         default_creator:
-          description: Default creator role (deprecated - use
+          description: Default creator role (deprecated - use 
             default_creator_role field instead)
-          $ref: '#/components/schemas/rolesUpdateDefaultRole'
+          $ref: "#/components/schemas/rolesUpdateDefaultRole"
           examples:
             - description: Role for creating resources
               display_name: Creator Role
@@ -9634,8 +9950,8 @@ components:
               name: creator
         default_creator_role:
           description: Name of the role to set as the default creator role. This
-            role will be automatically assigned to users who create new
-            resources in the environment. Must be a valid role name that exists
+            role will be automatically assigned to users who create new 
+            resources in the environment. Must be a valid role name that exists 
             in the environment.
           type: string
           examples:
@@ -9643,16 +9959,16 @@ components:
         default_member:
           description: Default member role (deprecated - use default_member_role
             field instead)
-          $ref: '#/components/schemas/rolesUpdateDefaultRole'
+          $ref: "#/components/schemas/rolesUpdateDefaultRole"
           examples:
             - description: Role for regular members
               display_name: Member Role
               id: role_0987654321
               name: member
         default_member_role:
-          description: Name of the role to set as the default member role. This
-            role will be automatically assigned to new users when they join the
-            environment. Must be a valid role name that exists in the
+          description: Name of the role to set as the default member role. This 
+            role will be automatically assigned to new users when they join the 
+            environment. Must be a valid role name that exists in the 
             environment.
           type: string
           examples:
@@ -9661,20 +9977,20 @@ components:
       type: object
       properties:
         default_creator:
-          description: The role that is now set as the default creator role for
-            the environment. Contains complete role information including
+          description: The role that is now set as the default creator role for 
+            the environment. Contains complete role information including 
             permissions and metadata.
-          $ref: '#/components/schemas/v1rolesRole'
+          $ref: "#/components/schemas/v1rolesRole"
           examples:
             - description: Role for creating resources
               display_name: Creator Role
               id: role_1234567890
               name: creator
         default_member:
-          description: The role that is now set as the default member role for
-            the environment. Contains complete role information including
+          description: The role that is now set as the default member role for 
+            the environment. Contains complete role information including 
             permissions and metadata.
-          $ref: '#/components/schemas/v1rolesRole'
+          $ref: "#/components/schemas/v1rolesRole"
           examples:
             - description: Role for regular members
               display_name: Member Role
@@ -9684,31 +10000,31 @@ components:
       type: object
       properties:
         role:
-          $ref: '#/components/schemas/v1rolesRole'
+          $ref: "#/components/schemas/v1rolesRole"
     rolesUpdatePermissionResponse:
       type: object
       properties:
         permission:
-          $ref: '#/components/schemas/rolesPermission'
+          $ref: "#/components/schemas/rolesPermission"
     rolesUpdateRoleResponse:
       type: object
       properties:
         role:
-          description: The updated role object with all current configuration
+          description: The updated role object with all current configuration 
             details.
-          $ref: '#/components/schemas/v1rolesRole'
+          $ref: "#/components/schemas/v1rolesRole"
           examples:
             - description: Can edit and approve content
               display_name: Senior Editor
               id: role_1234abcd5678efgh
               name: content_editor
     sessionsAuthenticatedClients:
-      description: AuthenticatedClients represents an authenticated client in a
+      description: AuthenticatedClients represents an authenticated client in a 
         session along with its organization context.
       type: object
       properties:
         client_id:
-          description: Unique identifier of the authenticated client
+          description: Unique identifier of the authenticated client 
             application.
           type: string
           examples:
@@ -9723,13 +10039,13 @@ components:
       type: object
       properties:
         browser:
-          description: 'Browser name and family extracted from the user agent. Examples:
-            Chrome, Safari, Firefox, Edge, Mobile Safari.'
+          description: "Browser name and family extracted from the user agent. Examples:
+            Chrome, Safari, Firefox, Edge, Mobile Safari."
           type: string
           examples:
             - Chrome
         browser_version:
-          description: Version of the browser application. Represents the
+          description: Version of the browser application. Represents the 
             specific release version of the browser being used.
           type: string
           examples:
@@ -9744,7 +10060,7 @@ components:
             - desktop
         ip:
           description: IP address of the device that initiated the session. This
-            is the public-facing IP address used to connect to the application.
+            is the public-facing IP address used to connect to the application. 
             Useful for security audits and geographic distribution analysis.
           type: string
           examples:
@@ -9753,23 +10069,23 @@ components:
           description: "Geographic location information derived from IP address geolocation.
             Includes country, region, city, and coordinates. Note: Based on IP location
             data and may not represent the user's exact physical location."
-          $ref: '#/components/schemas/v1sessionsLocation'
+          $ref: "#/components/schemas/v1sessionsLocation"
         os:
-          description: 'Operating system name extracted from the user agent and device
-            headers. Examples: macOS, Windows, Linux, iOS, Android.'
+          description: "Operating system name extracted from the user agent and device
+            headers. Examples: macOS, Windows, Linux, iOS, Android."
           type: string
           examples:
             - macOS
         os_version:
-          description: Version of the operating system. Represents the specific
+          description: Version of the operating system. Represents the specific 
             OS release the device is running.
           type: string
           examples:
-            - '14.2'
+            - "14.2"
         user_agent:
-          description: Complete HTTP User-Agent header string from the client
-            request. Contains browser type, version, and operating system
-            information. Used for detailed device fingerprinting and user agent
+          description: Complete HTTP User-Agent header string from the client 
+            request. Contains browser type, version, and operating system 
+            information. Used for detailed device fingerprinting and user agent 
             analysis.
           type: string
           examples:
@@ -9779,15 +10095,15 @@ components:
       type: object
       properties:
         revoked_sessions:
-          description: List of all sessions that were revoked, including
-            detailed information for each revoked session with IDs, timestamps,
+          description: List of all sessions that were revoked, including 
+            detailed information for each revoked session with IDs, timestamps, 
             and device details.
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/sessionsRevokedSessionDetails'
+            $ref: "#/components/schemas/sessionsRevokedSessionDetails"
         total_revoked:
-          description: Total count of active sessions that were revoked. Useful
+          description: Total count of active sessions that were revoked. Useful 
             for confirmation and audit logging.
           type: integer
           format: int64
@@ -9798,73 +10114,73 @@ components:
       properties:
         revoked_session:
           description: Details of the revoked session including session ID, user
-            ID, creation and revocation timestamps, and final device
+            ID, creation and revocation timestamps, and final device 
             information.
-          $ref: '#/components/schemas/sessionsRevokedSessionDetails'
+          $ref: "#/components/schemas/sessionsRevokedSessionDetails"
     sessionsRevokedSessionDetails:
       type: object
       properties:
         absolute_expires_at:
           description: The absolute expiration timestamp that was configured for
-            this session before revocation. Represents the hard deadline
+            this session before revocation. Represents the hard deadline 
             regardless of activity.
           type: string
           format: date-time
           examples:
             - 2025-01-22T10:30:00Z
         created_at:
-          description: Timestamp indicating when the session was originally
+          description: Timestamp indicating when the session was originally 
             created before revocation.
           type: string
           format: date-time
           examples:
             - 2025-01-15T10:30:00Z
         expired_at:
-          description: Timestamp when the session was actually terminated. Set
+          description: Timestamp when the session was actually terminated. Set 
             to the revocation time when the session is revoked.
           type: string
           format: date-time
           examples:
             - 2025-01-15T12:00:00Z
         idle_expires_at:
-          description: The idle expiration timestamp that was configured for
-            this session before revocation. Represents when the session would
+          description: The idle expiration timestamp that was configured for 
+            this session before revocation. Represents when the session would 
             have expired due to inactivity.
           type: string
           format: date-time
           examples:
             - 2025-01-15T11:30:00Z
         last_active_at:
-          description: Timestamp of the last recorded user activity in this
-            session before revocation. Helps identify inactive sessions that
+          description: Timestamp of the last recorded user activity in this 
+            session before revocation. Helps identify inactive sessions that 
             were revoked.
           type: string
           format: date-time
           examples:
             - 2025-01-15T10:55:30Z
         logout_at:
-          description: Timestamp when the user explicitly logged out (if
+          description: Timestamp when the user explicitly logged out (if 
             applicable). Null if the session was revoked without prior logout.
           type: string
           format: date-time
           examples:
             - 2025-01-15T14:00:00Z
         session_id:
-          description: Unique identifier for the revoked session.
+          description: Unique identifier for the revoked session. 
             System-generated read-only field.
           type: string
           examples:
             - ses_1234567890123456
         status:
-          description: Status of the session after revocation. Always 'revoked'
-            since only active sessions can be revoked. Sessions that were
-            already expired or logged out are not included in the revocation
+          description: Status of the session after revocation. Always 'revoked' 
+            since only active sessions can be revoked. Sessions that were 
+            already expired or logged out are not included in the revocation 
             response.
           type: string
           examples:
             - revoked
         updated_at:
-          description: Timestamp indicating when the session was last modified
+          description: Timestamp indicating when the session was last modified 
             before revocation.
           type: string
           format: date-time
@@ -9879,7 +10195,7 @@ components:
       type: object
       properties:
         absolute_expires_at:
-          description: Hard expiration timestamp for the session regardless of
+          description: Hard expiration timestamp for the session regardless of 
             user activity. The session will be forcibly terminated at this time.
             This represents the maximum session lifetime from creation.
           type: string
@@ -9887,47 +10203,47 @@ components:
           examples:
             - 2025-01-22T10:30:00Z
         authenticated_clients:
-          description: 'Details of the authenticated clients for this session: client
-            ID and organization context.'
+          description: "Details of the authenticated clients for this session: client
+            ID and organization context."
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/sessionsAuthenticatedClients'
+            $ref: "#/components/schemas/sessionsAuthenticatedClients"
         authenticated_organizations:
           description: List of organization IDs that have been authenticated for
-            this user within the current session. Contains all organizations
+            this user within the current session. Contains all organizations 
             where the user has successfully completed SSO or authentication.
           type: array
           items:
             type: string
           examples:
-            - - org_123
-              - org_456
+            -   - org_123
+                - org_456
         created_at:
-          description: Timestamp indicating when the session was created. This
-            is set once at session creation and remains constant throughout the
+          description: Timestamp indicating when the session was created. This 
+            is set once at session creation and remains constant throughout the 
             session lifetime.
           type: string
           format: date-time
           examples:
             - 2025-01-15T10:30:00Z
         device:
-          description: Complete device metadata associated with this session
-            including browser, operating system, device type, and geographic
+          description: Complete device metadata associated with this session 
+            including browser, operating system, device type, and geographic 
             location based on IP address.
-          $ref: '#/components/schemas/sessionsDeviceDetails'
+          $ref: "#/components/schemas/sessionsDeviceDetails"
         expired_at:
-          description: Timestamp when the session was terminated. Null if the
-            session is still active. Set when the session expires due to
-            reaching idle_expires_at or absolute_expires_at timeout, or when
-            administratively revoked. Not set for user-initiated logout (see
+          description: Timestamp when the session was terminated. Null if the 
+            session is still active. Set when the session expires due to 
+            reaching idle_expires_at or absolute_expires_at timeout, or when 
+            administratively revoked. Not set for user-initiated logout (see 
             logout_at instead).
           type: string
           format: date-time
           examples:
             - 2025-01-15T12:00:00Z
         idle_expires_at:
-          description: Projected expiration timestamp if the session remains
+          description: Projected expiration timestamp if the session remains 
             idle without user activity. This timestamp is recalculated with each
             user activity. Session will be automatically terminated at this time
             if no activity occurs.
@@ -9936,30 +10252,30 @@ components:
           examples:
             - 2025-01-15T11:30:00Z
         last_active_at:
-          description: Timestamp of the most recent user activity detected in
-            this session. Updated on each API request or user interaction. Used
+          description: Timestamp of the most recent user activity detected in 
+            this session. Updated on each API request or user interaction. Used 
             to determine if a session has exceeded the idle timeout threshold.
           type: string
           format: date-time
           examples:
             - 2025-01-15T10:55:30Z
         logout_at:
-          description: Timestamp when the user explicitly logged out from the
-            session. Null if the user has not logged out. When set, indicates
+          description: Timestamp when the user explicitly logged out from the 
+            session. Null if the user has not logged out. When set, indicates 
             the session ended due to explicit user logout rather than timeout.
           type: string
           format: date-time
           examples:
             - 2025-01-15T14:00:00Z
         organization_id:
-          description: Organization ID for the user's most recently active
-            organization within this session. This represents the primary
+          description: Organization ID for the user's most recently active 
+            organization within this session. This represents the primary 
             organization context for the current session.
           type: string
           examples:
             - org_1234567890123456
         session_id:
-          description: Unique identifier for the session. System-generated
+          description: Unique identifier for the session. System-generated 
             read-only field used to reference this session.
           type: string
           examples:
@@ -9974,15 +10290,15 @@ components:
           examples:
             - active
         updated_at:
-          description: Timestamp indicating when the session was last updated.
-            Updated whenever session state changes such as organization context
+          description: Timestamp indicating when the session was last updated. 
+            Updated whenever session state changes such as organization context 
             changes or metadata updates.
           type: string
           format: date-time
           examples:
             - 2025-01-15T10:45:00Z
         user_id:
-          description: Unique identifier for the user who owns and is
+          description: Unique identifier for the user who owns and is 
             authenticated within this session.
           type: string
           examples:
@@ -9992,29 +10308,29 @@ components:
       properties:
         next_page_token:
           description: Pagination token for retrieving the next page of results.
-            Empty string if there are no more pages (you have reached the final
+            Empty string if there are no more pages (you have reached the final 
             page of results).
           type: string
           examples:
             - eyJwYWdlIjogMiwgImxhc3RfaWQiOiAic2VzXzEyMzQ1In0=
         prev_page_token:
-          description: Pagination token for retrieving the previous page of
-            results. Empty string for the first page. Use this to navigate
+          description: Pagination token for retrieving the previous page of 
+            results. Empty string for the first page. Use this to navigate 
             backward through result pages.
           type: string
           examples:
             - eyJwYWdlIjogMCwgImZpcnN0X2lkIjogInNlc183OTAxIn0=
         sessions:
-          description: Array of session objects for the requested user. May
+          description: Array of session objects for the requested user. May 
             contain fewer entries than the requested page_size when reaching the
             final page of results.
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/sessionsSessionDetails'
+            $ref: "#/components/schemas/sessionsSessionDetails"
         total_size:
-          description: Total number of sessions matching the applied filter
-            criteria, regardless of pagination. This represents the complete
+          description: Total number of sessions matching the applied filter 
+            criteria, regardless of pagination. This represents the complete 
             result set size before pagination is applied.
           type: integer
           format: int64
@@ -10025,15 +10341,15 @@ components:
       properties:
         end_time:
           description: Filter to include only sessions created on or before this
-            timestamp. Optional. Uses RFC 3339 format. Must be after start_time
+            timestamp. Optional. Uses RFC 3339 format. Must be after start_time 
             if both are specified.
           type: string
           format: date-time
           examples:
             - 2025-12-31T23:59:59Z
         start_time:
-          description: Filter to include only sessions created on or after this
-            timestamp. Optional. Uses RFC 3339 format. Useful for querying
+          description: Filter to include only sessions created on or after this 
+            timestamp. Optional. Uses RFC 3339 format. Useful for querying 
             sessions within a specific time window.
           type: string
           format: date-time
@@ -10048,42 +10364,50 @@ components:
           items:
             type: string
           examples:
-            - - active
+            -   - active
     toolsExecuteToolRequest:
       type: object
       properties:
+        agent_run_id:
+          description: Optional. Customer-supplied identifier grouping multiple 
+            tool calls into a single agent run. Useful for correlating logs 
+            across an agentic workflow.
+          type: string
+          examples:
+            - run_abc123
         connected_account_id:
-          description: Optional. The unique ID of the connected account. Use
-            this to directly identify the connected account instead of using
+          description: Optional. The unique ID of the connected account. Use 
+            this to directly identify the connected account instead of using 
             identifier + connector combination.
           type: string
           examples:
             - ca_123
         connector:
-          description: Optional. The name of the connector/provider (e.g.,
-            'Google Workspace', 'Slack', 'Notion'). Use this in combination with
-            identifier to identify the connected account.
+          description: Optional. The name of the connector/provider (e.g., 
+            'Google Workspace', 'Slack', 'Notion'). Alphanumeric characters, 
+            spaces, hyphens, underscores, and colons are allowed. Use this in 
+            combination with identifier to identify the connected account.
           type: string
           examples:
             - Google Workspace
         identifier:
           description: Optional. The unique identifier for the connected account
-            within the third-party service (e.g., email address, user ID,
-            workspace identifier). Use this in combination with connector to
+            within the third-party service (e.g., email address, user ID, 
+            workspace identifier). Use this in combination with connector to 
             identify the connected account.
           type: string
           examples:
             - user@example.com
         organization_id:
-          description: Optional. The organization ID to scope the connected
-            account lookup. Use this to narrow down the search when the same
+          description: Optional. The organization ID to scope the connected 
+            account lookup. Use this to narrow down the search when the same 
             identifier exists across multiple organizations.
           type: string
           examples:
             - org_123
         params:
-          description: JSON object containing the parameters required for tool
-            execution. The structure depends on the specific tool being
+          description: JSON object containing the parameters required for tool 
+            execution. The structure depends on the specific tool being 
             executed.
           type: object
           examples:
@@ -10096,8 +10420,8 @@ components:
           examples:
             - send_email
         user_id:
-          description: Optional. The user ID to scope the connected account
-            lookup. Use this to narrow down the search when the same identifier
+          description: Optional. The user ID to scope the connected account 
+            lookup. Use this to narrow down the search when the same identifier 
             exists across multiple users.
           type: string
           examples:
@@ -10116,12 +10440,12 @@ components:
           description: Unique identifier for the tool execution
           type: string
           examples:
-            - '123456789'
+            - "123456789"
     usersCreateMembershipResponse:
       type: object
       properties:
         user:
-          $ref: '#/components/schemas/usersUser'
+          $ref: "#/components/schemas/usersUser"
     usersCreateUser:
       type: object
       properties:
@@ -10132,7 +10456,7 @@ components:
           examples:
             - user@example.com
         external_id:
-          description: Your application's unique identifier for this
+          description: Your application's unique identifier for this 
             organization, used to link Scalekit with your system.
           type: string
           examples:
@@ -10140,9 +10464,9 @@ components:
         membership:
           description: List of organization memberships. Automatically populated
             based on group assignments.
-          $ref: '#/components/schemas/v1usersCreateMembership'
+          $ref: "#/components/schemas/v1usersCreateMembership"
         metadata:
-          description: Custom key-value pairs for storing additional user
+          description: Custom key-value pairs for storing additional user 
             context. Keys (3-25 chars), values (1-256 chars).
           type: object
           additionalProperties:
@@ -10151,19 +10475,19 @@ components:
             - department: engineering
               location: nyc-office
         user_profile:
-          description: User's personal information including name, address, and
+          description: User's personal information including name, address, and 
             other profile attributes.
-          $ref: '#/components/schemas/usersCreateUserProfile'
+          $ref: "#/components/schemas/usersCreateUserProfile"
     usersCreateUserAndMembershipResponse:
       type: object
       properties:
         user:
-          $ref: '#/components/schemas/usersUser'
+          $ref: "#/components/schemas/usersUser"
     usersCreateUserProfile:
       type: object
       properties:
         custom_attributes:
-          description: Custom attributes for extended user profile data. Keys
+          description: Custom attributes for extended user profile data. Keys 
             (3-25 chars), values (1-256 chars).
           type: object
           additionalProperties:
@@ -10187,14 +10511,14 @@ components:
           examples:
             - John
         groups:
-          description: List of group names the user belongs to. Each group name
+          description: List of group names the user belongs to. Each group name 
             must be 1-250 characters
           type: array
           items:
             type: string
           examples:
-            - - engineering
-              - managers
+            -   - engineering
+                - managers
         locale:
           description: User's localization preference in BCP-47 format. Defaults
             to organization settings.
@@ -10202,7 +10526,7 @@ components:
           examples:
             - en-US
         metadata:
-          description: System-managed key-value pairs for internal tracking.
+          description: System-managed key-value pairs for internal tracking. 
             Keys (3-25 chars), values (1-256 chars).
           type: object
           additionalProperties:
@@ -10211,17 +10535,17 @@ components:
             - account_status: active
               signup_source: mobile_app
         name:
-          description: Full name in display format. Typically combines
+          description: Full name in display format. Typically combines 
             first_name and last_name.
           type: string
           examples:
             - John Michael Doe
         phone_number:
-          description: Phone number in E.164 international format. Required for
+          description: Phone number in E.164 international format. Required for 
             SMS-based authentication.
           type: string
           examples:
-            - '+14155552671'
+            - "+14155552671"
         picture:
           description: URL to the user's profile picture or avatar.
           type: string
@@ -10236,7 +10560,7 @@ components:
       type: object
       properties:
         user:
-          $ref: '#/components/schemas/usersUser'
+          $ref: "#/components/schemas/usersUser"
     usersInvite:
       type: object
       properties:
@@ -10253,7 +10577,7 @@ components:
           examples:
             - 2025-12-31T23:59:59Z
         inviter_email:
-          description: Identifier of the user or system that initiated the
+          description: Identifier of the user or system that initiated the 
             invite.
           type: string
           examples:
@@ -10276,13 +10600,13 @@ components:
           examples:
             - 2
         status:
-          description: Current status of the invite (e.g., pending, accepted,
+          description: Current status of the invite (e.g., pending, accepted, 
             expired, revoked).
           type: string
           examples:
             - pending_invite
         user_id:
-          description: User ID to whom the invite is sent. May be empty if the
+          description: User ID to whom the invite is sent. May be empty if the 
             user has not signed up yet.
           type: string
           examples:
@@ -10291,7 +10615,7 @@ components:
       type: object
       properties:
         next_page_token:
-          description: Opaque token for retrieving the next page of results.
+          description: Opaque token for retrieving the next page of results. 
             Empty if there are no more pages.
           type: string
           examples:
@@ -10303,19 +10627,19 @@ components:
           examples:
             - eyJwYWdlIjogMCwgImZpcnN0X2lkIjogInVzcl85ODc2NSJ9
         total_size:
-          description: Total number of users matching the request criteria,
+          description: Total number of users matching the request criteria, 
             regardless of pagination.
           type: integer
           format: int64
           examples:
             - 1042
         users:
-          description: List of user objects for the current page. May contain
+          description: List of user objects for the current page. May contain 
             fewer entries than requested page_size.
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/usersUser'
+            $ref: "#/components/schemas/usersUser"
     usersListUserPermissionsResponse:
       type: object
       properties:
@@ -10324,7 +10648,7 @@ components:
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/usersPermission'
+            $ref: "#/components/schemas/usersPermission"
     usersListUserRolesResponse:
       type: object
       properties:
@@ -10333,24 +10657,24 @@ components:
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/commonsRole'
+            $ref: "#/components/schemas/commonsRole"
     usersListUsersResponse:
       type: object
       properties:
         next_page_token:
-          description: Token for retrieving the next page of results. Empty if
+          description: Token for retrieving the next page of results. Empty if 
             there are no more pages.
           type: string
           examples:
             - eyJwYWdlIjogMiwgImxhc3RfaWQiOiAidXNyXzEyMzQ1In0=
         prev_page_token:
-          description: Token for retrieving the previous page of results. Empty
+          description: Token for retrieving the previous page of results. Empty 
             if this is the first page.
           type: string
           examples:
             - eyJwYWdlIjogMCwgImZpcnN0X2lkIjogInVzcl85ODc2NSJ9
         total_size:
-          description: Total number of users matching the request criteria,
+          description: Total number of users matching the request criteria, 
             regardless of pagination.
           type: integer
           format: int64
@@ -10361,7 +10685,7 @@ components:
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/usersUser'
+            $ref: "#/components/schemas/usersUser"
     usersPermission:
       type: object
       properties:
@@ -10385,10 +10709,10 @@ components:
       type: object
       properties:
         invite:
-          description: Updated invitation object containing the resent
-            invitation details, including new expiration time and incremented
+          description: Updated invitation object containing the resent 
+            invitation details, including new expiration time and incremented 
             resend counter.
-          $ref: '#/components/schemas/usersInvite'
+          $ref: "#/components/schemas/usersInvite"
           examples:
             - expires_at: 2025-12-31T23:59:59Z
               organization_id: org_123
@@ -10399,19 +10723,19 @@ components:
       type: object
       properties:
         next_page_token:
-          description: Token for retrieving the next page of results. Empty if
+          description: Token for retrieving the next page of results. Empty if 
             there are no more pages.
           type: string
           examples:
             - eyJwYWdlIjogMiwgImxhc3RfaWQiOiAidXNyXzEyMzQ1In0=
         prev_page_token:
-          description: Token for retrieving the previous page of results. Empty
+          description: Token for retrieving the previous page of results. Empty 
             if this is the first page.
           type: string
           examples:
             - eyJwYWdlIjogMCwgImZpcnN0X2lkIjogInVzcl85ODc2NSJ9
         total_size:
-          description: Total number of users matching the request criteria,
+          description: Total number of users matching the request criteria, 
             regardless of pagination.
           type: integer
           format: int64
@@ -10422,24 +10746,24 @@ components:
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/usersUser'
+            $ref: "#/components/schemas/usersUser"
     usersSearchUsersResponse:
       type: object
       properties:
         next_page_token:
-          description: Token for retrieving the next page of results. Empty if
+          description: Token for retrieving the next page of results. Empty if 
             there are no more pages.
           type: string
           examples:
             - eyJwYWdlIjogMiwgImxhc3RfaWQiOiAidXNyXzEyMzQ1In0=
         prev_page_token:
-          description: Token for retrieving the previous page of results. Empty
+          description: Token for retrieving the previous page of results. Empty 
             if this is the first page.
           type: string
           examples:
             - eyJwYWdlIjogMCwgImZpcnN0X2lkIjogInVzcl85ODc2NSJ9
         total_size:
-          description: Total number of users matching the request criteria,
+          description: Total number of users matching the request criteria, 
             regardless of pagination.
           type: integer
           format: int64
@@ -10450,23 +10774,23 @@ components:
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/usersUser'
+            $ref: "#/components/schemas/usersUser"
     usersUpdateMembershipResponse:
       type: object
       properties:
         user:
-          $ref: '#/components/schemas/usersUser'
+          $ref: "#/components/schemas/usersUser"
     usersUpdateUserProfile:
       type: object
       properties:
         custom_attributes:
-          description: Updates custom attributes for extended user profile data
-            and application-specific information. Use this field to store
-            business-specific user data like department, job title, security
-            clearances, project assignments, or any other organizational
-            attributes your application requires. Unlike system metadata, these
-            attributes are typically managed by administrators or applications
-            and are visible to end users. Keys must be 3-25 characters, values
+          description: Updates custom attributes for extended user profile data 
+            and application-specific information. Use this field to store 
+            business-specific user data like department, job title, security 
+            clearances, project assignments, or any other organizational 
+            attributes your application requires. Unlike system metadata, these 
+            attributes are typically managed by administrators or applications 
+            and are visible to end users. Keys must be 3-25 characters, values 
             must be 1-256 characters, with a maximum of 20 key-value pairs.
           type: object
           additionalProperties:
@@ -10475,7 +10799,7 @@ components:
             - department: engineering
               security_clearance: level2
         family_name:
-          description: Updates the user's family name (last name or surname).
+          description: Updates the user's family name (last name or surname). 
             Use this field to modify how the user's last name appears throughout
             the system. Maximum 255 characters allowed.
           type: string
@@ -10488,36 +10812,36 @@ components:
           examples:
             - John
         gender:
-          description: Updates the user's gender identity information. Use this
-            field to store the user's gender identity for personalization,
-            compliance, or reporting purposes. This field supports any string
+          description: Updates the user's gender identity information. Use this 
+            field to store the user's gender identity for personalization, 
+            compliance, or reporting purposes. This field supports any string 
             value to accommodate diverse gender identities and should be handled
-            with appropriate privacy considerations according to your
+            with appropriate privacy considerations according to your 
             organization's policies.
           type: string
           examples:
             - male
         given_name:
-          description: Updates the user's given name (first name). Use this
-            field to modify how the user's first name appears in the system and
+          description: Updates the user's given name (first name). Use this 
+            field to modify how the user's first name appears in the system and 
             user interfaces. Maximum 255 characters allowed.
           type: string
           examples:
             - John
         groups:
-          description: Updates the list of group names the user belongs to
-            within the organization. Use this field to manage the user's group
-            memberships for role-based access control, team assignments, or
-            organizational structure. Groups are typically used for permission
-            management and collaborative access. Each group name must be unique
-            within the list, 1-250 characters long, with a maximum of 50 groups
+          description: Updates the list of group names the user belongs to 
+            within the organization. Use this field to manage the user's group 
+            memberships for role-based access control, team assignments, or 
+            organizational structure. Groups are typically used for permission 
+            management and collaborative access. Each group name must be unique 
+            within the list, 1-250 characters long, with a maximum of 50 groups 
             per user.
           type: array
           items:
             type: string
           examples:
-            - - engineering
-              - managers
+            -   - engineering
+                - managers
         last_name:
           description: "[DEPRECATED] Use family_name instead. User's family name.
             Maximum 200 characters."
@@ -10526,21 +10850,21 @@ components:
             - Doe
         locale:
           description: Updates the user's preferred language and region settings
-            using BCP-47 format codes. Use this field to customize the user's
-            experience with localized content, date formats, number formatting,
-            and UI language. When not specified, the user inherits the
-            organization's default locale settings. Common values include
+            using BCP-47 format codes. Use this field to customize the user's 
+            experience with localized content, date formats, number formatting, 
+            and UI language. When not specified, the user inherits the 
+            organization's default locale settings. Common values include 
             `en-US`, `en-GB`, `fr-FR`, `de-DE`, and `es-ES`.
           type: string
           examples:
             - en-US
         metadata:
-          description: Updates system-managed key-value pairs for internal
-            tracking and operational data. Use this field to store
-            system-generated metadata like account status, signup source, last
+          description: Updates system-managed key-value pairs for internal 
+            tracking and operational data. Use this field to store 
+            system-generated metadata like account status, signup source, last 
             activity tracking, or integration-specific identifiers. These fields
             are typically managed by automated processes rather than direct user
-            input. Keys must be 3-25 characters, values must be 1-256
+            input. Keys must be 3-25 characters, values must be 1-256 
             characters, with a maximum of 20 key-value pairs.
           type: object
           additionalProperties:
@@ -10549,40 +10873,40 @@ components:
             - account_status: active
               signup_source: mobile_app
         name:
-          description: Updates the user's complete display name. Use this field
-            when you want to set the full name as a single string rather than
-            using separate given and family names. This name appears in user
-            interfaces, reports, and anywhere a formatted display name is
+          description: Updates the user's complete display name. Use this field 
+            when you want to set the full name as a single string rather than 
+            using separate given and family names. This name appears in user 
+            interfaces, reports, and anywhere a formatted display name is 
             needed.
           type: string
           examples:
             - John Doe
         phone_number:
-          description: Updates the user's phone number in E.164 international
-            format. Use this field to enable SMS-based authentication methods,
-            two-factor authentication, or phone-based account recovery. The
-            phone number must include the country code and be formatted
+          description: Updates the user's phone number in E.164 international 
+            format. Use this field to enable SMS-based authentication methods, 
+            two-factor authentication, or phone-based account recovery. The 
+            phone number must include the country code and be formatted 
             according to E.164 standards (e.g., `+1` for US numbers). This field
             is required when enabling SMS authentication features.
           type: string
           examples:
-            - '+14155552671'
+            - "+14155552671"
         picture:
-          description: Updates the URL to the user's profile picture or avatar
+          description: Updates the URL to the user's profile picture or avatar 
             image. Use this field to set or change the user's profile photo that
-            appears in user interfaces, directory listings, and collaborative
-            features. The URL should point to a publicly accessible image file.
-            Supported formats typically include JPEG, PNG, and GIF. Maximum URL
+            appears in user interfaces, directory listings, and collaborative 
+            features. The URL should point to a publicly accessible image file. 
+            Supported formats typically include JPEG, PNG, and GIF. Maximum URL 
             length is 2048 characters.
           type: string
           examples:
             - https://example.com/avatar.jpg
         preferred_username:
-          description: Updates the user's preferred username for display and
-            identification purposes. Use this field to set a custom username
-            that the user prefers to be known by, which may differ from their
-            email or formal name. This username appears in user interfaces,
-            mentions, and informal communications. Maximum 512 characters
+          description: Updates the user's preferred username for display and 
+            identification purposes. Use this field to set a custom username 
+            that the user prefers to be known by, which may differ from their 
+            email or formal name. This username appears in user interfaces, 
+            mentions, and informal communications. Maximum 512 characters 
             allowed.
           type: string
           examples:
@@ -10591,12 +10915,12 @@ components:
       type: object
       properties:
         user:
-          $ref: '#/components/schemas/usersUser'
+          $ref: "#/components/schemas/usersUser"
     usersUser:
       type: object
       properties:
         create_time:
-          description: Timestamp when the user account was initially created.
+          description: Timestamp when the user account was initially created. 
             Automatically set by the server.
           type: string
           format: date-time
@@ -10608,19 +10932,19 @@ components:
           examples:
             - user@example.com
         external_id:
-          description: Your application's unique identifier for this
+          description: Your application's unique identifier for this 
             organization, used to link Scalekit with your system.
           type: string
           examples:
             - ext_12345a67b89c
         id:
-          description: Unique system-generated identifier for the user.
+          description: Unique system-generated identifier for the user. 
             Immutable once created.
           type: string
           examples:
             - usr_1234abcd5678efgh
         last_login_time:
-          description: Timestamp of the user's most recent successful
+          description: Timestamp of the user's most recent successful 
             authentication. Updated automatically.
           type: string
           format: date-time
@@ -10631,9 +10955,9 @@ components:
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/commonsOrganizationMembership'
+            $ref: "#/components/schemas/commonsOrganizationMembership"
         metadata:
-          description: Custom key-value pairs for storing additional user
+          description: Custom key-value pairs for storing additional user 
             context. Keys (3-25 chars), values (1-256 chars).
           type: object
           additionalProperties:
@@ -10642,23 +10966,23 @@ components:
             - department: engineering
               location: nyc-office
         update_time:
-          description: Timestamp of the last modification to the user account.
+          description: Timestamp of the last modification to the user account. 
             Automatically updated by the server.
           type: string
           format: date-time
           readOnly: true
         user_profile:
-          description: User's personal information including name, address, and
+          description: User's personal information including name, address, and 
             other profile attributes.
-          $ref: '#/components/schemas/commonsUserProfile'
+          $ref: "#/components/schemas/commonsUserProfile"
     v1connected_accountsCreateConnectedAccount:
       type: object
-      title: Payload for creating a new connected account - authorization
+      title: Payload for creating a new connected account - authorization 
         details are optional
       properties:
         api_config:
-          description: Optional JSON configuration for connector-specific API
-            settings such as rate limits, custom API endpoints, timeouts, or
+          description: Optional JSON configuration for connector-specific API 
+            settings such as rate limits, custom API endpoints, timeouts, or 
             feature flags.
           type: object
           examples:
@@ -10666,11 +10990,11 @@ components:
               rate_limit: 1000
               timeout: 30
         authorization_details:
-          description: Optional authentication credentials for the connected
-            account. Include OAuth tokens (access_token, refresh_token, scopes)
-            or static auth details (API keys, bearer tokens). Can be provided
+          description: Optional authentication credentials for the connected 
+            account. Include OAuth tokens (access_token, refresh_token, scopes) 
+            or static auth details (API keys, bearer tokens). Can be provided 
             later via update.
-          $ref: '#/components/schemas/connected_accountsAuthorizationDetails'
+          $ref: "#/components/schemas/connected_accountsAuthorizationDetails"
           examples:
             - oauth_token:
                 access_token: ya29.a0...
@@ -10680,22 +11004,22 @@ components:
                   - profile
     v1connected_accountsUpdateConnectedAccount:
       type: object
-      title: Payload for updating an existing connected account - all fields
+      title: Payload for updating an existing connected account - all fields 
         optional
       properties:
         api_config:
-          description: Updated JSON configuration for API-specific settings.
-            Merges with existing configuration - only provided fields are
+          description: Updated JSON configuration for API-specific settings. 
+            Merges with existing configuration - only provided fields are 
             modified.
           type: object
           examples:
             - rate_limit: 2000
               timeout: 60
         authorization_details:
-          description: Updated authentication credentials. Provide new OAuth
-            tokens (e.g., after refresh) or updated static auth details. Only
+          description: Updated authentication credentials. Provide new OAuth 
+            tokens (e.g., after refresh) or updated static auth details. Only 
             included fields will be modified.
-          $ref: '#/components/schemas/connected_accountsAuthorizationDetails'
+          $ref: "#/components/schemas/connected_accountsAuthorizationDetails"
           examples:
             - oauth_token:
                 access_token: ya29.new_token...
@@ -10708,9 +11032,9 @@ components:
       type: object
       properties:
         domain:
-          description: The domain name to be configured. Must be a valid
-            business domain you control. Public and disposable domains
-            (gmail.com, outlook.com, etc.) are automatically blocked for
+          description: The domain name to be configured. Must be a valid 
+            business domain you control. Public and disposable domains 
+            (gmail.com, outlook.com, etc.) are automatically blocked for 
             security.
           type: string
           examples:
@@ -10724,7 +11048,7 @@ components:
 
             - ORGANIZATION_DOMAIN: SSO discovery domain used to route users to
             the correct SSO provider and enforce SSO.
-          $ref: '#/components/schemas/domainsDomainType'
+          $ref: "#/components/schemas/domainsDomainType"
           examples:
             - ORGANIZATION_DOMAIN
     v1organizationsCreateOrganization:
@@ -10733,47 +11057,86 @@ components:
         - display_name
       properties:
         display_name:
-          description: Name of the organization. Must be between 1 and 200
+          description: Name of the organization. Must be between 1 and 200 
             characters.
           type: string
           examples:
             - Megasoft Inc
         external_id:
-          description: Your application's unique identifier for this
+          description: Your application's unique identifier for this 
             organization, used to link Scalekit with your system.
           type: string
           examples:
             - my_unique_id
+        logo_url:
+          description: HTTPS URL of the organization's logo image. Maximum 2048 
+            characters. Must use the https scheme.
+          type: string
+          format: uri
+          maxLength: 2048
+          pattern: ^https://
+          examples:
+            - https://cdn.example.com/acme-logo.png
         metadata:
           type: object
           additionalProperties:
             type: string
+        slug:
+          description: DNS-safe slug for dynamic redirect URI resolution (e.g. 
+            acme for https://acme.example.com/callback). Lowercase alphanumeric 
+            and hyphens, 1-63 chars, must start and end with alphanumeric, 
+            unique per environment.
+          type: string
+          maxLength: 63
+          minLength: 1
+          pattern: ^[a-z0-9]([a-z0-9]|-[a-z0-9])*$
+          examples:
+            - acme
     v1organizationsUpdateOrganization:
-      description: For update messages ensure the indexes are same as the base
+      description: For update messages ensure the indexes are same as the base 
         model itself.
       type: object
       properties:
         display_name:
-          description: Name of the organization to display in the UI. Must be
+          description: Name of the organization to display in the UI. Must be 
             between 1 and 200 characters
           type: string
           examples:
             - Acme Corporation
         external_id:
-          description: Your application's unique identifier for this
+          description: Your application's unique identifier for this 
             organization, used to link Scalekit with your system
           type: string
           examples:
             - tenant_12345
+        logo_url:
+          description: HTTPS URL of the organization's logo image. Maximum 2048 
+            characters. Must use the https scheme.
+          type: string
+          format: uri
+          maxLength: 2048
+          pattern: ^https://
+          examples:
+            - https://cdn.example.com/acme-logo.png
         metadata:
-          description: Custom key-value pairs to store with the organization.
-            Keys must be 3-25 characters, values must be 1-256 characters.
+          description: Custom key-value pairs to store with the organization. 
+            Keys must be 3-25 characters, values must be 1-256 characters. 
             Maximum 10 pairs allowed.
           type: object
           additionalProperties:
             type: string
           examples:
             - industry: technology
+        slug:
+          description: DNS-safe slug for dynamic redirect URI resolution. 
+            Lowercase alphanumeric and hyphens, 1-63 chars, must start and end 
+            with alphanumeric, unique per environment.
+          type: string
+          maxLength: 63
+          minLength: 1
+          pattern: ^[a-z0-9]([a-z0-9]|-[a-z0-9])*$
+          examples:
+            - acme
     v1rolesCreateOrganizationRole:
       type: object
       properties:
@@ -10798,14 +11161,14 @@ components:
           examples:
             - org_viewer_role
         permissions:
-          description: List of permission names to assign to this role.
+          description: List of permission names to assign to this role. 
             Permissions must exist in the current environment.
           type: array
           items:
             type: string
           examples:
-            - - read:users
-              - write:documents
+            -   - read:users
+                - write:documents
     v1rolesCreatePermission:
       type: object
       properties:
@@ -10830,41 +11193,41 @@ components:
             - Can create, edit, and publish content but cannot delete content or
               manage user accounts
         display_name:
-          description: Human-readable display name for the role. Used in user
+          description: Human-readable display name for the role. Used in user 
             interfaces, reports, and user-facing communications.
           type: string
           examples:
             - Content Editor
         extends:
-          description: Name of the base role that this role extends. Enables
-            hierarchical role inheritance where this role inherits all
+          description: Name of the base role that this role extends. Enables 
+            hierarchical role inheritance where this role inherits all 
             permissions from the base role.
           type: string
           examples:
             - viewer
         name:
           description: Unique name identifier for the role. Must be alphanumeric
-            with underscores, 1-64 characters. This name is used in API calls
+            with underscores, 1-64 characters. This name is used in API calls 
             and cannot be changed after creation.
           type: string
           examples:
             - content_editor
         permissions:
-          description: List of permission names to assign to this role.
-            Permissions must exist in the current environment. Maximum 100
+          description: List of permission names to assign to this role. 
+            Permissions must exist in the current environment. Maximum 100 
             permissions per role.
           type: array
           items:
             type: string
           examples:
-            - - read:content
-              - write:content
-              - publish:content
+            -   - read:content
+                - write:content
+                - publish:content
     v1rolesRole:
       type: object
       properties:
         default_creator:
-          description: Indicates if this role is the default creator role for
+          description: Indicates if this role is the default creator role for 
             new organizations.
           type: boolean
           examples:
@@ -10876,33 +11239,33 @@ components:
           examples:
             - true
         dependent_roles_count:
-          description: Number of roles that extend from this role (dependent
+          description: Number of roles that extend from this role (dependent 
             roles count). Read-only field.
           type: integer
           format: int32
           examples:
             - 3
         description:
-          description: Detailed description of the role's purpose and
+          description: Detailed description of the role's purpose and 
             capabilities. Maximum 2000 characters.
           type: string
           examples:
-            - Can create, edit, and publish content but cannot delete or manage
+            - Can create, edit, and publish content but cannot delete or manage 
               users
         display_name:
-          description: Human-readable display name for the role. Used in user
+          description: Human-readable display name for the role. Used in user 
             interfaces and reports.
           type: string
           examples:
             - Content Editor
         extends:
-          description: Name of the base role that this role extends. Enables
+          description: Name of the base role that this role extends. Enables 
             hierarchical role inheritance.
           type: string
           examples:
             - admin_role
         id:
-          description: Unique system-generated identifier for the role.
+          description: Unique system-generated identifier for the role. 
             Immutable once created.
           type: string
           readOnly: true
@@ -10920,19 +11283,19 @@ components:
           examples:
             - content_editor
         permissions:
-          description: List of permissions with role source information. Only
+          description: List of permissions with role source information. Only 
             included when 'include' parameter is specified in the request.
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/rolesRolePermission'
+            $ref: "#/components/schemas/rolesRolePermission"
           examples:
-            - - description: Read Content
-                name: read:content
-                role_name: admin_role
-              - description: Write Content
-                name: write:content
-                role_name: editor_role
+            -   - description: Read Content
+                  name: read:content
+                  role_name: admin_role
+                - description: Write Content
+                  name: write:content
+                  role_name: editor_role
     v1rolesUpdateRole:
       type: object
       properties:
@@ -10941,39 +11304,39 @@ components:
             and intended use cases. Maximum 2000 characters.
           type: string
           examples:
-            - Can create, edit, publish, and approve content. Cannot delete
+            - Can create, edit, publish, and approve content. Cannot delete 
               content or manage user accounts.
         display_name:
-          description: Human-readable display name for the role. Used in user
+          description: Human-readable display name for the role. Used in user 
             interfaces, reports, and user-facing communications.
           type: string
           examples:
             - Senior Content Editor
         extends:
-          description: Name of the base role that this role extends. Enables
-            hierarchical role inheritance where this role inherits all
+          description: Name of the base role that this role extends. Enables 
+            hierarchical role inheritance where this role inherits all 
             permissions from the base role.
           type: string
           examples:
             - content_editor
         permissions:
-          description: List of permission names to assign to this role. When
-            provided, this replaces all existing role-permission mappings.
-            Permissions must exist in the current environment. Maximum 100
+          description: List of permission names to assign to this role. When 
+            provided, this replaces all existing role-permission mappings. 
+            Permissions must exist in the current environment. Maximum 100 
             permissions per role.
           type: array
           items:
             type: string
           examples:
-            - - read:content
-              - write:content
-              - publish:content
-              - approve:content
+            -   - read:content
+                - write:content
+                - publish:content
+                - approve:content
     v1sessionsLocation:
       type: object
       properties:
         city:
-          description: City name where the session originated based on IP
+          description: City name where the session originated based on IP 
             geolocation. Approximate location derived from IP address.
           type: string
           examples:
@@ -10984,24 +11347,24 @@ components:
             be precise."
           type: string
           examples:
-            - '37.7749'
+            - "37.7749"
         longitude:
           description: "Longitude coordinate of the estimated location. Decimal format
             (e.g., '-122.4194'). Note: Represents IP geolocation center and may not
             be precise."
           type: string
           examples:
-            - '-122.4194'
+            - "-122.4194"
         region:
-          description: Geographic region name derived from IP geolocation.
-            Represents the country-level location (e.g., 'United States',
+          description: Geographic region name derived from IP geolocation. 
+            Represents the country-level location (e.g., 'United States', 
             'France').
           type: string
           examples:
             - United States
         region_subdivision:
-          description: Regional subdivision code or name (e.g., state
-            abbreviation for US, province for Canada). Two-letter ISO format
+          description: Regional subdivision code or name (e.g., state 
+            abbreviation for US, province for Canada). Two-letter ISO format 
             when applicable.
           type: string
           examples:
@@ -11010,13 +11373,13 @@ components:
       type: object
       properties:
         inviter_email:
-          description: Email address of the user who invited this member. Must
+          description: Email address of the user who invited this member. Must 
             be a valid email address.
           type: string
           examples:
             - john.doe@example.com
         metadata:
-          description: Custom key-value pairs for storing additional user
+          description: Custom key-value pairs for storing additional user 
             context. Keys (3-25 chars), values (1-256 chars).
           type: object
           additionalProperties:
@@ -11029,14 +11392,14 @@ components:
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/commonsRole'
+            $ref: "#/components/schemas/commonsRole"
           examples:
-            - - name: admin
+            -   - name: admin
     v1usersUpdateMembership:
       type: object
       properties:
         metadata:
-          description: Custom key-value pairs for storing additional user
+          description: Custom key-value pairs for storing additional user 
             context. Keys (3-25 chars), values (1-256 chars).
           type: object
           additionalProperties:
@@ -11049,20 +11412,20 @@ components:
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/commonsRole'
+            $ref: "#/components/schemas/commonsRole"
           examples:
-            - - name: admin
+            -   - name: admin
     v1usersUpdateUser:
       type: object
       properties:
         external_id:
-          description: Your application's unique identifier for this
+          description: Your application's unique identifier for this 
             organization, used to link Scalekit with your system.
           type: string
           examples:
             - ext_12345a67b89c
         metadata:
-          description: Custom key-value pairs for storing additional user
+          description: Custom key-value pairs for storing additional user 
             context. Keys (3-25 chars), values (1-256 chars).
           type: object
           additionalProperties:
@@ -11071,9 +11434,9 @@ components:
             - department: engineering
               location: nyc-office
         user_profile:
-          description: User's personal information including name, address, and
+          description: User's personal information including name, address, and 
             other profile attributes.
-          $ref: '#/components/schemas/usersUpdateUserProfile'
+          $ref: "#/components/schemas/usersUpdateUserProfile"
     webauthnAllAcceptedCredentialsOptions:
       type: object
       properties:
@@ -11101,22 +11464,22 @@ components:
           examples:
             - true
         unknown_credential_options:
-          description: Options for handling unknown credentials in client
+          description: Options for handling unknown credentials in client 
             applications
-          $ref: '#/components/schemas/webauthnUnknownCredentialOptions'
+          $ref: "#/components/schemas/webauthnUnknownCredentialOptions"
     webauthnListCredentialsResponse:
       type: object
       properties:
         all_accepted_credentials_options:
-          description: Options including RP ID and all accepted credential IDs
+          description: Options including RP ID and all accepted credential IDs 
             for authentication
-          $ref: '#/components/schemas/webauthnAllAcceptedCredentialsOptions'
+          $ref: "#/components/schemas/webauthnAllAcceptedCredentialsOptions"
         credentials:
           description: All passkeys registered for the user
           type: array
           items:
             type: object
-            $ref: '#/components/schemas/webauthnWebAuthnCredential'
+            $ref: "#/components/schemas/webauthnWebAuthnCredential"
     webauthnUnknownCredentialOptions:
       type: object
       properties:
@@ -11135,7 +11498,7 @@ components:
       properties:
         credential:
           description: The updated credential with new display name
-          $ref: '#/components/schemas/webauthnWebAuthnCredential'
+          $ref: "#/components/schemas/webauthnWebAuthnCredential"
     webauthnWebAuthnCredential:
       type: object
       properties:
@@ -11146,13 +11509,13 @@ components:
             - direct
         authenticator:
           description: Authenticator information including model and name
-          $ref: '#/components/schemas/WebAuthnCredentialAuthenticator'
+          $ref: "#/components/schemas/WebAuthnCredentialAuthenticator"
         authenticator_flags:
           description: Flags indicating authenticator capabilities
-          $ref: '#/components/schemas/WebAuthnCredentialAuthenticatorFlags'
+          $ref: "#/components/schemas/WebAuthnCredentialAuthenticatorFlags"
         client_info:
           description: Geographic and network information from registration
-          $ref: '#/components/schemas/WebAuthnCredentialClientInfo'
+          $ref: "#/components/schemas/WebAuthnCredentialClientInfo"
         created_at:
           description: Timestamp when the credential was created
           type: string
@@ -11186,12 +11549,36 @@ components:
             - 2025-02-15T06:23:44.560000Z
         user_agent:
           description: Browser and device information from registration
-          $ref: '#/components/schemas/WebAuthnCredentialUserAgent'
+          $ref: "#/components/schemas/WebAuthnCredentialUserAgent"
         user_id:
           description: User ID this credential belongs to
           type: string
           examples:
             - user_xyz789
+    TestUser:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          description: "Whether test user mode is enabled for this environment."
+          example: true
+        emails:
+          type: array
+          items:
+            type: string
+            format: email
+          description: "Explicit list of test user email addresses. Each email must
+            contain '+sktest' in the local part (e.g. alice+sktest@example.com). Maximum
+            5 emails per environment (configurable server-side)."
+          example: ["alice+sktest@example.com", "bob+sktest@example.com"]
+        static_confirmation_code:
+          type: string
+          pattern: "^[0-9]{6}$"
+          minLength: 6
+          maxLength: 6
+          description: "Six-digit static OTP code used in place of a real verification
+            email for matched test users."
+          example: "424242"
     ScalekitEvent:
       type: object
       required:
@@ -11204,71 +11591,71 @@ components:
       properties:
         spec_version:
           type: string
-          example: '1'
+          example: "1"
           description: The webhook specification version
-          pattern: '^[0-9]+$'
+          pattern: "^[0-9]+$"
         id:
           type: string
-          pattern: '^evt_'
-          example: 'evt_1234567890abcdef'
+          pattern: "^evt_"
+          example: "evt_1234567890abcdef"
           description: Unique identifier for the webhook event (must be prefixed
             with "evt_")
           minLength: 1
           maxLength: 32
         type:
           type: string
-          example: 'organization.created'
+          example: "organization.created"
           description: The event type
           enum:
             # Organization events
-            - 'organization.created'
-            - 'organization.updated'
-            - 'organization.deleted'
-            - 'organization.sso_created'
-            - 'organization.sso_deleted'
-            - 'organization.sso_enabled'
-            - 'organization.sso_disabled'
+            - "organization.created"
+            - "organization.updated"
+            - "organization.deleted"
+            - "organization.sso_created"
+            - "organization.sso_deleted"
+            - "organization.sso_enabled"
+            - "organization.sso_disabled"
             # User events
-            - 'user.signup'
-            - 'user.login'
-            - 'user.logout'
-            - 'user.organization_invitation'
-            - 'user.organization_membership_created'
-            - 'user.organization_membership_updated'
-            - 'user.organization_membership_deleted'
+            - "user.signup"
+            - "user.login"
+            - "user.logout"
+            - "user.organization_invitation"
+            - "user.organization_membership_created"
+            - "user.organization_membership_updated"
+            - "user.organization_membership_deleted"
             # Directory events
-            - 'organization.directory.user_created'
-            - 'organization.directory.user_updated'
-            - 'organization.directory.user_deleted'
-            - 'organization.directory.group_created'
-            - 'organization.directory.group_updated'
-            - 'organization.directory.group_deleted'
-            - 'organization.directory_enabled'
-            - 'organization.directory_disabled'
+            - "organization.directory.user_created"
+            - "organization.directory.user_updated"
+            - "organization.directory.user_deleted"
+            - "organization.directory.group_created"
+            - "organization.directory.group_updated"
+            - "organization.directory.group_deleted"
+            - "organization.directory_enabled"
+            - "organization.directory_disabled"
             # Role events
-            - 'role.created'
-            - 'role.updated'
-            - 'role.deleted'
+            - "role.created"
+            - "role.updated"
+            - "role.deleted"
             # Permission events
-            - 'permission.created'
-            - 'permission.updated'
-            - 'permission.deleted'
+            - "permission.created"
+            - "permission.updated"
+            - "permission.deleted"
         occurred_at:
           type: string
           format: date-time
           description: When the event occurred (ISO 8601 format)
-          example: '2024-01-01T00:00:00Z'
+          example: "2024-01-01T00:00:00Z"
         environment_id:
           type: string
-          pattern: '^env_'
-          example: 'env_1234567890abcdef'
+          pattern: "^env_"
+          example: "env_1234567890abcdef"
           description: The environment ID where the event occurred
           minLength: 1
           maxLength: 32
         organization_id:
           type: string
-          pattern: '^org_'
-          example: 'org_1234567890abcdef'
+          pattern: "^org_"
+          example: "org_1234567890abcdef"
           description: The organization ID (if applicable)
           minLength: 1
           maxLength: 32
@@ -11276,28 +11663,28 @@ components:
           type: string
           description: The type of object that triggered the webhook
           enum:
-            - 'Organization'
-            - 'Connection'
-            - 'Role'
-            - 'Directory'
-            - 'DirectoryUser'
-            - 'DirectoryGroup'
-            - 'Permission'
-            - 'OrgMembership'
-            - 'User'
-          example: 'Organization'
+            - "Organization"
+            - "Connection"
+            - "Role"
+            - "Directory"
+            - "DirectoryUser"
+            - "DirectoryGroup"
+            - "Permission"
+            - "OrgMembership"
+            - "User"
+          example: "Organization"
         data:
           type: object
           description: The event payload (structure varies by event type)
           additionalProperties: true
           example:
-            id: 'org_1234567890abcdef'
-            name: 'Example Organization'
-            created_at: '2024-01-01T00:00:00Z'
+            id: "org_1234567890abcdef"
+            name: "Example Organization"
+            created_at: "2024-01-01T00:00:00Z"
         display_name:
           type: string
           description: Human-readable display name for the event
-          example: 'Organization Created'
+          example: "Organization Created"
           minLength: 1
           maxLength: 200
   securitySchemes:
@@ -11335,28 +11722,28 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_1234567890'
-              type: 'organization.created'
-              object: 'Organization'
-              occurred_at: '2024-01-15T10:30:00.123456789Z'
-              environment_id: 'env_1234567890'
-              organization_id: 'org_1234567890'
+              spec_version: "1"
+              id: "evt_1234567890"
+              type: "organization.created"
+              object: "Organization"
+              occurred_at: "2024-01-15T10:30:00.123456789Z"
+              environment_id: "env_1234567890"
+              organization_id: "org_1234567890"
               data:
-                create_time: '2025-12-09T09:25:02.02Z'
-                display_name: 'AcmeCorp'
-                external_id: 'org_external_123'
-                id: 'org_1234567890'
+                create_time: "2025-12-09T09:25:02.02Z"
+                display_name: "AcmeCorp"
+                external_id: "org_external_123"
+                id: "org_1234567890"
                 metadata:
-                region_code: 'US'
-                update_time: '2025-12-09T09:25:02.025330364Z'
+                region_code: "US"
+                update_time: "2025-12-09T09:25:02.025330364Z"
                 settings:
                   features:
                     - enabled: true
-                      name: 'sso'
+                      name: "sso"
                     - enabled: false
-                      name: 'dir_sync'
-              display_name: 'Organization Created'
+                      name: "dir_sync"
+              display_name: "Organization Created"
       responses:
         '200':
           description: Webhook received successfully
@@ -11371,28 +11758,28 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_2345678901'
-              type: 'organization.updated'
-              object: 'Organization'
-              occurred_at: '2024-01-15T10:35:00.123456789Z'
-              environment_id: 'env_1234567890'
-              organization_id: 'org_1234567890'
+              spec_version: "1"
+              id: "evt_2345678901"
+              type: "organization.updated"
+              object: "Organization"
+              occurred_at: "2024-01-15T10:35:00.123456789Z"
+              environment_id: "env_1234567890"
+              organization_id: "org_1234567890"
               data:
-                create_time: '2025-12-09T09:25:02.02Z'
-                display_name: 'AcmeCorp'
-                external_id: 'org_external_123'
-                id: 'org_1234567890'
+                create_time: "2025-12-09T09:25:02.02Z"
+                display_name: "AcmeCorp"
+                external_id: "org_external_123"
+                id: "org_1234567890"
                 metadata:
-                region_code: 'US'
-                update_time: '2025-12-09T09:25:02.025330364Z'
+                region_code: "US"
+                update_time: "2025-12-09T09:25:02.025330364Z"
                 settings:
                   features:
                     - enabled: true
-                      name: 'sso'
+                      name: "sso"
                     - enabled: false
-                      name: 'dir_sync'
-              display_name: 'Organization Updated'
+                      name: "dir_sync"
+              display_name: "Organization Updated"
       responses:
         '200':
           description: Webhook received successfully
@@ -11407,29 +11794,29 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_3456789012'
-              type: 'organization.deleted'
-              object: 'Organization'
-              occurred_at: '2024-01-15T10:40:00.123456789Z'
-              environment_id: 'env_1234567890'
-              organization_id: 'org_1234567890'
+              spec_version: "1"
+              id: "evt_3456789012"
+              type: "organization.deleted"
+              object: "Organization"
+              occurred_at: "2024-01-15T10:40:00.123456789Z"
+              environment_id: "env_1234567890"
+              organization_id: "org_1234567890"
               data:
-                create_time: '2025-12-09T09:25:02.02Z'
-                deleted_at: '2025-12-09T10:25:45.337417Z'
-                display_name: 'AcmeCorp'
-                external_id: 'org_external_123'
-                id: 'org_1234567890'
+                create_time: "2025-12-09T09:25:02.02Z"
+                deleted_at: "2025-12-09T10:25:45.337417Z"
+                display_name: "AcmeCorp"
+                external_id: "org_external_123"
+                id: "org_1234567890"
                 metadata:
-                region_code: 'US'
-                update_time: '2025-12-09T09:25:02.025330364Z'
+                region_code: "US"
+                update_time: "2025-12-09T09:25:02.025330364Z"
                 settings:
                   features:
                     - enabled: true
-                      name: 'sso'
+                      name: "sso"
                     - enabled: false
-                      name: 'dir_sync'
-              display_name: 'Organization Deleted'
+                      name: "dir_sync"
+              display_name: "Organization Deleted"
       responses:
         '200':
           description: Webhook received successfully
@@ -11445,52 +11832,52 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_1234567890'
-              type: 'user.signup'
-              object: 'OrgMembership'
-              occurred_at: '2024-01-15T10:30:00.123456789Z'
-              environment_id: 'env_1234567890'
-              organization_id: 'org_102690563312124938'
+              spec_version: "1"
+              id: "evt_1234567890"
+              type: "user.signup"
+              object: "OrgMembership"
+              occurred_at: "2024-01-15T10:30:00.123456789Z"
+              environment_id: "env_1234567890"
+              organization_id: "org_102690563312124938"
               data:
                 organization:
-                  id: 'org_102690563312124938'
-                  create_time: '2025-12-09T10:19:05.48Z'
-                  display_name: ''
+                  id: "org_102690563312124938"
+                  create_time: "2025-12-09T10:19:05.48Z"
+                  display_name: ""
                   external_id:
                   metadata:
-                  region_code: 'US'
-                  update_time: '2025-12-09T12:04:41.386974738Z'
+                  region_code: "US"
+                  update_time: "2025-12-09T12:04:41.386974738Z"
                   settings:
                     features:
                       - enabled: true
-                        name: 'sso'
+                        name: "sso"
                       - enabled: true
-                        name: 'dir_sync'
+                        name: "dir_sync"
                 user:
-                  create_time: '2025-12-09T12:04:41.39Z'
-                  email: 'amit.ash1996@gmail.com'
-                  external_id: ''
-                  id: 'usr_102701193205121289'
+                  create_time: "2025-12-09T12:04:41.39Z"
+                  email: "amit.ash1996@gmail.com"
+                  external_id: ""
+                  id: "usr_102701193205121289"
                   metadata: {}
-                  update_time: '2025-12-09T12:04:41.391988278Z'
+                  update_time: "2025-12-09T12:04:41.391988278Z"
                   user_profile:
                     custom_attributes:
                     email_verified: true
                     external_identities:
-                    family_name: 'doe'
-                    gender: ''
-                    given_name: 'John'
+                    family_name: "doe"
+                    gender: ""
+                    given_name: "John"
                     groups:
-                    id: 'usp_102701193205186825'
-                    locale: ''
+                    id: "usp_102701193205186825"
+                    locale: ""
                     metadata: {}
-                    name: 'John Doe'
-                    phone_number: ''
+                    name: "John Doe"
+                    phone_number: ""
                     phone_number_verified: false
-                    picture: 'https://lh3.googleusercontent.com/a/abcdef'
-                    preferred_username: ''
-              display_name: 'User Signup'
+                    picture: "https://lh3.googleusercontent.com/a/abcdef"
+                    preferred_username: ""
+              display_name: "User Signup"
       responses:
         '200':
           description: Webhook received successfully
@@ -11505,75 +11892,75 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_102701193859432713'
-              type: 'user.login'
-              object: 'User'
-              occurred_at: '2025-12-09T12:04:41.781873312Z'
-              environment_id: 'env_96736846679245078'
-              organization_id: 'org_102701193188409609'
+              spec_version: "1"
+              id: "evt_102701193859432713"
+              type: "user.login"
+              object: "User"
+              occurred_at: "2025-12-09T12:04:41.781873312Z"
+              environment_id: "env_96736846679245078"
+              organization_id: "org_102701193188409609"
               data:
                 user:
-                  create_time: '2025-12-09T12:04:41.39Z'
-                  email: 'john.doe@acmecorp.com'
-                  external_id: 'ext_123456789'
-                  id: 'usr_123456789'
-                  last_login_time: '2025-12-09T12:04:41.48Z'
+                  create_time: "2025-12-09T12:04:41.39Z"
+                  email: "john.doe@acmecorp.com"
+                  external_id: "ext_123456789"
+                  id: "usr_123456789"
+                  last_login_time: "2025-12-09T12:04:41.48Z"
                   metadata: {}
-                  update_time: '2025-12-09T12:04:41.391988Z'
+                  update_time: "2025-12-09T12:04:41.391988Z"
                   user_profile:
                     custom_attributes:
                     email_verified: true
                     external_identities:
-                      - connection_id: 'conn_97896332307464201'
-                        connection_provider: 'GOOGLE'
-                        connection_type: 'OAUTH'
-                        connection_user_id: '105055379523565727691'
-                        created_time: '2025-12-09T12:04:41.47Z'
+                      - connection_id: "conn_97896332307464201"
+                        connection_provider: "GOOGLE"
+                        connection_type: "OAUTH"
+                        connection_user_id: "105055379523565727691"
+                        created_time: "2025-12-09T12:04:41.47Z"
                         is_social: true
-                        last_login_time: '2025-12-09T12:04:41.469311Z'
-                        last_synced_time: '2025-12-09T12:04:41.469311Z'
-                    family_name: 'Doe'
-                    gender: ''
-                    given_name: 'John'
+                        last_login_time: "2025-12-09T12:04:41.469311Z"
+                        last_synced_time: "2025-12-09T12:04:41.469311Z"
+                    family_name: "Doe"
+                    gender: ""
+                    given_name: "John"
                     groups:
-                    id: 'usp_102701193205186825'
-                    locale: ''
+                    id: "usp_102701193205186825"
+                    locale: ""
                     metadata: {}
-                    name: 'John Doe'
-                    phone_number: ''
+                    name: "John Doe"
+                    phone_number: ""
                     phone_number_verified: false
-                    picture: 'https://lh3.googleusercontent.com/a/abcdef'
-                    preferred_username: ''
+                    picture: "https://lh3.googleusercontent.com/a/abcdef"
+                    preferred_username: ""
                 user_session:
-                  absolute_expires_at: '2026-01-08T12:04:41.737394Z'
-                  authenticated_organizations: ['org_102701193188409609']
-                  created_at: '2025-12-09T12:04:41.48Z'
+                  absolute_expires_at: "2026-01-08T12:04:41.737394Z"
+                  authenticated_organizations: ["org_102701193188409609"]
+                  created_at: "2025-12-09T12:04:41.48Z"
                   expired_at:
-                  idle_expires_at: '2025-12-16T12:04:41.737395Z'
-                  last_active_at: '2025-12-09T12:04:41.747206Z'
+                  idle_expires_at: "2025-12-16T12:04:41.737395Z"
+                  last_active_at: "2025-12-09T12:04:41.747206Z"
                   logout_at:
-                  organization_id: 'org_102701193188409609'
-                  session_id: 'ses_102701193356116233'
-                  status: 'ACTIVE'
-                  updated_at: '2025-12-09T12:04:41.748512Z'
-                  user_id: 'usr_102701193205121289'
+                  organization_id: "org_102701193188409609"
+                  session_id: "ses_102701193356116233"
+                  status: "ACTIVE"
+                  updated_at: "2025-12-09T12:04:41.748512Z"
+                  user_id: "usr_102701193205121289"
                   device:
-                    browser: 'Chrome'
-                    browser_version: '142.0.0.0'
-                    device_type: 'Desktop'
-                    ip: '152.59.144.211'
+                    browser: "Chrome"
+                    browser_version: "142.0.0.0"
+                    device_type: "Desktop"
+                    ip: "152.59.144.211"
                     location:
-                      city: 'Patna'
-                      latitude: '25.594095'
-                      longitude: '85.137564'
-                      region: 'IN'
-                      region_subdivision: 'INBR'
-                    os: 'macOS'
-                    os_version: '10.15.7'
-                    user_agent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
-                      (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36'
-              display_name: 'User Login'
+                      city: "Patna"
+                      latitude: "25.594095"
+                      longitude: "85.137564"
+                      region: "IN"
+                      region_subdivision: "INBR"
+                    os: "macOS"
+                    os_version: "10.15.7"
+                    user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
+                      (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36"
+              display_name: "User Login"
       responses:
         '200':
           description: Webhook received successfully
@@ -11588,75 +11975,75 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_102708230123160586'
-              type: 'user.logout'
-              object: 'User'
-              occurred_at: '2025-12-09T13:14:35.722070822Z'
-              environment_id: 'env_96736846679245078'
-              organization_id: 'org_102701193188409609'
+              spec_version: "1"
+              id: "evt_102708230123160586"
+              type: "user.logout"
+              object: "User"
+              occurred_at: "2025-12-09T13:14:35.722070822Z"
+              environment_id: "env_96736846679245078"
+              organization_id: "org_102701193188409609"
               data:
                 user:
-                  create_time: '2025-12-09T12:04:41.39Z'
-                  email: 'john.doe@acmecorp.com'
-                  external_id: 'ext_123456789'
-                  id: 'usr_123456789'
-                  last_login_time: '2025-12-09T12:04:41.48Z'
+                  create_time: "2025-12-09T12:04:41.39Z"
+                  email: "john.doe@acmecorp.com"
+                  external_id: "ext_123456789"
+                  id: "usr_123456789"
+                  last_login_time: "2025-12-09T12:04:41.48Z"
                   metadata: {}
-                  update_time: '2025-12-09T12:04:41.391988Z'
+                  update_time: "2025-12-09T12:04:41.391988Z"
                   user_profile:
                     custom_attributes:
                     email_verified: true
                     external_identities:
-                      - connection_id: 'conn_97896332307464201'
-                        connection_provider: 'GOOGLE'
-                        connection_type: 'OAUTH'
-                        connection_user_id: '105055379523565727691'
-                        created_time: '2025-12-09T12:04:41.47Z'
+                      - connection_id: "conn_97896332307464201"
+                        connection_provider: "GOOGLE"
+                        connection_type: "OAUTH"
+                        connection_user_id: "105055379523565727691"
+                        created_time: "2025-12-09T12:04:41.47Z"
                         is_social: true
-                        last_login_time: '2025-12-09T12:04:41.469311Z'
-                        last_synced_time: '2025-12-09T12:04:41.469311Z'
-                    family_name: 'Doe'
-                    gender: ''
-                    given_name: 'John'
+                        last_login_time: "2025-12-09T12:04:41.469311Z"
+                        last_synced_time: "2025-12-09T12:04:41.469311Z"
+                    family_name: "Doe"
+                    gender: ""
+                    given_name: "John"
                     groups:
-                    id: 'usp_102701193205186825'
-                    locale: ''
+                    id: "usp_102701193205186825"
+                    locale: ""
                     metadata: {}
-                    name: 'John Doe'
-                    phone_number: ''
+                    name: "John Doe"
+                    phone_number: ""
                     phone_number_verified: false
-                    picture: 'https://lh3.googleusercontent.com/a/abcdef'
-                    preferred_username: ''
+                    picture: "https://lh3.googleusercontent.com/a/abcdef"
+                    preferred_username: ""
                 user_session:
-                  absolute_expires_at: '2026-01-08T12:04:41.737394Z'
-                  authenticated_organizations: ['org_102701193188409609']
-                  created_at: '2025-12-09T12:04:41.48Z'
+                  absolute_expires_at: "2026-01-08T12:04:41.737394Z"
+                  authenticated_organizations: ["org_102701193188409609"]
+                  created_at: "2025-12-09T12:04:41.48Z"
                   expired_at:
-                  idle_expires_at: '2025-12-16T12:04:41.737395Z'
-                  last_active_at: '2025-12-09T12:04:41.747206Z'
+                  idle_expires_at: "2025-12-16T12:04:41.737395Z"
+                  last_active_at: "2025-12-09T12:04:41.747206Z"
                   logout_at:
-                  organization_id: 'org_102701193188409609'
-                  session_id: 'ses_102701193356116233'
-                  status: 'ACTIVE'
-                  updated_at: '2025-12-09T12:04:41.748512Z'
-                  user_id: 'usr_102701193205121289'
+                  organization_id: "org_102701193188409609"
+                  session_id: "ses_102701193356116233"
+                  status: "ACTIVE"
+                  updated_at: "2025-12-09T12:04:41.748512Z"
+                  user_id: "usr_102701193205121289"
                   device:
-                    browser: 'Chrome'
-                    browser_version: '142.0.0.0'
-                    device_type: 'Desktop'
-                    ip: '152.59.144.211'
+                    browser: "Chrome"
+                    browser_version: "142.0.0.0"
+                    device_type: "Desktop"
+                    ip: "152.59.144.211"
                     location:
-                      city: 'Patna'
-                      latitude: '25.594095'
-                      longitude: '85.137564'
-                      region: 'IN'
-                      region_subdivision: 'INBR'
-                    os: 'macOS'
-                    os_version: '10.15.7'
-                    user_agent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
-                      (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36'
-              display_name: 'User Logout'
+                      city: "Patna"
+                      latitude: "25.594095"
+                      longitude: "85.137564"
+                      region: "IN"
+                      region_subdivision: "INBR"
+                    os: "macOS"
+                    os_version: "10.15.7"
+                    user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
+                      (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36"
+              display_name: "User Logout"
       responses:
         '200':
           description: Webhook received successfully
@@ -11672,60 +12059,60 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_4567890123'
-              type: 'user.organization_invitation'
-              object: 'OrgMembership'
-              occurred_at: '2024-01-15T11:00:00.123456789Z'
-              environment_id: 'env_1234567890'
-              organization_id: 'org_102690563312124938'
+              spec_version: "1"
+              id: "evt_4567890123"
+              type: "user.organization_invitation"
+              object: "OrgMembership"
+              occurred_at: "2024-01-15T11:00:00.123456789Z"
+              environment_id: "env_1234567890"
+              organization_id: "org_102690563312124938"
               data:
                 organization:
-                  id: 'org_102690563312124938'
-                  create_time: '2025-12-09T10:19:05.48Z'
-                  display_name: 'Acme Corp'
-                  external_id: 'org_external_123'
+                  id: "org_102690563312124938"
+                  create_time: "2025-12-09T10:19:05.48Z"
+                  display_name: "Acme Corp"
+                  external_id: "org_external_123"
                   metadata:
-                  region_code: 'US'
-                  update_time: '2025-12-09T12:04:41.386974738Z'
+                  region_code: "US"
+                  update_time: "2025-12-09T12:04:41.386974738Z"
                   settings:
                     features:
                       - enabled: true
-                        name: 'sso'
+                        name: "sso"
                       - enabled: true
-                        name: 'dir_sync'
+                        name: "dir_sync"
                 user:
-                  create_time: '2025-12-09T12:04:41.39Z'
-                  email: 'john.doe@acmecorp.com'
-                  external_id: 'ext_123456789'
-                  id: 'usr_123456789'
+                  create_time: "2025-12-09T12:04:41.39Z"
+                  email: "john.doe@acmecorp.com"
+                  external_id: "ext_123456789"
+                  id: "usr_123456789"
                   metadata: {}
-                  update_time: '2025-12-09T12:04:41.391988Z'
+                  update_time: "2025-12-09T12:04:41.391988Z"
                   user_profile:
                     custom_attributes:
                     email_verified: true
                     external_identities:
-                      - connection_id: 'conn_97896332307464201'
-                        connection_provider: 'GOOGLE'
-                        connection_type: 'OAUTH'
-                        connection_user_id: '105055379523565727691'
-                        created_time: '2025-12-09T12:04:41.47Z'
+                      - connection_id: "conn_97896332307464201"
+                        connection_provider: "GOOGLE"
+                        connection_type: "OAUTH"
+                        connection_user_id: "105055379523565727691"
+                        created_time: "2025-12-09T12:04:41.47Z"
                         is_social: true
-                        last_login_time: '2025-12-09T12:04:41.469311Z'
-                        last_synced_time: '2025-12-09T12:04:41.469311Z'
-                    family_name: 'Doe'
-                    gender: ''
-                    given_name: 'John'
+                        last_login_time: "2025-12-09T12:04:41.469311Z"
+                        last_synced_time: "2025-12-09T12:04:41.469311Z"
+                    family_name: "Doe"
+                    gender: ""
+                    given_name: "John"
                     groups:
-                    id: 'usp_102701193205186825'
-                    locale: ''
+                    id: "usp_102701193205186825"
+                    locale: ""
                     metadata: {}
-                    name: 'John Doe'
-                    phone_number: ''
+                    name: "John Doe"
+                    phone_number: ""
                     phone_number_verified: false
-                    picture: 'https://lh3.googleusercontent.com/a/abcdef'
-                    preferred_username: ''
-              display_name: 'User Organization Invitation'
+                    picture: "https://lh3.googleusercontent.com/a/abcdef"
+                    preferred_username: ""
+              display_name: "User Organization Invitation"
       responses:
         '200':
           description: Webhook received successfully
@@ -11740,60 +12127,60 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_5678901234'
-              type: 'user.organization_membership_created'
-              object: 'OrgMembership'
-              occurred_at: '2024-01-15T11:05:00.123456789Z'
-              environment_id: 'env_1234567890'
-              organization_id: 'org_102690563312124938'
+              spec_version: "1"
+              id: "evt_5678901234"
+              type: "user.organization_membership_created"
+              object: "OrgMembership"
+              occurred_at: "2024-01-15T11:05:00.123456789Z"
+              environment_id: "env_1234567890"
+              organization_id: "org_102690563312124938"
               data:
                 organization:
-                  id: 'org_102690563312124938'
-                  create_time: '2025-12-09T10:19:05.48Z'
-                  display_name: 'Acme Corp'
-                  external_id: 'org_external_123'
+                  id: "org_102690563312124938"
+                  create_time: "2025-12-09T10:19:05.48Z"
+                  display_name: "Acme Corp"
+                  external_id: "org_external_123"
                   metadata:
-                  region_code: 'US'
-                  update_time: '2025-12-09T12:04:41.386974738Z'
+                  region_code: "US"
+                  update_time: "2025-12-09T12:04:41.386974738Z"
                   settings:
                     features:
                       - enabled: true
-                        name: 'sso'
+                        name: "sso"
                       - enabled: true
-                        name: 'dir_sync'
+                        name: "dir_sync"
                 user:
-                  create_time: '2025-12-09T12:04:41.39Z'
-                  email: 'john.doe@acmecorp.com'
-                  external_id: 'ext_123456789'
-                  id: 'usr_123456789'
+                  create_time: "2025-12-09T12:04:41.39Z"
+                  email: "john.doe@acmecorp.com"
+                  external_id: "ext_123456789"
+                  id: "usr_123456789"
                   metadata: {}
-                  update_time: '2025-12-09T12:04:41.391988Z'
+                  update_time: "2025-12-09T12:04:41.391988Z"
                   user_profile:
                     custom_attributes:
                     email_verified: true
                     external_identities:
-                      - connection_id: 'conn_97896332307464201'
-                        connection_provider: 'GOOGLE'
-                        connection_type: 'OAUTH'
-                        connection_user_id: '105055379523565727691'
-                        created_time: '2025-12-09T12:04:41.47Z'
+                      - connection_id: "conn_97896332307464201"
+                        connection_provider: "GOOGLE"
+                        connection_type: "OAUTH"
+                        connection_user_id: "105055379523565727691"
+                        created_time: "2025-12-09T12:04:41.47Z"
                         is_social: true
-                        last_login_time: '2025-12-09T12:04:41.469311Z'
-                        last_synced_time: '2025-12-09T12:04:41.469311Z'
-                    family_name: 'Doe'
-                    gender: ''
-                    given_name: 'John'
+                        last_login_time: "2025-12-09T12:04:41.469311Z"
+                        last_synced_time: "2025-12-09T12:04:41.469311Z"
+                    family_name: "Doe"
+                    gender: ""
+                    given_name: "John"
                     groups:
-                    id: 'usp_102701193205186825'
-                    locale: ''
+                    id: "usp_102701193205186825"
+                    locale: ""
                     metadata: {}
-                    name: 'John Doe'
-                    phone_number: ''
+                    name: "John Doe"
+                    phone_number: ""
                     phone_number_verified: false
-                    picture: 'https://lh3.googleusercontent.com/a/abcdef'
-                    preferred_username: ''
-              display_name: 'User Organization Membership Created'
+                    picture: "https://lh3.googleusercontent.com/a/abcdef"
+                    preferred_username: ""
+              display_name: "User Organization Membership Created"
       responses:
         '200':
           description: Webhook received successfully
@@ -11801,7 +12188,7 @@ webhooks:
   user.organization_membership_deleted:
     post:
       summary: User Organization Membership Deleted
-      description: Triggered when a user's membership in an organization is
+      description: Triggered when a user's membership in an organization is 
         removed or deleted
       requestBody:
         content:
@@ -11809,60 +12196,60 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_9012345678'
-              type: 'user.organization_membership_deleted'
-              object: 'OrgMembership'
-              occurred_at: '2024-01-15T11:10:00.123456789Z'
-              environment_id: 'env_1234567890'
-              organization_id: 'org_102690563312124938'
+              spec_version: "1"
+              id: "evt_9012345678"
+              type: "user.organization_membership_deleted"
+              object: "OrgMembership"
+              occurred_at: "2024-01-15T11:10:00.123456789Z"
+              environment_id: "env_1234567890"
+              organization_id: "org_102690563312124938"
               data:
                 organization:
-                  id: 'org_102690563312124938'
-                  create_time: '2025-12-09T10:19:05.48Z'
-                  display_name: 'Acme Corp'
-                  external_id: 'org_external_123'
+                  id: "org_102690563312124938"
+                  create_time: "2025-12-09T10:19:05.48Z"
+                  display_name: "Acme Corp"
+                  external_id: "org_external_123"
                   metadata:
-                  region_code: 'US'
-                  update_time: '2025-12-09T12:04:41.386974738Z'
+                  region_code: "US"
+                  update_time: "2025-12-09T12:04:41.386974738Z"
                   settings:
                     features:
                       - enabled: true
-                        name: 'sso'
+                        name: "sso"
                       - enabled: true
-                        name: 'dir_sync'
+                        name: "dir_sync"
                 user:
-                  create_time: '2025-12-09T12:04:41.39Z'
-                  email: 'john.doe@acmecorp.com'
-                  external_id: 'ext_123456789'
-                  id: 'usr_123456789'
+                  create_time: "2025-12-09T12:04:41.39Z"
+                  email: "john.doe@acmecorp.com"
+                  external_id: "ext_123456789"
+                  id: "usr_123456789"
                   metadata: {}
-                  update_time: '2025-12-09T12:04:41.391988Z'
+                  update_time: "2025-12-09T12:04:41.391988Z"
                   user_profile:
                     custom_attributes:
                     email_verified: true
                     external_identities:
-                      - connection_id: 'conn_97896332307464201'
-                        connection_provider: 'GOOGLE'
-                        connection_type: 'OAUTH'
-                        connection_user_id: '105055379523565727691'
-                        created_time: '2025-12-09T12:04:41.47Z'
+                      - connection_id: "conn_97896332307464201"
+                        connection_provider: "GOOGLE"
+                        connection_type: "OAUTH"
+                        connection_user_id: "105055379523565727691"
+                        created_time: "2025-12-09T12:04:41.47Z"
                         is_social: true
-                        last_login_time: '2025-12-09T12:04:41.469311Z'
-                        last_synced_time: '2025-12-09T12:04:41.469311Z'
-                        raw_attributes: '{}'
-                        updated_time: '2025-12-09T12:04:41.473087Z'
-                    family_name: 'Doe'
-                    gender: ''
-                    given_name: 'John'
-                    locale: ''
+                        last_login_time: "2025-12-09T12:04:41.469311Z"
+                        last_synced_time: "2025-12-09T12:04:41.469311Z"
+                        raw_attributes: "{}"
+                        updated_time: "2025-12-09T12:04:41.473087Z"
+                    family_name: "Doe"
+                    gender: ""
+                    given_name: "John"
+                    locale: ""
                     metadata: {}
-                    name: 'John Doe'
-                    phone_number: ''
+                    name: "John Doe"
+                    phone_number: ""
                     phone_number_verified: false
-                    picture: 'https://lh3.googleusercontent.com/a/abcdef'
-                    preferred_username: ''
-              display_name: 'User Organization Membership Deleted'
+                    picture: "https://lh3.googleusercontent.com/a/abcdef"
+                    preferred_username: ""
+              display_name: "User Organization Membership Deleted"
       responses:
         '200':
           description: Webhook received successfully
@@ -11870,7 +12257,7 @@ webhooks:
   user.organization_membership_updated:
     post:
       summary: User Organization Membership Updated
-      description: Triggered when a user's organization membership is updated,
+      description: Triggered when a user's organization membership is updated, 
         e.g., change of user's role in an organization
       requestBody:
         content:
@@ -11878,60 +12265,60 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_6789012345'
-              type: 'user.organization_membership_updated'
-              object: 'OrgMembership'
-              occurred_at: '2024-01-15T11:10:00.123456789Z'
-              environment_id: 'env_1234567890'
-              organization_id: 'org_102690563312124938'
+              spec_version: "1"
+              id: "evt_6789012345"
+              type: "user.organization_membership_updated"
+              object: "OrgMembership"
+              occurred_at: "2024-01-15T11:10:00.123456789Z"
+              environment_id: "env_1234567890"
+              organization_id: "org_102690563312124938"
               data:
                 organization:
-                  id: 'org_102690563312124938'
-                  create_time: '2025-12-09T10:19:05.48Z'
-                  display_name: 'Acme Corp'
-                  external_id: 'org_external_123'
+                  id: "org_102690563312124938"
+                  create_time: "2025-12-09T10:19:05.48Z"
+                  display_name: "Acme Corp"
+                  external_id: "org_external_123"
                   metadata:
-                  region_code: 'US'
-                  update_time: '2025-12-09T12:04:41.386974738Z'
+                  region_code: "US"
+                  update_time: "2025-12-09T12:04:41.386974738Z"
                   settings:
                     features:
                       - enabled: true
-                        name: 'sso'
+                        name: "sso"
                       - enabled: true
-                        name: 'dir_sync'
+                        name: "dir_sync"
                 user:
-                  create_time: '2025-12-09T12:04:41.39Z'
-                  email: 'john.doe@acmecorp.com'
-                  external_id: 'ext_123456789'
-                  id: 'usr_123456789'
+                  create_time: "2025-12-09T12:04:41.39Z"
+                  email: "john.doe@acmecorp.com"
+                  external_id: "ext_123456789"
+                  id: "usr_123456789"
                   metadata: {}
-                  update_time: '2025-12-09T12:04:41.391988Z'
+                  update_time: "2025-12-09T12:04:41.391988Z"
                   user_profile:
                     custom_attributes:
                     email_verified: true
                     external_identities:
-                      - connection_id: 'conn_97896332307464201'
-                        connection_provider: 'GOOGLE'
-                        connection_type: 'OAUTH'
-                        connection_user_id: '105055379523565727691'
-                        created_time: '2025-12-09T12:04:41.47Z'
+                      - connection_id: "conn_97896332307464201"
+                        connection_provider: "GOOGLE"
+                        connection_type: "OAUTH"
+                        connection_user_id: "105055379523565727691"
+                        created_time: "2025-12-09T12:04:41.47Z"
                         is_social: true
-                        last_login_time: '2025-12-09T12:04:41.469311Z'
-                        last_synced_time: '2025-12-09T12:04:41.469311Z'
-                        raw_attributes: '{}'
-                        updated_time: '2025-12-09T12:04:41.473087Z'
-                    family_name: 'Doe'
-                    gender: ''
-                    given_name: 'John'
-                    locale: ''
+                        last_login_time: "2025-12-09T12:04:41.469311Z"
+                        last_synced_time: "2025-12-09T12:04:41.469311Z"
+                        raw_attributes: "{}"
+                        updated_time: "2025-12-09T12:04:41.473087Z"
+                    family_name: "Doe"
+                    gender: ""
+                    given_name: "John"
+                    locale: ""
                     metadata: {}
-                    name: 'John Doe'
-                    phone_number: ''
+                    name: "John Doe"
+                    phone_number: ""
                     phone_number_verified: false
-                    picture: 'https://lh3.googleusercontent.com/a/abcdef'
-                    preferred_username: ''
-              display_name: 'User Organization Membership Updated'
+                    picture: "https://lh3.googleusercontent.com/a/abcdef"
+                    preferred_username: ""
+              display_name: "User Organization Membership Updated"
       responses:
         '200':
           description: Webhook received successfully
@@ -11947,21 +12334,21 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_55136848686613000'
-              type: 'organization.directory_enabled'
-              object: 'Directory'
-              occurred_at: '2025-01-15T08:55:22.802860294Z'
-              environment_id: 'env_27758032200925221'
-              organization_id: 'org_55135410258444802'
+              spec_version: "1"
+              id: "evt_55136848686613000"
+              type: "organization.directory_enabled"
+              object: "Directory"
+              occurred_at: "2025-01-15T08:55:22.802860294Z"
+              environment_id: "env_27758032200925221"
+              organization_id: "org_55135410258444802"
               data:
-                directory_type: 'SCIM'
+                directory_type: "SCIM"
                 enabled: true
-                id: 'dir_55135622825771522'
-                organization_id: 'org_55135410258444802'
-                provider: 'OKTA'
-                updated_at: '2025-01-15T08:55:22.792993454Z'
-              display_name: 'Directory Enabled'
+                id: "dir_55135622825771522"
+                organization_id: "org_55135410258444802"
+                provider: "OKTA"
+                updated_at: "2025-01-15T08:55:22.792993454Z"
+              display_name: "Directory Enabled"
       responses:
         '200':
           description: Webhook received successfully
@@ -11976,21 +12363,21 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_53891640779079756'
-              type: 'organization.directory_disabled'
-              object: 'Directory'
-              occurred_at: '2025-01-06T18:45:21.057814Z'
-              environment_id: 'env_53814739859406915'
-              organization_id: 'org_53879494091473415'
+              spec_version: "1"
+              id: "evt_53891640779079756"
+              type: "organization.directory_disabled"
+              object: "Directory"
+              occurred_at: "2025-01-06T18:45:21.057814Z"
+              environment_id: "env_53814739859406915"
+              organization_id: "org_53879494091473415"
               data:
-                directory_type: 'SCIM'
+                directory_type: "SCIM"
                 enabled: false
-                id: 'dir_53879621145330183'
-                organization_id: 'org_53879494091473415'
-                provider: 'OKTA'
-                updated_at: '2025-01-06T18:45:21.04978184Z'
-              display_name: 'Directory Disabled'
+                id: "dir_53879621145330183"
+                organization_id: "org_53879494091473415"
+                provider: "OKTA"
+                updated_at: "2025-01-06T18:45:21.04978184Z"
+              display_name: "Directory Disabled"
       responses:
         '200':
           description: Webhook received successfully
@@ -12006,45 +12393,45 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_53891546994442316'
-              type: 'organization.directory.user_created'
-              object: 'DirectoryUser'
-              occurred_at: '2025-01-06T18:44:25.153954Z'
-              environment_id: 'env_53814739859406915'
-              organization_id: 'org_53879494091473415'
+              spec_version: "1"
+              id: "evt_53891546994442316"
+              type: "organization.directory.user_created"
+              object: "DirectoryUser"
+              occurred_at: "2025-01-06T18:44:25.153954Z"
+              environment_id: "env_53814739859406915"
+              organization_id: "org_53879494091473415"
               data:
                 active: true
-                cost_center: 'QAUZJUHSTYCN'
+                cost_center: "QAUZJUHSTYCN"
                 custom_attributes:
-                  mobile_phone_number: '1-579-4072'
-                department: 'HNXJPGISMIFN'
-                division: 'MJFUEYJOKICN'
-                dp_id: '<id from IDP>'
-                email: 'flavio@runolfsdottir.co.duk'
-                employee_id: 'AWNEDTILGaIZN'
-                family_name: 'Jaquelin'
-                given_name: 'Dayton'
+                  mobile_phone_number: "1-579-4072"
+                department: "HNXJPGISMIFN"
+                division: "MJFUEYJOKICN"
+                dp_id: "<id from IDP>"
+                email: "flavio@runolfsdottir.co.duk"
+                employee_id: "AWNEDTILGaIZN"
+                family_name: "Jaquelin"
+                given_name: "Dayton"
                 groups:
-                  - id: 'dirgroup_12312312312312'
-                    name: 'Group Name'
-                id: 'diruser_53891546960887884'
-                language: 'se'
-                locale: 'LLWLEWESPLDC'
-                name: 'QDRGUZZDYMFU'
-                nickname: 'DTUODYKGFPPC'
-                organization: 'AUIITQVUQGVH'
-                organization_id: 'org_53879494091473415'
-                phone_number: '1-579-4072'
-                preferred_username: 'kuntala1233a'
-                profile: 'YMIUQUHKGVAX'
+                  - id: "dirgroup_12312312312312"
+                    name: "Group Name"
+                id: "diruser_53891546960887884"
+                language: "se"
+                locale: "LLWLEWESPLDC"
+                name: "QDRGUZZDYMFU"
+                nickname: "DTUODYKGFPPC"
+                organization: "AUIITQVUQGVH"
+                organization_id: "org_53879494091473415"
+                phone_number: "1-579-4072"
+                preferred_username: "kuntala1233a"
+                profile: "YMIUQUHKGVAX"
                 raw_attributes: {}
-                title: 'FKQBHCWJXZSC'
-                user_type: 'RBQFJSQEFAEH'
-                zoneinfo: 'America/Araguaina'
+                title: "FKQBHCWJXZSC"
+                user_type: "RBQFJSQEFAEH"
+                zoneinfo: "America/Araguaina"
                 roles:
-                  - role_name: 'billing_admin'
-              display_name: 'Directory User Created'
+                  - role_name: "billing_admin"
+              display_name: "Directory User Created"
       responses:
         '200':
           description: Webhook received successfully
@@ -12059,40 +12446,40 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_53891546994442317'
-              type: 'organization.directory.user_updated'
-              object: 'DirectoryUser'
-              occurred_at: '2025-01-06T18:44:25.153954Z'
-              environment_id: 'env_53814739859406915'
-              organization_id: 'org_53879494091473415'
+              spec_version: "1"
+              id: "evt_53891546994442317"
+              type: "organization.directory.user_updated"
+              object: "DirectoryUser"
+              occurred_at: "2025-01-06T18:44:25.153954Z"
+              environment_id: "env_53814739859406915"
+              organization_id: "org_53879494091473415"
               data:
-                id: 'diruser_12312312312312'
-                organization_id: 'org_53879494091473415'
-                dp_id: '<scim_external_id>'
-                preferred_username: '<idp_user_name>'
-                email: 'john.doe@example.com'
+                id: "diruser_12312312312312"
+                organization_id: "org_53879494091473415"
+                dp_id: "<scim_external_id>"
+                preferred_username: "<idp_user_name>"
+                email: "john.doe@example.com"
                 active: true
-                name: 'John Doe'
+                name: "John Doe"
                 roles:
-                  - role_name: 'billing_admin'
+                  - role_name: "billing_admin"
                 groups:
-                  - id: 'dirgroup_12312312312312'
-                    name: 'Group Name'
-                given_name: 'John'
-                family_name: 'Doe'
-                nickname: 'Jhonny boy'
-                picture: 'https://image.com/profile.jpg'
-                phone_number: '1234567892'
+                  - id: "dirgroup_12312312312312"
+                    name: "Group Name"
+                given_name: "John"
+                family_name: "Doe"
+                nickname: "Jhonny boy"
+                picture: "https://image.com/profile.jpg"
+                phone_number: "1234567892"
                 address:
-                  postal_code: '64112'
-                  state: 'Missouri'
-                  formatted: '123, Oxford Lane, Kansas City, Missouri, 64112'
+                  postal_code: "64112"
+                  state: "Missouri"
+                  formatted: "123, Oxford Lane, Kansas City, Missouri, 64112"
                 custom_attributes:
-                  attribute1: 'value1'
-                  attribute2: 'value2'
+                  attribute1: "value1"
+                  attribute2: "value2"
                 raw_attributes: {}
-              display_name: 'Directory User Updated'
+              display_name: "Directory User Updated"
       responses:
         '200':
           description: Webhook received successfully
@@ -12107,19 +12494,19 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_53891546994442318'
-              type: 'organization.directory.user_deleted'
-              object: 'DirectoryUser'
-              occurred_at: '2025-01-06T18:44:25.153954Z'
-              environment_id: 'env_53814739859406915'
-              organization_id: 'org_53879494091473415'
+              spec_version: "1"
+              id: "evt_53891546994442318"
+              type: "organization.directory.user_deleted"
+              object: "DirectoryUser"
+              occurred_at: "2025-01-06T18:44:25.153954Z"
+              environment_id: "env_53814739859406915"
+              organization_id: "org_53879494091473415"
               data:
-                id: 'diruser_12312312312312'
-                organization_id: 'org_12312312312312'
-                dp_id: '<scim_external_id>'
-                email: 'john.doe@example.com'
-              display_name: 'Directory User Deleted'
+                id: "diruser_12312312312312"
+                organization_id: "org_12312312312312"
+                dp_id: "<scim_external_id>"
+                email: "john.doe@example.com"
+              display_name: "Directory User Deleted"
       responses:
         '200':
           description: Webhook received successfully
@@ -12135,21 +12522,21 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_38862741515010639'
-              type: 'organization.directory.group_created'
-              object: 'DirectoryGroup'
-              occurred_at: '2024-09-25T02:26:39.036398577Z'
-              environment_id: 'env_32080745237316098'
-              organization_id: 'org_38609339635728478'
+              spec_version: "1"
+              id: "evt_38862741515010639"
+              type: "organization.directory.group_created"
+              object: "DirectoryGroup"
+              occurred_at: "2024-09-25T02:26:39.036398577Z"
+              environment_id: "env_32080745237316098"
+              organization_id: "org_38609339635728478"
               data:
-                directory_id: 'dir_38610496391217780'
-                display_name: 'Avengers'
+                directory_id: "dir_38610496391217780"
+                display_name: "Avengers"
                 external_id:
-                id: 'dirgroup_38862741498233423'
-                organization_id: 'org_38609339635728478'
+                id: "dirgroup_38862741498233423"
+                organization_id: "org_38609339635728478"
                 raw_attributes: {}
-              display_name: 'Directory Group Created'
+              display_name: "Directory Group Created"
       responses:
         '200':
           description: Webhook received successfully
@@ -12164,21 +12551,21 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_38864948910162368'
-              type: 'organization.directory.group_updated'
-              object: 'DirectoryGroup'
-              occurred_at: '2024-09-25T02:48:34.745030921Z'
-              environment_id: 'env_32080745237316098'
-              organization_id: 'org_38609339635728478'
+              spec_version: "1"
+              id: "evt_38864948910162368"
+              type: "organization.directory.group_updated"
+              object: "DirectoryGroup"
+              occurred_at: "2024-09-25T02:48:34.745030921Z"
+              environment_id: "env_32080745237316098"
+              organization_id: "org_38609339635728478"
               data:
-                directory_id: 'dir_38610496391217780'
-                display_name: 'Avengers'
-                external_id: '<external_id>'
-                id: 'dirgroup_38862741498233423'
-                organization_id: 'org_38609339635728478'
+                directory_id: "dir_38610496391217780"
+                display_name: "Avengers"
+                external_id: "<external_id>"
+                id: "dirgroup_38862741498233423"
+                organization_id: "org_38609339635728478"
                 raw_attributes: {}
-              display_name: 'Directory Group Updated'
+              display_name: "Directory Group Updated"
       responses:
         '200':
           description: Webhook received successfully
@@ -12193,21 +12580,21 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_40650399597723966'
-              type: 'organization.directory.group_deleted'
-              object: 'DirectoryGroup'
-              occurred_at: '2024-10-07T10:25:26.289331747Z'
-              environment_id: 'env_12205603854221623'
-              organization_id: 'org_39802449573184223'
+              spec_version: "1"
+              id: "evt_40650399597723966"
+              type: "organization.directory.group_deleted"
+              object: "DirectoryGroup"
+              occurred_at: "2024-10-07T10:25:26.289331747Z"
+              environment_id: "env_12205603854221623"
+              organization_id: "org_39802449573184223"
               data:
-                directory_id: 'dir_39802485862301855'
-                display_name: 'Admins'
-                dp_id: '7c66a173-79c6-4270-ac78-8f35a8121e0a'
-                id: 'dirgroup_40072007005503806'
-                organization_id: 'org_39802449573184223'
+                directory_id: "dir_39802485862301855"
+                display_name: "Admins"
+                dp_id: "7c66a173-79c6-4270-ac78-8f35a8121e0a"
+                id: "dirgroup_40072007005503806"
+                organization_id: "org_39802449573184223"
                 raw_attributes: {}
-              display_name: 'Directory Group Deleted'
+              display_name: "Directory Group Deleted"
       responses:
         '200':
           description: Webhook received successfully
@@ -12216,7 +12603,7 @@ webhooks:
   organization.sso_created:
     post:
       summary: SSO Connection Created
-      description: Triggered when a new SSO connection is created for an
+      description: Triggered when a new SSO connection is created for an 
         organization
       requestBody:
         content:
@@ -12224,19 +12611,19 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_94567862441607493'
-              type: 'organization.sso_created'
-              object: 'Connection'
-              environment_id: 'env_74418471961625391'
-              occurred_at: '2025-10-14T09:27:18.488720586Z'
-              organization_id: 'org_83544995172188677'
+              spec_version: "1"
+              id: "evt_94567862441607493"
+              type: "organization.sso_created"
+              object: "Connection"
+              environment_id: "env_74418471961625391"
+              occurred_at: "2025-10-14T09:27:18.488720586Z"
+              organization_id: "org_83544995172188677"
               data:
-                id: 'conn_94567862424830277'
-                organization_id: 'org_83544995172188677'
-                connection_type: 'OIDC'
-                provider: 'OKTA'
-              display_name: 'SSO Connection Created'
+                id: "conn_94567862424830277"
+                organization_id: "org_83544995172188677"
+                connection_type: "OIDC"
+                provider: "OKTA"
+              display_name: "SSO Connection Created"
       responses:
         '200':
           description: Webhook received successfully
@@ -12244,7 +12631,7 @@ webhooks:
   organization.sso_enabled:
     post:
       summary: SSO Connection Enabled
-      description: Triggered when an SSO connection is enabled for an
+      description: Triggered when an SSO connection is enabled for an 
         organization
       requestBody:
         content:
@@ -12252,21 +12639,21 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_94568078213382471'
-              type: 'organization.sso_enabled'
-              object: 'Connection'
-              environment_id: 'env_74418471961625391'
-              occurred_at: '2025-10-14T09:29:27.098914861Z'
-              organization_id: 'org_83544995172188677'
+              spec_version: "1"
+              id: "evt_94568078213382471"
+              type: "organization.sso_enabled"
+              object: "Connection"
+              environment_id: "env_74418471961625391"
+              occurred_at: "2025-10-14T09:29:27.098914861Z"
+              organization_id: "org_83544995172188677"
               data:
-                id: 'conn_94567862424830277'
-                organization_id: 'org_83544995172188677'
-                connection_type: 'OIDC'
-                provider: 'OKTA'
+                id: "conn_94567862424830277"
+                organization_id: "org_83544995172188677"
+                connection_type: "OIDC"
+                provider: "OKTA"
                 enabled: true
-                status: 'COMPLETED'
-              display_name: 'SSO Connection Enabled'
+                status: "COMPLETED"
+              display_name: "SSO Connection Enabled"
       responses:
         '200':
           description: Webhook received successfully
@@ -12274,7 +12661,7 @@ webhooks:
   organization.sso_disabled:
     post:
       summary: SSO Connection Disabled
-      description: Triggered when an SSO connection is disabled for an
+      description: Triggered when an SSO connection is disabled for an 
         organization
       requestBody:
         content:
@@ -12282,21 +12669,21 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_94557976165089560'
-              type: 'organization.sso_disabled'
-              object: 'Connection'
-              environment_id: 'env_74418471961625391'
-              occurred_at: '2025-10-14T07:49:05.809554456Z'
-              organization_id: 'org_83544995172188677'
+              spec_version: "1"
+              id: "evt_94557976165089560"
+              type: "organization.sso_disabled"
+              object: "Connection"
+              environment_id: "env_74418471961625391"
+              occurred_at: "2025-10-14T07:49:05.809554456Z"
+              organization_id: "org_83544995172188677"
               data:
-                id: 'conn_83545002856153607'
-                organization_id: 'org_83544995172188677'
-                connection_type: 'OIDC'
-                provider: 'OKTA'
+                id: "conn_83545002856153607"
+                organization_id: "org_83544995172188677"
+                connection_type: "OIDC"
+                provider: "OKTA"
                 enabled: false
-                status: 'COMPLETED'
-              display_name: 'SSO Connection Disabled'
+                status: "COMPLETED"
+              display_name: "SSO Connection Disabled"
       responses:
         '200':
           description: Webhook received successfully
@@ -12304,7 +12691,7 @@ webhooks:
   organization.sso_deleted:
     post:
       summary: SSO Connection Deleted
-      description: Triggered when an SSO connection is deleted for an
+      description: Triggered when an SSO connection is deleted for an 
         organization
       requestBody:
         content:
@@ -12312,19 +12699,19 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_94557997639926040'
-              type: 'organization.sso_deleted'
-              object: 'Connection'
-              environment_id: 'env_74418471961625391'
-              occurred_at: '2025-10-14T07:49:18.604546332Z'
-              organization_id: 'org_83544995172188677'
+              spec_version: "1"
+              id: "evt_94557997639926040"
+              type: "organization.sso_deleted"
+              object: "Connection"
+              environment_id: "env_74418471961625391"
+              occurred_at: "2025-10-14T07:49:18.604546332Z"
+              organization_id: "org_83544995172188677"
               data:
-                id: 'conn_83545002856153607'
-                organization_id: 'org_83544995172188677'
-                connection_type: 'OIDC'
-                provider: 'OKTA'
-              display_name: 'SSO Connection Deleted'
+                id: "conn_83545002856153607"
+                organization_id: "org_83544995172188677"
+                connection_type: "OIDC"
+                provider: "OKTA"
+              display_name: "SSO Connection Deleted"
       responses:
         '200':
           description: Webhook received successfully
@@ -12340,19 +12727,19 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_1234567890'
-              type: 'role.created'
-              object: 'Role'
-              occurred_at: '2024-01-15T10:30:00.123456789Z'
-              environment_id: 'env_1234567890'
+              spec_version: "1"
+              id: "evt_1234567890"
+              type: "role.created"
+              object: "Role"
+              occurred_at: "2024-01-15T10:30:00.123456789Z"
+              environment_id: "env_1234567890"
               data:
-                description: 'Viewer role with read-only access'
-                display_name: 'Viewer'
-                extends: 'member'
-                id: 'role_1234567890'
-                name: 'viewer'
-              display_name: 'Role Created'
+                description: "Viewer role with read-only access"
+                display_name: "Viewer"
+                extends: "member"
+                id: "role_1234567890"
+                name: "viewer"
+              display_name: "Role Created"
       responses:
         '200':
           description: Webhook received successfully
@@ -12367,19 +12754,19 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_2345678901'
-              type: 'role.updated'
-              object: 'Role'
-              occurred_at: '2024-01-15T10:35:00.123456789Z'
-              environment_id: 'env_1234567890'
+              spec_version: "1"
+              id: "evt_2345678901"
+              type: "role.updated"
+              object: "Role"
+              occurred_at: "2024-01-15T10:35:00.123456789Z"
+              environment_id: "env_1234567890"
               data:
-                description: 'Updated viewer role with limited permissions'
-                display_name: 'Viewer'
-                extends: 'member'
-                id: 'role_1234567890'
-                name: 'viewer'
-              display_name: 'Role Updated'
+                description: "Updated viewer role with limited permissions"
+                display_name: "Viewer"
+                extends: "member"
+                id: "role_1234567890"
+                name: "viewer"
+              display_name: "Role Updated"
       responses:
         '200':
           description: Webhook received successfully
@@ -12394,19 +12781,19 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_3456789012'
-              type: 'role.deleted'
-              object: 'Role'
-              occurred_at: '2024-01-15T10:40:00.123456789Z'
-              environment_id: 'env_1234567890'
+              spec_version: "1"
+              id: "evt_3456789012"
+              type: "role.deleted"
+              object: "Role"
+              occurred_at: "2024-01-15T10:40:00.123456789Z"
+              environment_id: "env_1234567890"
               data:
-                description: 'Updated viewer role with limited permissions'
-                display_name: 'Viewer'
-                extends: 'member'
-                id: 'role_1234567890'
-                name: 'viewer'
-              display_name: 'Role Deleted'
+                description: "Updated viewer role with limited permissions"
+                display_name: "Viewer"
+                extends: "member"
+                id: "role_1234567890"
+                name: "viewer"
+              display_name: "Role Deleted"
       responses:
         '200':
           description: Webhook received successfully
@@ -12422,17 +12809,17 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_1234567890'
-              type: 'permission.created'
-              object: 'Permission'
-              occurred_at: '2024-01-15T10:30:00.123456789Z'
-              environment_id: 'env_1234567890'
+              spec_version: "1"
+              id: "evt_1234567890"
+              type: "permission.created"
+              object: "Permission"
+              occurred_at: "2024-01-15T10:30:00.123456789Z"
+              environment_id: "env_1234567890"
               data:
-                description: 'Permission to manage data'
-                id: 'perm_1234567890'
-                name: 'data:manage'
-              display_name: 'Permission Created'
+                description: "Permission to manage data"
+                id: "perm_1234567890"
+                name: "data:manage"
+              display_name: "Permission Created"
       responses:
         '200':
           description: Webhook received successfully
@@ -12447,17 +12834,17 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_2345678901'
-              type: 'permission.updated'
-              object: 'Permission'
-              occurred_at: '2024-01-15T10:35:00.123456789Z'
-              environment_id: 'env_1234567890'
+              spec_version: "1"
+              id: "evt_2345678901"
+              type: "permission.updated"
+              object: "Permission"
+              occurred_at: "2024-01-15T10:35:00.123456789Z"
+              environment_id: "env_1234567890"
               data:
-                description: 'Updated permission to manage all data'
-                id: 'perm_1234567890'
-                name: 'data:manage'
-              display_name: 'Permission Updated'
+                description: "Updated permission to manage all data"
+                id: "perm_1234567890"
+                name: "data:manage"
+              display_name: "Permission Updated"
       responses:
         '200':
           description: Webhook received successfully
@@ -12472,17 +12859,17 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_3456789012'
-              type: 'permission.deleted'
-              object: 'Permission'
-              occurred_at: '2024-01-15T10:40:00.123456789Z'
-              environment_id: 'env_1234567890'
+              spec_version: "1"
+              id: "evt_3456789012"
+              type: "permission.deleted"
+              object: "Permission"
+              occurred_at: "2024-01-15T10:40:00.123456789Z"
+              environment_id: "env_1234567890"
               data:
-                description: 'Updated permission to manage all data'
-                id: 'perm_1234567890'
-                name: 'data:manage'
-              display_name: 'Permission Deleted'
+                description: "Updated permission to manage all data"
+                id: "perm_1234567890"
+                name: "data:manage"
+              display_name: "Permission Deleted"
       responses:
         '200':
           description: Webhook received successfully
@@ -12498,19 +12885,19 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_101531404017336586'
-              type: 'connected_account.created'
-              object: 'ConnectedAccount'
-              occurred_at: '2025-12-01T10:23:52.702980847Z'
-              environment_id: 'env_88640229614813449'
+              spec_version: "1"
+              id: "evt_101531404017336586"
+              type: "connected_account.created"
+              object: "ConnectedAccount"
+              occurred_at: "2025-12-01T10:23:52.702980847Z"
+              environment_id: "env_88640229614813449"
               data:
-                authorization_type: 'OAUTH'
-                connection_id: 'conn_100668583155073286'
-                id: 'ca_101531404000559370'
-                identifier: 'Bruce'
-                provider: 'CANVA'
-                status: 'PENDING_AUTH'
+                authorization_type: "OAUTH"
+                connection_id: "conn_100668583155073286"
+                id: "ca_101531404000559370"
+                identifier: "Bruce"
+                provider: "CANVA"
+                status: "PENDING_AUTH"
       responses:
         '200':
           description: Webhook received successfully
@@ -12525,20 +12912,20 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_101652975398683158'
-              type: 'connected_account.updated'
-              object: 'ConnectedAccount'
-              occurred_at: '2025-12-02T06:31:34.895815554Z'
-              environment_id: 'env_88640229614813449'
-              display_name: 'Connected account updated'
+              spec_version: "1"
+              id: "evt_101652975398683158"
+              type: "connected_account.updated"
+              object: "ConnectedAccount"
+              occurred_at: "2025-12-02T06:31:34.895815554Z"
+              environment_id: "env_88640229614813449"
+              display_name: "Connected account updated"
               data:
-                authorization_type: 'OAUTH'
-                connection_id: 'conn_100510054016352776'
-                id: 'ca_100510623602835982'
-                identifier: 'Pranesh'
-                provider: 'SUPABASE'
-                status: 'PENDING_AUTH'
+                authorization_type: "OAUTH"
+                connection_id: "conn_100510054016352776"
+                id: "ca_100510623602835982"
+                identifier: "Pranesh"
+                provider: "SUPABASE"
+                status: "PENDING_AUTH"
       responses:
         '200':
           description: Webhook received successfully
@@ -12553,22 +12940,22 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_101653010731500290'
-              type: 'connected_account.deleted'
-              object: 'ConnectedAccount'
-              occurred_at: '2025-12-02T06:31:55.954027187Z'
-              environment_id: 'env_88640229614813449'
-              display_name: 'connected account deleted'
+              spec_version: "1"
+              id: "evt_101653010731500290"
+              type: "connected_account.deleted"
+              object: "ConnectedAccount"
+              occurred_at: "2025-12-02T06:31:55.954027187Z"
+              environment_id: "env_88640229614813449"
+              display_name: "connected account deleted"
               data:
-                authorization_type: 'OAUTH'
-                connection_id: 'conn_101644109747323155'
-                id: 'ca_101649788113519113'
-                identifier: 'Clark'
-                last_used_at: '2025-12-02T06:00:01.374253Z'
-                provider: 'GOOGLE_ADS'
-                status: 'ACTIVE'
-                token_expires_at: '2025-12-02T06:59:57.237447Z'
+                authorization_type: "OAUTH"
+                connection_id: "conn_101644109747323155"
+                id: "ca_101649788113519113"
+                identifier: "Clark"
+                last_used_at: "2025-12-02T06:00:01.374253Z"
+                provider: "GOOGLE_ADS"
+                status: "ACTIVE"
+                token_expires_at: "2025-12-02T06:59:57.237447Z"
       responses:
         '200':
           description: Webhook received successfully
@@ -12583,19 +12970,19 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_101652975398683158'
-              type: 'connected_account.magic_link_generated'
-              object: 'ConnectedAccount'
-              occurred_at: '2025-12-02T06:31:34.895815554Z'
-              environment_id: 'env_88640229614813448'
+              spec_version: "1"
+              id: "evt_101652975398683158"
+              type: "connected_account.magic_link_generated"
+              object: "ConnectedAccount"
+              occurred_at: "2025-12-02T06:31:34.895815554Z"
+              environment_id: "env_88640229614813448"
               data:
-                authorization_type: 'OAUTH'
-                connection_id: 'conn_100510054016352776'
-                id: 'ca_100510623602835982'
-                identifier: 'Pranesh'
-                provider: 'SUPABASE'
-                status: 'PENDING_AUTH'
+                authorization_type: "OAUTH"
+                connection_id: "conn_100510054016352776"
+                id: "ca_100510623602835982"
+                identifier: "Pranesh"
+                provider: "SUPABASE"
+                status: "PENDING_AUTH"
       responses:
         '200':
           description: Webhook received successfully
@@ -12610,20 +12997,20 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_101649795042509316'
-              type: 'connected_account.oauth_tokens_fetched'
-              object: 'ConnectedAccount'
-              occurred_at: '2025-12-02T05:59:59.250126407Z'
-              environment_id: 'env_88640229614813449'
+              spec_version: "1"
+              id: "evt_101649795042509316"
+              type: "connected_account.oauth_tokens_fetched"
+              object: "ConnectedAccount"
+              occurred_at: "2025-12-02T05:59:59.250126407Z"
+              environment_id: "env_88640229614813449"
               data:
-                authorization_type: 'OAUTH'
-                connection_id: 'conn_101644109747323155'
-                id: 'ca_101649788113519113'
-                identifier: 'Clark'
-                provider: 'GOOGLE_ADS'
-                status: 'ACTIVE'
-                token_expires_at: '2025-12-02T06:59:57.237447778Z'
+                authorization_type: "OAUTH"
+                connection_id: "conn_101644109747323155"
+                id: "ca_101649788113519113"
+                identifier: "Clark"
+                provider: "GOOGLE_ADS"
+                status: "ACTIVE"
+                token_expires_at: "2025-12-02T06:59:57.237447778Z"
       responses:
         '200':
           description: Webhook received successfully
@@ -12638,21 +13025,21 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_101651946317808143'
-              type: 'connected_account.token_refresh_succeeded'
-              object: 'ConnectedAccount'
-              occurred_at: '2025-12-02T06:21:21.517480021Z'
-              environment_id: 'env_88640229614813449'
+              spec_version: "1"
+              id: "evt_101651946317808143"
+              type: "connected_account.token_refresh_succeeded"
+              object: "ConnectedAccount"
+              occurred_at: "2025-12-02T06:21:21.517480021Z"
+              environment_id: "env_88640229614813449"
               data:
-                authorization_type: 'OAUTH'
-                connection_id: 'conn_101644109747323155'
-                id: 'ca_101644170698948883'
-                identifier: 'Pranesh'
-                last_used_at: '2025-12-02T06:21:21.393723232Z'
-                provider: 'GOOGLE_ADS'
-                status: 'ACTIVE'
-                token_expires_at: '2025-12-02T07:21:20.508197312Z'
+                authorization_type: "OAUTH"
+                connection_id: "conn_101644109747323155"
+                id: "ca_101644170698948883"
+                identifier: "Pranesh"
+                last_used_at: "2025-12-02T06:21:21.393723232Z"
+                provider: "GOOGLE_ADS"
+                status: "ACTIVE"
+                token_expires_at: "2025-12-02T07:21:20.508197312Z"
       responses:
         '200':
           description: Webhook received successfully
@@ -12667,20 +13054,20 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_101649795042509316'
-              type: 'connected_account.token_refresh_failed'
-              object: 'ConnectedAccount'
-              occurred_at: '2025-12-02T05:59:59.250126407Z'
-              environment_id: 'env_88640229614813445'
+              spec_version: "1"
+              id: "evt_101649795042509316"
+              type: "connected_account.token_refresh_failed"
+              object: "ConnectedAccount"
+              occurred_at: "2025-12-02T05:59:59.250126407Z"
+              environment_id: "env_88640229614813445"
               data:
-                authorization_type: 'OAUTH'
-                connection_id: 'conn_101644109747323155'
-                id: 'ca_101649788113519113'
-                identifier: 'Clark'
-                provider: 'GOOGLE_ADS'
-                status: 'ACTIVE'
-                token_expires_at: '2025-12-02T06:59:57.237447778Z'
+                authorization_type: "OAUTH"
+                connection_id: "conn_101644109747323155"
+                id: "ca_101649788113519113"
+                identifier: "Clark"
+                provider: "GOOGLE_ADS"
+                status: "ACTIVE"
+                token_expires_at: "2025-12-02T06:59:57.237447778Z"
       responses:
         '200':
           description: Webhook received successfully
@@ -12695,20 +13082,20 @@ webhooks:
             schema:
               $ref: '#/components/schemas/ScalekitEvent'
             example:
-              spec_version: '1'
-              id: 'evt_101649484227871236'
-              type: 'connected_account.oauth_succeeded'
-              object: 'ConnectedAccount'
-              occurred_at: '2025-12-02T05:56:53.994604757Z'
-              environment_id: 'env_88640229614813449'
+              spec_version: "1"
+              id: "evt_101649484227871236"
+              type: "connected_account.oauth_succeeded"
+              object: "ConnectedAccount"
+              occurred_at: "2025-12-02T05:56:53.994604757Z"
+              environment_id: "env_88640229614813449"
               data:
-                authorization_type: 'OAUTH'
-                connection_id: 'conn_101644109747323155'
-                id: 'ca_101649474950005257'
-                identifier: 'Bruce'
-                provider: 'GOOGLE_ADS'
-                status: 'ACTIVE'
-                token_expires_at: '2025-12-02T06:56:52.976081699Z'
+                authorization_type: "OAUTH"
+                connection_id: "conn_101644109747323155"
+                id: "ca_101649474950005257"
+                identifier: "Bruce"
+                provider: "GOOGLE_ADS"
+                status: "ACTIVE"
+                token_expires_at: "2025-12-02T06:56:52.976081699Z"
       responses:
         '200':
           description: Webhook received successfully


### PR DESCRIPTION
## Summary

Syncs the OpenAPI spec from `scalekit` repo after applying PREVIEW visibility tags based on product team review ([SK-398](https://linear.app/scalekit/issue/SK-398)).

### New public endpoints
- `GET /api/v1/connected_accounts/details` (confirmed by Akshay)
- `GET/PATCH /api/v1/organizations/{organization_id}/session-policy` (confirmed by Srinivas)

### Endpoints hidden via PREVIEW
- `GET /api/v1/connected_accounts/this` and `/{id}`
- `POST /api/v1/connected_accounts/{id}:disconnect` and `/-:disconnect`
- `DELETE /api/v1/roles/{role_name}/base`
- `DELETE /api/v1/organizations/{org_id}/roles/{role_name}/base`

### Proto changes
Upstream PR: https://github.com/scalekit-inc/scalekit/pull/2157

Closes #548, Closes #549