### PR TITLE
docs: polish Chargebee B2B billing cookbook

### DIFF
--- a/src/content/docs/cookbooks/sync-b2b-billing-with-chargebee.mdx
+++ b/src/content/docs/cookbooks/sync-b2b-billing-with-chargebee.mdx
@@ -727,30 +727,35 @@ curl -s http://localhost:3000/api/session \
 
 ## Helpful prompts
 
-Use these FAQ-style prompts with an AI coding agent (Cursor, Claude Code, Copilot CLI, and similar). Expand a question, copy the prompt block into chat, and replace bracketed placeholders with your stack.
+Use these FAQ-style prompts with an AI coding agent (Cursor, Claude Code, Copilot CLI, Codex, and similar). First install the Scalekit authstack plugin for your agent, then paste a prompt from a section below (replace bracketed placeholders with your stack).
 
-For better Scalekit-aware answers, install Scalekit skills into your agent with the Skills CLI (`npx`), then run the prompts below:
+### 1. Set up your coding agent
 
-```bash title="Terminal"
-# List available skills
-npx skills add scalekit-inc/skills --list
-
-# Add skills you need (examples)
-npx skills add scalekit-inc/skills --skill implementing-saaskit
-npx skills add scalekit-inc/skills --skill scalekit-code-doctor
-
-# Or install everything from the skills repo
-npx skills add scalekit-inc/skills --all
-```
-
-You can also install the authstack plugin skills the same way when your agent supports plugins:
+Run the Scalekit CLI setup so your agent loads Scalekit auth patterns (reduces hallucinations on sessions, webhooks, and orgs):
 
 ```bash title="Terminal"
-npx skills add scalekit-inc/authstack --list
-npx skills add scalekit-inc/authstack --skill implementing-saaskit
+npx @scalekit-inc/cli setup
 ```
 
-After `npx skills add …`, restart or reload the agent so the skill loads, then paste a prompt from a section below.
+For repeated use:
+
+```bash title="Terminal"
+npm install -g @scalekit-inc/cli
+scalekit setup
+```
+
+`setup` with no arguments launches an interactive wizard and detects installed tools. Target one agent explicitly if you prefer:
+
+```bash title="Terminal"
+npx @scalekit-inc/cli setup cursor
+npx @scalekit-inc/cli setup claude
+npx @scalekit-inc/cli setup codex
+npx @scalekit-inc/cli setup copilot
+```
+
+See the [Scalekit CLI](/dev-kit/cli/) for flags and what gets installed. After setup, open your agent and use a prompt below.
+
+### 2. Prompts (after setup)
 
 <details>
 <summary>How do I scaffold Scalekit webhooks and Chargebee customer provisioning?</summary>

--- a/src/content/docs/cookbooks/sync-b2b-billing-with-chargebee.mdx
+++ b/src/content/docs/cookbooks/sync-b2b-billing-with-chargebee.mdx
@@ -2,7 +2,7 @@
 title: 'Sync B2B billing with Scalekit and Chargebee'
 description: 'Map Scalekit organizations to Chargebee customers, run hosted checkout, and keep subscription state in sync via webhooks.'
 date: 2026-06-15
-tags: ['Full stack auth', 'Webhooks', 'Next.js']
+tags: ['Organizations', 'Webhooks', 'Next.js']
 sidebar:
   label: 'Chargebee B2B billing'
 tableOfContents: true
@@ -23,10 +23,10 @@ import { Aside } from '@astrojs/starlight/components';
 
 Multi-tenant B2B SaaS apps authenticate users through Scalekit organizations, but bill through Chargebee subscriptions. Those two systems do not share a database. Without an explicit mapping, you end up with duplicate Chargebee customers, subscriptions that never activate after checkout, or feature gates that read stale plan data.
 
-This cookbook wires Scalekit Full Stack Auth to Chargebee using **org-mode billing**: the organization ID from the access token (`oid`) becomes the billing `referenceId`, Scalekit webhooks provision Chargebee customers, and Chargebee webhooks keep your local subscription table current. You own the routes, schema, and authorization that connect the two systems.
+This cookbook wires Scalekit organizations and sessions to Chargebee using **org-mode billing**: the organization ID from the access token (`oid`) becomes the billing `referenceId`, Scalekit webhooks provision Chargebee customers, and Chargebee webhooks keep your local subscription table current. You own the routes, schema, and authorization that connect the two systems.
 
 <Aside type="note" title="Working example repo">
