### PR TITLE
fix(nav): keep product topics reachable on narrow screens

### DIFF
--- a/src/components/SecondaryNav.astro
+++ b/src/components/SecondaryNav.astro
@@ -252,8 +252,9 @@ const navItems = secondaryNavConfig[activeProduct]
     display: none;
   }
 
-  /* Show the sidebar topics on mobile */
-  @media (max-width: 48rem) {
+  /* Show the sidebar topics whenever the secondary nav bar is hidden (<= 60rem),
+     so product topics stay reachable in the sidebar and there is no dead zone */
+  @media (max-width: 60rem) {
     :global(.starlight-sidebar-topics) {
       display: block !important;
     }


### PR DESCRIPTION
The secondary nav bar is hidden at max-width 60rem, but the sidebar-topics fallback only reappeared at max-width 48rem, leaving a 48-60rem dead zone with no reachable top navigation. Align the fallback breakpoint to 60rem so topics show in the sidebar exactly when the bar is hidden.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the visibility behavior for the sidebar topics list so it appears on wider screens when the secondary navigation is hidden, improving navigation access on more layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->