### PR TITLE
docs(multiapp): add Configure custom scopes step to manage-apps guide

### DIFF
--- a/src/content/docs/authenticate/fsa/multiapp/manage-apps.mdx
+++ b/src/content/docs/authenticate/fsa/multiapp/manage-apps.mdx
@@ -129,8 +129,6 @@ Register and manage applications in Scalekit. Each application gets its own OAut
    2. Under **Define Scopes**, select an existing scope or type a new one and add it
    3. Click **Save**
 
-   ![Define Scopes section in Advanced Settings showing custom scope checkboxes](@/assets/docs/guides/multi-app/app-advanced-settings-scopes.png)
-
    When initiating the authorization request, pass the custom scope in the `scope` parameter alongside the standard scopes:
 
    ```

--- a/src/content/docs/authenticate/fsa/multiapp/manage-apps.mdx
+++ b/src/content/docs/authenticate/fsa/multiapp/manage-apps.mdx
@@ -120,7 +120,26 @@ Register and manage applications in Scalekit. Each application gets its own OAut
 
    For definitions, validation rules, custom URI schemes, and environment-specific behavior, see [Redirect URL configuration](/guides/dashboard/redirects/).
 
-5. ## Delete an application
+5. ## Configure custom scopes
+
+   Scalekit includes `openid`, `email`, `profile`, and `offline_access` as default scopes. If your application needs additional scopes — such as `todo:read` or `data:read` — in the access token during an OAuth authorization flow, define them in the application's **Advanced Settings**.
+
+   To configure a custom scope:
+   1. Open the application and go to the **Advanced Settings** tab
+   2. Under **Define Scopes**, select an existing scope or type a new one and add it
+   3. Click **Save**
+
+   ![Define Scopes section in Advanced Settings showing custom scope checkboxes](@/assets/docs/guides/multi-app/app-advanced-settings-scopes.png)
+
+   When initiating the authorization request, pass the custom scope in the `scope` parameter alongside the standard scopes:
+
+   ```
+   scope=openid profile email offline_access todo:read
+   ```
+
+   Scalekit includes the requested scopes in the access token, provided they are configured for the application.
+
+6. ## Delete an application
 
    Delete applications from the bottom of the configuration page.
 


### PR DESCRIPTION
## Summary

- Adds a new step 5 "Configure custom scopes" to the manage-apps guide (`/authenticate/fsa/multiapp/manage-apps/`)
- Explains that `openid`, `email`, `profile`, and `offline_access` are available by default, and how to add custom scopes (e.g. `todo:read`, `data:read`) via **Advanced Settings > Define Scopes**
- Documents that custom scopes must be passed in the `scope` parameter of the authorization request alongside the standard scopes
- Renumbers the former step 5 (Delete an application) to step 6

> **Note:** The screenshot (`src/assets/docs/guides/multi-app/app-advanced-settings-scopes.png`) referenced in step 5 needs to be added manually — the image was shared as an inline chat attachment and couldn't be written to disk automatically.

## Preview

https://deploy-preview-726--scalekit-starlight.netlify.app/authenticate/fsa/multiapp/manage-apps/

---
_Generated by [Claude Code](https://claude.ai/code/session_01AmQQGUySvg6Z7PXryMCaVp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new step "Configure custom scopes" to the application management docs, explaining default scopes, how to add custom scopes via Advanced Settings, how to include them in OAuth scope parameters, and that requested scopes are reflected in access tokens. Renumbered the "Delete an application" step accordingly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalekit-inc/developer-docs/pull/726?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->