### PR TITLE
Improve messaging for Hosted UI widgets

### DIFF
--- a/src/content/docs/authenticate/manage-users-orgs/hosted-widgets.mdx
+++ b/src/content/docs/authenticate/manage-users-orgs/hosted-widgets.mdx
@@ -8,7 +8,7 @@ tags: [hosted-widgets, organizations, users, permissions, branding, user-managem
 
 import { Aside, Steps, Tabs, TabItem } from '@astrojs/starlight/components'
 
-Your customers, especially workspace administrators, want to manage organizations and users for their members. Scalekit provides **Hosted UI widgets** — a ready-made, branded portal at `<SCALEKIT_ENVIRONMENT_URL>/ui/` — so they can do this themselves without you building custom admin UIs.
+Your customers, especially workspace administrators, want to manage organizations and users for their members. Scalekit provides **Hosted UI widgets**, a ready-made, branded portal at `<SCALEKIT_ENVIRONMENT_URL>/ui/`, so they can do this themselves without you building custom admin UIs.
 
 To integrate hosted widgets, redirect your organization members to the Hosted Widgets URL:
 
@@ -163,7 +163,7 @@ Organization widgets let your customers manage their organization's settings, me
 
 6. ### Manage session policy
 
-    Your customers can view and configure their organization's session policy — setting custom absolute and idle session timeouts that override your application defaults. Scalekit always enforces the stricter of the two.
+    Your customers can view and configure their organization's session policy, setting custom absolute and idle session timeouts that override your application defaults. Scalekit always enforces the stricter of the two.
 
     <Aside title="Feature entitlement required">
     Session policy widget visibility depends on the organization's feature entitlements. It appears only if the **Session Policy** feature is enabled for the organization. You can enable it in the Scalekit dashboard or using the [organization settings API](/apis/#tag/organizations/PATCH/api/v1/organizations/{id}/settings).
@@ -235,9 +235,9 @@ If no session exists, the user is redirected automatically to the hosted login p
 
 <details>
 <summary>What happens when a user logs out from Hosted Widgets?</summary>
-When a user logs out from Hosted Widgets, they are redirected to the hosted login page of your application. This can cause your app session and the Scalekit session to fall out of sync.
+When a user logs out from Hosted Widgets, they are redirected to your configured post-logout destination. This can leave your app session and the Scalekit session out of sync.
 
-If you manage sessions in your own backend (instead of using Scalekit's default session management), you must handle logout propagation yourself. We recommend one of the following approaches:
+If you manage sessions in your own backend instead of using Scalekit's default session management, handle logout propagation yourself. Use one of the following approaches:
 - Implementing [back-channel logout](/guides/dashboard/redirects/#back-channel-logout-url) so Scalekit can notify your app about session termination.
 - Listening for the [user logout webhook](/apis/#webhook/userlogout) to get notified about session termination.
 </details>

--- a/src/content/docs/authenticate/manage-users-orgs/hosted-widgets.mdx
+++ b/src/content/docs/authenticate/manage-users-orgs/hosted-widgets.mdx
@@ -1,14 +1,14 @@
 ---
-title: UI widgets - Sign up, login, user profiles
-description: Customers manage organizations and users for their workspace through hosted widgets
+title: 'Hosted UI widgets'
+description: 'Redirect users to a branded self-serve portal for organization settings, member management, SSO, SCIM, domains, and user profiles.'
 sidebar:
-  label: Hosted UI widgets
+  label: 'Hosted UI widgets'
 tags: [hosted-widgets, organizations, users, permissions, branding, user-management, ui]
 ---
 
 import { Aside, Steps, Tabs, TabItem } from '@astrojs/starlight/components'
 
-Your customers, especially workspace administrators, want to manage organizations and users for their members. Scalekit provides a hosted widgets portal that lets your customers view and manage organizations, users, and settings for their workspace on their own—without you building custom UI.
+Your customers, especially workspace administrators, want to manage organizations and users for their members. Scalekit provides **Hosted UI widgets** — a ready-made, branded portal at `<SCALEKIT_ENVIRONMENT_URL>/ui/` — so they can do this themselves without you building custom admin UIs.
 
 To integrate hosted widgets, redirect your organization members to the Hosted Widgets URL:
 
@@ -52,6 +52,14 @@ hosted -> auth_widgets
 hosted -> user_widgets
 hosted -> org_widgets
 ```
+
+## When to use Hosted UI widgets
+
+Use Hosted UI widgets when you want customers to self-manage their organizations and accounts without you building custom UIs.
+
+- **Advantages**: Enterprise customers can self-serve member management, SSO setup, SCIM provisioning, domain verification, session policy, and their own profiles. Permissions and feature entitlements are handled automatically. The portal stays up to date with new Scalekit capabilities.
+- **Trade-offs**: If you build equivalent UIs yourself, you must implement the full set of management screens, enforce the corresponding permissions, and keep the interfaces current as features evolve.
+- **Custom frontends**: You can use Hosted UI widgets even if you handle login and signup in your own frontend. After users complete authentication through your flow, redirect them to the widgets portal for self-service.
 
 ## Signup/login widgets
 
@@ -222,12 +230,14 @@ You can also change the Hosted Widgets URL to match your application URL by sett
 
 <details>
 <summary>What happens if a user does not have a session?</summary>
-If no session exists, the user is redirected automatically to the hosted login page of your application.
+If no session exists, the user is redirected automatically to the hosted login page of your application. When using your own session management, ensure your application redirects unauthenticated users to your login flow before they reach the widgets.
 </details>
 
 <details>
 <summary>What happens when a user logs out from Hosted Widgets?</summary>
-When a user logs out from Hosted Widgets, they are redirected to the hosted login page of your application. This can cause your app session and the Scalekit session to fall out of sync. We recommend one of the following approaches:
+When a user logs out from Hosted Widgets, they are redirected to the hosted login page of your application. This can cause your app session and the Scalekit session to fall out of sync.
+
+If you manage sessions in your own backend (instead of using Scalekit's default session management), you must handle logout propagation yourself. We recommend one of the following approaches:
 - Implementing [back-channel logout](/guides/dashboard/redirects/#back-channel-logout-url) so Scalekit can notify your app about session termination.
 - Listening for the [user logout webhook](/apis/#webhook/userlogout) to get notified about session termination.
 </details>

--- a/src/content/docs/authenticate/manage-users-orgs/hosted-widgets.mdx
+++ b/src/content/docs/authenticate/manage-users-orgs/hosted-widgets.mdx
@@ -230,7 +230,7 @@ You can also change the Hosted Widgets URL to match your application URL by sett
 
 <details>
 <summary>What happens if a user does not have a session?</summary>
-If no session exists, the user is redirected automatically to the hosted login page of your application. When using your own session management, ensure your application redirects unauthenticated users to your login flow before they reach the widgets.
+If no session exists, Scalekit redirects the user to your application's login endpoint so your app can start the authentication flow again. If you manage sessions yourself, redirect unauthenticated users to your login flow before they reach the widgets.
 </details>
 
 <details>


### PR DESCRIPTION
Improve messaging for Hosted UI widgets per prospect feedback and documentation style.

Changes:
- Updated frontmatter for better title, description, and sidebar label.
- Improved the opening to clearly state the purpose.
- Added a new early section "When to use Hosted UI widgets" that explains advantages, trade-offs, and compatibility with custom frontends.
- Updated common scenarios section to better handle custom session management cases.
- Followed documentation writing style guidelines.

This addresses messaging improvements for the Hosted UI widgets feature based on real prospect questions (e.g., Axium AI feedback on using backend SDK + own frontend vs hosted experiences).

Preview: https://deploy-preview-807--scalekit-starlight.netlify.app/authenticate/manage-users-orgs/hosted-widgets/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Hosted UI widgets overview to describe it as a branded, self-serve portal at `<SCALEKIT_ENVIRONMENT_URL>/ui/`, including how it fits into authentication flows.
  * Added a “When to use Hosted UI widgets” section with advantages, trade-offs, and guidance for pairing custom frontends with a post-auth redirect to the hosted portal.
  * Clarified Hosted UI widget session behavior (including missing-session redirects) and expanded logout guidance, including considerations around session desynchronization and recommended logout propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->