### PR TITLE
docs: remove tags frontmatter from cookbooks

### DIFF
--- a/src/content/docs/cookbooks/add-enterprise-sso-nextjs-authjs.mdx
+++ b/src/content/docs/cookbooks/add-enterprise-sso-nextjs-authjs.mdx
@@ -2,7 +2,6 @@
 title: 'Add Enterprise SSO to Next.js with Auth.js'
 description: 'Wire Scalekit''s OIDC interface into Auth.js to ship per-tenant enterprise SSO in Next.js without touching SAML or IdP-specific code.'
 date: 2026-03-10
-tags: ['SSO', 'Next.js', 'Full stack auth']
 excerpt: >
   Every enterprise customer wants their own IdP — Okta, Azure AD, Google Workspace.
   Handling SAML handshakes and per-tenant routing before you've shipped a feature is

--- a/src/content/docs/cookbooks/apify-actor-per-user-oauth.mdx
+++ b/src/content/docs/cookbooks/apify-actor-per-user-oauth.mdx
@@ -2,7 +2,6 @@
 title: 'Apify Actor with per-user OAuth via Scalekit'
 description: 'Build an Apify Actor that uses Scalekit Agent Auth so each user connects their OAuth accounts, keyed by Apify userId.'
 date: 2026-04-21
-tags: ['Agent auth']
 sidebar:
   label: 'Apify Actor per-user OAuth'
 excerpt: >

--- a/src/content/docs/cookbooks/building-custom-org-switcher.mdx
+++ b/src/content/docs/cookbooks/building-custom-org-switcher.mdx
@@ -2,7 +2,6 @@
 title: 'Building a Custom Organization Switcher'
 description: 'Learn how to build your own organization switcher UI for complete control over multi-tenant user experiences.'
 date: 2025-01-21
-tags: ['Full stack auth']
 excerpt: When users belong to multiple organizations, the default Scalekit organization switcher handles most use cases. However, some applications require deeper integration—a custom switcher embedded directly in your app's navigation, or a specialized UI that matches your design system.
 featured: false
 authors:

--- a/src/content/docs/cookbooks/crewai-agentkit-email-triage.mdx
+++ b/src/content/docs/cookbooks/crewai-agentkit-email-triage.mdx
@@ -2,7 +2,6 @@
 title: 'Build a multi-agent email triage crew with CrewAI'
 description: 'Use CrewAI multi-agent orchestration with Scalekit-authenticated Gmail tools to scan, classify, and draft replies to emails.'
 date: 2026-07-12
-tags: ['Agent auth', 'Python']
 sidebar:
   label: 'CrewAI email triage'
 tableOfContents: true

--- a/src/content/docs/cookbooks/daily-briefing-agent.mdx
+++ b/src/content/docs/cookbooks/daily-briefing-agent.mdx
@@ -2,7 +2,6 @@
 title: 'Build a daily briefing agent with Vercel AI SDK and Scalekit Agent Auth'
 description: 'Connect a TypeScript or Python agent via Vercel AI SDK and Scalekit Agent Auth to Google Calendar and Gmail using two integration patterns.'
 date: 2026-03-27
-tags: ['Agent auth']
 sidebar:
   label: 'Daily briefing agent'
 excerpt: >

--- a/src/content/docs/cookbooks/fastrouter-agentkit-tool-calling.mdx
+++ b/src/content/docs/cookbooks/fastrouter-agentkit-tool-calling.mdx
@@ -2,7 +2,6 @@
 title: 'FastRouter + Scalekit tool calling'
 description: 'Build a Node.js agent that routes LLM calls through FastRouter and uses Scalekit for per-user OAuth tools.'
 date: 2026-05-26
-tags: ['Agent auth', 'Gmail', 'FastRouter', 'Tool calling', 'AgentKit']
 sidebar:
   label: 'Tool calling with FastRouter'
 tableOfContents: true

--- a/src/content/docs/cookbooks/implement-nextjs-auth.mdx
+++ b/src/content/docs/cookbooks/implement-nextjs-auth.mdx
@@ -2,7 +2,6 @@
 title: 'Implement passwordless auth in Next.js 15'
 description: 'Add magic link and OTP authentication to your Next.js application using Scalekit''s headless API.'
 date: 2025-02-19
