### PR TITLE
docs: clarify PRE_SESSION_CREATION session paths and add invitation FAQ

### DIFF
--- a/src/configs/sidebar.config.ts
+++ b/src/configs/sidebar.config.ts
@@ -117,7 +117,7 @@ export const sidebar = [
         link: 'guides/integrations',
       },
       {
-        label: 'Go Live',
+        label: 'Go live',
         items: [
           'authenticate/launch-checklist',
           'authenticate/run-e2e-tests',

--- a/src/content/docs/authenticate/interceptors/auth-flow-interceptors.mdx
+++ b/src/content/docs/authenticate/interceptors/auth-flow-interceptors.mdx
@@ -48,7 +48,7 @@ Scalekit -> User: Proceed or block sign-up
 
 ```
 
-## Implementing interceptors
+## Implement interceptors
 
 You can define interceptors at several trigger points during authentication flows.
 
@@ -847,6 +847,15 @@ After the interceptor returns custom claims, Scalekit includes them in the acces
 <Aside type='note' title='Token size considerations'>
   Keep custom claims minimal to avoid exceeding JWT size limits. Store large datasets in your database and use claims only for frequently-accessed metadata that needs to be available in the token.
 </Aside>
+
+## Common scenarios
+
+<details>
+<summary>Does `PRE_SESSION_CREATION` fire on an invitee’s first login?</summary>
+
+Yes. It fires the same as any other path that creates a session token. Custom claims your interceptor returns are embedded in the issued access token. No additional configuration is required.
+
+</details>
 
 ### Provision a user into an existing organization
 Use the **Pre-signup** interceptor to provision a user into an existing organization instead of creating a new one during signup. This is useful when you want users from specific email domains to always join a pre-defined organization, avoiding duplicate organization creation. 

--- a/src/content/docs/authenticate/interceptors/auth-flow-interceptors.mdx
+++ b/src/content/docs/authenticate/interceptors/auth-flow-interceptors.mdx
@@ -729,7 +729,9 @@ async def pre_signup(request: Request):
 
 ### Modify claims in session tokens
 
-Add custom claims to Access tokens issued by Scalekit. Fetch user metadata from your database and return claims in the `response.claims` object. Claims are automatically included in the access token after authentication.
+Add custom claims to access tokens issued by Scalekit. Your `PRE_SESSION_CREATION` interceptor fires on every path that creates a new session token: standard login (password, SSO, social), magic link and email OTP, invitation magic link (including an invitee's first login), and organization switch. Fetch user metadata from your database and return claims in the `response.claims` object. Scalekit embeds them in the access token under the `custom_claims` key.
+
+If you need custom scope strings validated directly by your resource server (for example, Spring Security's `@PreAuthorize`), use [native custom scopes](/authenticate/fsa/multiapp/single-page-app/) instead — `custom_claims` do not appear in the `scope` claim.
 
 <Tabs syncKey="tech-stack">
 <TabItem value="node" label="Node.js">

--- a/src/content/docs/authenticate/interceptors/auth-flow-interceptors.mdx
+++ b/src/content/docs/authenticate/interceptors/auth-flow-interceptors.mdx
@@ -729,7 +729,7 @@ async def pre_signup(request: Request):
 
 ### Modify claims in session tokens
 
-Add custom claims to access tokens issued by Scalekit. Your `PRE_SESSION_CREATION` interceptor fires on every path that creates a new session token: standard login (password, SSO, social), magic link and email OTP, invitation magic link (including an invitee's first login), and organization switch. Fetch user metadata from your database and return claims in the `response.claims` object. Scalekit embeds them in the access token under the `custom_claims` key.
+To include additional custom claims in the access token, use the `PRE_SESSION_CREATION` interceptor. This interceptor makes an API call to your configured endpoint with user and organization data from Scalekit. You can respond with the format below, and the claims are included in the access token under the `custom_claims` key. This interceptor fires on every path that creates a new session token: standard login (password, SSO, social), magic link and email OTP, invitation magic link (including an invitee's first login), and organization switch.
 
 If you need custom scope strings validated directly by your resource server (for example, Spring Security's `@PreAuthorize`), use [native custom scopes and permissions](/authenticate/authz/implement-access-control/) instead — `custom_claims` do not appear in the `scope` claim.
 

--- a/src/content/docs/authenticate/interceptors/auth-flow-interceptors.mdx
+++ b/src/content/docs/authenticate/interceptors/auth-flow-interceptors.mdx
@@ -731,7 +731,7 @@ async def pre_signup(request: Request):
 
 Add custom claims to access tokens issued by Scalekit. Your `PRE_SESSION_CREATION` interceptor fires on every path that creates a new session token: standard login (password, SSO, social), magic link and email OTP, invitation magic link (including an invitee's first login), and organization switch. Fetch user metadata from your database and return claims in the `response.claims` object. Scalekit embeds them in the access token under the `custom_claims` key.
 
-If you need custom scope strings validated directly by your resource server (for example, Spring Security's `@PreAuthorize`), use [native custom scopes](/authenticate/fsa/multiapp/single-page-app/) instead — `custom_claims` do not appear in the `scope` claim.
+If you need custom scope strings validated directly by your resource server (for example, Spring Security's `@PreAuthorize`), use [native custom scopes and permissions](/authenticate/authz/implement-access-control/) instead — `custom_claims` do not appear in the `scope` claim.
 
 <Tabs syncKey="tech-stack">
 <TabItem value="node" label="Node.js">

--- a/src/content/docs/authenticate/interceptors/auth-flow-interceptors.mdx
+++ b/src/content/docs/authenticate/interceptors/auth-flow-interceptors.mdx
@@ -729,7 +729,7 @@ async def pre_signup(request: Request):
 
 ### Modify claims in session tokens
 
-To include additional custom claims in the access token, use the `PRE_SESSION_CREATION` interceptor. This interceptor makes an API call to your configured endpoint with user and organization data from Scalekit. You can respond with the format below, and the claims are included in the access token under the `custom_claims` key. This interceptor fires on every path that creates a new session token: standard login (password, SSO, social), magic link and email OTP, invitation magic link (including an invitee's first login), and organization switch.
+To include additional custom claims in the access token, use the `PRE_SESSION_CREATION` interceptor. This interceptor makes an API call to your configured endpoint with user and organization data from Scalekit. You can respond with the format below, and the claims are included in the access token under the `custom_claims` key. This interceptor fires on every path that creates a new session token: standard login and organization switch.
 
 If you need custom scope strings validated directly by your resource server (for example, Spring Security's `@PreAuthorize`), use [native custom scopes and permissions](/authenticate/authz/implement-access-control/) instead — `custom_claims` do not appear in the `scope` claim.
 

--- a/src/content/docs/authenticate/manage-organizations/add-users-to-organization.mdx
+++ b/src/content/docs/authenticate/manage-organizations/add-users-to-organization.mdx
@@ -272,3 +272,14 @@ The user will receive an email with a link to accept the invitation and join you
 Users belonging to multiple organizations will see an organization selection interface in subsequent login flows, allowing them to choose their desired organization.
 
 </Aside>
+
+## Common questions
+
+<details>
+<summary>Does PRE_SESSION_CREATION fire on an invitee's first login?</summary>
+
+Yes. When an invitee clicks their magic link and completes signup, `PRE_SESSION_CREATION` fires the same as any other login path. Custom claims your interceptor returns are embedded in the issued JWT. No additional configuration is required.
+
+See [Intercept auth flows](/authenticate/interceptors/auth-flow-interceptors/#modify-claims-in-session-tokens).
+
+</details>

--- a/src/content/docs/authenticate/set-up-scalekit.mdx
+++ b/src/content/docs/authenticate/set-up-scalekit.mdx
@@ -13,7 +13,7 @@ head:
         font-size: var(--sl-text-lg);
       }
 sidebar:
-  label: 'Set up environment & SDK'
+  label: 'Set up'
 prev: false
 
 ---
@@ -22,7 +22,7 @@ import { LinkButton, Aside, Steps, Tabs, TabItem, Badge } from '@astrojs/starlig
 import { VideoPlayer } from 'starlight-videos/components'
 import InstallSDK from '@components/templates/_installsdk.mdx'
 
-This guide shows you how to set up Scalekit in your development environment. You'll configure your workspace, get API credentials, install the SDK, verify everything works correctly, and optionally set up AI-powered development tools.
+Create a Scalekit account, install the SDK, configure your credentials, and verify the setup. This prepares your environment for adding authentication to your application.
 
 Before you begin, create a Scalekit account if you haven't already. After creating your account, a Scalekit workspace is automatically set up for you with dedicated development and production environments.
 

--- a/src/content/docs/cookbooks/implement-nextjs-auth.mdx
+++ b/src/content/docs/cookbooks/implement-nextjs-auth.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Implementing Passwordless Auth in Next.js 15'
+title: 'Implement passwordless auth in Next.js 15'
 description: 'Add magic link and OTP authentication to your Next.js application using Scalekit''s headless API.'
 date: 2025-02-19
 tags: ['Full stack auth', 'Next.js']

--- a/src/content/docs/dev-kit/build-with-ai/full-stack-auth.mdx
+++ b/src/content/docs/dev-kit/build-with-ai/full-stack-auth.mdx
@@ -39,7 +39,7 @@ import {
   SkillsCLICodingAgentSection
 } from '@/components/templates'
 
-Use AI coding agents like Claude Code, GitHub Copilot CLI, Cursor, and OpenCode to implement Scalekit's full-stack authentication end-to-end in your web applications. This guide shows you how to configure these agents so they analyze your codebase, apply consistent authentication patterns, and generate production-ready code for login, session management, and logout that follows security best practices while reducing implementation time from hours to minutes.
+Use AI coding agents like Claude Code, GitHub Copilot CLI, Cursor, and OpenCode to implement Scalekit's full-stack authentication end-to-end in your web applications. Configure the agents to analyze your codebase, apply consistent authentication patterns, and generate production-ready code for login, session management, and logout. This approach follows security best practices while reducing implementation time from hours to minutes.
 
 <Tabs syncKey="coding-agent">
   <TabItem label="Claude Code" icon="claude">

--- a/src/content/docs/dev-kit/build-with-ai/mcp-auth.mdx
+++ b/src/content/docs/dev-kit/build-with-ai/mcp-auth.mdx
@@ -39,7 +39,7 @@ import {
   SkillsCLICodingAgentSection
 } from '@/components/templates'
 
-Use AI coding agents like Claude Code, GitHub Copilot CLI, Cursor, and OpenCode to add Scalekit's OAuth 2.1 authentication to your MCP servers. This guide shows you how to configure these agents so they analyze your codebase, apply consistent authentication patterns, and generate production-ready code that integrates OAuth 2.1 end-to-end, reduces implementation time from hours to minutes, and follows security best practices.
+Use AI coding agents like Claude Code, GitHub Copilot CLI, Cursor, and OpenCode to add Scalekit's OAuth 2.1 authentication to your MCP servers. Configure the agents to analyze your codebase, apply consistent authentication patterns, and generate production-ready code that integrates OAuth 2.1 end-to-end. This reduces implementation time from hours to minutes and follows security best practices.
 
 **Prerequisites**
 

--- a/src/content/docs/dev-kit/build-with-ai/scim.mdx
+++ b/src/content/docs/dev-kit/build-with-ai/scim.mdx
@@ -36,7 +36,7 @@ import {
   SkillsCLICodingAgentSection
 } from '@/components/templates'
 
-Use AI coding agents like Claude Code, GitHub Copilot CLI, Cursor, and OpenCode to add Scalekit's Modular SCIM directory sync to your applications. This guide shows you how to configure these agents so they analyze your codebase, apply SCIM patterns, and generate production-ready code for user provisioning, deprovisioning, and lifecycle management that follows security best practices and reduces implementation time from hours to minutes.
+Use AI coding agents like Claude Code, GitHub Copilot CLI, Cursor, and OpenCode to add Scalekit's Modular SCIM directory sync to your applications. Configure the agents to analyze your codebase, apply SCIM patterns, and generate production-ready code for user provisioning, deprovisioning, and lifecycle management. This follows security best practices and reduces implementation time from hours to minutes.
 
 <Tabs syncKey="coding-agent">
   <TabItem label="Claude Code" icon="claude">

--- a/src/content/docs/dev-kit/build-with-ai/sso.mdx
+++ b/src/content/docs/dev-kit/build-with-ai/sso.mdx
@@ -36,7 +36,7 @@ import {
   SkillsCLICodingAgentSection
 } from '@/components/templates'
 
-Use AI coding agents like Claude Code, GitHub Copilot CLI, Cursor, and OpenCode to add Scalekit's Modular SSO to your existing applications. This guide shows you how to configure these agents so they analyze your codebase, apply SSO patterns, and generate production-ready code that integrates enterprise identity providers and follows security best practices while reducing implementation time from hours to minutes.
+Use AI coding agents like Claude Code, GitHub Copilot CLI, Cursor, and OpenCode to add Scalekit's Modular SSO to your existing applications. Configure the agents to analyze your codebase, apply SSO patterns, and generate production-ready code that integrates enterprise identity providers. This follows security best practices while reducing implementation time from hours to minutes.
 
 <Tabs syncKey="coding-agent">
   <TabItem label="Claude Code" icon="claude">

--- a/src/content/docs/home/saaskit/index.mdx
+++ b/src/content/docs/home/saaskit/index.mdx
@@ -11,6 +11,10 @@ banner:
 hero:
   tagline: Add SSO, SCIM, or MCP Auth as modular capabilities, or adopt Scalekit as your full identity layer for your SaaS app
 head:
+  - tag: meta
+    attrs:
+      name: robots
+      content: noindex
   - tag: style
     content: |
       right-sidebar-panel {
@@ -260,7 +264,7 @@ import complianceImage from '@/content/docs/compliance.svg'
   </div>
 </div>
 
-<div class="fold-section fold--background-muted fold-full-width">
+<div class="fold-section fold--background-muted fold-full-width" data-docsearch-ignore>
   <div class="fold-container">
     <div class="modular-auth-layout">
       <div class="modular-auth-left">
@@ -302,7 +306,7 @@ import complianceImage from '@/content/docs/compliance.svg'
   </div>
 </div>
 
-<div class="fold-section fold-full-width" style="padding-top: 0;">
+<div class="fold-section fold-full-width" style="padding-top: 0;" data-docsearch-ignore>
   <div class="fold-container">
     <ResponsiveCardGrid columnsDesktop={3} columnsLarge={3}>
       <FoldCard title="User lifecycle" iconKey="usercheck" href="/fsa/data-modelling" clickable={true}>
@@ -327,7 +331,7 @@ import complianceImage from '@/content/docs/compliance.svg'
   </div>
 </div>
 
-<div class="fold-section fold--background-muted fold-full-width">
+<div class="fold-section fold--background-muted fold-full-width" data-docsearch-ignore>
   <div class="fold-container">
     <div>
       <h2 style="font-size: 1.8rem; margin: 0.5rem 0; text-align: left;">Extensibility & Controls</h2>
@@ -353,7 +357,7 @@ import complianceImage from '@/content/docs/compliance.svg'
   </div>
 </div>
 
-<div class="fold-section fold-full-width">
+<div class="fold-section fold-full-width" data-docsearch-ignore>
   <div class="fold-container">
     <div>
       <h2 style="font-size: 1.8rem; margin: 0.5rem 0; text-align: left;">Developer Resources</h2>

--- a/src/content/docs/passwordless/oidc.mdx
+++ b/src/content/docs/passwordless/oidc.mdx
@@ -46,7 +46,7 @@ import Tabs from '@components/ui/Tabs.astro';
 import IconTdesignSequence from '~icons/tdesign/sequence'
 
 
-This guide shows you how to implement passwordless authentication with Scalekit over OIDC protocol. Users verify with a email verification code (OTP) or a magic link or both.
+Implement passwordless authentication with Scalekit over the OIDC protocol. Users verify their identity with an email verification code (OTP) or a magic link.
 
 <details>
 <summary><IconTdesignSequence style="display: inline; width: 1rem; height: 1rem; vertical-align: middle; margin-right: 0.5rem;" /> Review the authentication sequence</summary>

--- a/src/content/docs/passwordless/quickstart.mdx
+++ b/src/content/docs/passwordless/quickstart.mdx
@@ -62,7 +62,7 @@ import IconLucidePlay from '~icons/lucide/play'
 import IconTdesignSequence from '~icons/tdesign/sequence'
 import InstallSDK from '@components/templates/_installsdk.mdx'
 
-This guide shows you how to implement magic link and OTP authentication using Scalekit's headless APIs. You send either a one-time passcode (OTP) or a magic link to the user's email and then verify their identity. Magic link and OTP offer two email-based authentication methods—clickable links or one-time passcodes—so users can sign in without passwords. You control the UI and user flows, while Scalekit provides the backend authentication infrastructure.
+Implement magic link and OTP authentication using Scalekit's headless APIs. Send either a one-time passcode (OTP) or a magic link to the user's email, then verify their identity. Magic link and OTP offer two email-based authentication methods—clickable links or one-time passcodes—so users can sign in without passwords. You control the UI and user flows, while Scalekit provides the backend authentication infrastructure.
 
 <details>
 <summary><IconLucidePlay style="display: inline; width: 1rem; height: 1rem; vertical-align: middle; margin-right: 0.5rem;" /> See the integration in action</summary>

--- a/src/content/docs/reference/interceptors/triggers.mdx
+++ b/src/content/docs/reference/interceptors/triggers.mdx
@@ -179,7 +179,7 @@ Fires before a user creates a new organization. Use this to validate email domai
 
 ## `PRE_SESSION_CREATION`
 
-Fires before session tokens are issued for a user. Use this to add custom claims to tokens, apply conditional access policies, or integrate with external authorization systems.
+Fires before session tokens are issued for a user. Use this to add custom claims to the access token, apply conditional access policies, or integrate with external authorization systems.
 
 ### Request body from Scalekit
 
@@ -233,7 +233,7 @@ Fires before session tokens are issued for a user. Use this to add custom claims
 {
   "decision": "ALLOW", // Required: ALLOW to issue tokens, DENY to block login
   "response": {
-    "claims": { // Optional: Custom claims added to both access and ID tokens
+    "claims": { // Optional: Custom claims added to the access token (under `custom_claims`)
       "subscription_tier": "enterprise",
       "data_region": "us-west-2",
       "feature_flags": ["analytics_dashboard", "api_access", "custom_branding"],
@@ -244,7 +244,7 @@ Fires before session tokens are issued for a user. Use this to add custom claims
 ```
 
 <Aside type='note' title='Modify token claims in the response'>
- The `claims` field lets you add custom information that will be included in both access tokens and ID tokens issued by Scalekit.
+ The `claims` field lets you add custom information that will be included in the access token issued by Scalekit (under the `custom_claims` key).
 </Aside>
 
 ## `PRE_USER_INVITATION`


### PR DESCRIPTION
## What changed

### auth-flow-interceptors.mdx
- Rewrote the "Modify claims in session tokens" intro to explicitly list all session paths covered by `PRE_SESSION_CREATION`: standard login, magic link/email OTP, invitation magic link (invitee first login), and org switch
- Added inline cross-reference to native custom scopes for scope-string use cases

### add-users-to-organization.mdx
- Added "Common questions" section with a `<details>` FAQ block answering: does `PRE_SESSION_CREATION` fire on an invitee's first login? (Yes, no extra config)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced clarity on session token interceptor documentation with guidance on custom claims handling across multiple login paths including standard login, magic links, and organization switching.
  * Added FAQ section addressing interceptor behavior during first login scenarios.
  * Updated search engine indexing configuration for documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->