### PR TITLE
docs: fix broken step-3 anchor link in encryption keys guide

### DIFF
--- a/src/components/templates/_encryption-keys.mdx
+++ b/src/components/templates/_encryption-keys.mdx
@@ -167,7 +167,7 @@ Use BYOK to register an encryption key from Google Cloud KMS that your team owns
 
    - In the Scalekit dashboard, go to **Settings** and open the **Encryption keys** tab.
    - Click **Create New Key** and select **BYOK - GCP Cloud KMS**.
-   - Copy the Scalekit service account email shown in the modal. You need it for [step 3](#step-3-grant-scalekit-access-to-the-key) if you have not granted IAM access yet.
+   - Copy the Scalekit service account email shown in the modal. You need it for step 3 (grant Scalekit access to the key) if you have not granted IAM access yet.
    - Enter the fully-qualified GCP key resource name:
 
    ```


### PR DESCRIPTION
## Summary
- Step items in `_encryption-keys.mdx`'s `<Steps>` list use bold text, not headings, so no anchor ID exists for `#step-3-grant-scalekit-access-to-the-key`
- This broke `starlight-links-validator` and failed the site build
- Replaces the dead markdown link with plain text

## Test plan
- `pnpm run build` completes clean with this fix (previously failed at the link-validation build step)

Preview links:
- https://deploy-preview-836--scalekit-starlight.netlify.app/authenticate/encryption-keys/
- https://deploy-preview-836--scalekit-starlight.netlify.app/agentkit/encryption-keys/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the BYOK setup instructions to make the “Register the key in Scalekit” step clearer by replacing an inline link with plain text referencing the next step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->