-tags: ['Full stack auth', 'Next.js']
 excerpt: Next.js 15's App Router requires server-first authentication. This guide shows you how to implement magic link + OTP passwordless login using Scalekit's headless API, keeping all security logic server-side while maintaining full control over your UI.
 featured: false
 authors:

--- a/src/content/docs/cookbooks/java-spring-boot-jwt-timeout.mdx
+++ b/src/content/docs/cookbooks/java-spring-boot-jwt-timeout.mdx
@@ -2,7 +2,6 @@
 title: 'Configuring JWT Validation Timeouts in Spring Boot 4.0+'
 description: 'Fix connection timeout errors when validating Scalekit JWT tokens in Spring Boot 4.0.0 and later versions.'
 date: 2025-02-19
-tags: ['Java', 'Spring Boot', 'Full Stack Auth']
 excerpt: Spring Boot 4.0.0 introduced stricter timeout defaults for JWT validation that can cause connection failures when verifying Scalekit tokens. This guide shows you how to configure appropriate timeouts for production environments.
 featured: false
 authors:

--- a/src/content/docs/cookbooks/langsmith-tracing-agentkit.mdx
+++ b/src/content/docs/cookbooks/langsmith-tracing-agentkit.mdx
@@ -2,7 +2,6 @@
 title: 'Trace AgentKit tool calls in LangSmith'
 description: 'Add LangSmith observability to a LangChain agent that uses Scalekit AgentKit tools for Gmail, Slack, GitHub, and 200+ connectors.'
 date: 2026-05-12
-tags: ['Agent auth', 'LangChain', 'LangSmith']
 sidebar:
   label: 'LangSmith tracing'
 tableOfContents: true

--- a/src/content/docs/cookbooks/litellm-agentkit-inbox-triage.mdx
+++ b/src/content/docs/cookbooks/litellm-agentkit-inbox-triage.mdx
@@ -2,7 +2,6 @@
 title: 'Triage a Gmail inbox with AgentKit and the LiteLLM gateway'
 description: 'Node.js inbox triage agent: classify Gmail threads, route to GitHub repos, draft issues and replies via LiteLLM, and approve before any side effects.'
 date: 2026-05-06
-tags: ['Agent auth', 'Gmail', 'GitHub', 'Slack', 'LiteLLM']
 sidebar:
   label: 'Inbox triage + LiteLLM'
 tableOfContents: true

--- a/src/content/docs/cookbooks/m2m-jwks-and-oauth-scopes.mdx
+++ b/src/content/docs/cookbooks/m2m-jwks-and-oauth-scopes.mdx
@@ -2,7 +2,6 @@
 title: 'M2M JWT verification with JWKS and OAuth scopes'
 description: 'How JSON Web Key Sets work with Scalekit, how to use the /keys endpoint to verify machine-to-machine tokens, and how OAuth scopes map to JWT claims for authorization.'
 date: 2026-04-15
-tags: ['Machine-to-machine', 'API auth', 'OAuth', 'JWT']
 excerpt: Machine-to-machine access tokens are JWTs signed by Scalekit. Your API verifies signatures using the published JWKS at /keys, then authorizes requests using the scopes embedded in each token. This cookbook ties those ideas together end to end.
 featured: false
 authors:

--- a/src/content/docs/cookbooks/mastra-agentkit.mdx
+++ b/src/content/docs/cookbooks/mastra-agentkit.mdx
@@ -2,7 +2,6 @@
 title: 'Build a Mastra agent with Scalekit AgentKit tools'
 description: 'Give a Mastra agent access to Gmail and 200+ connectors through Scalekit AgentKit — zero manual OAuth handling.'
 date: 2026-05-19
-tags: ['Agent auth', 'Node.js']
 sidebar:
   label: 'Mastra AgentKit'
 tableOfContents: true

--- a/src/content/docs/cookbooks/render-github-pr-summarizer.mdx
+++ b/src/content/docs/cookbooks/render-github-pr-summarizer.mdx
@@ -2,7 +2,6 @@
 title: 'Build a multi-user GitHub PR summarizer agent'
 description: 'Build a GitHub PR summarizer that binds each connected GitHub account to a secure browser session instead of trusting a client-supplied user ID.'
 date: 2026-04-11
