### PR TITLE
Add AkshayParihar33 as code owner for MDX files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,10 +10,10 @@
 * @saif-at-scalekit
 
 # Most MDX: exclude @saif-at-scalekit from review requests
-*.mdx @saif-at-scalekit @amitash1912 @ravibits
+*.mdx @saif-at-scalekit @amitash1912 @ravibits @AkshayParihar33
 
 # Exception: agentkit connector docs — include @saif-at-scalekit again
-/src/content/docs/agentkit/connectors/**/*.mdx @saif-at-scalekit @amitash1912 @ravibits
+/src/content/docs/agentkit/connectors/**/*.mdx @saif-at-scalekit @amitash1912 @ravibits @AkshayParihar33
 
 # Folder specific owners (last so this path takes precedence)
 /src/content/docs/guides/integrations/ @amitash1912 @saravanan2003-hub

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,16 +3,15 @@
 # Owners will be automatically requested for review when someone opens a pull request.
 #
 # Order matters: the last matching pattern wins. * is @saif-at-scalekit; *.mdx
-# narrows to amit and ravi (excludes saif for most MDX); connector MDX restores saif;
-# integrations/ lists dedicated owners last for that tree.
+# adds amit, ravi, and akshay; integrations/ lists dedicated owners last for that tree.
 
 # Default owners for everything in the repo
 * @saif-at-scalekit
 
-# Most MDX: exclude @saif-at-scalekit from review requests
+# MDX files: all docs reviewers
 *.mdx @saif-at-scalekit @amitash1912 @ravibits @AkshayParihar33
 
-# Exception: agentkit connector docs — include @saif-at-scalekit again
+# Agentkit connector docs: same reviewers (explicit for precedence)
 /src/content/docs/agentkit/connectors/**/*.mdx @saif-at-scalekit @amitash1912 @ravibits @AkshayParihar33
 
 # Folder specific owners (last so this path takes precedence)


### PR DESCRIPTION
Adds `@AkshayParihar33` as a code owner alongside `@amitash1912` and `@ravibits` on both MDX ownership rules:

- `*.mdx` (general MDX files)
- `/src/content/docs/agentkit/connectors/**/*.mdx` (agentkit connector docs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated code ownership rules for documentation files: restored general ownership for MDX docs and aligned ownership for the connectors/docs path so both patterns share the same maintainers. Adjusted ownership entries to better reflect current doc maintainers and clarify responsibility for documentation updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalekit-inc/developer-docs/pull/720?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->