### PR TITLE
Add redirect from /dev-kit/ to /dev-kit/build-with-ai/

### DIFF
--- a/src/configs/redirects.config.ts
+++ b/src/configs/redirects.config.ts
@@ -334,6 +334,7 @@ export const redirects = {
   // =============================================================================
   // DEV KIT REDIRECTS
   // =============================================================================
+  '/dev-kit': '/dev-kit/build-with-ai/',
   '/dev-kit/mcp/': '/dev-kit/ai-assisted-development/scalekit-mcp-server/',
   '/dev-kit/guides/testing/sso-simulator': '/dev-kit/tools/sso-simulator/',
   '/dev-kit/nodejs': '/dev-kit/sdks/',


### PR DESCRIPTION
Redirects `/dev-kit/` to `/dev-kit/build-with-ai/` so visitors landing on the bare dev-kit path reach the build-with-ai section directly.

With `trailingSlash: 'ignore'`, the single entry handles both `/dev-kit` and `/dev-kit/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic redirect from `/dev-kit` to the AI build section for improved navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalekit-inc/developer-docs/pull/711?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->