-tags: ['Agent auth', 'GitHub', 'user-verification']
 sidebar:
   label: 'GitHub PR summarizer'
 tableOfContents: true

--- a/src/content/docs/cookbooks/schedule-meeting-and-draft-email.mdx
+++ b/src/content/docs/cookbooks/schedule-meeting-and-draft-email.mdx
@@ -2,7 +2,6 @@
 title: 'Build an agent that books meetings and drafts emails'
 description: 'Connect a Python agent to Google Calendar and Gmail via Scalekit to find free slots, book meetings, and draft follow-up emails.'
 date: 2026-03-06
-tags: ['Agent auth']
 excerpt: >
   Building a scheduling agent means coordinating authentication to two separate tools — Google Calendar and Gmail — then chaining their outputs in one workflow. Without managed OAuth, each connector requires its own token lifecycle and error-handling logic. This recipe shows how Scalekit handles auth per connector so your agent can focus on finding a free slot, creating the event, and drafting the confirmation.
 featured: false

--- a/src/content/docs/cookbooks/scim-seat-limit-enforcement.mdx
+++ b/src/content/docs/cookbooks/scim-seat-limit-enforcement.mdx
@@ -2,7 +2,6 @@
 title: 'Enforce seat limits with SCIM provisioning'
 description: 'Block over-quota user creation and alert admins when SCIM pushes users beyond your plan seat limit.'
 date: 2026-04-14
-tags: ['SCIM', 'Modular SCIM']
 sidebar:
   label: 'Enforce seat limits'
 tableOfContents: true

--- a/src/content/docs/cookbooks/search-scalekit-docs-in-your-ide.mdx
+++ b/src/content/docs/cookbooks/search-scalekit-docs-in-your-ide.mdx
@@ -4,7 +4,6 @@ description: 'Configure ref.tools MCP to search Scalekit documentation directly 
 sidebar:
   label: 'Search Scalekit docs in IDE'
 date: 2026-03-26
-tags: ['Agent auth', 'MCP']
 excerpt: >
   Switching to a browser to look up Scalekit docs breaks your coding flow.
   This cookbook shows you how to configure the ref.tools MCP server so your

--- a/src/content/docs/cookbooks/set-up-agentkit-with-your-coding-agent.mdx
+++ b/src/content/docs/cookbooks/set-up-agentkit-with-your-coding-agent.mdx
@@ -2,7 +2,6 @@
 title: 'Set up AgentKit with your coding agent'
 description: 'Add Scalekit Agent Auth to your codebase using Claude Code, Codex, GitHub Copilot CLI, Cursor, or any of 40+ coding agents.'
 date: 2026-04-15
-tags: ['Agent auth']
 sidebar:
   label: 'Set up AgentKit with coding agents'
 excerpt: >

--- a/src/content/docs/cookbooks/sync-b2b-billing-with-chargebee.mdx
+++ b/src/content/docs/cookbooks/sync-b2b-billing-with-chargebee.mdx
@@ -2,7 +2,6 @@
 title: 'Sync B2B billing with Scalekit and Chargebee'
 description: 'Map Scalekit organizations to Chargebee customers, run hosted checkout, and keep subscription state in sync via webhooks.'
 date: 2026-06-15
-tags: ['Organizations', 'Webhooks', 'Next.js']
 sidebar:
   label: 'Chargebee B2B billing'
 tableOfContents: true


### PR DESCRIPTION
Removes the `tags` frontmatter from all cookbook pages.

This hides the tags UI (and the associated sidebar section) completely for cookbooks, since the starlight-blog plugin has no configuration option to disable tags display (confirmed via source at HiDeoo/starlight-blog).

- 18 files changed, 18 deletions
- All `tags: [...] ` lines removed from MDX frontmatter under `cookbooks/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated one cookbook entry with a new publication date.
  * Removed outdated topic tags from several cookbook pages to better reflect current documentation organization.
  * No instructional content, examples, or code snippets were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->