### PR TITLE
Loosen agent connector deployment controls and upgrade paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,7 @@
 # Folder specific owners (last so this path takes precedence)
 /src/content/docs/guides/integrations/ @amitash1912 @saravanan2003-hub
 
-# Agent connector docs: single reviewer (overrides *.mdx for these trees)
-/src/components/templates/agent-connectors/ @AkshayParihar33
-/src/content/docs/agentkit/connectors/ @AkshayParihar33
-/src/data/agent-connectors/ @AkshayParihar33
+# Agent connector docs (overrides *.mdx for these trees)
+/src/components/templates/agent-connectors/ @AkshayParihar33 @Avinash-Kamath @saif-at-scalekit
+/src/content/docs/agentkit/connectors/ @AkshayParihar33 @Avinash-Kamath @saif-at-scalekit
+/src/data/agent-connectors/ @AkshayParihar33 @Avinash-Kamath @saif-at-scalekit

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # Owners will be automatically requested for review when someone opens a pull request.
 #
 # Order matters: the last matching pattern wins. * is @saif-at-scalekit; *.mdx
-# adds amit, ravi, and akshay; integrations/ lists dedicated owners last for that tree.
+# adds amit, ravi, and akshay; integrations/ and agent-connectors/ override below.
 
 # Default owners for everything in the repo
 * @saif-at-scalekit
@@ -11,8 +11,10 @@
 # MDX files: all docs reviewers
 *.mdx @saif-at-scalekit @amitash1912 @ravibits @AkshayParihar33
 
-# Agentkit connector docs: same reviewers (explicit for precedence)
-/src/content/docs/agentkit/connectors/**/*.mdx @saif-at-scalekit @amitash1912 @ravibits @AkshayParihar33
-
 # Folder specific owners (last so this path takes precedence)
 /src/content/docs/guides/integrations/ @amitash1912 @saravanan2003-hub
+
+# Agent connector docs: single reviewer (overrides *.mdx for these trees)
+/src/components/templates/agent-connectors/ @AkshayParihar33
+/src/content/docs/agentkit/connectors/ @AkshayParihar33
+/src/data/agent-connectors/ @AkshayParihar33

--- a/.github/rulesets/protect-main.json
+++ b/.github/rulesets/protect-main.json
@@ -14,7 +14,7 @@
     {
       "type": "pull_request",
       "parameters": {
-        "required_approving_review_count": 2,
+        "required_approving_review_count": 1,
         "dismiss_stale_reviews_on_push": false,
         "required_reviewers": [],
         "require_code_owner_review": false,

--- a/.github/rulesets/protect-main.json
+++ b/.github/rulesets/protect-main.json
@@ -17,7 +17,7 @@
         "required_approving_review_count": 1,
         "dismiss_stale_reviews_on_push": false,
         "required_reviewers": [],
-        "require_code_owner_review": false,
+        "require_code_owner_review": true,
         "require_last_push_approval": false,
         "required_review_thread_resolution": false,
         "allowed_merge_methods": ["merge", "squash", "rebase"]


### PR DESCRIPTION
## Summary

- Reduces required approving review count on `main` from **2** to **1** in the branch protection ruleset.
- Narrows agent connector CODEOWNERS to **@AkshayParihar33** only for:
  - `/src/components/templates/agent-connectors/`
  - `/src/content/docs/agentkit/connectors/`
  - `/src/data/agent-connectors/`

## Why

Streamlines review and merge flow for agent connector docs and related assets without requiring the full MDX reviewer set.

## Preview

https://deploy-preview-775--scalekit-starlight.netlify.app/

_No docs content changed — GitHub configuration only._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated review-routing rules so documentation and agent-connector content follow the correct ownership and override precedence.
  * Simplified main-branch protection by reducing the number of required approving reviews from 2 to 1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->