-  Patterns below are implemented end-to-end in [saas-auth-chargebee-example](https://github.com/scalekit-developers/saas-auth-chargebee-example) (Next.js, Scalekit FSA, Chargebee Node SDK, Drizzle + SQLite). Clone it to follow along locally, including the in-app journey at `/guide`.
+  Patterns below are implemented end-to-end in [saas-auth-chargebee-example](https://github.com/scalekit-developers/saas-auth-chargebee-example) (Next.js, Scalekit, Chargebee Node SDK, Drizzle + SQLite). Clone it to follow along locally, including the in-app journey at `/guide`.
 </Aside>
 
 ## What you get
@@ -42,7 +42,7 @@ This cookbook wires Scalekit Full Stack Auth to Chargebee using **org-mode billi
 
 This cookbook is for you if:
 
-- ✅ You run **Full Stack Auth** with organization support (`oid` in access tokens)
+- ✅ You authenticate with Scalekit and use **organizations** (`oid` in access tokens)
 - ✅ You bill **per organization**, not per individual user
 - ✅ You use Chargebee hosted checkout or the customer portal
 - ✅ You maintain a local subscription cache to gate features in your app
@@ -63,7 +63,7 @@ Treat the Scalekit **organization ID** as the single billing reference for the t
 
 ```text
 Scalekit organization.created → local organization + Chargebee customer
-User login (FSA) → session with oid claim
+User login (Scalekit) → session with oid claim
 POST /api/subscription/create → future row + hosted checkout URL
 Chargebee checkout success → /api/subscription/success (eager sync)
 Chargebee webhooks → sync subscription + items to your database
@@ -712,7 +712,7 @@ Use these with an AI assistant to accelerate common tasks. Replace bracketed pla
 **Scaffold server wiring**
 
 ```text
-I'm integrating Chargebee with Scalekit Full Stack Auth (org-mode billing). Generate:
+I'm integrating Chargebee with Scalekit organizations (org-mode billing). Generate:
 1. Scalekit webhook route that verifies the raw body with verifyWebhookPayload
 2. createOrgCustomer that upserts local org and creates a Chargebee customer with
    meta_data.organizationId and customerType organization
@@ -777,7 +777,7 @@ Walk through DNS, routing, middleware, signature/Basic Auth, and env configurati
 
 ```text
 Subscription status in my database does not update after checkout or cancel.
-Setup: Scalekit FSA + Chargebee, local future row + pendingSubscriptionId.
+Setup: Scalekit organizations + Chargebee, local future row + pendingSubscriptionId.
 List likely causes and how to verify chargebee_customer_id and
 chargebee_subscription_id are populated.
 ```

--- a/src/content/docs/cookbooks/sync-b2b-billing-with-chargebee.mdx
+++ b/src/content/docs/cookbooks/sync-b2b-billing-with-chargebee.mdx
@@ -23,7 +23,7 @@ import { Aside } from '@astrojs/starlight/components';
 
 Multi-tenant B2B SaaS apps authenticate users through Scalekit organizations, but bill through Chargebee subscriptions. Those two systems do not share a database. Without an explicit mapping, you end up with duplicate Chargebee customers, subscriptions that never activate after checkout, or feature gates that read stale plan data.
 
-This cookbook wires Scalekit Full Stack Auth to Chargebee using **org-mode billing**: the organization ID from the access token (`oid`) becomes the billing `referenceId`, Scalekit webhooks provision Chargebee customers, and Chargebee webhooks keep your local subscription table current. There is no unified billing plugin—you own the routes, schema, and authorization.
+This cookbook wires Scalekit Full Stack Auth to Chargebee using **org-mode billing**: the organization ID from the access token (`oid`) becomes the billing `referenceId`, Scalekit webhooks provision Chargebee customers, and Chargebee webhooks keep your local subscription table current. You own the routes, schema, and authorization that connect the two systems.
 
 <Aside type="note" title="Working example repo">
   Patterns below are implemented end-to-end in [saas-auth-chargebee-example](https://github.com/scalekit-developers/saas-auth-chargebee-example) (Next.js, Scalekit FSA, Chargebee Node SDK, Drizzle + SQLite). Clone it to follow along locally, including the in-app journey at `/guide`.
@@ -50,7 +50,6 @@ This cookbook is for you if:
 You **don't** need this if:
 
 - ❌ You bill per user, not per organization
-- ❌ You use the [Chargebee Better Auth adapter](https://github.com/chargebee/js-framework-adapters/tree/main/packages/better-auth) and Better Auth's session model
 - ❌ Scalekit manages your entire product catalog and entitlements (no separate billing system)
 
 ## How the integration fits together
@@ -593,14 +592,14 @@ Redirect users to the Chargebee customer portal so they manage payment methods a
 
 ```ts title="api/subscription/portal/route.ts"
 // After authorizeReference(..., action: 'portal')
-const result = await chargebee.hostedPage.managePaymentSources({
+const portalSession = await chargebee.portalSession.create({
   customer: { id: chargebeeCustomerId },
   redirect_url: absoluteUrl(returnUrl),
 });
-return NextResponse.json({ url: result.hosted_page.url });
+return NextResponse.json({
+  url: portalSession.portal_session.access_url,
+});
 ```
-
-(Exact portal API may vary by Chargebee product surface; the reference app exposes `POST /api/subscription/portal`.)
 
 ### Gate a feature behind an active plan
 

--- a/src/content/docs/cookbooks/sync-b2b-billing-with-chargebee.mdx
+++ b/src/content/docs/cookbooks/sync-b2b-billing-with-chargebee.mdx
@@ -543,9 +543,12 @@ export const PLANS: PlanConfig[] = [
 
 ## Common flows
 
-### Create a subscription (hosted checkout)
+Expand a question when you need that path. Each answer assumes the numbered steps above are in place (schema, webhooks, authorize, hosted checkout).
 
-Call your create route from the client with the item price ID and redirect URLs:
+<details>
+<summary>How do I start hosted checkout for a plan?</summary>
+
+Call your create route from the client with the Chargebee **item price ID** and redirect URLs. After authorize and a local `future` row, the server returns a hosted page URL.
 
 ```ts title="app/billing/checkout (client)"
 const res = await fetch('/api/subscription/create', {
@@ -563,9 +566,12 @@ if (data.url) {
 }
 ```
 
-### List active subscriptions
+</details>
 
-Read from your local cache after authorize:
+<details>
+<summary>How do I list active subscriptions for the current org?</summary>
+
+Read from your **local** cache after `authorizeReference` — not from Chargebee on every request. Use that result for billing UI and feature gates.
 
 ```ts title="api/subscription/list/route.ts"
 const subs = await findActiveByReferenceId(ctx.organizationId);
@@ -580,15 +586,21 @@ return NextResponse.json({
 });
 ```
 
-Gate features from this table—not from a Chargebee API call on every request.
+</details>
 
-### Change plans
+<details>
+<summary>How do I change plans when a subscription already exists?</summary>
 
-Use an update route that authorizes the reference, then opens Chargebee hosted update (or applies a subscription change API) for the existing `chargebee_subscription_id`. Attempting create while an active subscription exists should return a clear error (for example `400` with “active subscription already exists”) so the UI can send the user to the portal instead.
+Use an update route that authorizes the reference, then opens Chargebee hosted update (or applies a subscription change API) for the existing `chargebee_subscription_id`.
 
-### Billing portal
+Do not call create again while an active subscription exists. Return a clear error (for example `400` with “active subscription already exists”) so the UI can open the portal or update flow instead.
 
-Redirect users to the Chargebee customer portal so they manage payment methods and invoices:
+</details>
+
+<details>
+<summary>How do I send users to the Chargebee billing portal?</summary>
+
+Create a portal session for the org’s Chargebee customer and redirect to `access_url` so they manage payment methods and invoices.
 
 ```ts title="api/subscription/portal/route.ts"
 // After authorizeReference(..., action: 'portal')
@@ -601,7 +613,12 @@ return NextResponse.json({
 });
 ```
 
-### Gate a feature behind an active plan
+</details>
+
+<details>
+<summary>How do I gate a feature behind an active plan?</summary>
+
+Check local subscription status (and plan line items if you store them). Treat `active` and `in_trial` as entitled unless your product rules differ.
 
 ```ts title="lib/billing/require-active-plan.ts"
 async function requireActivePlan(
@@ -619,9 +636,14 @@ async function requireActivePlan(
 }
 ```
 
-### Organization access control
+</details>
 
-Org-mode billing already scopes by `oid`. Tighten who may create or update subscriptions by combining `authorizeReference` with role checks (owner/admin) from your Scalekit token or membership store before calling Chargebee.
+<details>
+<summary>How do I restrict who can create or update org billing?</summary>
+
+Org-mode billing already scopes by session `oid` via `authorizeReference`. Tighten further by combining that check with role checks (owner/admin) from the Scalekit token or your membership store before calling Chargebee.
+
+</details>
 
 ## Customer customization (optional)
 

--- a/src/content/docs/cookbooks/sync-b2b-billing-with-chargebee.mdx
+++ b/src/content/docs/cookbooks/sync-b2b-billing-with-chargebee.mdx
@@ -727,11 +727,33 @@ curl -s http://localhost:3000/api/session \
 
 ## Helpful prompts
 
-Use these with an AI assistant to accelerate common tasks. Replace bracketed placeholders with your stack.
+Use these FAQ-style prompts with an AI coding agent (Cursor, Claude Code, Copilot CLI, and similar). Expand a question, copy the prompt block into chat, and replace bracketed placeholders with your stack.
 
-### Initial setup
+For better Scalekit-aware answers, install Scalekit skills into your agent with the Skills CLI (`npx`), then run the prompts below:
 
-**Scaffold server wiring**
+```bash title="Terminal"
+# List available skills
+npx skills add scalekit-inc/skills --list
+
+# Add skills you need (examples)
+npx skills add scalekit-inc/skills --skill implementing-saaskit
+npx skills add scalekit-inc/skills --skill scalekit-code-doctor
+
+# Or install everything from the skills repo
+npx skills add scalekit-inc/skills --all
+```
+
+You can also install the authstack plugin skills the same way when your agent supports plugins:
+
+```bash title="Terminal"
+npx skills add scalekit-inc/authstack --list
+npx skills add scalekit-inc/authstack --skill implementing-saaskit
+```
+
+After `npx skills add …`, restart or reload the agent so the skill loads, then paste a prompt from a section below.
+
+<details>
+<summary>How do I scaffold Scalekit webhooks and Chargebee customer provisioning?</summary>
 
 ```text
 I'm integrating Chargebee with Scalekit organizations (org-mode billing). Generate:
@@ -742,7 +764,10 @@ I'm integrating Chargebee with Scalekit organizations (org-mode billing). Genera
 My framework is [Next.js App Router / Express / Hono]. Database is [Drizzle / Prisma / Kysely].
 ```
 
-**Scaffold subscription create**
+</details>
+
+<details>
+<summary>How do I scaffold subscription create with a future row and hosted checkout?</summary>
 
 ```text
 Write POST /api/subscription/create that:
@@ -755,9 +780,10 @@ Write POST /api/subscription/create that:
 Return { mode: "hosted", url }.
 ```
 
-### Webhooks
+</details>
 
-**Test both webhook planes locally**
+<details>
+<summary>How do I test Scalekit and Chargebee webhooks locally?</summary>
 
 ```text
 Walk me through testing Scalekit and Chargebee webhooks locally with ngrok.
@@ -766,9 +792,10 @@ Include ngrok command, dashboard URLs to register, SCALEKIT_WEBHOOK_SECRET,
 and CHARGEBEE_WEBHOOK_USERNAME/PASSWORD Basic Auth.
 ```
 
-### Subscription flows
+</details>
 
-**Pricing page**
+<details>
+<summary>How do I generate a pricing page that starts checkout?</summary>
 
 ```text
 Generate a React pricing page that calls POST /api/subscription/create with
@@ -777,7 +804,10 @@ Show loading while redirecting. If the API says an active subscription exists,
 call POST /api/subscription/portal instead.
 ```
 
-**Feature gate**
+</details>
+
+<details>
+<summary>How do I implement a feature gate for an active plan?</summary>
 
 ```text
 Using a local subscriptions table keyed by Scalekit organization ID, write
@@ -785,9 +815,10 @@ requireActivePlan(organizationId, itemPriceId) that returns true only for
 active or in_trial rows. Show usage in a Next.js API route.
 ```
 
-### Debugging
+</details>
 
-**Webhooks not received**
+<details>
+<summary>Why are my webhooks not reaching the server?</summary>
 
 ```text
 My Scalekit or Chargebee webhooks are not reaching the server. Auth base paths
@@ -795,7 +826,10 @@ are /api/webhooks/scalekit and /api/webhooks/chargebee. Host is [Vercel / Railwa
 Walk through DNS, routing, middleware, signature/Basic Auth, and env configuration.
 ```
 
-**Status not updating**
+</details>
+
+<details>
+<summary>Why is subscription status not updating after checkout or cancel?</summary>
 
 ```text
 Subscription status in my database does not update after checkout or cancel.
@@ -803,6 +837,8 @@ Setup: Scalekit organizations + Chargebee, local future row + pendingSubscriptio
 List likely causes and how to verify chargebee_customer_id and
 chargebee_subscription_id are populated.
 ```
+
+</details>
 
 ## Resources
 

--- a/src/content/docs/cookbooks/sync-b2b-billing-with-chargebee.mdx
+++ b/src/content/docs/cookbooks/sync-b2b-billing-with-chargebee.mdx
@@ -760,7 +760,7 @@ See the [Scalekit CLI](/dev-kit/cli/) for flags and what gets installed. After s
 <details>
 <summary>How do I scaffold Scalekit webhooks and Chargebee customer provisioning?</summary>
 
-```text
+```text showLineNumbers=false
 I'm integrating Chargebee with Scalekit organizations (org-mode billing). Generate:
 1. Scalekit webhook route that verifies the raw body with verifyWebhookPayload
 2. createOrgCustomer that upserts local org and creates a Chargebee customer with
@@ -774,7 +774,7 @@ My framework is [Next.js App Router / Express / Hono]. Database is [Drizzle / Pr
 <details>
 <summary>How do I scaffold subscription create with a future row and hosted checkout?</summary>
 
-```text
+```text showLineNumbers=false
 Write POST /api/subscription/create that:
 - requireSession with oid
 - authorizeReference for action create
@@ -790,7 +790,7 @@ Return { mode: "hosted", url }.
 <details>
 <summary>How do I test Scalekit and Chargebee webhooks locally?</summary>
 
-```text
+```text showLineNumbers=false
 Walk me through testing Scalekit and Chargebee webhooks locally with ngrok.
 App runs on port 3000. Endpoints: /api/webhooks/scalekit and /api/webhooks/chargebee.
 Include ngrok command, dashboard URLs to register, SCALEKIT_WEBHOOK_SECRET,
@@ -802,7 +802,7 @@ and CHARGEBEE_WEBHOOK_USERNAME/PASSWORD Basic Auth.
 <details>
 <summary>How do I generate a pricing page that starts checkout?</summary>
 
-```text
+```text showLineNumbers=false
 Generate a React pricing page that calls POST /api/subscription/create with
 itemPriceId, successUrl /billing?success=1, cancelUrl /billing.
 Show loading while redirecting. If the API says an active subscription exists,
@@ -814,7 +814,7 @@ call POST /api/subscription/portal instead.
 <details>
 <summary>How do I implement a feature gate for an active plan?</summary>
 
-```text
+```text showLineNumbers=false
 Using a local subscriptions table keyed by Scalekit organization ID, write
 requireActivePlan(organizationId, itemPriceId) that returns true only for
 active or in_trial rows. Show usage in a Next.js API route.
@@ -825,7 +825,7 @@ active or in_trial rows. Show usage in a Next.js API route.
 <details>
 <summary>Why are my webhooks not reaching the server?</summary>
 
-```text
+```text showLineNumbers=false
 My Scalekit or Chargebee webhooks are not reaching the server. Auth base paths
 are /api/webhooks/scalekit and /api/webhooks/chargebee. Host is [Vercel / Railway / VPS].
 Walk through DNS, routing, middleware, signature/Basic Auth, and env configuration.
@@ -836,7 +836,7 @@ Walk through DNS, routing, middleware, signature/Basic Auth, and env configurati
 <details>
 <summary>Why is subscription status not updating after checkout or cancel?</summary>
 
-```text
+```text showLineNumbers=false
 Subscription status in my database does not update after checkout or cancel.
 Setup: Scalekit organizations + Chargebee, local future row + pendingSubscriptionId.
 List likely causes and how to verify chargebee_customer_id and


### PR DESCRIPTION
## Summary

Follow-up polish to the Chargebee B2B billing cookbook after #801:

- Remove Better Auth mentions and “plugin” framing
- Drop Full Stack Auth / FSA wording in favor of Scalekit organizations / sessions
- Align portal snippet with `portalSession.create` from the reference app
- Common flows as FAQ-style `<details>` / `<summary>` collapsibles
- Helpful prompts as FAQ collapsibles, preceded by `npx @scalekit-inc/cli setup` (not `npx skills`)
- Prompt code blocks use `showLineNumbers=false`
- Resources remain: reference app, external IDs, implement webhooks

## Test plan

- [ ] Preview http://localhost:4321/cookbooks/sync-b2b-billing-with-chargebee/ (or deploy preview)
- [ ] Expand Common flows and Helpful prompts collapsibles
- [ ] Confirm CLI setup + prompts section; no line numbers on prompt blocks
- [ ] Confirm Resources has only three links