### PR TITLE
docs: fix agent-visited broken URLs and point to YAML OpenAPI specs

### DIFF
--- a/llms-judge-prompt.txt
+++ b/llms-judge-prompt.txt
@@ -66,7 +66,7 @@ For working examples per framework: https://docs.scalekit.com/agentkit/examples.
 ## Optional
 
 - [API reference markdown](https://docs.scalekit.com/apis.md): LLM-friendly Markdown from the Scalekit OpenAPI specification
-- [OpenAPI Specification](https://docs.scalekit.com/api/scalekit.scalar.json): OpenAPI Specification for Scalekit REST API
+- [OpenAPI Specification](https://docs.scalekit.com/api/scalekit.scalar.yaml): OpenAPI Specification for Scalekit REST API (YAML)
 
 ## Home
 

--- a/scripts/generate-llms-index.js
+++ b/scripts/generate-llms-index.js
@@ -313,7 +313,7 @@ const lines = [
   '## Optional',
   '',
   `- [API reference markdown](${BASE_URL}/apis.md): LLM-friendly Markdown from the Scalekit OpenAPI specification`,
-  `- [OpenAPI Specification](${BASE_URL}/api/scalekit.scalar.json): OpenAPI Specification for Scalekit REST API`,
+  `- [OpenAPI Specification](${BASE_URL}/api/scalekit.scalar.yaml): OpenAPI Specification for Scalekit REST API (YAML)`,
   '',
 ]
 

--- a/src/configs/llms.config.ts
+++ b/src/configs/llms.config.ts
@@ -201,8 +201,8 @@ Start with the Quickstart Collection, then follow the developer's question to th
     },
     {
       label: 'OpenAPI Specification',
-      url: '/api/scalekit.scalar.json',
-      description: 'OpenAPI Specification for Scalekit REST API',
+      url: '/api/scalekit.scalar.yaml',
+      description: 'OpenAPI Specification for Scalekit REST API (YAML)',
     },
     {
       label: 'Postman Collection',

--- a/src/configs/redirects.config.ts
+++ b/src/configs/redirects.config.ts
@@ -410,4 +410,35 @@ export const redirects = {
   '/fsa/data-modeling': '/fsa/data-modelling/',
   '/guides': '/',
   '/mcp': '/authenticate/mcp/quickstart/',
+
+  // =============================================================================
+  // AGENT / API DOCS REDIRECTS (from Usesapient Actions.csv)
+  // =============================================================================
+  // Legacy and broken paths that AI agents frequently hit (404s, 401s, empty content).
+  // Primary goal: route to current /apis (Scalar reference) or LLM-friendly
+  // /api/scalekit.scalar.yaml (or .json) + generated /apis.md .
+  // Scalar at /apis is client-rendered; redirects help agents land on usable content.
+  // We primarily edit this file (public/_redirects left mostly untouched).
+
+  // Core API reference 404s (critical)
+  '/api-reference': '/apis',
+  '/api-reference/': '/apis',
+  '/api-reference/*': '/apis',
+
+  // OpenAPI / spec variants (critical + high)
+  // Point to YAML for better LLM/agent consumption (JSON also available at .json)
+  '/openapi.json': '/api/scalekit.scalar.yaml',
+  '/apis/openapi.json': '/api/scalekit.scalar.yaml',
+  '/scalekit.json': '/api/scalekit.scalar.yaml',
+  '/swagger.json': '/api/scalekit.scalar.yaml',
+  '/apis/openapi.yaml': '/api/scalekit.scalar.yaml',
+
+  // Other legacy paths appearing in agent actionables
+  '/sdk': '/authenticate/set-up-scalekit/',
+  '/reference': '/reference/glossary/',
+  '/tools': '/dev-kit/tools/',
+
+  // Additional API subpaths and variants seen in agent evals
+  '/apis/connected-accounts': '/apis',
+  '/apis/connected-accounts/*': '/apis',
 }

--- a/src/pages/apis.astro
+++ b/src/pages/apis.astro
@@ -54,6 +54,7 @@ const frontmatter = {
 }
 ---
 
+<!-- Agent/LLM note: For machine-readable API reference, prefer /apis.md (generated OpenAPI markdown) or /api/scalekit.scalar.yaml -->
 <div class="scalar-api-reference">
   {
     /* Persist the selected "Request Example" client globally across endpoints.


### PR DESCRIPTION
Fixes 404s and improves LLM/agent compatibility for API docs.

Redirects legacy/broken paths (e.g. /api-reference/*, /openapi.json, /openapi.yaml variants, /sdk, /reference, /tools) to current pages. Points agents to /api/scalekit.scalar.yaml (and /apis) for better readability over JSON.

Resolves issues from Usesapient report / Actions.csv by ensuring agent-visited URLs work and use YAML OpenAPI spec.

Preview: https://deploy-preview-808--scalekit-starlight.netlify.app/apis/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the YAML version of the API specification as the preferred reference link.
  * Improved routing so common legacy API-doc and OpenAPI URLs now redirect to the current API pages.

* **Bug Fixes**
  * Fixed several outdated or broken API reference paths, including common JSON-based spec links, to send visitors to the correct destination.
  * Updated the API reference page guidance to point machine-readable consumers to the best available formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->