### PR TITLE
docs(agentkit): add meeting prep agent example to examples index

### DIFF
--- a/src/content/docs/agentkit/examples/index.mdx
+++ b/src/content/docs/agentkit/examples/index.mdx
@@ -96,6 +96,18 @@ These integrations give you full control. Fetch Scalekit tool schemas, wire them
 </FoldCard>
 
 <FoldCard
+  title="Meeting prep agent"
+  iconKey="python"
+  href="https://github.com/scalekit-inc/meeting-prep-agent-example"
+  variant="secondary"
+  target="_blank"
+  showCta={false}
+  clickable={true}
+>
+  <p>Pulls context from Google Cal, Gmail, HubSpot, and Slack before each external meeting. Delivers a structured brief in under 60 seconds using delegated user identity.</p>
+</FoldCard>
+
+<FoldCard
   title="Browse all agent auth examples"
   iconKey="github"
   href="https://github.com/scalekit-developers/agent-auth-examples"


### PR DESCRIPTION
## Summary

Added a FoldCard for the meeting-prep-agent-example repo to the agentkit examples index page. This example demonstrates building agents that access multiple tools (Google Calendar, Gmail, HubSpot, and Slack) using Scalekit for authentication and delegated user identity.

## Preview

https://deploy-preview-{PR_NUMBER}--scalekit-starlight.netlify.app/agentkit/examples/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new example showcasing a meeting prep agent that integrates with Google Calendar, Gmail, HubSpot, and Slack to generate meeting briefs in under 60 seconds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalekit-inc/developer-docs/pull/724?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->