### PR TITLE
Rename "Run end-to-end tests" page to "Test users"

### DIFF
--- a/src/content/docs/authenticate/run-e2e-tests.mdx
+++ b/src/content/docs/authenticate/run-e2e-tests.mdx
@@ -1,9 +1,9 @@
 ---
-title: Run end-to-end tests
+title: Test users
 description: Set up test users to run automated E2E tests for login and signup flows
 tags: [testing, e2e, playwright, cypress, otp, go-live, automation]
 sidebar:
-  label: Run end-to-end tests
+  label: Test users
 tableOfContents: true
 prev:
   label: Production readiness checklist


### PR DESCRIPTION
## Summary

Updated the page title and sidebar label for the E2E testing documentation to better reflect the actual content focus: setting up test users for automated testing rather than the mechanics of running tests themselves.

## Changes

- Updated page `title` from "Run end-to-end tests" to "Test users"
- Updated sidebar `label` from "Run end-to-end tests" to "Test users"
- Description and tags remain unchanged to preserve SEO and categorization

## Rationale

The new title more accurately describes the page's primary purpose: helping developers create and configure test users for E2E testing workflows. This improves discoverability and sets clearer expectations for readers navigating the authentication documentation.

https://claude.ai/code/session_01KBJN9PJJMRoaJGc21wRtH9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the authentication documentation page title from "Run end-to-end tests" to "Test users."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->