### PR TITLE
fix: prevent SaaSKit landing page from appearing in Algolia search for feature names

### DIFF
--- a/src/content/docs/home/saaskit/index.mdx
+++ b/src/content/docs/home/saaskit/index.mdx
@@ -11,6 +11,10 @@ banner:
 hero:
   tagline: Add SSO, SCIM, or MCP Auth as modular capabilities, or adopt Scalekit as your full identity layer for your SaaS app
 head:
+  - tag: meta
+    attrs:
+      name: robots
+      content: noindex
   - tag: style
     content: |
       right-sidebar-panel {
@@ -260,7 +264,7 @@ import complianceImage from '@/content/docs/compliance.svg'
   </div>
 </div>
 
-<div class="fold-section fold--background-muted fold-full-width">
+<div class="fold-section fold--background-muted fold-full-width" data-docsearch-ignore>
   <div class="fold-container">
     <div class="modular-auth-layout">
       <div class="modular-auth-left">
@@ -302,7 +306,7 @@ import complianceImage from '@/content/docs/compliance.svg'
   </div>
 </div>
 
-<div class="fold-section fold-full-width" style="padding-top: 0;">
+<div class="fold-section fold-full-width" style="padding-top: 0;" data-docsearch-ignore>
   <div class="fold-container">
     <ResponsiveCardGrid columnsDesktop={3} columnsLarge={3}>
       <FoldCard title="User lifecycle" iconKey="usercheck" href="/fsa/data-modelling" clickable={true}>
@@ -327,7 +331,7 @@ import complianceImage from '@/content/docs/compliance.svg'
   </div>
 </div>
 
-<div class="fold-section fold--background-muted fold-full-width">
+<div class="fold-section fold--background-muted fold-full-width" data-docsearch-ignore>
   <div class="fold-container">
     <div>
       <h2 style="font-size: 1.8rem; margin: 0.5rem 0; text-align: left;">Extensibility & Controls</h2>
@@ -353,7 +357,7 @@ import complianceImage from '@/content/docs/compliance.svg'
   </div>
 </div>
 
-<div class="fold-section fold-full-width">
+<div class="fold-section fold-full-width" data-docsearch-ignore>
   <div class="fold-container">
     <div>
       <h2 style="font-size: 1.8rem; margin: 0.5rem 0; text-align: left;">Developer Resources</h2>


### PR DESCRIPTION
Problem: Algolia was returning https://docs.scalekit.com/home/saaskit/#_top when searching for feature terms like "Auth logs". This occurred because navigation card titles and content on the SaaSKit hub page were being indexed by the crawler.

Changes:
- Wrapped the navigation card grids in `data-docsearch-ignore` to exclude them from Algolia indexing.
- Added a `robots: noindex` meta tag to the page.

Preview: https://deploy-preview-{PR_NUMBER}--scalekit-starlight.netlify.app/home/saaskit/

After the preview deploys, the Algolia crawler will need to reindex (or manually trigger a re-crawl in the Algolia dashboard) before the change takes effect in search results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation page metadata to prevent search engine indexing.
  * Configured documentation search to exclude specific sections from search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->