### PR TITLE
Promote unified @scalekit-inc/cli for authstack setup across LLM wirings and docs

### DIFF
--- a/public/AGENTS.md
+++ b/public/AGENTS.md
@@ -2,43 +2,24 @@
 
 ## Building with AI coding agents?
 
-If you're using an AI coding agent, install the official Scalekit plugin.
-It gives your agent full awareness of the Scalekit API — reducing
-hallucinations and enabling faster, more accurate code generation.
+Install the authstack plugin for your coding agent with one command.
 
-### Claude Code
+**Recommended**:
 
 ```bash
-claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install <auth-type>@scalekit-auth-stack
+npx @scalekit-inc/cli setup
 ```
 
-### GitHub Copilot CLI
-
-```
-copilot plugin marketplace add scalekit-inc/github-copilot-authstack
-copilot plugin install <auth-type>@scalekit-auth-stack
-```
-
-### Codex
+For repeated use:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/scalekit-inc/codex-authstack/main/install.sh | bash
+npm install -g @scalekit-inc/cli
+scalekit setup
 ```
 
-Then restart Codex, open the Plugin Directory, select **Scalekit Auth Stack**, and install `<auth-type>`.
+This gives your agent full awareness of Scalekit authentication patterns (full-stack-auth, agent-auth, mcp-auth, modular-sso, modular-scim) and reduces hallucinations.
 
-### Skills CLI (Windsurf, Cline, and 40+ agents)
-
-```bash
-npx skills add scalekit-inc/skills --list
-npx skills add scalekit-inc/skills --skill <skill-name>
-```
-
----
-
-`<auth-type>` / `<skill-name>`: `agent-auth`, `full-stack-auth`, `mcp-auth`, `modular-sso`, `modular-scim`
-
-All commands are idempotent — safe to re-run.
+The CLI sets up plugins for Claude Code, Cursor, GitHub Copilot, Codex, and skills for 40+ other agents.
 
 Full guide: https://docs.scalekit.com/dev-kit/build-with-ai/
 

--- a/public/d2/docs/cookbooks/litellm-agentkit-inbox-triage-0.svg
+++ b/public/d2/docs/cookbooks/litellm-agentkit-inbox-triage-0.svg
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" data-d2-version="0.7.1" preserveAspectRatio="xMinYMin meet" viewBox="0 0 1625 225"><svg class="d2-3523082719 d2-svg" width="1625" height="225" viewBox="-29 -13 1625 225"><rect x="-29.000000" y="-13.000000" width="1625.000000" height="225.000000" rx="0.000000" class=" fill-N7" stroke-width="0" /><style type="text/css"><![CDATA[
+<?xml version="1.0" encoding="utf-8"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" data-d2-version="v0.7.1" preserveAspectRatio="xMinYMin meet" viewBox="0 0 1625 225"><svg class="d2-3523082719 d2-svg" width="1625" height="225" viewBox="-29 -13 1625 225"><rect x="-29.000000" y="-13.000000" width="1625.000000" height="225.000000" rx="0.000000" class=" fill-N7" stroke-width="0" /><style type="text/css"><![CDATA[
 .d2-3523082719 .text {
 	font-family: "d2-3523082719-font-regular";
 }

--- a/public/d2/docs/cookbooks/litellm-agentkit-inbox-triage-1.svg
+++ b/public/d2/docs/cookbooks/litellm-agentkit-inbox-triage-1.svg
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" data-d2-version="0.7.1" preserveAspectRatio="xMinYMin meet" viewBox="0 0 1380 282"><svg class="d2-2989760306 d2-svg" width="1380" height="282" viewBox="-29 -29 1380 282"><rect x="-29.000000" y="-29.000000" width="1380.000000" height="282.000000" rx="0.000000" class=" fill-N7" stroke-width="0" /><style type="text/css"><![CDATA[
+<?xml version="1.0" encoding="utf-8"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" data-d2-version="v0.7.1" preserveAspectRatio="xMinYMin meet" viewBox="0 0 1380 282"><svg class="d2-2989760306 d2-svg" width="1380" height="282" viewBox="-29 -29 1380 282"><rect x="-29.000000" y="-29.000000" width="1380.000000" height="282.000000" rx="0.000000" class=" fill-N7" stroke-width="0" /><style type="text/css"><![CDATA[
 .d2-2989760306 .text-bold {
 	font-family: "d2-2989760306-font-bold";
 }

--- a/public/d2/docs/directory/scim/quickstart-0.svg
+++ b/public/d2/docs/directory/scim/quickstart-0.svg
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" data-d2-version="0.7.1" preserveAspectRatio="xMinYMin meet" viewBox="0 0 1083 905"><svg class="d2-3460092668 d2-svg" width="1083" height="905" viewBox="-39 -44 1083 905"><rect x="-39.000000" y="-44.000000" width="1083.000000" height="905.000000" rx="0.000000" class=" fill-N7" stroke-width="0" /><style type="text/css"><![CDATA[
+<?xml version="1.0" encoding="utf-8"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" data-d2-version="v0.7.1" preserveAspectRatio="xMinYMin meet" viewBox="0 0 1083 905"><svg class="d2-3460092668 d2-svg" width="1083" height="905" viewBox="-39 -44 1083 905"><rect x="-39.000000" y="-44.000000" width="1083.000000" height="905.000000" rx="0.000000" class=" fill-N7" stroke-width="0" /><style type="text/css"><![CDATA[
 .d2-3460092668 .text {
 	font-family: "d2-3460092668-font-regular";
 }

--- a/scripts/generate-llms-index.js
+++ b/scripts/generate-llms-index.js
@@ -241,10 +241,36 @@ const classified = classifyPages(pages)
 const rootPage = pages.find((p) => p.urlPath === '/')
 
 // --- Build the llms.txt content ---
+// Include agent plugin install instructions (sourced from the same guidance as the wirings)
+const AGENT_PLUGIN_BLOCK = `
+## Building with AI coding agents?
+
+Install the authstack plugin for coding agents with one command. This is the recommended way to give your agent accurate Scalekit implementation guidance.
+
+**Recommended**:
+\`\`\`bash
+npx @scalekit-inc/cli setup
+\`\`\`
+
+For repeated use:
+\`\`\`bash
+npm install -g @scalekit-inc/cli
+scalekit setup
+\`\`\`
+
+The CLI installs the authstack plugin for Claude Code, Cursor, GitHub Copilot, Codex, and skills for 40+ other agents.
+
+Use natural language or the specific feature skills: full-stack-auth, agent-auth, mcp-auth, modular-sso, modular-scim.
+
+[Full setup guide](https://docs.scalekit.com/dev-kit/build-with-ai/)
+`
+
 const lines = [
   '# Scalekit',
   '',
   '> Scalekit is a developer platform for enterprise authentication, providing Full Stack Auth (FSA), Single Sign-On (SSO), SCIM provisioning, Agent Authentication, MCP Authentication, and API authentication solutions for B2B and AI applications.',
+  '',
+  AGENT_PLUGIN_BLOCK.trim(),
   '',
   '## How to use',
   '',

--- a/src/components/templates/coding-agents/_agentkit-claude-code.mdx
+++ b/src/components/templates/coding-agents/_agentkit-claude-code.mdx
@@ -1,33 +1,27 @@
 import { Steps, Aside } from '@astrojs/starlight/components'
 
 <Steps>
-1. ## Install the Scalekit Auth Stack
-
-   Not yet on Claude Code? Follow the [official quickstart guide](https://code.claude.com/docs/en/quickstart) to install it.
-
-   Register Scalekit's plugin marketplace and install the Agent Auth plugin in a single command:
+1. ## Install the authstack plugin
 
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install agent-auth@scalekit-auth-stack
+   npx @scalekit-inc/cli setup
    ```
 
-   The marketplace provides specialized authentication plugins that understand Agent Auth patterns and OAuth 2.0 security requirements. These plugins guide the coding agent to generate implementation code that matches your project structure.
+   For repeated use, install globally:
+
+   ```bash title="Terminal" frame="terminal" showLineNumbers=false
+   npm install -g @scalekit-inc/cli
+   scalekit setup
+   ```
+
+   The CLI installs the Agent Auth (and other) plugins for Claude Code.
 
    <details>
-   <summary>Alternative: Enable authentication plugins via plugin wizard</summary>
+   <summary>Tool-native alternative</summary>
 
-   Run the plugin wizard to browse and enable available plugins:
-
-   ```bash title="Claude REPL" showLineNumbers=false
-   /plugins
+   ```bash
+   claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install agent-auth@scalekit-auth-stack
    ```
-
-   Navigate through the visual interface to enable the Agent Auth plugin.
-
-   <Aside type="tip" title="Auto-update recommendations">
-   Enable auto-updates for authentication plugins to receive security patches and improvements. Scalekit regularly updates plugins based on community feedback and security best practices.
-   </Aside>
-
    </details>
 
 2. ## Generate authentication implementation

--- a/src/components/templates/coding-agents/_agentkit-claude-code.mdx
+++ b/src/components/templates/coding-agents/_agentkit-claude-code.mdx
@@ -20,21 +20,19 @@ import { Steps, Aside } from '@astrojs/starlight/components'
    <summary>Tool-native alternative</summary>
 
    ```bash
-   claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install agent-auth@scalekit-auth-stack
+   claude plugin marketplace add scalekit-inc/authstack
+   claude plugin install agentkit@authstack
+   claude plugin install saaskit@authstack
    ```
    </details>
 
 2. ## Generate authentication implementation
 
-   Use a structured prompt to direct the coding agent. A well-formed prompt ensures the agent generates complete, production-ready Agent Auth code that includes all required security components.
-
    Copy the following prompt into your coding agent:
 
    ```md wrap showLineNumbers=false title="Authentication implementation prompt"
-   Guide me through configuring the installed Scalekit marketplace plugin to handle agent authentication for Gmail. Provide the code to trigger the auth flow, retrieve the secure user token, and then use that authenticated session to fetch and list the last 5 unread emails. Add logging to verify the flow.
+   Add AgentKit to my app. I need to connect my agent to Gmail with delegated auth.
    ```
-
-    When you submit this prompt, Claude Code loads the Agent Auth skill from the marketplace -> analyzes your existing application structure -> generates Scalekit client initialization -> creates connected account management functions -> implements OAuth authorization link generation -> adds token fetching and refresh logic.
 
    <Aside type="caution" title="Review generated code">
    Always review AI-generated authentication code before deployment. Verify that environment variables, token validation logic, and error handling match your security requirements. The coding agent provides a foundation, but you must ensure it aligns with your application's specific needs.

--- a/src/components/templates/coding-agents/_agentkit-codex.mdx
+++ b/src/components/templates/coding-agents/_agentkit-codex.mdx
@@ -1,25 +1,34 @@
 import { Steps, Aside } from '@astrojs/starlight/components'
 
 <Steps>
-1. ## Install the Scalekit Auth Stack marketplace
-
-   Install Scalekit's Codex-native marketplace to access focused authentication plugins and reusable implementation guidance.
-
-   Run the bootstrap installer:
+1. ## Install the authstack plugin
 
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
+   npx @scalekit-inc/cli setup
+   ```
+
+   For repeated use:
+
+   ```bash title="Terminal" frame="terminal" showLineNumbers=false
+   npm install -g @scalekit-inc/cli
+   scalekit setup
+   ```
+
+   Choose Codex when prompted. The CLI installs the authstack plugin.
+
+   <details>
+   <summary>Tool-native alternative</summary>
+
+   ```bash
    curl -fsSL https://raw.githubusercontent.com/scalekit-inc/codex-authstack/main/install.sh | bash
    ```
 
-   This installer downloads the marketplace from GitHub, installs it into `~/.codex/marketplaces/scalekit-auth-stack`, and only updates `~/.agents/plugins/marketplace.json` when it is safe to do so.
-
-   <Aside type="tip" title="If Codex skips your personal marketplace file">
-   The installer avoids overwriting another personal marketplace by default. If it skips that file, follow the installer's manual path and select the marketplace from `~/.codex/marketplaces/scalekit-auth-stack/.agents/plugins/marketplace.json`.
-   </Aside>
+   Then restart Codex, open Plugin Directory, and enable the authstack plugin.
+   </details>
 
 2. ## Enable the Agent Auth plugin
 
-   Restart Codex so it reloads installed marketplaces, then open the Plugin Directory and select **Scalekit Auth Stack**.
+   Restart Codex, then open the Plugin Directory and enable the authstack plugin.
 
    Install the `agent-auth` plugin. This plugin includes the workflows, connector guidance, and references Codex uses to generate Agent Auth code for connected accounts and delegated OAuth flows.
 
@@ -33,7 +42,7 @@ import { Steps, Aside } from '@astrojs/starlight/components'
    Guide me through configuring the installed Scalekit marketplace plugin to handle agent authentication for Gmail. Provide the code to trigger the auth flow, retrieve the secure user token, and then use that authenticated session to fetch and list the last 5 unread emails. Add logging to verify the flow.
    ```
 
-   When you submit this prompt, Codex loads the Agent Auth plugin from the Scalekit Auth Stack marketplace, analyzes your existing application structure, generates Scalekit client initialization, creates connected account management functions, implements OAuth authorization link generation, and adds token fetching and refresh logic.
+   When you submit this prompt, Codex loads the Agent Auth plugin from the authstack plugin, analyzes your existing application structure, generates Scalekit client initialization, creates connected account management functions, implements OAuth authorization link generation, and adds token fetching and refresh logic.
 
    <Aside type="caution" title="Review generated code">
    Always review AI-generated authentication code before deployment. Verify that environment variables, token validation logic, and error handling match your security requirements. The coding agent provides a foundation, but you must ensure it aligns with your application's specific needs.

--- a/src/components/templates/coding-agents/_agentkit-codex.mdx
+++ b/src/components/templates/coding-agents/_agentkit-codex.mdx
@@ -16,16 +16,6 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
    Choose Codex when prompted. The CLI installs the authstack plugin.
 
-   <details>
-   <summary>Tool-native alternative</summary>
-
-   ```bash
-   curl -fsSL https://raw.githubusercontent.com/scalekit-inc/codex-authstack/main/install.sh | bash
-   ```
-
-   Then restart Codex, open Plugin Directory, and enable the authstack plugin.
-   </details>
-
 2. ## Enable the AgentKit plugin
 
    Restart Codex, then open the Plugin Directory and enable the authstack plugin.

--- a/src/components/templates/coding-agents/_agentkit-codex.mdx
+++ b/src/components/templates/coding-agents/_agentkit-codex.mdx
@@ -26,23 +26,19 @@ import { Steps, Aside } from '@astrojs/starlight/components'
    Then restart Codex, open Plugin Directory, and enable the authstack plugin.
    </details>
 
-2. ## Enable the Agent Auth plugin
+2. ## Enable the AgentKit plugin
 
    Restart Codex, then open the Plugin Directory and enable the authstack plugin.
 
-   Install the `agent-auth` plugin. This plugin includes the workflows, connector guidance, and references Codex uses to generate Agent Auth code for connected accounts and delegated OAuth flows.
-
 3. ## Generate the authentication implementation
-
-   Use a structured prompt to direct Codex. A well-formed prompt helps Codex generate complete, production-ready Agent Auth code that includes all required security components.
 
    Copy the following prompt into Codex:
 
    ```md wrap showLineNumbers=false title="Authentication implementation prompt"
-   Guide me through configuring the installed Scalekit marketplace plugin to handle agent authentication for Gmail. Provide the code to trigger the auth flow, retrieve the secure user token, and then use that authenticated session to fetch and list the last 5 unread emails. Add logging to verify the flow.
+   Add AgentKit to my app. I need to connect my agent to Gmail with delegated auth.
    ```
 
-   When you submit this prompt, Codex loads the Agent Auth plugin from the authstack plugin, analyzes your existing application structure, generates Scalekit client initialization, creates connected account management functions, implements OAuth authorization link generation, and adds token fetching and refresh logic.
+   Codex loads the AgentKit plugin from the authstack plugin, analyzes your existing application structure, generates Scalekit client initialization, creates connected account management functions, implements OAuth authorization link generation, and adds token fetching and refresh logic.
 
    <Aside type="caution" title="Review generated code">
    Always review AI-generated authentication code before deployment. Verify that environment variables, token validation logic, and error handling match your security requirements. The coding agent provides a foundation, but you must ensure it aligns with your application's specific needs.

--- a/src/components/templates/coding-agents/_agentkit-github-copilot-cli.mdx
+++ b/src/components/templates/coding-agents/_agentkit-github-copilot-cli.mdx
@@ -22,8 +22,9 @@ import { Steps, Aside } from '@astrojs/starlight/components'
    <summary>Tool-native alternative</summary>
 
    ```bash
-   copilot plugin marketplace add scalekit-inc/github-copilot-authstack
-   copilot plugin install agent-auth@scalekit-auth-stack
+   copilot plugin marketplace add scalekit-inc/authstack
+   copilot plugin install agentkit@authstack
+   copilot plugin install saaskit@authstack
    ```
    </details>
 
@@ -36,27 +37,17 @@ import { Steps, Aside } from '@astrojs/starlight/components'
    copilot plugin list
    ```
 
-   <Aside type="tip" title="Keep plugins updated">
-   Update authentication plugins regularly to receive security patches and improvements:
-
-   ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   copilot plugin update agent-auth@scalekit-auth-stack
-   ```
-   </Aside>
-
    </details>
 
 3. ## Generate authentication implementation
 
-   Use a structured prompt to direct GitHub Copilot. A well-formed prompt ensures the agent generates complete, production-ready Agent Auth code that includes all required security components.
-
    Copy the following command into your terminal:
 
    ```bash wrap title="Terminal" frame="terminal" showLineNumbers=false
-   copilot "Configure Scalekit agent authentication for Gmail — provide the code to trigger the auth flow, retrieve the secure user token, and then use that authenticated session to fetch and list the last 5 unread emails. Add logging to verify the flow."
+   copilot "Add AgentKit to my app. I need to connect my agent to Gmail with delegated auth."
    ```
 
-   GitHub Copilot uses the Agent Auth plugin to analyze your existing application structure, generate Scalekit client initialization code, create connected account management functions, implement OAuth authorization link generation, and add token fetching and refresh logic.
+   GitHub Copilot uses the AgentKit plugin to analyze your existing application structure, generate Scalekit client initialization code, create connected account management functions, implement OAuth authorization link generation, and add token fetching and refresh logic.
 
    <Aside type="caution" title="Review generated code">
    Always review AI-generated authentication code before deployment. Verify that environment variables, token validation logic, and error handling match your security requirements. The coding agent provides a foundation, but you must ensure it aligns with your application's specific needs.

--- a/src/components/templates/coding-agents/_agentkit-github-copilot-cli.mdx
+++ b/src/components/templates/coding-agents/_agentkit-github-copilot-cli.mdx
@@ -1,25 +1,31 @@
 import { Steps, Aside } from '@astrojs/starlight/components'
 
 <Steps>
-1. ## Add the Scalekit authstack marketplace
+1. ## Install the authstack plugin (recommended)
 
    Need to install GitHub Copilot CLI? See the [getting started guide](https://docs.github.com/en/copilot/how-tos/copilot-cli/cli-getting-started) — an active GitHub Copilot subscription is required.
 
-   Register Scalekit's plugin marketplace to access pre-configured authentication plugins. This marketplace provides implementation skills that help GitHub Copilot generate correct Agent Auth code.
-
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   copilot plugin marketplace add scalekit-inc/github-copilot-authstack
+   npx @scalekit-inc/cli setup
    ```
 
-   The marketplace provides specialized plugins that understand Agent Auth patterns and OAuth 2.0 security requirements. These plugins guide GitHub Copilot to generate implementation code that matches your project structure.
-
-2. ## Install the Agent Auth plugin
-
-   Install the Agent Auth plugin to give GitHub Copilot the skills needed to generate agent authentication code:
+   For repeated use, install globally:
 
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
+   npm install -g @scalekit-inc/cli
+   scalekit setup
+   ```
+
+   The CLI installs the authstack plugin for GitHub Copilot.
+
+   <details>
+   <summary>Tool-native alternative</summary>
+
+   ```bash
+   copilot plugin marketplace add scalekit-inc/github-copilot-authstack
    copilot plugin install agent-auth@scalekit-auth-stack
    ```
+   </details>
 
    <details>
    <summary>Verify the plugin is installed</summary>

--- a/src/components/templates/coding-agents/_cursor.mdx
+++ b/src/components/templates/coding-agents/_cursor.mdx
@@ -1,45 +1,38 @@
 import { Steps, Aside } from '@astrojs/starlight/components'
 
-<Aside type="note" title="Scalekit Auth Stack is under review on Cursor Marketplace">
-The Scalekit Auth Stack plugin is currently under review and not yet live on [cursor.com/marketplace](https://cursor.com/marketplace). Once approved, you'll be able to install it directly with an "Add to Cursor" button.
-
-Until then, use the local installer to load the plugins into Cursor.
-</Aside>
-
 <Steps>
-1. ## Install the Scalekit Auth Stack locally
+1. ## Install the authstack plugin (recommended)
 
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   curl -fsSL https://raw.githubusercontent.com/scalekit-inc/cursor-authstack/main/install.sh | bash
+   npx @scalekit-inc/cli setup
    ```
 
-   This installer downloads the latest Scalekit Cursor plugin bundle and installs each auth plugin into `~/.cursor/plugins/local/<plugin-name>`.
-
-   <Aside type="tip" title="Use a symlink when iterating locally">
-   If you're developing the plugin repo locally and want changes to show up without recopies, use the local installer path described in the repository README to symlink plugins into `~/.cursor/plugins/local`.
-   </Aside>
-
-2. ## Reload Cursor and enable the plugin
-
-   Restart Cursor, or run **Developer: Reload Window**, then open **Settings > Cursor Settings > Plugins**.
-
-   {/* IMAGE PLACEHOLDER: Screenshot of Cursor Settings > Plugins showing Scalekit Auth Stack */}
-
-   Select the authentication plugin you need, such as **Full Stack Auth**, **Modular SSO**, or **MCP Auth**, and enable it.
-
-   <Aside type="note" title="Alternatively: Install via Skills CLI">
-   You can also install Scalekit skills with the Vercel Skills CLI:
+   For repeated use, install globally:
 
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
+   npm install -g @scalekit-inc/cli
+   scalekit setup
+   ```
+
+   The CLI detects Cursor and installs the authstack plugin directly.
+
+2. ## Reload and select plugins
+
+   Restart Cursor (or run **Developer: Reload Window**), then open **Settings > Cursor Settings > Plugins**.
+
+   Enable the Scalekit plugins you need (Full Stack Auth, Agent Auth, MCP Auth, etc.).
+
+   <Aside type="note" title="Alternative for other agents">
+   For 40+ agents (Windsurf, Cline, etc.) or to install skills manually, the CLI also offers the skills option, or run:
+
+   ```bash
    npx skills add scalekit-inc/skills
    ```
-
-   Use `--list` to browse available skills or `--skill <name>` to install a specific auth type. Refer to Cursor's documentation for how to invoke skills once installed.
    </Aside>
 
 3. ## Generate the implementation
 
-   Open Cursor's chat panel with **Cmd+L** (macOS) or **Ctrl+L** (Windows/Linux) and paste in an implementation prompt. Use the same prompt from the corresponding Claude Code tab — the Scalekit plugins and their authentication skills work identically in Cursor.
+   Open Cursor's chat panel with **Cmd+L** (macOS) or **Ctrl+L** (Windows/Linux) and paste in an implementation prompt from the feature page (or describe what you need in natural language). The installed Scalekit plugins provide the agent with accurate patterns.
 
    <Aside type="caution" title="Review generated code">
    Always review AI-generated authentication code before deployment. Verify that environment variables, token validation logic, and error handling match your application's security requirements.
@@ -55,5 +48,3 @@ Until then, use the local installer to load the plugins into Cursor.
    - Session or token integration matching your application's existing patterns
 
 </Steps>
-
-Once the Scalekit Auth Stack is live on [cursor.com/marketplace](https://cursor.com/marketplace), you'll be able to skip the local installer and install it directly inside Cursor.

--- a/src/components/templates/coding-agents/_cursor.mdx
+++ b/src/components/templates/coding-agents/_cursor.mdx
@@ -20,7 +20,7 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
    Restart Cursor (or run **Developer: Reload Window**), then open **Settings > Cursor Settings > Plugins**.
 
-   Enable the Scalekit plugins you need (Full Stack Auth, Agent Auth, MCP Auth, etc.).
+   Enable the Scalekit plugins you need (AgentKit, SaaSKit, etc.).
 
    <Aside type="note" title="Alternative for other agents">
    For 40+ agents (Windsurf, Cline, etc.) or to install skills manually, the CLI also offers the skills option, or run:

--- a/src/components/templates/coding-agents/_cursor.mdx
+++ b/src/components/templates/coding-agents/_cursor.mdx
@@ -26,7 +26,7 @@ import { Steps, Aside } from '@astrojs/starlight/components'
    For 40+ agents (Windsurf, Cline, etc.) or to install skills manually, the CLI also offers the skills option, or run:
 
    ```bash
-   npx skills add scalekit-inc/skills
+   npx skills add scalekit-inc/authstack
    ```
    </Aside>
 

--- a/src/components/templates/coding-agents/_fsa-claude-code.mdx
+++ b/src/components/templates/coding-agents/_fsa-claude-code.mdx
@@ -2,32 +2,29 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
 <Steps>
 
-1. ## Install the Scalekit Auth Stack
-
-   Not yet on Claude Code? Follow the [official quickstart guide](https://code.claude.com/docs/en/quickstart) to install it.
-
-   Register Scalekit's plugin marketplace and install the Full Stack Auth plugin in a single command:
+1. ## Install the authstack plugin
 
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
+   npx @scalekit-inc/cli setup
+   ```
+
+   For repeated use, install globally:
+
+   ```bash title="Terminal" frame="terminal" showLineNumbers=false
+   npm install -g @scalekit-inc/cli
+   scalekit setup
+   ```
+
+   Select Claude Code when prompted. The CLI installs the authstack plugin for you.
+
+   <details>
+   <summary>Tool-native alternative (if not using the CLI)</summary>
+
+   ```bash
    claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install full-stack-auth@scalekit-auth-stack
    ```
 
-   The marketplace provides specialized authentication plugins that understand full-stack auth patterns and OAuth 2.0 security requirements. These plugins guide the coding agent to generate implementation code that matches your project structure.
-
-   <details>
-   <summary>Alternative: Enable authentication plugins via plugin wizard</summary>
-
-   Run the plugin wizard to browse and enable available plugins:
-
-   ```bash title="Claude REPL" showLineNumbers=false
-   /plugins
-   ```
-
-   Navigate through the visual interface to enable the Full Stack Auth plugin.
-
-   <Aside type="tip" title="Auto-update recommendations">
-   Enable auto-updates for authentication plugins to receive security patches and improvements. Scalekit regularly updates plugins based on community feedback and security best practices.
-   </Aside>
+   Or run `/plugins` inside Claude to enable via the wizard.
 
    </details>
 

--- a/src/components/templates/coding-agents/_fsa-claude-code.mdx
+++ b/src/components/templates/coding-agents/_fsa-claude-code.mdx
@@ -21,7 +21,9 @@ import { Steps, Aside } from '@astrojs/starlight/components'
    <summary>Tool-native alternative (if not using the CLI)</summary>
 
    ```bash
-   claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install full-stack-auth@scalekit-auth-stack
+   claude plugin marketplace add scalekit-inc/authstack
+   claude plugin install agentkit@authstack
+   claude plugin install saaskit@authstack
    ```
 
    Or run `/plugins` inside Claude to enable via the wizard.
@@ -30,15 +32,11 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
 2. ## Generate authentication implementation
 
-   Use a structured prompt to direct the coding agent. A well-formed prompt ensures the agent generates complete, production-ready Full Stack Auth code that includes all required security components.
-
    Copy the following prompt into your coding agent:
 
    ```md wrap showLineNumbers=false title="Authentication implementation prompt"
-   Guide the coding agent to implement Scalekit full-stack auth — initialize ScalekitClient with environment credentials, implement the login redirect, handle the OAuth callback to exchange the code for tokens, store the session securely, and add a logout endpoint that clears the session. Code only.
+   Add SaaSKit auth to my app. I need login, sessions, and logout.
    ```
-
-    When you submit this prompt, Claude Code loads the Full Stack Auth skill from the marketplace -> analyzes your existing application structure -> generates Scalekit client initialization with environment credentials -> creates the login redirect handler -> implements the OAuth callback to exchange the authorization code for tokens -> adds secure session storage and a logout endpoint.
 
    <Aside type="caution" title="Review generated code">
    Always review AI-generated authentication code before deployment. Verify that environment variables, token validation logic, and error handling match your security requirements. The coding agent provides a foundation, but you must ensure it aligns with your application's specific needs.
@@ -59,4 +57,3 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
 </Steps>
 
-When you connect, users authenticate through the OAuth 2.0 flow you configured. Verify that protected routes require a valid session and that the logout endpoint properly clears session state.

--- a/src/components/templates/coding-agents/_fsa-codex.mdx
+++ b/src/components/templates/coding-agents/_fsa-codex.mdx
@@ -17,16 +17,6 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
    Choose Codex when prompted. The CLI installs the authstack plugin.
 
-   <details>
-   <summary>Tool-native alternative</summary>
-
-   ```bash
-   curl -fsSL https://raw.githubusercontent.com/scalekit-inc/codex-authstack/main/install.sh | bash
-   ```
-
-   Then restart Codex, open Plugin Directory, and enable the authstack plugin.
-   </details>
-
 2. ## Enable the SaaSKit plugin
 
    Restart Codex and enable the authstack plugin in the Plugin Directory.

--- a/src/components/templates/coding-agents/_fsa-codex.mdx
+++ b/src/components/templates/coding-agents/_fsa-codex.mdx
@@ -2,27 +2,34 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
 <Steps>
 
-1. ## Install the Scalekit Auth Stack marketplace
-
-   Install Scalekit's Codex-native marketplace to access focused authentication plugins and reusable implementation guidance.
-
-   Run the bootstrap installer:
+1. ## Install the authstack plugin (recommended)
 
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
+   npx @scalekit-inc/cli setup
+   ```
+
+   For repeated use, install globally:
+
+   ```bash title="Terminal" frame="terminal" showLineNumbers=false
+   npm install -g @scalekit-inc/cli
+   scalekit setup
+   ```
+
+   Choose Codex when prompted. The CLI installs the authstack plugin.
+
+   <details>
+   <summary>Tool-native alternative</summary>
+
+   ```bash
    curl -fsSL https://raw.githubusercontent.com/scalekit-inc/codex-authstack/main/install.sh | bash
    ```
 
-   This installer downloads the marketplace from GitHub, installs it into `~/.codex/marketplaces/scalekit-auth-stack`, and only updates `~/.agents/plugins/marketplace.json` when it is safe to do so.
+   Then restart Codex, open Plugin Directory, and enable the authstack plugin.
+   </details>
 
-   <Aside type="tip" title="If Codex skips your personal marketplace file">
-   The installer avoids overwriting another personal marketplace by default. If it skips that file, follow the installer's manual path and select the marketplace from `~/.codex/marketplaces/scalekit-auth-stack/.agents/plugins/marketplace.json`.
-   </Aside>
+2. ## Enable the plugin (if not auto-enabled)
 
-2. ## Enable the Full Stack Auth plugin
-
-   Restart Codex so it reloads installed marketplaces, then open the Plugin Directory and select **Scalekit Auth Stack**.
-
-   Install the `full-stack-auth` plugin. This plugin includes the workflows, references, and prompts Codex uses to generate Full Stack Auth code that matches your existing project structure.
+   Restart Codex and enable the Full Stack Auth plugin from the authstack plugin in the Plugin Directory.
 
 3. ## Generate the authentication implementation
 
@@ -34,7 +41,7 @@ import { Steps, Aside } from '@astrojs/starlight/components'
    Guide the coding agent to implement Scalekit full-stack auth — initialize ScalekitClient with environment credentials, implement the login redirect, handle the OAuth callback to exchange the code for tokens, store the session securely, and add a logout endpoint that clears the session. Code only.
    ```
 
-   When you submit this prompt, Codex loads the Full Stack Auth plugin from the Scalekit Auth Stack marketplace, analyzes your existing application structure, generates Scalekit client initialization with environment credentials, creates the login redirect handler, implements the OAuth callback to exchange the authorization code for tokens, and adds secure session storage with a logout endpoint.
+   When you submit this prompt, Codex loads the Full Stack Auth plugin from the authstack plugin, analyzes your existing application structure, generates Scalekit client initialization with environment credentials, creates the login redirect handler, implements the OAuth callback to exchange the authorization code for tokens, and adds secure session storage with a logout endpoint.
 
    <Aside type="caution" title="Review generated code">
    Always review AI-generated authentication code before deployment. Verify that environment variables, token validation logic, and error handling match your security requirements. The coding agent provides a foundation, but you must ensure it aligns with your application's specific needs.

--- a/src/components/templates/coding-agents/_fsa-codex.mdx
+++ b/src/components/templates/coding-agents/_fsa-codex.mdx
@@ -27,21 +27,19 @@ import { Steps, Aside } from '@astrojs/starlight/components'
    Then restart Codex, open Plugin Directory, and enable the authstack plugin.
    </details>
 
-2. ## Enable the plugin (if not auto-enabled)
+2. ## Enable the SaaSKit plugin
 
-   Restart Codex and enable the Full Stack Auth plugin from the authstack plugin in the Plugin Directory.
+   Restart Codex and enable the authstack plugin in the Plugin Directory.
 
 3. ## Generate the authentication implementation
-
-   Use a structured prompt to direct Codex. A well-formed prompt helps Codex generate complete, production-ready Full Stack Auth code that includes the core security components.
 
    Copy the following prompt into Codex:
 
    ```md wrap showLineNumbers=false title="Authentication implementation prompt"
-   Guide the coding agent to implement Scalekit full-stack auth — initialize ScalekitClient with environment credentials, implement the login redirect, handle the OAuth callback to exchange the code for tokens, store the session securely, and add a logout endpoint that clears the session. Code only.
+   Add SaaSKit auth to my app. I need login, sessions, and logout.
    ```
 
-   When you submit this prompt, Codex loads the Full Stack Auth plugin from the authstack plugin, analyzes your existing application structure, generates Scalekit client initialization with environment credentials, creates the login redirect handler, implements the OAuth callback to exchange the authorization code for tokens, and adds secure session storage with a logout endpoint.
+   Codex loads the SaaSKit plugin from the authstack plugin, analyzes your existing application structure, generates Scalekit client initialization with environment credentials, creates the login redirect handler, implements the OAuth callback to exchange the authorization code for tokens, and adds secure session storage with a logout endpoint.
 
    <Aside type="caution" title="Review generated code">
    Always review AI-generated authentication code before deployment. Verify that environment variables, token validation logic, and error handling match your security requirements. The coding agent provides a foundation, but you must ensure it aligns with your application's specific needs.

--- a/src/components/templates/coding-agents/_fsa-github-copilot-cli.mdx
+++ b/src/components/templates/coding-agents/_fsa-github-copilot-cli.mdx
@@ -1,43 +1,30 @@
 import { Steps, Aside } from '@astrojs/starlight/components'
 
 <Steps>
-1. ## Add the Scalekit authstack marketplace
-
-   Need to install GitHub Copilot CLI? See the [getting started guide](https://docs.github.com/en/copilot/how-tos/copilot-cli/cli-getting-started) — an active GitHub Copilot subscription is required.
-
-   Register Scalekit's plugin marketplace to access pre-configured authentication plugins. This marketplace provides implementation skills that help GitHub Copilot generate correct Full Stack Auth code.
+1. ## Install the authstack plugin (recommended)
 
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   copilot plugin marketplace add scalekit-inc/github-copilot-authstack
+   npx @scalekit-inc/cli setup
    ```
 
-   The marketplace provides specialized plugins that understand full-stack auth patterns and OAuth 2.0 security requirements. These plugins guide GitHub Copilot to generate implementation code that matches your project structure.
-
-2. ## Install the Full Stack Auth plugin
-
-   Install the Full Stack Auth plugin to give GitHub Copilot the skills needed to generate complete authentication code:
+   For repeated use, install globally:
 
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
+   npm install -g @scalekit-inc/cli
+   scalekit setup
+   ```
+
+   The CLI installs the authstack plugin for GitHub Copilot.
+
+   <details>
+   <summary>Tool-native alternative</summary>
+
+   ```bash
+   copilot plugin marketplace add scalekit-inc/github-copilot-authstack
    copilot plugin install full-stack-auth@scalekit-auth-stack
    ```
 
-   <details>
-   <summary>Verify the plugin is installed</summary>
-
-   Confirm the plugin installed successfully:
-
-   ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   copilot plugin list
-   ```
-
-   <Aside type="tip" title="Keep plugins updated">
-   Update authentication plugins regularly to receive security patches and improvements:
-
-   ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   copilot plugin update full-stack-auth@scalekit-auth-stack
-   ```
-   </Aside>
-
+   Use `copilot plugin list` and `copilot plugin update ...` to manage.
    </details>
 
 3. ## Generate authentication implementation

--- a/src/components/templates/coding-agents/_fsa-github-copilot-cli.mdx
+++ b/src/components/templates/coding-agents/_fsa-github-copilot-cli.mdx
@@ -28,7 +28,7 @@ import { Steps, Aside } from '@astrojs/starlight/components'
    Use `copilot plugin list` to verify.
    </details>
 
-3. ## Generate authentication implementation
+2. ## Generate authentication implementation
 
    Copy the following command into your terminal:
 
@@ -42,7 +42,7 @@ import { Steps, Aside } from '@astrojs/starlight/components'
    Always review AI-generated authentication code before deployment. Verify that environment variables, token validation logic, and error handling match your security requirements. The coding agent provides a foundation, but you must ensure it aligns with your application's specific needs.
    </Aside>
 
-4. ## Verify the implementation
+3. ## Verify the implementation
 
    After GitHub Copilot completes, verify that all authentication components are properly configured:
 

--- a/src/components/templates/coding-agents/_fsa-github-copilot-cli.mdx
+++ b/src/components/templates/coding-agents/_fsa-github-copilot-cli.mdx
@@ -20,24 +20,23 @@ import { Steps, Aside } from '@astrojs/starlight/components'
    <summary>Tool-native alternative</summary>
 
    ```bash
-   copilot plugin marketplace add scalekit-inc/github-copilot-authstack
-   copilot plugin install full-stack-auth@scalekit-auth-stack
+   copilot plugin marketplace add scalekit-inc/authstack
+   copilot plugin install agentkit@authstack
+   copilot plugin install saaskit@authstack
    ```
 
-   Use `copilot plugin list` and `copilot plugin update ...` to manage.
+   Use `copilot plugin list` to verify.
    </details>
 
 3. ## Generate authentication implementation
 
-   Use a structured prompt to direct GitHub Copilot. A well-formed prompt ensures the agent generates complete, production-ready Full Stack Auth code that includes all required security components.
-
    Copy the following command into your terminal:
 
    ```bash wrap title="Terminal" frame="terminal" showLineNumbers=false
-   copilot "Implement Scalekit full-stack auth — initialize ScalekitClient with environment credentials, implement the login redirect, handle the OAuth callback to exchange the code for tokens, store the session securely, and add a logout endpoint that clears the session. Code only."
+   copilot "Add SaaSKit auth to my app. I need login, sessions, and logout."
    ```
 
-   GitHub Copilot uses the Full Stack Auth plugin to analyze your existing application structure, generate Scalekit client initialization code, create the login redirect handler, implement the OAuth callback for token exchange, add secure session storage, and provide a logout endpoint.
+   GitHub Copilot uses the SaaSKit plugin to analyze your existing application structure, generate Scalekit client initialization code, create the login redirect handler, implement the OAuth callback for token exchange, add secure session storage, and provide a logout endpoint.
 
    <Aside type="caution" title="Review generated code">
    Always review AI-generated authentication code before deployment. Verify that environment variables, token validation logic, and error handling match your security requirements. The coding agent provides a foundation, but you must ensure it aligns with your application's specific needs.

--- a/src/components/templates/coding-agents/_mcp-auth-claude-code.mdx
+++ b/src/components/templates/coding-agents/_mcp-auth-claude-code.mdx
@@ -5,17 +5,22 @@ import skillActivationImage from '@/assets/docs/ai-assisted-mcp-quickstart/skill
 
 <Steps>
 
-1. ## Install the Scalekit Auth Stack
+1. ## Install the authstack plugin
 
    Not yet on Claude Code? Follow the [official quickstart guide](https://code.claude.com/docs/en/quickstart) to install it.
 
-   Register Scalekit's plugin marketplace and install the MCP Auth plugin in a single command:
-
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install mcp-auth@scalekit-auth-stack
+   npx @scalekit-inc/cli setup
    ```
 
-   The marketplace provides specialized authentication plugins that understand MCP server architectures and OAuth 2.1 security requirements. These plugins guide the coding agent to generate implementation code that matches your project structure.
+   For repeated use:
+
+   ```bash title="Terminal" frame="terminal" showLineNumbers=false
+   npm install -g @scalekit-inc/cli
+   scalekit setup
+   ```
+
+   The CLI installs the authstack plugin for you. The plugins guide the coding agent to generate implementation code that matches your project structure.
 
    <details>
    <summary>Alternative: Enable authentication plugins via plugin wizard</summary>

--- a/src/components/templates/coding-agents/_mcp-auth-codex.mdx
+++ b/src/components/templates/coding-agents/_mcp-auth-codex.mdx
@@ -17,16 +17,6 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
    Choose Codex when prompted. The CLI installs the authstack plugin.
 
-   <details>
-   <summary>Tool-native alternative</summary>
-
-   ```bash
-   curl -fsSL https://raw.githubusercontent.com/scalekit-inc/codex-authstack/main/install.sh | bash
-   ```
-
-   Then restart Codex, open Plugin Directory, and enable the authstack plugin.
-   </details>
-
 2. ## Enable the MCP Auth plugin
 
    Restart Codex, then open the Plugin Directory and enable the authstack plugin.

--- a/src/components/templates/coding-agents/_mcp-auth-codex.mdx
+++ b/src/components/templates/coding-agents/_mcp-auth-codex.mdx
@@ -2,25 +2,34 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
 <Steps>
 
-1. ## Install the Scalekit Auth Stack marketplace
-
-   Install Scalekit's Codex-native marketplace to access focused authentication plugins and reusable implementation guidance.
-
-   Run the bootstrap installer:
+1. ## Install the authstack plugin (recommended)
 
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
+   npx @scalekit-inc/cli setup
+   ```
+
+   For repeated use, install globally:
+
+   ```bash title="Terminal" frame="terminal" showLineNumbers=false
+   npm install -g @scalekit-inc/cli
+   scalekit setup
+   ```
+
+   Choose Codex when prompted. The CLI installs the authstack plugin.
+
+   <details>
+   <summary>Tool-native alternative</summary>
+
+   ```bash
    curl -fsSL https://raw.githubusercontent.com/scalekit-inc/codex-authstack/main/install.sh | bash
    ```
 
-   This installer downloads the marketplace from GitHub, installs it into `~/.codex/marketplaces/scalekit-auth-stack`, and only updates `~/.agents/plugins/marketplace.json` when it is safe to do so.
-
-   <Aside type="tip" title="If Codex skips your personal marketplace file">
-   The installer avoids overwriting another personal marketplace by default. If it skips that file, follow the installer's manual path and select the marketplace from `~/.codex/marketplaces/scalekit-auth-stack/.agents/plugins/marketplace.json`.
-   </Aside>
+   Then restart Codex, open Plugin Directory, and enable the authstack plugin.
+   </details>
 
 2. ## Enable the MCP Auth plugin
 
-   Restart Codex so it reloads installed marketplaces, then open the Plugin Directory and select **Scalekit Auth Stack**.
+   Restart Codex, then open the Plugin Directory and enable the authstack plugin.
 
    Install the `mcp-auth` plugin. This plugin includes the workflows, framework-specific guidance, and references Codex uses to generate OAuth 2.1 protection for remote MCP servers.
 
@@ -34,7 +43,7 @@ import { Steps, Aside } from '@astrojs/starlight/components'
    Add OAuth 2.1 authentication to my MCP server using Scalekit. Initialize ScalekitClient with environment credentials, implement /.well-known/ metadata endpoint for discovery, and add authentication middleware that validates JWT bearer tokens on all MCP requests. Code only.
    ```
 
-   When you submit this prompt, Codex loads the MCP Auth plugin from the Scalekit Auth Stack marketplace, analyzes your existing MCP server structure, generates authentication middleware with token validation, creates the OAuth discovery endpoint, and configures environment variable handling.
+   When you submit this prompt, Codex loads the MCP Auth plugin from the authstack plugin, analyzes your existing MCP server structure, generates authentication middleware with token validation, creates the OAuth discovery endpoint, and configures environment variable handling.
 
    <Aside type="caution" title="Review generated code">
    Always review AI-generated authentication code before deployment. Verify that environment variables, token validation logic, and error handling match your security requirements. The coding agent provides a foundation, but you must ensure it aligns with your application's specific needs.

--- a/src/components/templates/coding-agents/_mcp-auth-github-copilot-cli.mdx
+++ b/src/components/templates/coding-agents/_mcp-auth-github-copilot-cli.mdx
@@ -22,8 +22,9 @@ import { Steps, Aside } from '@astrojs/starlight/components'
    <summary>Tool-native alternative</summary>
 
    ```bash
-   copilot plugin marketplace add scalekit-inc/github-copilot-authstack
-   copilot plugin install mcp-auth@scalekit-auth-stack
+   copilot plugin marketplace add scalekit-inc/authstack
+   copilot plugin install agentkit@authstack
+   copilot plugin install saaskit@authstack
    ```
    </details>
 
@@ -35,14 +36,6 @@ import { Steps, Aside } from '@astrojs/starlight/components'
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
    copilot plugin list
    ```
-
-   <Aside type="tip" title="Keep plugins updated">
-   Update authentication plugins regularly to receive security patches and improvements:
-
-   ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   copilot plugin update mcp-auth@scalekit-auth-stack
-   ```
-   </Aside>
 
    </details>
 

--- a/src/components/templates/coding-agents/_mcp-auth-github-copilot-cli.mdx
+++ b/src/components/templates/coding-agents/_mcp-auth-github-copilot-cli.mdx
@@ -1,25 +1,31 @@
 import { Steps, Aside } from '@astrojs/starlight/components'
 
 <Steps>
-1. ## Add the Scalekit authstack marketplace
+1. ## Install the authstack plugin (recommended)
 
    Need to install GitHub Copilot CLI? See the [getting started guide](https://docs.github.com/en/copilot/how-tos/copilot-cli/cli-getting-started) — an active GitHub Copilot subscription is required.
 
-   Register Scalekit's plugin marketplace to access pre-configured authentication plugins. This marketplace provides implementation skills that help GitHub Copilot generate correct MCP server authentication code.
-
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   copilot plugin marketplace add scalekit-inc/github-copilot-authstack
+   npx @scalekit-inc/cli setup
    ```
 
-   The marketplace provides specialized plugins that understand MCP server architectures and OAuth 2.1 security requirements. These plugins guide GitHub Copilot to generate implementation code that matches your project structure.
-
-2. ## Install the MCP Auth plugin
-
-   Install the MCP Auth plugin to give GitHub Copilot the skills needed to generate OAuth 2.1 authentication code for MCP servers:
+   For repeated use, install globally:
 
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
+   npm install -g @scalekit-inc/cli
+   scalekit setup
+   ```
+
+   The CLI installs the authstack plugin for GitHub Copilot.
+
+   <details>
+   <summary>Tool-native alternative</summary>
+
+   ```bash
+   copilot plugin marketplace add scalekit-inc/github-copilot-authstack
    copilot plugin install mcp-auth@scalekit-auth-stack
    ```
+   </details>
 
    <details>
    <summary>Verify the plugin is installed</summary>

--- a/src/components/templates/coding-agents/_scim-claude-code.mdx
+++ b/src/components/templates/coding-agents/_scim-claude-code.mdx
@@ -2,17 +2,22 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
 <Steps>
 
-1. ## Install the Scalekit Auth Stack
+1. ## Install the authstack plugin
 
    Not yet on Claude Code? Follow the [official quickstart guide](https://code.claude.com/docs/en/quickstart) to install it.
 
-   Register Scalekit's plugin marketplace and install the Modular SCIM plugin in a single command:
-
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install modular-scim@scalekit-auth-stack
+   npx @scalekit-inc/cli setup
    ```
 
-   The marketplace provides specialized SCIM plugins that understand directory sync patterns and webhook security requirements. These plugins guide the coding agent to generate implementation code that matches your project structure.
+   For repeated use:
+
+   ```bash title="Terminal" frame="terminal" showLineNumbers=false
+   npm install -g @scalekit-inc/cli
+   scalekit setup
+   ```
+
+   The CLI installs the authstack plugin for you. The plugins guide the coding agent to generate implementation code that matches your project structure.
 
    <details>
    <summary>Alternative: Enable SCIM plugins via plugin wizard</summary>

--- a/src/components/templates/coding-agents/_scim-codex.mdx
+++ b/src/components/templates/coding-agents/_scim-codex.mdx
@@ -2,25 +2,34 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
 <Steps>
 
-1. ## Install the Scalekit Auth Stack marketplace
-
-   Install Scalekit's Codex-native marketplace to access focused authentication plugins and reusable implementation guidance.
-
-   Run the bootstrap installer:
+1. ## Install the authstack plugin (recommended)
 
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
+   npx @scalekit-inc/cli setup
+   ```
+
+   For repeated use, install globally:
+
+   ```bash title="Terminal" frame="terminal" showLineNumbers=false
+   npm install -g @scalekit-inc/cli
+   scalekit setup
+   ```
+
+   Choose Codex when prompted. The CLI installs the authstack plugin.
+
+   <details>
+   <summary>Tool-native alternative</summary>
+
+   ```bash
    curl -fsSL https://raw.githubusercontent.com/scalekit-inc/codex-authstack/main/install.sh | bash
    ```
 
-   This installer downloads the marketplace from GitHub, installs it into `~/.codex/marketplaces/scalekit-auth-stack`, and only updates `~/.agents/plugins/marketplace.json` when it is safe to do so.
-
-   <Aside type="tip" title="If Codex skips your personal marketplace file">
-   The installer avoids overwriting another personal marketplace by default. If it skips that file, follow the installer's manual path and select the marketplace from `~/.codex/marketplaces/scalekit-auth-stack/.agents/plugins/marketplace.json`.
-   </Aside>
+   Then restart Codex, open Plugin Directory, and enable the authstack plugin.
+   </details>
 
 2. ## Enable the Modular SCIM plugin
 
-   Restart Codex so it reloads installed marketplaces, then open the Plugin Directory and select **Scalekit Auth Stack**.
+   Restart Codex, then open the Plugin Directory and enable the authstack plugin.
 
    Install the `modular-scim` plugin. This plugin includes the workflows, references, and prompts Codex uses to generate SCIM provisioning and deprovisioning code for your application.
 
@@ -34,7 +43,7 @@ import { Steps, Aside } from '@astrojs/starlight/components'
    Guide the coding agent to add Scalekit SCIM directory sync to my app — set up the webhook endpoint to receive SCIM events, validate the webhook signature, and handle user provisioning and deprovisioning events to create, update, and delete users in my database. Code only.
    ```
 
-   When you submit this prompt, Codex loads the Modular SCIM plugin from the Scalekit Auth Stack marketplace, analyzes your existing application structure, generates a webhook endpoint to receive SCIM events from Scalekit, implements webhook signature validation to prevent unauthorized requests, creates handlers for user provisioning events, and adds deprovisioning logic to delete or deactivate users in your database.
+   When you submit this prompt, Codex loads the Modular SCIM plugin from the authstack plugin, analyzes your existing application structure, generates a webhook endpoint to receive SCIM events from Scalekit, implements webhook signature validation to prevent unauthorized requests, creates handlers for user provisioning events, and adds deprovisioning logic to delete or deactivate users in your database.
 
    <Aside type="caution" title="Review generated code">
    Always review AI-generated SCIM code before deployment. Verify that webhook signature validation, event handling logic, and database operations match your security requirements. The coding agent provides a foundation, but you must ensure it aligns with your application's specific needs.

--- a/src/components/templates/coding-agents/_scim-codex.mdx
+++ b/src/components/templates/coding-agents/_scim-codex.mdx
@@ -17,16 +17,6 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
    Choose Codex when prompted. The CLI installs the authstack plugin.
 
-   <details>
-   <summary>Tool-native alternative</summary>
-
-   ```bash
-   curl -fsSL https://raw.githubusercontent.com/scalekit-inc/codex-authstack/main/install.sh | bash
-   ```
-
-   Then restart Codex, open Plugin Directory, and enable the authstack plugin.
-   </details>
-
 2. ## Enable the Modular SCIM plugin
 
    Restart Codex, then open the Plugin Directory and enable the authstack plugin.

--- a/src/components/templates/coding-agents/_scim-github-copilot-cli.mdx
+++ b/src/components/templates/coding-agents/_scim-github-copilot-cli.mdx
@@ -23,8 +23,9 @@ import { Steps, Aside } from '@astrojs/starlight/components'
    <summary>Tool-native alternative</summary>
 
    ```bash
-   copilot plugin marketplace add scalekit-inc/github-copilot-authstack
-   copilot plugin install modular-scim@scalekit-auth-stack
+   copilot plugin marketplace add scalekit-inc/authstack
+   copilot plugin install agentkit@authstack
+   copilot plugin install saaskit@authstack
    ```
    </details>
 
@@ -36,14 +37,6 @@ import { Steps, Aside } from '@astrojs/starlight/components'
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
    copilot plugin list
    ```
-
-   <Aside type="tip" title="Keep plugins updated">
-   Update SCIM plugins regularly to receive security patches and improvements:
-
-   ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   copilot plugin update modular-scim@scalekit-auth-stack
-   ```
-   </Aside>
 
    </details>
 

--- a/src/components/templates/coding-agents/_scim-github-copilot-cli.mdx
+++ b/src/components/templates/coding-agents/_scim-github-copilot-cli.mdx
@@ -2,25 +2,31 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
 <Steps>
 
-1. ## Add the Scalekit authstack marketplace
+1. ## Install the authstack plugin (recommended)
 
    Need to install GitHub Copilot CLI? See the [getting started guide](https://docs.github.com/en/copilot/how-tos/copilot-cli/cli-getting-started) — an active GitHub Copilot subscription is required.
 
-   Register Scalekit's plugin marketplace to access pre-configured SCIM plugins. This marketplace provides implementation skills that help GitHub Copilot generate correct directory sync code.
-
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   copilot plugin marketplace add scalekit-inc/github-copilot-authstack
+   npx @scalekit-inc/cli setup
    ```
 
-   The marketplace provides specialized plugins that understand directory sync patterns and webhook security requirements. These plugins guide GitHub Copilot to generate implementation code that matches your project structure.
-
-2. ## Install the Modular SCIM plugin
-
-   Install the Modular SCIM plugin to give GitHub Copilot the skills needed to generate SCIM webhook handling code:
+   For repeated use, install globally:
 
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
+   npm install -g @scalekit-inc/cli
+   scalekit setup
+   ```
+
+   The CLI installs the authstack plugin for GitHub Copilot.
+
+   <details>
+   <summary>Tool-native alternative</summary>
+
+   ```bash
+   copilot plugin marketplace add scalekit-inc/github-copilot-authstack
    copilot plugin install modular-scim@scalekit-auth-stack
    ```
+   </details>
 
    <details>
    <summary>Verify the plugin is installed</summary>

--- a/src/components/templates/coding-agents/_skills-cli.mdx
+++ b/src/components/templates/coding-agents/_skills-cli.mdx
@@ -25,7 +25,7 @@ You can also install the skills directly:
    Run the command with no flags to be guided through the available skills:
 
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   npx skills add scalekit-inc/skills
+   npx skills add scalekit-inc/authstack
    ```
 
 2. ## Browse and install a specific skill
@@ -34,10 +34,10 @@ You can also install the skills directly:
 
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
    # List all available skills
-   npx skills add scalekit-inc/skills --list
+   npx skills add scalekit-inc/authstack --list
 
    # Install a specific skill
-   npx skills add scalekit-inc/skills --skill adding-mcp-oauth
+   npx skills add scalekit-inc/authstack --skill adding-mcp-oauth
    ```
 
 3. ## Invoke the skill <Badge variant="note" text="Varies by agent" />
@@ -60,7 +60,7 @@ You can also install the skills directly:
    To add all Scalekit authentication skills to your agents:
 
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   npx skills add scalekit-inc/skills --all --global
+   npx skills add scalekit-inc/authstack --all --global
    ```
 
    This installs all AgentKit and SaaSKit skills.

--- a/src/components/templates/coding-agents/_skills-cli.mdx
+++ b/src/components/templates/coding-agents/_skills-cli.mdx
@@ -1,8 +1,23 @@
 import { Steps, Badge } from '@astrojs/starlight/components'
 
-Scalekit skills work with 40+ AI agents via the [Vercel Skills CLI](https://vercel.com/docs/agent-resources/skills). Install skills to add Scalekit authentication to your agent.
+The authstack plugin works with 40+ AI agents. Skills are installed via the Scalekit CLI or the Vercel Skills CLI.
 
-Supported agents include Claude Code, Cursor, GitHub Copilot CLI, OpenCode, Windsurf, Cline, Gemini CLI, Codex, and 30+ others.
+The easiest way for most developers is:
+
+```bash title="Terminal" frame="terminal" showLineNumbers=false
+npx @scalekit-inc/cli setup
+```
+
+For repeated use, install globally:
+
+```bash title="Terminal" frame="terminal" showLineNumbers=false
+npm install -g @scalekit-inc/cli
+scalekit setup
+```
+
+Then choose the "Other agents" / skills option when prompted.
+
+You can also install the skills directly:
 
 <Steps>
 1. ## Install interactively

--- a/src/components/templates/coding-agents/_skills-cli.mdx
+++ b/src/components/templates/coding-agents/_skills-cli.mdx
@@ -63,6 +63,6 @@ You can also install the skills directly:
    npx skills add scalekit-inc/skills --all --global
    ```
 
-   This installs skills for Full Stack Auth, Agent Auth, MCP Auth, Modular SSO, and Modular SCIM.
+   This installs all AgentKit and SaaSKit skills.
 
 </Steps>

--- a/src/components/templates/coding-agents/_sso-claude-code.mdx
+++ b/src/components/templates/coding-agents/_sso-claude-code.mdx
@@ -2,17 +2,22 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
 <Steps>
 
-1. ## Install the Scalekit Auth Stack
+1. ## Install the authstack plugin
 
    Not yet on Claude Code? Follow the [official quickstart guide](https://code.claude.com/docs/en/quickstart) to install it.
 
-   Register Scalekit's plugin marketplace and install the Modular SSO plugin in a single command:
-
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install modular-sso@scalekit-auth-stack
+   npx @scalekit-inc/cli setup
    ```
 
-   The marketplace provides specialized authentication plugins that understand SSO patterns and SAML/OIDC security requirements. These plugins guide the coding agent to generate implementation code that matches your project structure.
+   For repeated use:
+
+   ```bash title="Terminal" frame="terminal" showLineNumbers=false
+   npm install -g @scalekit-inc/cli
+   scalekit setup
+   ```
+
+   The CLI installs the authstack plugin for you. The plugins guide the coding agent to generate implementation code that matches your project structure.
 
    <details>
    <summary>Alternative: Enable authentication plugins via plugin wizard</summary>

--- a/src/components/templates/coding-agents/_sso-codex.mdx
+++ b/src/components/templates/coding-agents/_sso-codex.mdx
@@ -17,16 +17,6 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
    Choose Codex when prompted. The CLI installs the authstack plugin.
 
-   <details>
-   <summary>Tool-native alternative</summary>
-
-   ```bash
-   curl -fsSL https://raw.githubusercontent.com/scalekit-inc/codex-authstack/main/install.sh | bash
-   ```
-
-   Then restart Codex, open Plugin Directory, and enable the authstack plugin.
-   </details>
-
 2. ## Enable the Modular SSO plugin
 
    Restart Codex, then open the Plugin Directory and enable the authstack plugin.

--- a/src/components/templates/coding-agents/_sso-codex.mdx
+++ b/src/components/templates/coding-agents/_sso-codex.mdx
@@ -2,25 +2,34 @@ import { Steps, Aside } from '@astrojs/starlight/components'
 
 <Steps>
 
-1. ## Install the Scalekit Auth Stack marketplace
-
-   Install Scalekit's Codex-native marketplace to access focused authentication plugins and reusable implementation guidance.
-
-   Run the bootstrap installer:
+1. ## Install the authstack plugin (recommended)
 
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
+   npx @scalekit-inc/cli setup
+   ```
+
+   For repeated use, install globally:
+
+   ```bash title="Terminal" frame="terminal" showLineNumbers=false
+   npm install -g @scalekit-inc/cli
+   scalekit setup
+   ```
+
+   Choose Codex when prompted. The CLI installs the authstack plugin.
+
+   <details>
+   <summary>Tool-native alternative</summary>
+
+   ```bash
    curl -fsSL https://raw.githubusercontent.com/scalekit-inc/codex-authstack/main/install.sh | bash
    ```
 
-   This installer downloads the marketplace from GitHub, installs it into `~/.codex/marketplaces/scalekit-auth-stack`, and only updates `~/.agents/plugins/marketplace.json` when it is safe to do so.
-
-   <Aside type="tip" title="If Codex skips your personal marketplace file">
-   The installer avoids overwriting another personal marketplace by default. If it skips that file, follow the installer's manual path and select the marketplace from `~/.codex/marketplaces/scalekit-auth-stack/.agents/plugins/marketplace.json`.
-   </Aside>
+   Then restart Codex, open Plugin Directory, and enable the authstack plugin.
+   </details>
 
 2. ## Enable the Modular SSO plugin
 
-   Restart Codex so it reloads installed marketplaces, then open the Plugin Directory and select **Scalekit Auth Stack**.
+   Restart Codex, then open the Plugin Directory and enable the authstack plugin.
 
    Install the `modular-sso` plugin. This plugin includes the workflows, references, and prompts Codex uses to generate SAML and OIDC SSO code for your existing application.
 
@@ -34,7 +43,7 @@ import { Steps, Aside } from '@astrojs/starlight/components'
    Guide the coding agent to add Scalekit SSO to my existing app — initialize ScalekitClient, generate an SSO authorization URL for a given organization, handle the SSO callback to validate and exchange the code for user identity, and integrate the SSO user into my existing session system. Code only.
    ```
 
-   When you submit this prompt, Codex loads the Modular SSO plugin from the Scalekit Auth Stack marketplace, analyzes your existing application structure, generates Scalekit client initialization with environment credentials, creates an SSO authorization URL generator for organization-based routing, implements the SSO callback handler to validate and exchange the code for user identity, and integrates SSO user data into your existing session system.
+   When you submit this prompt, Codex loads the Modular SSO plugin from the authstack plugin, analyzes your existing application structure, generates Scalekit client initialization with environment credentials, creates an SSO authorization URL generator for organization-based routing, implements the SSO callback handler to validate and exchange the code for user identity, and integrates SSO user data into your existing session system.
 
    <Aside type="caution" title="Review generated code">
    Always review AI-generated authentication code before deployment. Verify that environment variables, token validation logic, and error handling match your security requirements. The coding agent provides a foundation, but you must ensure it aligns with your application's specific needs.

--- a/src/components/templates/coding-agents/_sso-github-copilot-cli.mdx
+++ b/src/components/templates/coding-agents/_sso-github-copilot-cli.mdx
@@ -22,8 +22,9 @@ import { Steps, Aside } from '@astrojs/starlight/components'
    <summary>Tool-native alternative</summary>
 
    ```bash
-   copilot plugin marketplace add scalekit-inc/github-copilot-authstack
-   copilot plugin install modular-sso@scalekit-auth-stack
+   copilot plugin marketplace add scalekit-inc/authstack
+   copilot plugin install agentkit@authstack
+   copilot plugin install saaskit@authstack
    ```
    </details>
 
@@ -35,14 +36,6 @@ import { Steps, Aside } from '@astrojs/starlight/components'
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
    copilot plugin list
    ```
-
-   <Aside type="tip" title="Keep plugins updated">
-   Update authentication plugins regularly to receive security patches and improvements:
-
-   ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   copilot plugin update modular-sso@scalekit-auth-stack
-   ```
-   </Aside>
 
    </details>
 

--- a/src/components/templates/coding-agents/_sso-github-copilot-cli.mdx
+++ b/src/components/templates/coding-agents/_sso-github-copilot-cli.mdx
@@ -1,25 +1,31 @@
 import { Steps, Aside } from '@astrojs/starlight/components'
 
 <Steps>
-1. ## Add the Scalekit authstack marketplace
+1. ## Install the authstack plugin (recommended)
 
    Need to install GitHub Copilot CLI? See the [getting started guide](https://docs.github.com/en/copilot/how-tos/copilot-cli/cli-getting-started) — an active GitHub Copilot subscription is required.
 
-   Register Scalekit's plugin marketplace to access pre-configured authentication plugins. This marketplace provides implementation skills that help GitHub Copilot generate correct Modular SSO code.
-
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
-   copilot plugin marketplace add scalekit-inc/github-copilot-authstack
+   npx @scalekit-inc/cli setup
    ```
 
-   The marketplace provides specialized plugins that understand SSO patterns and SAML/OIDC security requirements. These plugins guide GitHub Copilot to generate implementation code that matches your project structure.
-
-2. ## Install the Modular SSO plugin
-
-   Install the Modular SSO plugin to give GitHub Copilot the skills needed to generate SSO code:
+   For repeated use, install globally:
 
    ```bash title="Terminal" frame="terminal" showLineNumbers=false
+   npm install -g @scalekit-inc/cli
+   scalekit setup
+   ```
+
+   The CLI installs the authstack plugin for GitHub Copilot.
+
+   <details>
+   <summary>Tool-native alternative</summary>
+
+   ```bash
+   copilot plugin marketplace add scalekit-inc/github-copilot-authstack
    copilot plugin install modular-sso@scalekit-auth-stack
    ```
+   </details>
 
    <details>
    <summary>Verify the plugin is installed</summary>

--- a/src/configs/agent-instructions.ts
+++ b/src/configs/agent-instructions.ts
@@ -5,39 +5,36 @@
 
 /** HTML comment prepended to copied markdown — read by agents that receive raw page content. */
 export const AGENT_PLUGIN_HEADER = `<!-- Building with AI coding agents?
-If you're using an AI coding agent, install the official Scalekit plugin.
-It gives your agent full awareness of the Scalekit API — reducing hallucinations and enabling faster, more accurate code generation.
+Install the authstack plugin for your coding agent with one command.
 
-Claude Code:
-  claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install <auth-type>@scalekit-auth-stack
+Recommended:
+  npx @scalekit-inc/cli setup
 
-GitHub Copilot CLI:
-  copilot plugin marketplace add scalekit-inc/github-copilot-authstack
-  copilot plugin install <auth-type>@scalekit-auth-stack
+For repeated use:
+  npm install -g @scalekit-inc/cli
+  scalekit setup
 
-Codex:
-  curl -fsSL https://raw.githubusercontent.com/scalekit-inc/codex-authstack/main/install.sh | bash
-  Then restart Codex, open Plugin Directory, select Scalekit Auth Stack, and enable <auth-type>.
+This gives your agent full awareness of Scalekit authentication patterns and reduces hallucinations.
 
-Skills CLI (Windsurf, Cline, and 40+ agents):
-  npx skills add scalekit-inc/skills --list
-  npx skills add scalekit-inc/skills --skill <skill-name>
+After installing the plugin, ask your agent to implement Scalekit authentication using the provided patterns and skills.
 
-<auth-type> / <skill-name>: agentkit, full-stack-auth, mcp-auth, modular-sso, modular-scim
+<auth-type> values: agent-auth, full-stack-auth, mcp-auth, modular-sso, modular-scim
 Full guide: https://docs.scalekit.com/dev-kit/build-with-ai/ -->
 
 `
 
 /** Plain-text block for the page-actions prompt (injected into "Open in Claude/Cursor" messages). */
 export const AGENT_PLUGIN_INLINE = `Building with AI coding agents?
-If you're using an AI coding agent, install the official Scalekit plugin. It gives your agent full awareness of the Scalekit API — reducing hallucinations and enabling faster, more accurate code generation.
+Install the authstack plugin with one command:
 
-Claude Code: claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install <auth-type>@scalekit-auth-stack
-GitHub Copilot CLI: copilot plugin marketplace add scalekit-inc/github-copilot-authstack then copilot plugin install <auth-type>@scalekit-auth-stack
-Codex: run the bash installer, restart Codex, then open Plugin Directory and enable <auth-type>
-Skills CLI (Windsurf, Cline, and 40+ agents): npx skills add scalekit-inc/skills --list then npx skills add scalekit-inc/skills --skill <skill-name>
+  npx @scalekit-inc/cli setup
 
-<auth-type> / <skill-name>: agentkit, full-stack-auth, mcp-auth, modular-sso, modular-scim
+Or globally:
+  npm install -g @scalekit-inc/cli
+  scalekit setup
+
+The authstack plugin gives your agent accurate Scalekit implementation patterns (full-stack-auth, agent-auth, mcp-auth, modular-sso, modular-scim).
+
 Full guide: https://docs.scalekit.com/dev-kit/build-with-ai/`
 
 /**
@@ -47,24 +44,22 @@ Full guide: https://docs.scalekit.com/dev-kit/build-with-ai/`
  */
 export const AGENT_PLUGIN_DETAILS_MD = `## Building with AI coding agents?
 
-If you're using an AI coding agent, install the official Scalekit plugin. It gives your agent full awareness of the Scalekit API — reducing hallucinations and enabling faster, more accurate code generation.
+Install the authstack plugin for coding agents with one command. This is the recommended way to give your agent accurate Scalekit implementation guidance.
 
-**Claude Code**:
-\`claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install <auth-type>@scalekit-auth-stack\`
+**Recommended**:
+\`\`\`bash
+npx @scalekit-inc/cli setup
+\`\`\`
 
-**GitHub Copilot CLI**:
-1. \`copilot plugin marketplace add scalekit-inc/github-copilot-authstack\`
-2. \`copilot plugin install <auth-type>@scalekit-auth-stack\`
+For repeated use:
+\`\`\`bash
+npm install -g @scalekit-inc/cli
+scalekit setup
+\`\`\`
 
-**Codex**:
-1. \`curl -fsSL https://raw.githubusercontent.com/scalekit-inc/codex-authstack/main/install.sh | bash\`
-2. Restart Codex → open Plugin Directory → select **Scalekit Auth Stack** → install \`<auth-type>\`
+The CLI installs the authstack plugin for Claude Code, Cursor, GitHub Copilot, Codex, and skills for 40+ other agents.
 
-**Skills CLI** (Windsurf, Cline, and 40+ agents):
-1. \`npx skills add scalekit-inc/skills --list\` — see available skills
-2. \`npx skills add scalekit-inc/skills --skill <skill-name>\` — install the one you need
-
-\`<auth-type>\` / \`<skill-name>\`: \`agentkit\`, \`full-stack-auth\`, \`mcp-auth\`, \`modular-sso\`, \`modular-scim\`
+Use natural language or the specific feature skills: full-stack-auth, agent-auth, mcp-auth, modular-sso, modular-scim.
 
 [Full setup guide](https://docs.scalekit.com/dev-kit/build-with-ai/)
 
@@ -76,14 +71,22 @@ If you're using an AI coding agent, install the official Scalekit plugin. It giv
  * Visible markdown block prepended to static .md files fetched directly by agents.
  * Uses a blockquote with imperative language — visible to agents, not stripped like HTML comments.
  */
-export const AGENT_PLUGIN_VISIBLE_MD = `> **Building with AI coding agents?** If you're using an AI coding agent, install the official Scalekit plugin. It gives your agent full awareness of the Scalekit API — reducing hallucinations and enabling faster, more accurate code generation.
+export const AGENT_PLUGIN_VISIBLE_MD = `> **Building with AI coding agents?** Install the authstack plugin with one command. This equips your agent with accurate Scalekit implementation patterns.
 >
-> - **Claude Code**: \`claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install <auth-type>@scalekit-auth-stack\`
-> - **GitHub Copilot CLI**: \`copilot plugin marketplace add scalekit-inc/github-copilot-authstack\` then \`copilot plugin install <auth-type>@scalekit-auth-stack\`
-> - **Codex**: run the bash installer, restart, then open Plugin Directory and enable \`<auth-type>\`
-> - **Skills CLI** (Windsurf, Cline, 40+ agents): \`npx skills add scalekit-inc/skills --list\` then \`--skill <skill-name>\`
+> **Recommended**:
+> \`\`\`bash
+> npx @scalekit-inc/cli setup
+> \`\`\`
 >
-> \`<auth-type>\` / \`<skill-name>\`: \`agentkit\`, \`full-stack-auth\`, \`mcp-auth\`, \`modular-sso\`, \`modular-scim\` — [Full setup guide](https://docs.scalekit.com/dev-kit/build-with-ai/)
+> Global:
+> \`\`\`bash
+> npm install -g @scalekit-inc/cli
+> scalekit setup
+> \`\`\`
+>
+> Supports Claude Code, Cursor, GitHub Copilot, Codex + skills for 40+ agents.
+> Features: full-stack-auth, agent-auth, mcp-auth, modular-sso, modular-scim.
+> [Full setup guide](https://docs.scalekit.com/dev-kit/build-with-ai/)
 
 ---
 
@@ -105,9 +108,7 @@ export const AGENT_DOCS_FOOTER = `
 
 /** Single-line string safe for an HTML meta content attribute. */
 export const AGENT_PLUGIN_META =
-  'Building with AI coding agents? Install the official Scalekit plugin for full API awareness and reduced hallucinations. ' +
-  'Claude Code: claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install <auth-type>@scalekit-auth-stack. ' +
-  'GitHub Copilot CLI: copilot plugin marketplace add scalekit-inc/github-copilot-authstack then copilot plugin install <auth-type>@scalekit-auth-stack. ' +
-  'Codex: run bash installer, restart, enable in Plugin Directory. ' +
-  'Skills CLI (Windsurf, Cline, 40+ agents): npx skills add scalekit-inc/skills --list then --skill <skill-name>. ' +
+  'Building with AI coding agents? Install the authstack plugin with one command: npx @scalekit-inc/cli setup (or npm i -g @scalekit-inc/cli then scalekit setup). ' +
+  'Sets up Claude Code, Cursor, GitHub Copilot, Codex + 40+ agents. ' +
+  'Features: full-stack-auth, agent-auth, mcp-auth, modular-sso, modular-scim. ' +
   'Guide: https://docs.scalekit.com/dev-kit/build-with-ai/'

--- a/src/configs/llms.config.ts
+++ b/src/configs/llms.config.ts
@@ -4,7 +4,7 @@ import { AGENT_PLUGIN_DETAILS_MD } from './agent-instructions'
 export const llmsConfig: LlmsTxtConfig = {
   projectName: 'Scalekit',
   description:
-    'Scalekit is a developer platform for enterprise authentication, providing SaaSKit (FSA, SSO, SCIM), AgentKit (OAuth for AI agents, tool calling, connectors), MCP Authentication, and API authentication solutions for B2B and AI applications. An official Auth Stack plugin is available for AI coding agents with up-to-date API references and code snippets — see install details below.',
+    'Scalekit is a developer platform for enterprise authentication, providing SaaSKit (FSA, SSO, SCIM), AgentKit (OAuth for AI agents, tool calling, connectors), MCP Authentication, and API authentication solutions for B2B and AI applications. The authstack plugin is available for AI coding agents and provides up-to-date implementation guidance — see install details below.',
 
   details:
     AGENT_PLUGIN_DETAILS_MD +

--- a/src/configs/sidebar.config.ts
+++ b/src/configs/sidebar.config.ts
@@ -232,7 +232,6 @@ export const sidebar = [
       {
         label: 'Build with coding agents',
         items: [
-          'dev-kit/cli',
           'dev-kit/build-with-ai',
           'dev-kit/build-with-ai/full-stack-auth',
           'dev-kit/build-with-ai/mcp-auth',
@@ -244,6 +243,7 @@ export const sidebar = [
         label: 'AI tools',
         collapsed: false,
         items: [
+          'dev-kit/cli',
           'dev-kit/ai-assisted-development/scalekit-mcp-server',
           'dev-kit/resources/ai-assisted-setup',
           'dev-kit/ai-assisted-development/context7',

--- a/src/configs/sidebar.config.ts
+++ b/src/configs/sidebar.config.ts
@@ -232,6 +232,7 @@ export const sidebar = [
       {
         label: 'Build with coding agents',
         items: [
+          'dev-kit/cli',
           'dev-kit/build-with-ai',
           'dev-kit/build-with-ai/full-stack-auth',
           'dev-kit/build-with-ai/mcp-auth',

--- a/src/content/docs/agentkit/bring-your-own-connector/create-connector.mdx
+++ b/src/content/docs/agentkit/bring-your-own-connector/create-connector.mdx
@@ -34,10 +34,10 @@ Find these in the Scalekit Dashboard under **Developers → Settings → API Cre
 ## Create a connector
 
 <Aside type="tip" title="Recommended approach">
-The recommended way to manage connectors is with the <a href="https://github.com/scalekit-inc/skills/blob/main/skills/sk-actions-custom-provider/SKILL.md" target="_blank" rel="noopener noreferrer">`sk-actions-custom-provider` skill</a>.
+The recommended way to manage connectors is with the <a href="https://github.com/scalekit-inc/authstack/blob/main/skills/sk-actions-custom-provider/SKILL.md" target="_blank" rel="noopener noreferrer">`sk-actions-custom-provider` skill</a>.
 
 ```sh frame="none" showLineNumbers=false
-npx skills add scalekit-inc/skills --skill sk-actions-custom-provider
+npx skills add scalekit-inc/authstack --skill sk-actions-custom-provider
 ```
 
 It keeps payload generation, review, and promotion consistent across Dev and Production.

--- a/src/content/docs/agentkit/bring-your-own-connector/create-connector.mdx
+++ b/src/content/docs/agentkit/bring-your-own-connector/create-connector.mdx
@@ -37,7 +37,7 @@ Find these in the Scalekit Dashboard under **Developers → Settings → API Cre
 The recommended way to manage connectors is with the <a href="https://github.com/scalekit-inc/authstack/blob/main/skills/sk-actions-custom-provider/SKILL.md" target="_blank" rel="noopener noreferrer">`sk-actions-custom-provider` skill</a>.
 
 ```sh frame="none" showLineNumbers=false
-npx skills add scalekit-inc/authstack --skill sk-actions-custom-provider
+npx skills add scalekit-inc/authstack --skill integrating-agentkit
 ```
 
 It keeps payload generation, review, and promotion consistent across Dev and Production.

--- a/src/content/docs/agentkit/mcp/connect-mcp-client.mdx
+++ b/src/content/docs/agentkit/mcp/connect-mcp-client.mdx
@@ -1,9 +1,0 @@
----
-title: Connect to an MCP server
-description: This page has moved to Set up and connect a Virtual MCP server.
-sidebar:
-  label: Connect to MCP
-  hidden: true
----
-
-This page has moved. See [Set up and connect a Virtual MCP server](/agentkit/mcp/configure-mcp-server/).

--- a/src/content/docs/agentkit/quickstart.mdx
+++ b/src/content/docs/agentkit/quickstart.mdx
@@ -45,48 +45,13 @@ Complete these steps in the Scalekit dashboard before writing any code:
 <Tabs syncKey="build-mode">
   <TabItem label="Using a coding agent">
 
-    Install the Scalekit Auth Stack for your coding agent, complete the browser authorization when prompted, then paste the implementation prompt. The agent scaffolds connected account setup, the OAuth flow, and tool execution.
+    Install the authstack plugin for your coding agent with `npx @scalekit-inc/cli setup` (or install globally with `npm install -g @scalekit-inc/cli` then `scalekit setup`), complete the browser authorization when prompted, then paste the implementation prompt. The agent scaffolds connected account setup, the OAuth flow, and tool execution.
 
-    <Tabs syncKey="coding-agent">
-      <TabItem label="Claude Code" icon="claude">
-        ```bash title="Terminal" frame="terminal" showLineNumbers=false
-        claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install agent-auth@scalekit-auth-stack
-        ```
+    ```bash title="Terminal" frame="terminal" showLineNumbers=false
+    npx @scalekit-inc/cli setup
+    ```
 
-        Installing the plugin sets up Scalekit's MCP server and triggers an OAuth authorization flow in your browser. Complete the authorization before continuing. This gives Claude Code direct access to your Scalekit environment to search docs, manage connections, and check connected account status. Then paste the prompt below.
-      </TabItem>
-      <TabItem label="Codex" icon="codex">
-        ```bash title="Terminal" frame="terminal" showLineNumbers=false
-        curl -fsSL https://raw.githubusercontent.com/scalekit-inc/codex-authstack/main/install.sh | bash
-        ```
-        Restart Codex → Plugin Directory → **Scalekit Auth Stack** → install **agent-auth**. If a browser authorization prompt appears, complete the OAuth flow before continuing. Then paste the prompt below.
-      </TabItem>
-      <TabItem label="GitHub Copilot CLI" icon="githubcopilot">
-        ```bash title="Terminal" frame="terminal" showLineNumbers=false
-        copilot plugin marketplace add scalekit-inc/github-copilot-authstack
-        copilot plugin install agent-auth@scalekit-auth-stack
-        ```
-        If a browser authorization prompt appears, complete the OAuth flow before continuing. Then run:
-        ```bash title="Terminal" frame="terminal" showLineNumbers=false wrap
-        copilot "Configure Scalekit agent authentication for Gmail. Provide code to create a connected account, generate an authorization link, and fetch the last 5 unread emails using Scalekit's tool API."
-        ```
-      </TabItem>
-      <TabItem label="Cursor" icon="cursor">
-        <Aside type="note" title="Marketplace under review">
-          Scalekit Auth Stack is under review on Cursor Marketplace. Use the local installer below until it's live.
-        </Aside>
-        ```bash title="Terminal" frame="terminal" showLineNumbers=false
-        curl -fsSL https://raw.githubusercontent.com/scalekit-inc/cursor-authstack/main/install.sh | bash
-        ```
-        Reload Cursor → **Settings → Plugins** → enable **Agent Auth**. If a browser authorization prompt appears, complete the OAuth flow before continuing. Open chat (Cmd+L / Ctrl+L) and paste the prompt below.
-      </TabItem>
-      <TabItem label="40+ agents" icon="sparkle">
-        ```bash title="Terminal" frame="terminal" showLineNumbers=false
-        npx skills add scalekit-inc/skills --skill integrating-agent-auth
-        ```
-        Then ask your agent: "Configure Scalekit agent authentication for Gmail, create a connected account, generate an authorization link, and fetch the last 5 unread emails using Scalekit's tool API."
-      </TabItem>
-    </Tabs>
+    The wizard sets up the right plugins and skills for your editors. Complete any browser authorization for the Scalekit MCP server when prompted. Then use the prompt below (or describe your goal in natural language).
 
     ```md title="Implementation prompt" wrap showLineNumbers=false
     Configure Scalekit agent authentication for Gmail. Provide code to create a connected account, generate an authorization link, and, once the user authorizes, fetch the last 5 unread emails using Scalekit's tool API.

--- a/src/content/docs/authenticate/fsa/quickstart.mdx
+++ b/src/content/docs/authenticate/fsa/quickstart.mdx
@@ -75,8 +75,6 @@ Scalekit handles the complex authentication flow while you focus on your core pr
   showCta={false}
   clickable={false}
 >
-  Install the authstack plugin for your coding agents:
-
   <Tabs syncKey="fsa-cli-install">
     <TabItem label="Global install (recommended)">
       ```bash title="Terminal" frame="terminal" showLineNumbers=false
@@ -91,7 +89,6 @@ Scalekit handles the complex authentication flow while you focus on your core pr
     </TabItem>
   </Tabs>
 
-  The CLI sets up the authstack plugin (with full-stack auth support) for Claude Code, Cursor, GitHub Copilot, Codex, and 40+ other agents.
 </FoldCard>
 
 ---- 

--- a/src/content/docs/authenticate/fsa/quickstart.mdx
+++ b/src/content/docs/authenticate/fsa/quickstart.mdx
@@ -6,9 +6,6 @@ tableOfContents: true
 next:
   label: "Manage users"
   link: "/fsa/data-modelling/"
-banner:
-  content: |
-    Build this faster with AI coding agents. <a href="/dev-kit/build-with-ai/full-stack-auth/">Build with AI →</a>
 head:
   - tag: style
     content: |
@@ -78,40 +75,26 @@ Scalekit handles the complex authentication flow while you focus on your core pr
   showCta={false}
   clickable={false}
 >
-  <Tabs syncKey="build-with-agent">
-   <TabItem label="Claude Code" icon="claude">
-     ```bash title="Terminal" frame="terminal" showLineNumbers=false
-     claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install full-stack-auth@scalekit-auth-stack
-     ```
-   </TabItem>
-   <TabItem label="Codex" icon="codex">
-     ```bash title="Terminal" showLineNumbers=false frame="none"
-     curl -fsSL https://raw.githubusercontent.com/scalekit-inc/codex-authstack/main/install.sh | bash
-     ```
-     ```bash title="Codex" showLineNumbers=false frame="none"
-     # Restart Codex
-     # Plugin Directory -> Scalekit Auth Stack -> install full-stack-auth
-     ```
-   </TabItem>
-   <TabItem label="GitHub Copilot CLI" icon="githubcopilot">
-     ```bash title="Terminal" showLineNumbers=false frame="none"
-     copilot plugin marketplace add scalekit-inc/github-copilot-authstack
-     ```
-     ```bash title="Terminal" showLineNumbers=false frame="none"
-     copilot plugin install full-stack-auth@scalekit-auth-stack
-     ```
-   </TabItem>
-   <TabItem label="40+ agents" icon="sparkle">
-     ```bash title="Terminal" showLineNumbers=false frame="none"
-     npx skills add scalekit-inc/skills --skill implementing-scalekit-fsa
-     ```
-   </TabItem>
+  Install the authstack plugin for your coding agents:
+
+  <Tabs syncKey="fsa-cli-install">
+    <TabItem label="Global install (recommended)">
+      ```bash title="Terminal" frame="terminal" showLineNumbers=false
+      npm install -g @scalekit-inc/cli
+      scalekit setup
+      ```
+    </TabItem>
+    <TabItem label="npx (one-off)">
+      ```bash title="Terminal" frame="terminal" showLineNumbers=false
+      npx @scalekit-inc/cli setup
+      ```
+    </TabItem>
   </Tabs>
 
-  [Continue building with AI →](/dev-kit/build-with-ai/full-stack-auth/)
+  The CLI sets up the authstack plugin (with full-stack auth support) for Claude Code, Cursor, GitHub Copilot, Codex, and 40+ other agents.
 </FoldCard>
 
-----
+---- 
 
 <Steps>
 1. ## Set up Scalekit
@@ -960,5 +943,4 @@ Scalekit handles the complex authentication flow while you focus on your core pr
 
 </Steps>
 
-
- This single integration unlocks multiple authentication methods, including Magic Link & OTP, social sign-ins, enterprise single sign-on (SSO), and robust user management features. As you continue working with Scalekit, you'll discover even more features that enhance your authentication workflows.
+This single integration unlocks multiple authentication methods, including Magic Link & OTP, social sign-ins, enterprise single sign-on (SSO), and robust user management features. As you continue working with Scalekit, you'll discover even more features that enhance your authentication workflows.

--- a/src/content/docs/authenticate/mcp/overview.mdx
+++ b/src/content/docs/authenticate/mcp/overview.mdx
@@ -8,9 +8,6 @@ sidebar:
   label: Overview
 prev: false
 next: false
-banner:
-  content: |
-    Build this faster with AI coding agents. <a href="/dev-kit/build-with-ai/mcp-auth/">Build with AI →</a>
 ---
 
 import { Steps, LinkCard } from '@astrojs/starlight/components';

--- a/src/content/docs/authenticate/mcp/quickstart.mdx
+++ b/src/content/docs/authenticate/mcp/quickstart.mdx
@@ -47,8 +47,6 @@ This guide shows you how to add production-ready OAuth 2.1 authorization to your
   showCta={false}
   clickable={false}
 >
-  Install the authstack plugin for your coding agents:
-
   <Tabs syncKey="mcp-cli-install">
     <TabItem label="Global install (recommended)">
       ```bash title="Terminal" frame="terminal" showLineNumbers=false
@@ -63,7 +61,6 @@ This guide shows you how to add production-ready OAuth 2.1 authorization to your
     </TabItem>
   </Tabs>
 
-  The CLI sets up the authstack plugin (with MCP auth support) for Claude Code, Cursor, GitHub Copilot, Codex, and 40+ other agents.
 </FoldCard>
 
 <details>

--- a/src/content/docs/authenticate/mcp/quickstart.mdx
+++ b/src/content/docs/authenticate/mcp/quickstart.mdx
@@ -4,9 +4,6 @@ description: Secure your Model Context Protocol (MCP) servers with Scalekit's dr
 tags: [mcp-auth, quickstart, oauth2, model-context-protocol, ai-agents, api-security]
 tableOfContents:
   maxHeadingLevel: 3
-banner:
-  content: |
-    Build this faster with AI coding agents. <a href="/dev-kit/build-with-ai/mcp-auth/">Build with AI →</a>
 head:
   - tag: style
     content: |
@@ -50,37 +47,23 @@ This guide shows you how to add production-ready OAuth 2.1 authorization to your
   showCta={false}
   clickable={false}
 >
-  <Tabs syncKey="build-with-agent">
-   <TabItem label="Claude Code" icon="claude">
-     ```bash title="Terminal" frame="terminal" showLineNumbers=false
-     claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install mcp-auth@scalekit-auth-stack
-     ```
-   </TabItem>
-   <TabItem label="Codex" icon="codex">
-     ```bash title="Terminal" showLineNumbers=false frame="none"
-     curl -fsSL https://raw.githubusercontent.com/scalekit-inc/codex-authstack/main/install.sh | bash
-     ```
-     ```bash title="Codex" showLineNumbers=false frame="none"
-     # Restart Codex
-     # Plugin Directory -> Scalekit Auth Stack -> install mcp-auth
-     ```
-   </TabItem>
-   <TabItem label="GitHub Copilot CLI" icon="githubcopilot">
-     ```bash title="Terminal" showLineNumbers=false frame="none"
-     copilot plugin marketplace add scalekit-inc/github-copilot-authstack
-     ```
-     ```bash title="Terminal" showLineNumbers=false frame="none"
-     copilot plugin install mcp-auth@scalekit-auth-stack
-     ```
-   </TabItem>
-   <TabItem label="40+ agents" icon="sparkle">
-     ```bash title="Terminal" showLineNumbers=false frame="none"
-     npx skills add scalekit-inc/skills --skill adding-mcp-oauth
-     ```
-   </TabItem>
+  Install the authstack plugin for your coding agents:
+
+  <Tabs syncKey="mcp-cli-install">
+    <TabItem label="Global install (recommended)">
+      ```bash title="Terminal" frame="terminal" showLineNumbers=false
+      npm install -g @scalekit-inc/cli
+      scalekit setup
+      ```
+    </TabItem>
+    <TabItem label="npx (one-off)">
+      ```bash title="Terminal" frame="terminal" showLineNumbers=false
+      npx @scalekit-inc/cli setup
+      ```
+    </TabItem>
   </Tabs>
 
-  [Continue building with AI →](/dev-kit/build-with-ai/mcp-auth/)
+  The CLI sets up the authstack plugin (with MCP auth support) for Claude Code, Cursor, GitHub Copilot, Codex, and 40+ other agents.
 </FoldCard>
 
 <details>

--- a/src/content/docs/authenticate/sso/add-modular-sso.mdx
+++ b/src/content/docs/authenticate/sso/add-modular-sso.mdx
@@ -4,9 +4,6 @@ description: "Enable enterprise SSO for any customer in minutes with built-in SA
 tags: [sso, modular-auth, saml, oidc, enterprise, okta, azure-ad, quickstart]
 sidebar:
   label: 'Code it yourself'
-banner:
-  content: |
-    Build this faster with AI coding agents. <a href="/dev-kit/build-with-ai/sso/">Build with AI →</a>
 ---
 
 import {
@@ -67,37 +64,23 @@ Choose Modular SSO when you:
   showCta={false}
   clickable={false}
 >
-  <Tabs syncKey="build-with-agent">
-   <TabItem label="Claude Code" icon="claude">
-     ```bash title="Terminal" frame="terminal" showLineNumbers=false
-     claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install modular-sso@scalekit-auth-stack
-     ```
-   </TabItem>
-   <TabItem label="Codex" icon="codex">
-     ```bash title="Terminal" showLineNumbers=false frame="none"
-     curl -fsSL https://raw.githubusercontent.com/scalekit-inc/codex-authstack/main/install.sh | bash
-     ```
-     ```bash title="Codex" showLineNumbers=false frame="none"
-     # Restart Codex
-     # Plugin Directory -> Scalekit Auth Stack -> install modular-sso
-     ```
-   </TabItem>
-   <TabItem label="GitHub Copilot CLI" icon="githubcopilot">
-     ```bash title="Terminal" showLineNumbers=false frame="none"
-     copilot plugin marketplace add scalekit-inc/github-copilot-authstack
-     ```
-     ```bash title="Terminal" showLineNumbers=false frame="none"
-     copilot plugin install modular-sso@scalekit-auth-stack
-     ```
-   </TabItem>
-   <TabItem label="40+ agents" icon="sparkle">
-     ```bash title="Terminal" showLineNumbers=false frame="none"
-     npx skills add scalekit-inc/skills --skill modular-sso
-     ```
-   </TabItem>
+  Install the authstack plugin for your coding agents:
+
+  <Tabs syncKey="sso-cli-install">
+    <TabItem label="Global install (recommended)">
+      ```bash title="Terminal" frame="terminal" showLineNumbers=false
+      npm install -g @scalekit-inc/cli
+      scalekit setup
+      ```
+    </TabItem>
+    <TabItem label="npx (one-off)">
+      ```bash title="Terminal" frame="terminal" showLineNumbers=false
+      npx @scalekit-inc/cli setup
+      ```
+    </TabItem>
   </Tabs>
 
-  [Continue building with AI →](/dev-kit/build-with-ai/sso/)
+  The CLI sets up the authstack plugin (with modular SSO support) for Claude Code, Cursor, GitHub Copilot, Codex, and 40+ other agents.
 </FoldCard>
 
 <Steps>

--- a/src/content/docs/authenticate/sso/add-modular-sso.mdx
+++ b/src/content/docs/authenticate/sso/add-modular-sso.mdx
@@ -64,8 +64,6 @@ Choose Modular SSO when you:
   showCta={false}
   clickable={false}
 >
-  Install the authstack plugin for your coding agents:
-
   <Tabs syncKey="sso-cli-install">
     <TabItem label="Global install (recommended)">
       ```bash title="Terminal" frame="terminal" showLineNumbers=false
@@ -80,7 +78,6 @@ Choose Modular SSO when you:
     </TabItem>
   </Tabs>
 
-  The CLI sets up the authstack plugin (with modular SSO support) for Claude Code, Cursor, GitHub Copilot, Codex, and 40+ other agents.
 </FoldCard>
 
 <Steps>

--- a/src/content/docs/cookbooks/set-up-agentkit-with-your-coding-agent.mdx
+++ b/src/content/docs/cookbooks/set-up-agentkit-with-your-coding-agent.mdx
@@ -47,7 +47,7 @@ Install the authstack plugin into your coding agent and paste one prompt. The ag
 
     - Claude Code / Copilot: marketplace + plugin install is handled by the CLI.
     - Cursor / Codex: plugins are installed locally by the CLI.
-    - 40+ agents: use the skills option in the CLI or `npx skills add scalekit-inc/authstack --skill integrating-agent-auth`.
+    - 40+ agents: use the skills option in the CLI or `npx skills add scalekit-inc/authstack --skill integrating-agentkit`.
 
     Use the prompt below.
   </TabItem>

--- a/src/content/docs/cookbooks/set-up-agentkit-with-your-coding-agent.mdx
+++ b/src/content/docs/cookbooks/set-up-agentkit-with-your-coding-agent.mdx
@@ -6,7 +6,7 @@ tags: ['Agent auth']
 sidebar:
   label: 'Set up AgentKit with coding agents'
 excerpt: >
-  Install the Scalekit Auth Stack plugin into your coding agent and paste one
+  Install the authstack plugin into your coding agent and paste one
   prompt. The agent scaffolds OAuth handling, token management, and connected
   account logic so you can start writing agent logic immediately.
 featured: false
@@ -20,7 +20,7 @@ authors:
 import { TabItem, Aside } from '@astrojs/starlight/components'
 import Tabs from '@components/ui/Tabs.astro'
 
-Install the Scalekit Auth Stack plugin into your coding agent and paste one prompt. The agent generates client initialization, connected account management, OAuth authorization, and token handling — no boilerplate required.
+Install the authstack plugin into your coding agent and paste one prompt. The agent generates client initialization, connected account management, OAuth authorization, and token handling — no boilerplate required.
 
 ## Before you start
 
@@ -31,50 +31,25 @@ Install the Scalekit Auth Stack plugin into your coding agent and paste one prom
 ## Pick your coding agent
 
 <Tabs syncKey="coding-agent">
-  <TabItem label="Claude Code" icon="claude">
+  <TabItem label="Recommended: one command" icon="sparkle">
     ```bash title="Terminal" frame="terminal" showLineNumbers=false
-    claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install agent-auth@scalekit-auth-stack
+    npx @scalekit-inc/cli setup
     ```
 
-    Installing the plugin sets up Scalekit's MCP server and triggers an OAuth authorization flow in your browser. Complete the authorization before continuing — this gives Claude Code direct access to your Scalekit environment to search docs, manage connections, and check connected account status.
+    For repeated use: `npm install -g @scalekit-inc/cli` then `scalekit setup`.
 
-    Then paste this prompt:
-    ```md title="Implementation prompt" wrap showLineNumbers=false
-    Configure Scalekit agent authentication for [connector-name]. Provide code to create a connected account, generate an authorization link, retrieve the token, and call the API on behalf of the user.
-    ```
-  </TabItem>
-  <TabItem label="Codex" icon="codex">
-    ```bash title="Terminal" frame="terminal" showLineNumbers=false
-    curl -fsSL https://raw.githubusercontent.com/scalekit-inc/codex-authstack/main/install.sh | bash
-    ```
-    Restart Codex → Plugin Directory → **Scalekit Auth Stack** → install **agent-auth**. If a browser authorization prompt appears, complete the OAuth flow before continuing. Then paste the implementation prompt above.
-  </TabItem>
-  <TabItem label="GitHub Copilot CLI" icon="githubcopilot">
-    ```bash title="Terminal" frame="terminal" showLineNumbers=false
-    copilot plugin marketplace add scalekit-inc/github-copilot-authstack
-    copilot plugin install agent-auth@scalekit-auth-stack
-    ```
-    Then run:
-    ```bash title="Terminal" frame="terminal" showLineNumbers=false wrap
-    copilot "Configure Scalekit agent authentication for [connector-name]. Provide code to create a connected account, generate an authorization link, retrieve the token, and call the API on behalf of the user."
-    ```
-  </TabItem>
-  <TabItem label="Cursor" icon="cursor">
-    <Aside type="note" title="Marketplace under review">
-      Scalekit Auth Stack is under review on Cursor Marketplace. Use the local installer below until it's live.
-    </Aside>
-    ```bash title="Terminal" frame="terminal" showLineNumbers=false
-    curl -fsSL https://raw.githubusercontent.com/scalekit-inc/cursor-authstack/main/install.sh | bash
-    ```
-    Reload Cursor → **Settings → Plugins** → enable **Agent Auth**. If a browser authorization prompt appears, complete the OAuth flow before continuing. Open chat (Cmd+L / Ctrl+L) and paste the implementation prompt above.
-  </TabItem>
-  <TabItem label="40+ agents" icon="sparkle">
-    ```bash title="Terminal" frame="terminal" showLineNumbers=false
-    npx skills add scalekit-inc/skills --skill integrating-agent-auth
-    ```
-    Then ask your agent to configure Scalekit authentication for your connector and generate connected account, auth link, and token-fetch code.
+    The CLI installs the authstack plugin (including Agent Auth skills) for your editor. Complete any browser OAuth prompt for the Scalekit MCP server.
 
-    Supported agents include Claude Code, Cursor, GitHub Copilot CLI, OpenCode, Windsurf, Cline, Gemini CLI, Codex, and 30+ others.
+    Then paste the implementation prompt (or describe your goal naturally).
+  </TabItem>
+  <TabItem label="Per-tool details">
+    After the CLI (or if you prefer tool-native flows):
+
+    - Claude Code / Copilot: marketplace + plugin install is handled by the CLI.
+    - Cursor / Codex: plugins are installed locally by the CLI.
+    - 40+ agents: use the skills option in the CLI or `npx skills add scalekit-inc/skills --skill integrating-agent-auth`.
+
+    Use the prompt below.
   </TabItem>
 </Tabs>
 

--- a/src/content/docs/cookbooks/set-up-agentkit-with-your-coding-agent.mdx
+++ b/src/content/docs/cookbooks/set-up-agentkit-with-your-coding-agent.mdx
@@ -47,7 +47,7 @@ Install the authstack plugin into your coding agent and paste one prompt. The ag
 
     - Claude Code / Copilot: marketplace + plugin install is handled by the CLI.
     - Cursor / Codex: plugins are installed locally by the CLI.
-    - 40+ agents: use the skills option in the CLI or `npx skills add scalekit-inc/skills --skill integrating-agent-auth`.
+    - 40+ agents: use the skills option in the CLI or `npx skills add scalekit-inc/authstack --skill integrating-agent-auth`.
 
     Use the prompt below.
   </TabItem>

--- a/src/content/docs/dev-kit/build-with-ai/full-stack-auth.mdx
+++ b/src/content/docs/dev-kit/build-with-ai/full-stack-auth.mdx
@@ -39,7 +39,7 @@ import {
   SkillsCLICodingAgentSection
 } from '@/components/templates'
 
-Use AI coding agents like Claude Code, GitHub Copilot CLI, Cursor, and OpenCode to implement Scalekit's full-stack authentication end-to-end in your web applications. Configure the agents to analyze your codebase, apply consistent authentication patterns, and generate production-ready code for login, session management, and logout. This approach follows security best practices while reducing implementation time from hours to minutes.
+Install the authstack plugin, then tell your coding agent to add SaaSKit auth to your app.
 
 <Tabs syncKey="coding-agent">
   <TabItem label="Claude Code" icon="claude">

--- a/src/content/docs/dev-kit/build-with-ai/index.mdx
+++ b/src/content/docs/dev-kit/build-with-ai/index.mdx
@@ -19,15 +19,15 @@ import ResponsiveCardGrid from '@components/ui/ResponsiveCardGrid.astro'
 Use the Scalekit CLI to install the authstack plugin for your coding agents. One command detects your tools and sets everything up.
 
 <Tabs syncKey="build-with-ai-cli">
-  <TabItem label="Global install (recommended)">
-    ```bash title="Terminal" frame="terminal" showLineNumbers=false
-    npm install -g @scalekit-inc/cli
-    scalekit setup   # or: sk setup
-    ```
-  </TabItem>
-  <TabItem label="npx (one-off)">
+  <TabItem label="Recommended">
     ```bash title="Terminal" frame="terminal" showLineNumbers=false
     npx @scalekit-inc/cli setup
+    ```
+  </TabItem>
+  <TabItem label="Global install (for repeated use)">
+    ```bash title="Terminal" frame="terminal" showLineNumbers=false
+    npm install -g @scalekit-inc/cli
+    scalekit setup
     ```
   </TabItem>
 </Tabs>

--- a/src/content/docs/dev-kit/build-with-ai/index.mdx
+++ b/src/content/docs/dev-kit/build-with-ai/index.mdx
@@ -18,16 +18,19 @@ import ResponsiveCardGrid from '@components/ui/ResponsiveCardGrid.astro'
 
 Use the Scalekit CLI to install the authstack plugin for your coding agents. One command detects your tools and sets everything up.
 
-```bash title="Recommended" frame="terminal" showLineNumbers=false
-npx @scalekit-inc/cli setup
-```
-
-For repeated use, install globally:
-
-```bash title="Global install" frame="terminal" showLineNumbers=false
-npm install -g @scalekit-inc/cli
-scalekit setup   # or: sk setup
-```
+<Tabs syncKey="build-with-ai-cli">
+  <TabItem label="Global install (recommended)">
+    ```bash title="Terminal" frame="terminal" showLineNumbers=false
+    npm install -g @scalekit-inc/cli
+    scalekit setup   # or: sk setup
+    ```
+  </TabItem>
+  <TabItem label="npx (one-off)">
+    ```bash title="Terminal" frame="terminal" showLineNumbers=false
+    npx @scalekit-inc/cli setup
+    ```
+  </TabItem>
+</Tabs>
 
 The CLI installs the authstack plugin (with AgentKit and SaaSKit skills) for Claude Code, Cursor, GitHub Copilot, and Codex. It also offers skills for 40+ other agents.
 

--- a/src/content/docs/dev-kit/build-with-ai/index.mdx
+++ b/src/content/docs/dev-kit/build-with-ai/index.mdx
@@ -16,61 +16,52 @@ import Tabs from '@components/ui/Tabs.astro'
 import FoldCard from '@components/ui/FoldCard.astro'
 import ResponsiveCardGrid from '@components/ui/ResponsiveCardGrid.astro'
 
-Pick the auth feature you need below. Each page gives you a ready-to-paste prompt for your coding agent — Claude Code, Cursor, GitHub Copilot CLI, or OpenCode. The agent reads your codebase, applies consistent patterns, and generates production-ready auth code in minutes.
+Use the Scalekit CLI to install the authstack plugin for your coding agents. One command detects your tools and sets everything up.
+
+```bash title="Recommended" frame="terminal" showLineNumbers=false
+npx @scalekit-inc/cli setup
+```
+
+For repeated use, install globally:
+
+```bash title="Global install" frame="terminal" showLineNumbers=false
+npm install -g @scalekit-inc/cli
+scalekit setup   # or: sk setup
+```
+
+The CLI installs the authstack plugin (with AgentKit and SaaSKit skills) for Claude Code, Cursor, GitHub Copilot, and Codex. It also offers skills for 40+ other agents.
+
+After setup, pick a feature below. Each page provides ready-to-use prompts your agent can follow to implement production-ready auth.
 
 <Tabs syncKey="coding-agent">
   <TabItem label="Claude Code" icon="claude">
-    ```bash title="Install the Scalekit Auth Stack" frame="terminal" showLineNumbers=false
-    # options: full-stack-auth, agent-auth, mcp-auth, modular-sso, modular-scim
-    claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install agent-auth@scalekit-auth-stack
+    Run the CLI above, then in Claude:
+
+    ```bash title="Ask Claude" frame="terminal" showLineNumbers=false
+    claude "Add Scalekit full-stack auth (or agent auth, MCP auth, SSO, or SCIM) to this project"
     ```
-
-    Now ask your agent to implement Scalekit auth in natural language.
-  </TabItem>
-  <TabItem label="Codex" icon="codex">
-    ```bash title="Step 1 — Install the Scalekit Auth Stack" frame="terminal" showLineNumbers=false
-    curl -fsSL https://raw.githubusercontent.com/scalekit-inc/codex-authstack/main/install.sh | bash
-    ```
-
-    Step 2 — Restart Codex, open **Plugin Directory**, select **Scalekit Auth Stack**, and enable your auth plugin.
-
-    Now ask your agent to implement Scalekit auth in natural language.
-  </TabItem>
-  <TabItem label="GitHub Copilot CLI" icon="githubcopilot">
-    ```bash title="Step 1 — Add the marketplace" frame="terminal" showLineNumbers=false
-    copilot plugin marketplace add scalekit-inc/github-copilot-authstack
-    ```
-
-    ```bash title="Step 2 — Install your auth plugin" frame="terminal" showLineNumbers=false
-    # options: full-stack-auth, agent-auth, mcp-auth, modular-sso, modular-scim
-    copilot plugin install agent-auth@scalekit-auth-stack
-    ```
-
-    Now ask your agent to implement Scalekit auth in natural language.
   </TabItem>
   <TabItem label="Cursor" icon="cursor">
-    The Scalekit Auth Stack is pending Cursor Marketplace review. Install it locally in Cursor:
+    Run the CLI above. Restart Cursor or reload the window if prompted, then open chat and use the prompts from the feature pages below.
+  </TabItem>
+  <TabItem label="GitHub Copilot CLI" icon="githubcopilot">
+    Run the CLI above, then:
 
-    ```bash title="Step 1 — Install the Scalekit Auth Stack" frame="terminal" showLineNumbers=false
-    curl -fsSL https://raw.githubusercontent.com/scalekit-inc/cursor-authstack/main/install.sh | bash
+    ```bash title="Ask Copilot" frame="terminal" showLineNumbers=false
+    copilot "Implement Scalekit full-stack auth (or the feature you need) following security best practices. Code only."
     ```
-
-    Step 2 — Restart Cursor, open **Settings > Cursor Settings > Plugins**, and enable your auth plugin.
-
-    Now ask your agent to implement Scalekit auth in natural language.
+  </TabItem>
+  <TabItem label="Codex" icon="codex">
+    Run the CLI above. Restart Codex, enable the authstack plugin in the Plugin Directory, then use the prompts from the feature pages.
   </TabItem>
   <TabItem label="40+ agents" icon="sparkle">
-    Works with OpenCode, Windsurf, Cline, Gemini CLI, Codex, and 35+ more agents via the [Vercel Skills CLI](https://vercel.com/docs/agent-resources/skills).
+    The CLI can also install the skills directly. Or use the skills CLI:
 
-    ```bash title="Step 1 — Browse available skills" frame="terminal" showLineNumbers=false
-    npx skills add scalekit-inc/skills --list
+    ```bash title="Install skills" frame="terminal" showLineNumbers=false
+    npx skills add scalekit-inc/skills --all
     ```
 
-    ```bash title="Step 2 — Install a specific skill" frame="terminal" showLineNumbers=false
-    npx skills add scalekit-inc/skills --skill adding-mcp-oauth
-    ```
-
-    Now ask your agent to implement Scalekit auth in natural language.
+    Then ask your agent in natural language. Specific skills are available for each auth feature.
   </TabItem>
 </Tabs>
 

--- a/src/content/docs/dev-kit/build-with-ai/index.mdx
+++ b/src/content/docs/dev-kit/build-with-ai/index.mdx
@@ -34,40 +34,6 @@ Use the Scalekit CLI to install the authstack plugin for your coding agents. One
 
 The CLI installs the authstack plugin (with AgentKit and SaaSKit skills) for Claude Code, Cursor, GitHub Copilot, and Codex. It also offers skills for 40+ other agents.
 
-After setup, pick a feature below. Each page provides ready-to-use prompts your agent can follow to implement production-ready auth.
-
-<Tabs syncKey="coding-agent">
-  <TabItem label="Claude Code" icon="claude">
-    Run the CLI above, then in Claude:
-
-    ```bash title="Ask Claude" frame="terminal" showLineNumbers=false
-    claude "Add Scalekit full-stack auth (or agent auth, MCP auth, SSO, or SCIM) to this project"
-    ```
-  </TabItem>
-  <TabItem label="Cursor" icon="cursor">
-    Run the CLI above. Restart Cursor or reload the window if prompted, then open chat and use the prompts from the feature pages below.
-  </TabItem>
-  <TabItem label="GitHub Copilot CLI" icon="githubcopilot">
-    Run the CLI above, then:
-
-    ```bash title="Ask Copilot" frame="terminal" showLineNumbers=false
-    copilot "Implement Scalekit full-stack auth (or the feature you need) following security best practices. Code only."
-    ```
-  </TabItem>
-  <TabItem label="Codex" icon="codex">
-    Run the CLI above. Restart Codex, enable the authstack plugin in the Plugin Directory, then use the prompts from the feature pages.
-  </TabItem>
-  <TabItem label="40+ agents" icon="sparkle">
-    The CLI can also install the skills directly. Or use the skills CLI:
-
-    ```bash title="Install skills" frame="terminal" showLineNumbers=false
-    npx skills add scalekit-inc/skills --all
-    ```
-
-    Then ask your agent in natural language. Specific skills are available for each auth feature.
-  </TabItem>
-</Tabs>
-
 <ResponsiveCardGrid columnsDesktop={3} columnsLarge={3}>
   <FoldCard
     title="Full Stack Auth"

--- a/src/content/docs/dev-kit/cli.mdx
+++ b/src/content/docs/dev-kit/cli.mdx
@@ -5,6 +5,7 @@ sidebar:
   label: Scalekit CLI
   order: 1
 tableOfContents: true
+tags: [cli, authstack, coding-agents, setup]
 ---
 
 import { TabItem } from '@astrojs/starlight/components'
@@ -14,7 +15,7 @@ The Scalekit CLI (`@scalekit-inc/cli`) installs the authstack plugin for your AI
 
 ```bash frame="terminal"
 npm install -g @scalekit-inc/cli
-scalekit setup   # or: sk setup
+scalekit setup
 ```
 
 Running `setup` with no arguments launches an interactive wizard that detects your installed tools and installs the authstack plugin for each one.
@@ -67,38 +68,38 @@ After setup, tell your coding agent what you're building. The authstack plugin r
 
 <Tabs syncKey="coding-agent">
   <TabItem label="Claude Code" icon="claude">
-    ```
+    ```text
     I want to add agent auth to my project. Help me get started with AgentKit.
     ```
 
-    ```
+    ```text
     Add enterprise SSO to my Next.js app using SaaSKit.
     ```
   </TabItem>
   <TabItem label="Cursor" icon="cursor">
-    ```
+    ```text
     I want to add agent auth to my project. Help me get started with AgentKit.
     ```
 
-    ```
+    ```text
     Add enterprise SSO to my Next.js app using SaaSKit.
     ```
   </TabItem>
   <TabItem label="GitHub Copilot" icon="githubcopilot">
-    ```
+    ```text
     I want to add agent auth to my project. Help me get started with AgentKit.
     ```
 
-    ```
+    ```text
     Add enterprise SSO to my Next.js app using SaaSKit.
     ```
   </TabItem>
   <TabItem label="Codex" icon="codex">
-    ```
+    ```text
     I want to add agent auth to my project. Help me get started with AgentKit.
     ```
 
-    ```
+    ```text
     Add enterprise SSO to my Next.js app using SaaSKit.
     ```
   </TabItem>

--- a/src/content/docs/dev-kit/cli.mdx
+++ b/src/content/docs/dev-kit/cli.mdx
@@ -1,0 +1,92 @@
+---
+title: Scalekit CLI
+description: Install and manage the authstack plugin for AI coding agents with the Scalekit CLI.
+sidebar:
+  label: CLI
+  order: 1
+tableOfContents: true
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components'
+
+The Scalekit CLI (`@scalekit-inc/cli`) installs the authstack plugin for your AI coding agents. Run one command and the CLI detects your active tools — Cursor, Claude Code, GitHub Copilot, Codex — and sets each one up automatically.
+
+## Install
+
+<Tabs syncKey="cli-install">
+  <TabItem label="npx (one-off)">
+    ```bash frame="terminal"
+    npx @scalekit-inc/cli setup
+    ```
+  </TabItem>
+  <TabItem label="Global install">
+    ```bash frame="terminal"
+    npm install -g @scalekit-inc/cli
+    scalekit setup   # or: sk setup
+    ```
+  </TabItem>
+</Tabs>
+
+Running `setup` with no arguments launches an interactive wizard that detects your installed tools and installs the authstack plugin for each one.
+
+## Target a specific tool
+
+Pass the tool name to skip the wizard and install directly:
+
+```bash frame="terminal"
+scalekit setup cursor
+scalekit setup claude      # aliases: claude-code, cc
+scalekit setup codex       # alias: opencode
+scalekit setup copilot     # aliases: github-copilot, ghcp
+```
+
+## Command reference
+
+### `setup [tool]`
+
+Installs the authstack plugin for one or all detected coding agents.
+
+| Argument / flag | Description |
+|---|---|
+| `[tool]` | Target a specific agent: `cursor`, `claude`, `codex`, `copilot` (and their aliases). Omit to run the interactive wizard. |
+| `-y`, `--yes` | Skip confirmation prompts. Useful in scripts. |
+| `--dry-run` | Print the commands that would run without executing them. |
+| `--skip-skills` | Skip installing generic Scalekit skills (installs the plugin only). |
+
+### Supported tools
+
+| Tool | ID | Aliases |
+|---|---|---|
+| Cursor | `cursor` | — |
+| Claude Code | `claude` | `claude-code`, `cc` |
+| GitHub Copilot | `copilot` | `github-copilot`, `ghcp` |
+| Codex / OpenCode | `codex` | `opencode` |
+
+### What gets installed
+
+For each detected tool, the CLI installs two kits from the authstack plugin:
+
+- **AgentKit** — skills for building agents with delegated auth, scoped permissions, and tool calls
+- **SaaSKit** — skills for adding SSO, SCIM, MFA, sessions, and API auth to SaaS apps
+
+For Cursor and Codex, the CLI downloads the plugin and copies it to the tool's local plugin directory. For Claude Code and GitHub Copilot, it runs the tool's native plugin marketplace commands.
+
+## Examples
+
+Preview what would be installed without making changes:
+
+```bash frame="terminal"
+scalekit setup --dry-run
+```
+
+Install for Cursor without prompts (useful in CI or onboarding scripts):
+
+```bash frame="terminal"
+scalekit setup cursor -y
+```
+
+Install the plugin only, skip the generic skills:
+
+```bash frame="terminal"
+scalekit setup --skip-skills
+```

--- a/src/content/docs/dev-kit/cli.mdx
+++ b/src/content/docs/dev-kit/cli.mdx
@@ -7,6 +7,8 @@ sidebar:
 tableOfContents: true
 ---
 
+import { Tabs, TabItem } from '@astrojs/starlight/components'
+
 The Scalekit CLI (`@scalekit-inc/cli`) installs the authstack plugin for your AI coding agents. Run one command and the CLI detects your active tools — Cursor, Claude Code, GitHub Copilot, Codex — and sets each one up automatically.
 
 ## Install
@@ -60,22 +62,47 @@ For each detected tool, the CLI installs two kits from the authstack plugin:
 
 For Cursor and Codex, the CLI downloads the plugin and copies it to the tool's local plugin directory. For Claude Code and GitHub Copilot, it runs the tool's native plugin marketplace commands.
 
-## Examples
+## Start building
 
-Preview what would be installed without making changes:
+After setup, tell your coding agent what you're building. The authstack plugin routes you to the right skill.
 
-```bash frame="terminal"
-scalekit setup --dry-run
-```
+<Tabs syncKey="authstack-goal">
+  <TabItem label="AgentKit">
+    Use AgentKit when building AI agents that call third-party apps (Gmail, Slack, Salesforce, etc.) on behalf of users.
 
-Install for Cursor without prompts (useful in CI or onboarding scripts):
+    Tell your agent:
 
-```bash frame="terminal"
-scalekit setup cursor -y
-```
+    ```
+    I want to add agent auth to my project. Help me get started with AgentKit.
+    ```
 
-Install the plugin only, skip the generic skills:
+    Or if you know what you're building:
 
-```bash frame="terminal"
-scalekit setup --skip-skills
-```
+    ```
+    I'm building an agent that needs to call Gmail and Slack on behalf of users. Set up AgentKit.
+    ```
+
+    The agent invokes `/agentkit:setup` and routes you to the right implementation skill based on what you're building.
+  </TabItem>
+  <TabItem label="SaaSKit">
+    Use SaaSKit when adding auth, SSO, SCIM, or sessions to a SaaS application.
+
+    Tell your agent:
+
+    ```
+    I want to add auth to my SaaS app. Help me get started with SaaSKit.
+    ```
+
+    Or if you know what you need:
+
+    ```
+    Add enterprise SSO (Okta, Azure AD) to my Next.js app using SaaSKit.
+    ```
+
+    ```
+    Set up SCIM provisioning for my SaaS app so enterprise customers can sync users.
+    ```
+
+    The agent invokes `/saaskit:setup` and routes you to the right skill for your framework and goal.
+  </TabItem>
+</Tabs>

--- a/src/content/docs/dev-kit/cli.mdx
+++ b/src/content/docs/dev-kit/cli.mdx
@@ -7,25 +7,14 @@ sidebar:
 tableOfContents: true
 ---
 
-import { Tabs, TabItem } from '@astrojs/starlight/components'
-
 The Scalekit CLI (`@scalekit-inc/cli`) installs the authstack plugin for your AI coding agents. Run one command and the CLI detects your active tools — Cursor, Claude Code, GitHub Copilot, Codex — and sets each one up automatically.
 
 ## Install
 
-<Tabs syncKey="cli-install">
-  <TabItem label="npx (one-off)">
-    ```bash frame="terminal"
-    npx @scalekit-inc/cli setup
-    ```
-  </TabItem>
-  <TabItem label="Global install">
-    ```bash frame="terminal"
-    npm install -g @scalekit-inc/cli
-    scalekit setup   # or: sk setup
-    ```
-  </TabItem>
-</Tabs>
+```bash frame="terminal"
+npm install -g @scalekit-inc/cli
+scalekit setup   # or: sk setup
+```
 
 Running `setup` with no arguments launches an interactive wizard that detects your installed tools and installs the authstack plugin for each one.
 

--- a/src/content/docs/dev-kit/cli.mdx
+++ b/src/content/docs/dev-kit/cli.mdx
@@ -7,9 +7,10 @@ sidebar:
 tableOfContents: true
 ---
 
-import { Tabs, TabItem } from '@astrojs/starlight/components'
+import { TabItem } from '@astrojs/starlight/components'
+import Tabs from '@components/ui/Tabs.astro'
 
-The Scalekit CLI (`@scalekit-inc/cli`) installs the authstack plugin for your AI coding agents. Run one command and the CLI detects your active tools — Cursor, Claude Code, GitHub Copilot, Codex — and sets each one up automatically.
+The Scalekit CLI (`@scalekit-inc/cli`) installs the authstack plugin for your AI coding agents. Run one command and the CLI detects your active tools (Cursor, Claude Code, GitHub Copilot, Codex) and sets each one up automatically.
 
 ```bash frame="terminal"
 npm install -g @scalekit-inc/cli
@@ -46,7 +47,7 @@ Installs the authstack plugin for one or all detected coding agents.
 
 | Tool | ID | Aliases |
 |---|---|---|
-| Cursor | `cursor` | — |
+| Cursor | `cursor` | |
 | Claude Code | `claude` | `claude-code`, `cc` |
 | GitHub Copilot | `copilot` | `github-copilot`, `ghcp` |
 | Codex / OpenCode | `codex` | `opencode` |
@@ -55,8 +56,8 @@ Installs the authstack plugin for one or all detected coding agents.
 
 For each detected tool, the CLI installs two kits from the authstack plugin:
 
-- **AgentKit** — skills for building agents with delegated auth, scoped permissions, and tool calls
-- **SaaSKit** — skills for adding SSO, SCIM, MFA, sessions, and API auth to SaaS apps
+- **AgentKit** - skills for building agents with delegated auth, scoped permissions, and tool calls
+- **SaaSKit** - skills for adding SSO, SCIM, MFA, sessions, and API auth to SaaS apps
 
 For Cursor and Codex, the CLI downloads the plugin and copies it to the tool's local plugin directory. For Claude Code and GitHub Copilot, it runs the tool's native plugin marketplace commands.
 
@@ -103,4 +104,4 @@ After setup, tell your coding agent what you're building. The authstack plugin r
   </TabItem>
 </Tabs>
 
-The authstack plugin picks up the prompt and routes to the right skill — AgentKit for agent auth, SaaSKit for app auth.
+The authstack plugin picks up the prompt and routes to the right skill: AgentKit for agent auth, SaaSKit for app auth.

--- a/src/content/docs/dev-kit/cli.mdx
+++ b/src/content/docs/dev-kit/cli.mdx
@@ -66,43 +66,43 @@ For Cursor and Codex, the CLI downloads the plugin and copies it to the tool's l
 
 After setup, tell your coding agent what you're building. The authstack plugin routes you to the right skill.
 
-<Tabs syncKey="authstack-goal">
-  <TabItem label="AgentKit">
-    Use AgentKit when building AI agents that call third-party apps (Gmail, Slack, Salesforce, etc.) on behalf of users.
-
-    Tell your agent:
-
+<Tabs syncKey="coding-agent">
+  <TabItem label="Claude Code" icon="claude">
     ```
     I want to add agent auth to my project. Help me get started with AgentKit.
     ```
 
-    Or if you know what you're building:
-
     ```
-    I'm building an agent that needs to call Gmail and Slack on behalf of users. Set up AgentKit.
+    Add enterprise SSO to my Next.js app using SaaSKit.
     ```
-
-    The agent invokes `/agentkit:setup` and routes you to the right implementation skill based on what you're building.
   </TabItem>
-  <TabItem label="SaaSKit">
-    Use SaaSKit when adding auth, SSO, SCIM, or sessions to a SaaS application.
-
-    Tell your agent:
-
+  <TabItem label="Cursor" icon="cursor">
     ```
-    I want to add auth to my SaaS app. Help me get started with SaaSKit.
-    ```
-
-    Or if you know what you need:
-
-    ```
-    Add enterprise SSO (Okta, Azure AD) to my Next.js app using SaaSKit.
+    I want to add agent auth to my project. Help me get started with AgentKit.
     ```
 
     ```
-    Set up SCIM provisioning for my SaaS app so enterprise customers can sync users.
+    Add enterprise SSO to my Next.js app using SaaSKit.
+    ```
+  </TabItem>
+  <TabItem label="GitHub Copilot" icon="githubcopilot">
+    ```
+    I want to add agent auth to my project. Help me get started with AgentKit.
     ```
 
-    The agent invokes `/saaskit:setup` and routes you to the right skill for your framework and goal.
+    ```
+    Add enterprise SSO to my Next.js app using SaaSKit.
+    ```
+  </TabItem>
+  <TabItem label="Codex" icon="codex">
+    ```
+    I want to add agent auth to my project. Help me get started with AgentKit.
+    ```
+
+    ```
+    Add enterprise SSO to my Next.js app using SaaSKit.
+    ```
   </TabItem>
 </Tabs>
+
+The authstack plugin picks up the prompt and routes to the right skill — AgentKit for agent auth, SaaSKit for app auth.

--- a/src/content/docs/dev-kit/cli.mdx
+++ b/src/content/docs/dev-kit/cli.mdx
@@ -2,7 +2,7 @@
 title: Scalekit CLI
 description: Install and manage the authstack plugin for AI coding agents with the Scalekit CLI.
 sidebar:
-  label: CLI
+  label: Scalekit CLI
   order: 1
 tableOfContents: true
 ---

--- a/src/content/docs/dev-kit/cli.mdx
+++ b/src/content/docs/dev-kit/cli.mdx
@@ -11,8 +11,6 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 The Scalekit CLI (`@scalekit-inc/cli`) installs the authstack plugin for your AI coding agents. Run one command and the CLI detects your active tools — Cursor, Claude Code, GitHub Copilot, Codex — and sets each one up automatically.
 
-## Install
-
 ```bash frame="terminal"
 npm install -g @scalekit-inc/cli
 scalekit setup   # or: sk setup

--- a/src/content/docs/dev-kit/index.mdx
+++ b/src/content/docs/dev-kit/index.mdx
@@ -5,9 +5,6 @@ description: "Accelerate your build with the Scalekit Dev Kit. Get instant acces
 tableOfContents: false
 sidebar:
   label: "Overview"
-banner:
-  content: |
-    Build this faster with AI coding agents. <a href="/dev-kit/build-with-ai/">Build with AI →</a>
 hero:
   tagline: Get up and running with SDKs, APIs, and integration tools
 ---

--- a/src/content/docs/directory/scim/quickstart.mdx
+++ b/src/content/docs/directory/scim/quickstart.mdx
@@ -96,15 +96,15 @@ Scalekit -> Directory Provider: Fetch latest data \n from directory provider
   clickable={false}
 >
   <Tabs syncKey="scim-cli-install">
-    <TabItem label="Global install (recommended)">
+    <TabItem label="Recommended">
+      ```bash title="Terminal" frame="terminal" showLineNumbers=false
+      npx @scalekit-inc/cli setup
+      ```
+    </TabItem>
+    <TabItem label="Global install (for repeated use)">
       ```bash title="Terminal" frame="terminal" showLineNumbers=false
       npm install -g @scalekit-inc/cli
       scalekit setup
-      ```
-    </TabItem>
-    <TabItem label="npx (one-off)">
-      ```bash title="Terminal" frame="terminal" showLineNumbers=false
-      npx @scalekit-inc/cli setup
       ```
     </TabItem>
   </Tabs>

--- a/src/content/docs/directory/scim/quickstart.mdx
+++ b/src/content/docs/directory/scim/quickstart.mdx
@@ -26,9 +26,6 @@ prev:
 next:
   label: "Directory API reference"
   link: "https://docs.scalekit.com/apis/"
-banner:
-  content: |
-    Build this faster with AI coding agents. <a href="/dev-kit/build-with-ai/scim/">Build with AI →</a>
 seeAlso:
   expanded: true
   items:
@@ -98,37 +95,23 @@ Scalekit -> Directory Provider: Fetch latest data \n from directory provider
   showCta={false}
   clickable={false}
 >
-  <Tabs syncKey="build-with-agent">
-   <TabItem label="Claude Code" icon="claude">
-     ```bash title="Terminal" frame="terminal" showLineNumbers=false
-     claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install modular-scim@scalekit-auth-stack
-     ```
-   </TabItem>
-   <TabItem label="Codex" icon="codex">
-     ```bash title="Terminal" showLineNumbers=false frame="none"
-     curl -fsSL https://raw.githubusercontent.com/scalekit-inc/codex-authstack/main/install.sh | bash
-     ```
-     ```bash title="Codex" showLineNumbers=false frame="none"
-     # Restart Codex
-     # Plugin Directory -> Scalekit Auth Stack -> install modular-scim
-     ```
-   </TabItem>
-   <TabItem label="GitHub Copilot CLI" icon="githubcopilot">
-     ```bash title="Terminal" showLineNumbers=false frame="none"
-     copilot plugin marketplace add scalekit-inc/github-copilot-authstack
-     ```
-     ```bash title="Terminal" showLineNumbers=false frame="none"
-     copilot plugin install modular-scim@scalekit-auth-stack
-     ```
-   </TabItem>
-   <TabItem label="40+ agents" icon="sparkle">
-     ```bash title="Terminal" showLineNumbers=false frame="none"
-     npx skills add scalekit-inc/skills --skill implementing-scim-provisioning
-     ```
-   </TabItem>
+  Install the authstack plugin for your coding agents:
+
+  <Tabs syncKey="scim-cli-install">
+    <TabItem label="Global install (recommended)">
+      ```bash title="Terminal" frame="terminal" showLineNumbers=false
+      npm install -g @scalekit-inc/cli
+      scalekit setup
+      ```
+    </TabItem>
+    <TabItem label="npx (one-off)">
+      ```bash title="Terminal" frame="terminal" showLineNumbers=false
+      npx @scalekit-inc/cli setup
+      ```
+    </TabItem>
   </Tabs>
 
-  [Continue building with AI →](/dev-kit/build-with-ai/scim/)
+  The CLI sets up the authstack plugin (with SCIM support) for Claude Code, Cursor, GitHub Copilot, Codex, and 40+ other agents.
 </FoldCard>
 
 ## User provisioning with Scalekit's directory API

--- a/src/content/docs/directory/scim/quickstart.mdx
+++ b/src/content/docs/directory/scim/quickstart.mdx
@@ -95,8 +95,6 @@ Scalekit -> Directory Provider: Fetch latest data \n from directory provider
   showCta={false}
   clickable={false}
 >
-  Install the authstack plugin for your coding agents:
-
   <Tabs syncKey="scim-cli-install">
     <TabItem label="Global install (recommended)">
       ```bash title="Terminal" frame="terminal" showLineNumbers=false
@@ -111,7 +109,6 @@ Scalekit -> Directory Provider: Fetch latest data \n from directory provider
     </TabItem>
   </Tabs>
 
-  The CLI sets up the authstack plugin (with SCIM support) for Claude Code, Cursor, GitHub Copilot, Codex, and 40+ other agents.
 </FoldCard>
 
 ## User provisioning with Scalekit's directory API

--- a/src/content/docs/home/saaskit/index.mdx
+++ b/src/content/docs/home/saaskit/index.mdx
@@ -5,9 +5,6 @@ description: Add SSO, SCIM, MCP auth, and user management to your B2B SaaS appli
 tableOfContents: false
 topic: authenticate
 tags: [mcp-auth, sso, scim, saas-user-management, b2b, ai-applications]
-banner:
-  content: |
-    Implement SSO, MCP auth, SCIM, and user management faster with AI coding agents. <a href="/dev-kit/build-with-ai/">Build with AI →</a>
 hero:
   tagline: Add SSO, SCIM, or MCP Auth as modular capabilities, or adopt Scalekit as your full identity layer for your SaaS app
 head:
@@ -206,55 +203,55 @@ import complianceImage from '@/content/docs/compliance.svg'
       <p style="font-size: 0.875rem; color: var(--sl-color-text-muted); margin: 0 0 0.75rem;">2 steps · ~5 minutes · works with any AI coding agent</p>
       <Tabs syncKey="coding-agent">
         <TabItem label="Claude Code" icon="claude">
-          ```bash title="Install the Scalekit Auth Stack" frame="terminal" showLineNumbers=false
-          # options: full-stack-auth, agent-auth, mcp-auth, modular-sso, modular-scim
-          claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install full-stack-auth@scalekit-auth-stack
+          ```bash title="Install the authstack plugin" frame="terminal" showLineNumbers=false
+          npx @scalekit-inc/cli setup
           ```
+
+          For repeated use: `npm install -g @scalekit-inc/cli` then `scalekit setup`.
 
           Now ask your agent to implement Scalekit auth in natural language. [See example starting prompts →](/agentkit/quickstart/)
         </TabItem>
         <TabItem label="Codex" icon="codex">
-          ```bash title="Step 1 — Install the Scalekit Auth Stack" frame="terminal" showLineNumbers=false
-          curl -fsSL https://raw.githubusercontent.com/scalekit-inc/codex-authstack/main/install.sh | bash
+          ```bash title="Install the authstack plugin" frame="terminal" showLineNumbers=false
+          npx @scalekit-inc/cli setup
           ```
 
-          Step 2 — Restart Codex, open **Plugin Directory**, select **Scalekit Auth Stack**, and enable your auth plugin.
+          For repeated use: `npm install -g @scalekit-inc/cli` then `scalekit setup`.
+
+          Restart Codex, open the Plugin Directory, and enable the Scalekit plugins you need.
 
           Now ask your agent to implement Scalekit auth in natural language. [See example starting prompts →](/agentkit/quickstart/)
         </TabItem>
         <TabItem label="GitHub Copilot CLI" icon="githubcopilot">
-          ```bash title="Step 1 — Add the marketplace" frame="terminal" showLineNumbers=false
-          copilot plugin marketplace add scalekit-inc/github-copilot-authstack
+          ```bash title="Install the authstack plugin" frame="terminal" showLineNumbers=false
+          npx @scalekit-inc/cli setup
           ```
 
-          ```bash title="Step 2 — Install your auth plugin" frame="terminal" showLineNumbers=false
-          # options: full-stack-auth, agent-auth, mcp-auth, modular-sso, modular-scim
-          copilot plugin install full-stack-auth@scalekit-auth-stack
-          ```
+          For repeated use: `npm install -g @scalekit-inc/cli` then `scalekit setup`.
+
+          Then ask Copilot to implement the auth feature.
 
           Now ask your agent to implement Scalekit auth in natural language. [See example starting prompts →](/agentkit/quickstart/)
         </TabItem>
         <TabItem label="Cursor" icon="cursor">
-          The Scalekit Auth Stack is pending Cursor Marketplace review. Install it locally in Cursor:
-
-          ```bash title="Step 1 — Install the Scalekit Auth Stack" frame="terminal" showLineNumbers=false
-          curl -fsSL https://raw.githubusercontent.com/scalekit-inc/cursor-authstack/main/install.sh | bash
+          ```bash title="Install the authstack plugin" frame="terminal" showLineNumbers=false
+          npx @scalekit-inc/cli setup
           ```
 
-          Step 2 — Restart Cursor, open **Settings > Cursor Settings > Plugins**, and enable your auth plugin.
+          For repeated use: `npm install -g @scalekit-inc/cli` then `scalekit setup`.
+
+          Restart Cursor (or run **Developer: Reload Window**), then enable the Scalekit plugins in Settings.
 
           Now ask your agent to implement Scalekit auth in natural language. [See example starting prompts →](/agentkit/quickstart/)
         </TabItem>
         <TabItem label="40+ agents" icon="sparkle">
-          Works with OpenCode, Windsurf, Cline, Gemini CLI, Codex, and 35+ more agents via the [Vercel Skills CLI](https://vercel.com/docs/agent-resources/skills).
-
-          ```bash title="Step 1 — Browse available skills" frame="terminal" showLineNumbers=false
-          npx skills add scalekit-inc/skills --list
+          ```bash title="Install the authstack plugin" frame="terminal" showLineNumbers=false
+          npx @scalekit-inc/cli setup
           ```
 
-          ```bash title="Step 2 — Install a specific skill" frame="terminal" showLineNumbers=false
-          npx skills add scalekit-inc/skills --skill adding-mcp-oauth
-          ```
+          For repeated use: `npm install -g @scalekit-inc/cli` then `scalekit setup`.
+
+          Choose the "Other agents" / skills option when prompted by the CLI.
 
           Now ask your agent to implement Scalekit auth in natural language. [See example starting prompts →](/agentkit/quickstart/)
         </TabItem>

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -424,21 +424,16 @@ head:
         margin: 0;
       }
 
-      .gateway-cli-inner {
-        font-size: 0.9rem;
+      .gateway-cli-label {
+        font-size: 0.85rem;
         color: var(--sl-color-text-muted);
-        margin: 0;
+        margin: 0 0 0.3rem;
       }
 
-      .gateway-cli-cmd {
-        font-family: var(--sl-font-mono);
-        background: #f1f5f9;
-        border: 1px solid #e2e8f0;
-        padding: 0.1em 0.45em;
-        border-radius: 4px;
-        font-size: 0.88rem;
-        color: var(--sl-color-text);
-        white-space: nowrap;
+      .gateway-cli .expressive-code {
+        max-width: 360px;
+        margin: 0 auto;
+        display: block;
       }
 
       .gateway-intro-inner {
@@ -477,7 +472,12 @@ import authForSaasHero from '../../assets/pages/hero/auth-for-saas.svg'
   </section>
 
   <div class="gateway-cli not-content">
-    <p class="gateway-cli-inner">Start with coding agents — Run <code class="gateway-cli-cmd">npx @scalekit-inc/cli setup</code></p>
+    <p class="gateway-cli-label">Start with coding agents</p>
+
+```sh frame="none" showLineNumbers=false
+$ npx @scalekit-inc/cli setup
+```
+
   </div>
 
   <div class="gateway">

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -197,24 +197,6 @@ head:
         margin: 0;
       }
 
-      .panel-cli-title {
-        font-size: 0.8rem;
-        font-weight: 600;
-        color: var(--sl-color-text);
-        margin: 0.5rem 0 0.25rem;
-        text-align: center;
-      }
-
-      .panel-cli-cmd {
-        font-family: var(--sl-font-mono);
-        background: #f8fafc;
-        border: 1px solid #e2e8f0;
-        padding: 0.15em 0.5em;
-        border-radius: 4px;
-        font-size: 0.8rem;
-        color: #0f172a;
-        white-space: nowrap;
-      }
 
       .panel-visual {
         width: min(100%, 36rem);
@@ -432,9 +414,31 @@ head:
         }
       }
 
-      /* CLI as top-level entry now that the question is gone */
       .gateway-intro {
         background: #fff;
+      }
+
+      .gateway-cli {
+        text-align: center;
+        padding: 0.5rem 0 0.75rem;
+        margin: 0;
+      }
+
+      .gateway-cli-inner {
+        font-size: 0.9rem;
+        color: var(--sl-color-text-muted);
+        margin: 0;
+      }
+
+      .gateway-cli-cmd {
+        font-family: var(--sl-font-mono);
+        background: #f1f5f9;
+        border: 1px solid #e2e8f0;
+        padding: 0.1em 0.45em;
+        border-radius: 4px;
+        font-size: 0.88rem;
+        color: var(--sl-color-text);
+        white-space: nowrap;
       }
 
       .gateway-intro-inner {
@@ -454,27 +458,6 @@ head:
         text-align: center;
       }
 
-      /* Compact terminal block in the gateway area */
-      .gateway-shell .expressive-code {
-        max-width: 480px;
-        margin: 0.5rem auto 0.75rem;
-        display: block;
-      }
-
-      .gateway-shell .expressive-code,
-      .gateway-shell .expressive-code code {
-        padding: 0 !important;
-      }
-
-      .gateway-shell .expressive-code pre {
-        font-size: 0.85rem;
-        padding: 0.5rem 0.75rem !important;
-      }
-
-      /* ensure space before the panels */
-      .gateway-shell .expressive-code + .gateway {
-        margin-top: 0;
-      }
 
 ---
 
@@ -493,16 +476,9 @@ import authForSaasHero from '../../assets/pages/hero/auth-for-saas.svg'
     </div>
   </section>
 
-```sh frame="none" showLineNumbers=false title="Start with coding agents"
-$ npx @scalekit-inc/cli setup
-```
-
-For repeated use:
-
-```bash title="Global install" frame="terminal" showLineNumbers=false
-npm install -g @scalekit-inc/cli
-scalekit setup
-```
+  <div class="gateway-cli not-content">
+    <p class="gateway-cli-inner">Start with coding agents — Run <code class="gateway-cli-cmd">npx @scalekit-inc/cli setup</code></p>
+  </div>
 
   <div class="gateway">
     <a
@@ -510,7 +486,6 @@ scalekit setup
       class="panel panel-agents"
     >
       <span class="panel-badge">For Agent Builders</span>
-      <p class="panel-cli-title">Start with coding agents <code class="panel-cli-cmd">npx @scalekit-inc/cli setup</code> (or `npm i -g @scalekit-inc/cli` then `scalekit setup`)</p>
       <p class="panel-label">Connect my agents to any enterprise app</p>
       <p class="panel-desc">Delegated auth. Scoped permissions. Tool calls.</p>
       <span class="panel-cta">Connect my agents to apps →</span>
@@ -532,7 +507,6 @@ scalekit setup
       class="panel panel-saas"
     >
       <span class="panel-badge">For SaaS Developers</span>
-      <p class="panel-cli-title">Start with coding agents <code class="panel-cli-cmd">npx @scalekit-inc/cli setup</code> (or `npm i -g @scalekit-inc/cli` then `scalekit setup`)</p>
       <p class="panel-label">{`Add auth and user\u00a0management to my SaaS app`}</p>
       <p class="panel-desc">Sessions, SSO, RBAC, SCIM - all in one stack.</p>
       <span class="panel-cta">Add auth to my app →</span>

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -472,7 +472,6 @@ import authForSaasHero from '../../assets/pages/hero/auth-for-saas.svg'
   </section>
 
   <div class="gateway-cli not-content">
-    <p class="gateway-cli-label">Start with coding agents</p>
 
 ```sh frame="none" showLineNumbers=false
 $ npx @scalekit-inc/cli setup

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -474,7 +474,7 @@ import authForSaasHero from '../../assets/pages/hero/auth-for-saas.svg'
   <div class="gateway-cli not-content">
 
 ```sh frame="none" showLineNumbers=false
-$ npx @scalekit-inc/cli setup
+npx @scalekit-inc/cli setup
 ```
 
   </div>

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -62,50 +62,12 @@ head:
         z-index: 1;
       }
 
-      .gateway-intro {
-        background: #fff;
-        border-bottom: 1px solid var(--sl-color-hairline);
-      }
-
-      .gateway-intro-inner {
-        max-width: 1280px;
-        margin: 0 auto;
-        padding: 2rem 4rem 2rem;
-      }
-
-      .gateway-intro-kicker {
-        margin: 0 auto 0.75rem;
-        font-size: 0.8rem;
-        font-weight: 600;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        color: var(--sl-color-text-muted);
-        text-align: center;
-      }
-
-      .gateway-intro-title {
-        max-width: 42rem;
-        margin: 0 auto;
-        font-size: clamp(2rem, 1.6rem + 1.2vw, 3rem);
-        line-height: 1.08;
-        letter-spacing: -0.04em;
-        color: var(--sl-color-text-heading);
-        text-align: center;
-      }
-
-      .gateway-intro-copy {
-        max-width: 46rem;
-        margin: 1rem 0 0;
-        font-size: 1.05rem;
-        line-height: 1.7;
-        color: var(--sl-color-text);
-      }
-
       .gateway {
         display: flex;
         flex-direction: row;
         min-height: clamp(22rem, calc(100vh - var(--sl-nav-height) - 20rem), 35rem);
         margin-top: 0;
+        padding-top: 0.5rem;
         overflow: hidden;
         background: var(--sl-color-bg);
       }
@@ -233,6 +195,25 @@ head:
         line-height: 1.6;
         max-width: 24rem;
         margin: 0;
+      }
+
+      .panel-cli-title {
+        font-size: 0.8rem;
+        font-weight: 600;
+        color: var(--sl-color-text);
+        margin: 0.5rem 0 0.25rem;
+        text-align: center;
+      }
+
+      .panel-cli-cmd {
+        font-family: var(--sl-font-mono);
+        background: #f8fafc;
+        border: 1px solid #e2e8f0;
+        padding: 0.15em 0.5em;
+        border-radius: 4px;
+        font-size: 0.8rem;
+        color: #0f172a;
+        white-space: nowrap;
       }
 
       .panel-visual {
@@ -389,9 +370,6 @@ head:
       }
 
       @media (max-width: 1023px) and (min-width: 768px) {
-        .gateway-intro-inner {
-          padding: 3rem 2rem 2.5rem;
-        }
         .panel {
           padding: 3rem 2rem;
         }
@@ -415,13 +393,6 @@ head:
       }
 
       @media (max-width: 767px) {
-        .gateway-intro-inner {
-          padding: 2.5rem 1rem 2rem;
-        }
-        .gateway-intro-copy {
-          font-size: 1rem;
-          line-height: 1.65;
-        }
         .gateway {
           flex-direction: column;
           min-height: auto;
@@ -460,6 +431,51 @@ head:
           margin-top: 0.5rem;
         }
       }
+
+      /* CLI as top-level entry now that the question is gone */
+      .gateway-intro {
+        background: #fff;
+      }
+
+      .gateway-intro-inner {
+        max-width: 1280px;
+        margin: 0 auto;
+        padding: 2rem 4rem 0.75rem;
+      }
+
+      .gateway-intro-title {
+        max-width: 42rem;
+        margin: 0 auto;
+        font-size: clamp(2rem, 1.6rem + 1.2vw, 3rem);
+        line-height: 1.08;
+        letter-spacing: -0.04em;
+        font-weight: 400;
+        color: var(--sl-color-text-heading);
+        text-align: center;
+      }
+
+      /* Compact terminal block in the gateway area */
+      .gateway-shell .expressive-code {
+        max-width: 480px;
+        margin: 0.5rem auto 0.75rem;
+        display: block;
+      }
+
+      .gateway-shell .expressive-code,
+      .gateway-shell .expressive-code code {
+        padding: 0 !important;
+      }
+
+      .gateway-shell .expressive-code pre {
+        font-size: 0.85rem;
+        padding: 0.5rem 0.75rem !important;
+      }
+
+      /* ensure space before the panels */
+      .gateway-shell .expressive-code + .gateway {
+        margin-top: 0;
+      }
+
 ---
 
 import agentkitHero from '../../assets/pages/hero/agentkit.svg'
@@ -467,7 +483,7 @@ import authForSaasHero from '../../assets/pages/hero/auth-for-saas.svg'
 
 
 
-<div class="gateway-shell">
+<div class="gateway-shell not-content">
   <section class="gateway-intro" aria-labelledby="gateway-intro-title">
     <div class="gateway-intro-inner">
       <h2 class="gateway-intro-title" id="gateway-intro-title">
@@ -477,12 +493,24 @@ import authForSaasHero from '../../assets/pages/hero/auth-for-saas.svg'
     </div>
   </section>
 
+```sh frame="none" showLineNumbers=false title="Start with coding agents"
+$ npx @scalekit-inc/cli setup
+```
+
+For repeated use:
+
+```bash title="Global install" frame="terminal" showLineNumbers=false
+npm install -g @scalekit-inc/cli
+scalekit setup
+```
+
   <div class="gateway">
     <a
       href="/agentkit/quickstart/"
       class="panel panel-agents"
     >
       <span class="panel-badge">For Agent Builders</span>
+      <p class="panel-cli-title">Start with coding agents <code class="panel-cli-cmd">npx @scalekit-inc/cli setup</code> (or `npm i -g @scalekit-inc/cli` then `scalekit setup`)</p>
       <p class="panel-label">Connect my agents to any enterprise app</p>
       <p class="panel-desc">Delegated auth. Scoped permissions. Tool calls.</p>
       <span class="panel-cta">Connect my agents to apps →</span>
@@ -504,6 +532,7 @@ import authForSaasHero from '../../assets/pages/hero/auth-for-saas.svg'
       class="panel panel-saas"
     >
       <span class="panel-badge">For SaaS Developers</span>
+      <p class="panel-cli-title">Start with coding agents <code class="panel-cli-cmd">npx @scalekit-inc/cli setup</code> (or `npm i -g @scalekit-inc/cli` then `scalekit setup`)</p>
       <p class="panel-label">{`Add auth and user\u00a0management to my SaaS app`}</p>
       <p class="panel-desc">Sessions, SSO, RBAC, SCIM - all in one stack.</p>
       <span class="panel-cta">Add auth to my app →</span>

--- a/src/content/docs/passwordless/oidc.mdx
+++ b/src/content/docs/passwordless/oidc.mdx
@@ -75,28 +75,23 @@ Your app -> User: "Create session and grant access"
   showCta={false}
   clickable={false}
 >
-  <Tabs syncKey="build-with-agent">
-   <TabItem label="Claude Code" icon="claude">
-    ```bash title="Terminal" frame="terminal" showLineNumbers=false
-    claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install full-stack-auth@scalekit-auth-stack
-    ```
-   </TabItem>
-   <TabItem label="GitHub Copilot CLI" icon="githubcopilot">
-    ```bash title="Terminal" showLineNumbers=false frame="none"
-    copilot plugin marketplace add scalekit-inc/github-copilot-authstack
-    ```
-    ```bash title="Terminal" showLineNumbers=false frame="none"
-    copilot plugin install full-stack-auth@scalekit-auth-stack
-    ```
-   </TabItem>
-   <TabItem label="40+ agents" icon="sparkle">
-    ```bash title="Terminal" showLineNumbers=false frame="none"
-    npx skills add scalekit-inc/skills --skill implementing-scalekit-fsa
-    ```
-   </TabItem>
+  Install the authstack plugin for your coding agents:
+
+  <Tabs syncKey="fsa-cli-install">
+    <TabItem label="Global install (recommended)">
+      ```bash title="Terminal" frame="terminal" showLineNumbers=false
+      npm install -g @scalekit-inc/cli
+      scalekit setup
+      ```
+    </TabItem>
+    <TabItem label="npx (one-off)">
+      ```bash title="Terminal" frame="terminal" showLineNumbers=false
+      npx @scalekit-inc/cli setup
+      ```
+    </TabItem>
   </Tabs>
 
-  [Continue building with AI →](/dev-kit/build-with-ai/full-stack-auth/)
+  The CLI sets up the authstack plugin (with full-stack auth support) for Claude Code, Cursor, GitHub Copilot, Codex, and 40+ other agents.
 </FoldCard>
 
 

--- a/src/content/docs/passwordless/oidc.mdx
+++ b/src/content/docs/passwordless/oidc.mdx
@@ -75,8 +75,6 @@ Your app -> User: "Create session and grant access"
   showCta={false}
   clickable={false}
 >
-  Install the authstack plugin for your coding agents:
-
   <Tabs syncKey="fsa-cli-install">
     <TabItem label="Global install (recommended)">
       ```bash title="Terminal" frame="terminal" showLineNumbers=false
@@ -91,7 +89,6 @@ Your app -> User: "Create session and grant access"
     </TabItem>
   </Tabs>
 
-  The CLI sets up the authstack plugin (with full-stack auth support) for Claude Code, Cursor, GitHub Copilot, Codex, and 40+ other agents.
 </FoldCard>
 
 

--- a/src/content/docs/passwordless/quickstart.mdx
+++ b/src/content/docs/passwordless/quickstart.mdx
@@ -84,8 +84,6 @@ Coming soon
   showCta={false}
   clickable={false}
 >
-  Install the authstack plugin for your coding agents:
-
   <Tabs syncKey="fsa-cli-install">
     <TabItem label="Global install (recommended)">
       ```bash title="Terminal" frame="terminal" showLineNumbers=false
@@ -100,7 +98,6 @@ Coming soon
     </TabItem>
   </Tabs>
 
-  The CLI sets up the authstack plugin (with full-stack auth support) for Claude Code, Cursor, GitHub Copilot, Codex, and 40+ other agents.
 </FoldCard>
 
 -------

--- a/src/content/docs/passwordless/quickstart.mdx
+++ b/src/content/docs/passwordless/quickstart.mdx
@@ -12,9 +12,6 @@ sidebar:
 badge:
    text: 'Headless'
    variant: 'default'
-banner:
-  content: |
-    Build this faster with AI coding agents. <a href="/dev-kit/build-with-ai/full-stack-auth/">Build with AI →</a>
 head:
   - tag: style
     content: |
@@ -87,28 +84,23 @@ Coming soon
   showCta={false}
   clickable={false}
 >
-  <Tabs syncKey="build-with-agent">
-   <TabItem label="Claude Code" icon="claude">
-    ```bash title="Terminal" frame="terminal" showLineNumbers=false
-    claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install full-stack-auth@scalekit-auth-stack
-    ```
-   </TabItem>
-   <TabItem label="GitHub Copilot CLI" icon="githubcopilot">
-    ```bash title="Terminal" showLineNumbers=false frame="none"
-    copilot plugin marketplace add scalekit-inc/github-copilot-authstack
-    ```
-    ```bash title="Terminal" showLineNumbers=false frame="none"
-    copilot plugin install full-stack-auth@scalekit-auth-stack
-    ```
-   </TabItem>
-   <TabItem label="40+ agents" icon="sparkle">
-    ```bash title="Terminal" showLineNumbers=false frame="none"
-    npx skills add scalekit-inc/skills --skill implementing-scalekit-fsa
-    ```
-   </TabItem>
+  Install the authstack plugin for your coding agents:
+
+  <Tabs syncKey="fsa-cli-install">
+    <TabItem label="Global install (recommended)">
+      ```bash title="Terminal" frame="terminal" showLineNumbers=false
+      npm install -g @scalekit-inc/cli
+      scalekit setup
+      ```
+    </TabItem>
+    <TabItem label="npx (one-off)">
+      ```bash title="Terminal" frame="terminal" showLineNumbers=false
+      npx @scalekit-inc/cli setup
+      ```
+    </TabItem>
   </Tabs>
 
-  [Continue building with AI →](/dev-kit/build-with-ai/full-stack-auth/)
+  The CLI sets up the authstack plugin (with full-stack auth support) for Claude Code, Cursor, GitHub Copilot, Codex, and 40+ other agents.
 </FoldCard>
 
 -------

--- a/src/content/docs/sso/quickstart.mdx
+++ b/src/content/docs/sso/quickstart.mdx
@@ -114,15 +114,15 @@ Choose Modular SSO when you:
   clickable={false}
 >
   <Tabs syncKey="sso-cli-install">
-    <TabItem label="Global install (recommended)">
+    <TabItem label="Recommended">
+      ```bash title="Terminal" frame="terminal" showLineNumbers=false
+      npx @scalekit-inc/cli setup
+      ```
+    </TabItem>
+    <TabItem label="Global install (for repeated use)">
       ```bash title="Terminal" frame="terminal" showLineNumbers=false
       npm install -g @scalekit-inc/cli
       scalekit setup
-      ```
-    </TabItem>
-    <TabItem label="npx (one-off)">
-      ```bash title="Terminal" frame="terminal" showLineNumbers=false
-      npx @scalekit-inc/cli setup
       ```
     </TabItem>
   </Tabs>

--- a/src/content/docs/sso/quickstart.mdx
+++ b/src/content/docs/sso/quickstart.mdx
@@ -5,9 +5,6 @@ tags: [sso, quickstart, enterprise, saml, oidc, okta, azure-ad, single-sign-on]
 sidebar:
   order: 1
   label: "Enterprise SSO"
-banner:
-  content: |
-    Build this faster with AI coding agents. <a href="/dev-kit/build-with-ai/sso/">Build with AI →</a>
 head:
   - tag: style
     content: |
@@ -116,28 +113,23 @@ Choose Modular SSO when you:
   showCta={false}
   clickable={false}
 >
-  <Tabs syncKey="build-with-agent">
-   <TabItem label="Claude Code" icon="claude">
-    ```bash title="Terminal" frame="terminal" showLineNumbers=false
-    claude plugin marketplace add scalekit-inc/claude-code-authstack && claude plugin install modular-sso@scalekit-auth-stack
-    ```
-   </TabItem>
-   <TabItem label="GitHub Copilot CLI" icon="githubcopilot">
-    ```bash title="Terminal" showLineNumbers=false frame="none"
-    copilot plugin marketplace add scalekit-inc/github-copilot-authstack
-    ```
-    ```bash title="Terminal" showLineNumbers=false frame="none"
-    copilot plugin install modular-sso@scalekit-auth-stack
-    ```
-   </TabItem>
-   <TabItem label="40+ agents" icon="sparkle">
-    ```bash title="Terminal" showLineNumbers=false frame="none"
-    npx skills add scalekit-inc/skills --skill modular-sso
-    ```
-   </TabItem>
+  Install the authstack plugin for your coding agents:
+
+  <Tabs syncKey="sso-cli-install">
+    <TabItem label="Global install (recommended)">
+      ```bash title="Terminal" frame="terminal" showLineNumbers=false
+      npm install -g @scalekit-inc/cli
+      scalekit setup
+      ```
+    </TabItem>
+    <TabItem label="npx (one-off)">
+      ```bash title="Terminal" frame="terminal" showLineNumbers=false
+      npx @scalekit-inc/cli setup
+      ```
+    </TabItem>
   </Tabs>
 
-  [Continue building with AI →](/dev-kit/build-with-ai/sso/)
+  The CLI sets up the authstack plugin (with modular SSO support) for Claude Code, Cursor, GitHub Copilot, Codex, and 40+ other agents.
 </FoldCard>
 
 

--- a/src/content/docs/sso/quickstart.mdx
+++ b/src/content/docs/sso/quickstart.mdx
@@ -113,8 +113,6 @@ Choose Modular SSO when you:
   showCta={false}
   clickable={false}
 >
-  Install the authstack plugin for your coding agents:
-
   <Tabs syncKey="sso-cli-install">
     <TabItem label="Global install (recommended)">
       ```bash title="Terminal" frame="terminal" showLineNumbers=false
@@ -129,7 +127,6 @@ Choose Modular SSO when you:
     </TabItem>
   </Tabs>
 
-  The CLI sets up the authstack plugin (with modular SSO support) for Claude Code, Cursor, GitHub Copilot, Codex, and 40+ other agents.
 </FoldCard>
 
 


### PR DESCRIPTION
Updates LLM wirings, injected headers, templates, quickstarts, homepage, and AI dev resources to use the new unified CLI for authstack plugin setup.

**Changes:**
- Updated `src/configs/agent-instructions.ts`, `src/configs/llms.config.ts`, `scripts/generate-llms-index.js`, and `public/AGENTS.md` to promote `npx @scalekit-inc/cli setup` (recommended) and global install form (`npm install -g @scalekit-inc/cli` + `scalekit setup`).
- Refreshed all coding-agents templates (`_*.mdx`) and page actions to feature the CLI commands for Claude Code, Cursor, GitHub Copilot, Codex, Windsurf, Cline and 40+ agents.
- Updated quickstarts and guides (authenticate/fsa, mcp, sso, directory/scim, passwordless, agentkit, cookbooks) plus homepage (`index.mdx`), saaskit, and dev-kit pages for consistent CLI messaging.
- The authstack plugin now provides accurate Scalekit implementation patterns (full-stack-auth, agent-auth, mcp-auth, modular-sso, modular-scim) via the single CLI entrypoint.

This ensures AI coding agents and LLM contexts always surface the current recommended setup command.

Preview: https://deploy-preview-760--scalekit-starlight.netlify.app/dev-kit/build-with-ai/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Scalekit CLI documentation page, including installation, setup, supported tools, and prompt-routing examples.
  * Added a new navigation entry for “AI tools” (CLI).
* **Documentation**
  * Updated coding-agent and auth quickstarts to a unified, CLI-first authstack plugin setup flow, with clear “for repeated use” guidance.
  * Refreshed per-tool instructions and tool-native alternative sections (Claude Code, Codex, GitHub Copilot CLI, Cursor, and 40+ agents).
  * Removed/adjusted “Build with AI” banner content and standardized wording across pages.
* **Chores**
  * Standardized shared install/agent guidance across generated and embedded documentation blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->