### PR TITLE
feat(connectors): add hyperlink support in connector descriptions

### DIFF
--- a/scripts/sync-agent-connectors.js
+++ b/scripts/sync-agent-connectors.js
@@ -39,6 +39,22 @@ function loadCapabilityOverrides() {
 const CAPABILITY_OVERRIDES = loadCapabilityOverrides()
 
 // ---------------------------------------------------------------------------
+// Description HTML overrides — hand-curated anchor-enriched descriptions
+// ---------------------------------------------------------------------------
+
+function loadDescriptionHtmlOverrides() {
+  const overridesPath = path.join(__dirname, '../src/data/agent-connectors/description-html.json')
+  try {
+    const raw = fs.readFileSync(overridesPath, 'utf8')
+    return JSON.parse(raw)
+  } catch {
+    return {}
+  }
+}
+
+const DESCRIPTION_HTML_OVERRIDES = loadDescriptionHtmlOverrides()
+
+// ---------------------------------------------------------------------------
 // Env loader (using dotenv)
 // ---------------------------------------------------------------------------
 
@@ -1256,6 +1272,8 @@ function generateMdxContent(provider, tools) {
   }
   descClean = descClean.replace(/'/g, "''")
   lines.push(`description: '${descClean}'`)
+  const descriptionHtml = DESCRIPTION_HTML_OVERRIDES[providerSlug]
+  if (descriptionHtml) lines.push(`descriptionHtml: '${descriptionHtml.replace(/'/g, "''")}'`)
   lines.push('sidebar:')
   lines.push(`  label: '${providerName.replace(/'/g, "''")}'`)
   lines.push(`overviewTitle: 'Quickstart'`)

--- a/src/components/AgentConnectorsSection.astro
+++ b/src/components/AgentConnectorsSection.astro
@@ -32,7 +32,7 @@ const sorted = [...connectors].sort((a, b) =>
         <LinkCard
           title={entry.data.title}
           href={`/${entry.id}/`}
-          description={entry.data.description}
+          description={entry.data.descriptionHtml || entry.data.description}
         />
       </div>
     ))

--- a/src/components/overrides/PageTitle.astro
+++ b/src/components/overrides/PageTitle.astro
@@ -1,8 +1,14 @@
 ---
 import StarlightPageActionsPageTitle from 'starlight-page-actions/overrides/PageTitle.astro'
 import { AGENT_PLUGIN_HEADER } from '@/configs/agent-instructions'
-const { title, description, connectorIcon, connectorAuthType, connectorCategories } =
-  Astro.locals.starlightRoute.entry.data
+const {
+  title,
+  description,
+  descriptionHtml,
+  connectorIcon,
+  connectorAuthType,
+  connectorCategories,
+} = Astro.locals.starlightRoute.entry.data
 const isConnectorPage = Boolean(connectorIcon)
 ---
 
@@ -22,7 +28,11 @@ const isConnectorPage = Boolean(connectorIcon)
                 <span class="connector-chip cat-chip">{cat}</span>
               ))}
             </div>
-            {description && <p class="page-description">{description}</p>}
+            {descriptionHtml ? (
+              <p class="page-description" set:html={descriptionHtml} />
+            ) : (
+              description && <p class="page-description">{description}</p>
+            )}
           </div>
         </div>
         {/* display:contents lets the action buttons become direct flex children,
@@ -34,7 +44,11 @@ const isConnectorPage = Boolean(connectorIcon)
     ) : (
       <>
         <StarlightPageActionsPageTitle />
-        {description && <p class="page-description">{description}</p>}
+        {descriptionHtml ? (
+          <p class="page-description" set:html={descriptionHtml} />
+        ) : (
+          description && <p class="page-description">{description}</p>
+        )}
       </>
     )
   }
@@ -57,6 +71,11 @@ const isConnectorPage = Boolean(connectorIcon)
     color: var(--sl-color-gray-2);
     font-size: var(--sl-text-sm);
     line-height: 1.6;
+  }
+
+  .page-description :global(a) {
+    color: inherit !important;
+    text-decoration: underline;
   }
 
   .page-title-wrapper :global(.actions-container) {

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -21,6 +21,7 @@ export const collections = {
               connectorIcon: z.string().optional(),
               connectorAuthType: z.string().optional(),
               connectorCategories: z.array(z.string()).optional(),
+              descriptionHtml: z.string().optional(),
             }),
           )
           .merge(

--- a/src/content/docs/agentkit/connectors/apifymcp.mdx
+++ b/src/content/docs/agentkit/connectors/apifymcp.mdx
@@ -2,6 +2,7 @@
 title: 'Apify MCP connector'
 tableOfContents: true
 description: 'Connect to Apify MCP to run web scraping, browser automation, and data extraction Actors directly from your AI workflows.'
+descriptionHtml: 'Connect to <a href="https://mcp.apify.com">Apify MCP</a> to run web scraping, browser automation, and data extraction Actors directly from your AI workflows.'
 sidebar:
   label: 'Apify MCP'
 overviewTitle: 'Quickstart'

--- a/src/data/agent-connectors/description-html.json
+++ b/src/data/agent-connectors/description-html.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "Hand-curated HTML descriptions per connector. Key = provider slug. The sync script emits descriptionHtml in frontmatter when a slug is listed here. Use sparingly — only when a hyperlink adds meaningful context (e.g. linking to the provider's hosted MCP endpoint). Plain description in frontmatter stays unmodified for SEO/meta use.",
+  "apifymcp": "Connect to <a href=\"https://mcp.apify.com\">Apify MCP</a> to run web scraping, browser automation, and data extraction Actors directly from your AI workflows."
+}


### PR DESCRIPTION
## Summary
- Adds `descriptionHtml` frontmatter field and schema entry for connectors that need a hyperlink in their description
- Connector page header (`PageTitle.astro`) and index card (`AgentConnectorsSection.astro`) render `descriptionHtml` via `set:html` when present, falling back to plain `description`
- Link styling inherits text color with underline so it feels native (not blue accent)
- `src/data/agent-connectors/description-html.json` stores overrides — survives connector re-sync (same pattern as `capabilities.json`)
- `sync-agent-connectors.js` emits `descriptionHtml` in generated frontmatter when a slug entry exists in that JSON
- First use: Apify MCP connector links to https://mcp.apify.com

## Test plan
- [ ] Apify MCP connector page shows "Apify MCP" as underlined link in description
- [ ] Connector index card shows same linked text
- [ ] Link color matches surrounding text (not blue accent)
- [ ] Plain `description` unchanged (SEO/meta unaffected)
- [ ] `pnpm build` passes

Preview: https://deploy-preview-{PR_NUMBER}--scalekit-starlight.netlify.app/agentkit/connectors/apifymcp/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Connector descriptions now support rich HTML formatting, including hyperlinks and styling.
  * Enhanced the Apify MCP connector description with a linked reference to the MCP documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalekit-inc/developer-docs/pull/727?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->