### PR TITLE
chore: suppress PostHog analytics on non-prod environments

### DIFF
--- a/public/js/posthog.js
+++ b/public/js/posthog.js
@@ -52,6 +52,9 @@ const INTERNAL_USER_EMAIL_PATTERNS = [
   /rexlosthismind/i,
   /^mabnuxr@gmail\.com$/i,
   /^rjmohan535@gmail\.com$/i,
+  /testscalekit/i,
+  /skituser/i,
+  /@scalekit\.cloud$/i,
 ]
 
 const isInternalUser = (function () {

--- a/public/js/posthog.js
+++ b/public/js/posthog.js
@@ -1,4 +1,7 @@
-// Only initialize PostHog in production environments
+// Set to true temporarily to test analytics on localhost or Netlify preview environments.
+// Must be false before merging to main.
+const ENABLE_NON_PROD_ANALYTICS = false
+
 const isLocalhost =
   window.location.host.includes('127.0.0.1') || window.location.host.includes('localhost')
 const isNetlify = window.location.host.includes('netlify.app')
@@ -193,6 +196,58 @@ if (!isLocalhost && !isNetlify) {
   watchForSession()
 }
 
+if (ENABLE_NON_PROD_ANALYTICS && (isNetlify || isLocalhost)) {
+  !(function (t, e) {
+    var o, n, p, r
+    e.__SV ||
+      ((window.posthog = e),
+      (e._i = []),
+      (e.init = function (i, s, a) {
+        function g(t, e) {
+          var o = e.split('.')
+          ;(2 == o.length && ((t = t[o[0]]), (e = o[1])),
+            (t[e] = function () {
+              t.push([e].concat(Array.prototype.slice.call(arguments, 0)))
+            }))
+        }
+        ;(((p = t.createElement('script')).type = 'text/javascript'),
+          (p.crossOrigin = 'anonymous'),
+          (p.async = !0),
+          (p.src =
+            s.api_host.replace('.i.posthog.com', '-assets.i.posthog.com') + '/static/array.js'),
+          (r = t.getElementsByTagName('script')[0]).parentNode.insertBefore(p, r))
+        var u = e
+        for (
+          void 0 !== a ? (u = e[a] = []) : (a = 'posthog'),
+            u.people = u.people || [],
+            u.toString = function (t) {
+              var e = 'posthog'
+              return ('posthog' !== a && (e += '.' + a), t || (e += ' (stub)'), e)
+            },
+            u.people.toString = function () {
+              return u.toString(1) + '.people (stub)'
+            },
+            o =
+              'init Re Ms Fs Pe Rs Cs capture Ve calculateEventProperties Ds register register_once register_for_session unregister unregister_for_session zs getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty Ls As createPersonProfile Ns Is Us opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing is_capturing clear_opt_in_out_capturing Os debug I js getPageViewId captureTraceFeedback captureTraceMetric'.split(
+                ' ',
+              ),
+            n = 0;
+          n < o.length;
+          n++
+        )
+          g(u, o[n])
+        e._i.push([i, s, a])
+      }),
+      (e.__SV = 1))
+  })(document, window.posthog || [])
+  posthog.init('phc_KUlqDD4PiELsO4iZiYdTI3syM4m9FfWcA9sTKgxfC0m', {
+    api_host: 'https://ph.scalekit.com',
+    defaults: '2025-05-24',
+    person_profiles: 'identified_only',
+  })
+  console.log('PostHog initialized - Staging')
+  watchForSession()
+}
 
 window.addEventListener('storage', (event) => {
   if (event.key === SESSION_STORAGE_KEY) {

--- a/public/js/posthog.js
+++ b/public/js/posthog.js
@@ -1,10 +1,46 @@
-// Set to true temporarily to test analytics on localhost or Netlify preview environments.
-// Must be false before merging to main.
-const ENABLE_NON_PROD_ANALYTICS = false
+/*
+ * PostHog staging project initialization (non-production).
+ *
+ * IMPORTANT: This is OFF BY DEFAULT because PostHog bills for events
+ * sent to the staging project from localhost and preview environments.
+ *
+ * How to toggle analytics on for localhost or Netlify previews (whenever you need it):
+ *
+ *   Quick toggle (easiest):
+ *     Add ?beacon=staging   or   ?enableBeaconStaging   to the URL, then reload.
+ *
+ *   Persistent for your current browser session:
+ *     In DevTools console:
+ *       localStorage.setItem('enableBeaconStaging', 'true'); location.reload();
+ *
+ *   Turn back off:
+ *     Remove the query param, or run:
+ *       localStorage.removeItem('enableBeaconStaging'); location.reload();
+ *
+ * Never leave this enabled in code that gets merged to main.
+ */
 
 const isLocalhost =
   window.location.host.includes('127.0.0.1') || window.location.host.includes('localhost')
 const isNetlify = window.location.host.includes('netlify.app')
+
+const isNonProdHost = isLocalhost || isNetlify
+
+/**
+ * Runtime "escape hatch" to turn on the staging analytics project.
+ * Designed for on-demand debugging without code changes or risk of shipping "on".
+ */
+const hasStagingToggle = () => {
+  const search = new URLSearchParams(window.location.search)
+  return (
+    search.has('enableBeaconStaging') ||
+    search.get('beacon') === 'staging' ||
+    search.has('debugAnalytics') ||
+    localStorage.getItem('enableBeaconStaging') === 'true'
+  )
+}
+
+const ENABLE_NON_PROD_ANALYTICS = isNonProdHost && hasStagingToggle()
 
 const SESSION_STORAGE_KEY = 'sk_auth_session'
 const SESSION_POLL_INTERVAL_MS = 1000
@@ -60,21 +96,17 @@ const INTERNAL_USER_EMAIL_PATTERNS = [
   /@scalekit\.cloud$/i,
 ]
 
-const isInternalUser = (function () {
-  var cache = new Map()
+const internalUserCache = new Map()
 
-  return function (email) {
-    if (!email) return false
-    if (cache.has(email)) {
-      return cache.get(email)
-    }
-    var result = INTERNAL_USER_EMAIL_PATTERNS.some(function (pattern) {
-      return pattern.test(email)
-    })
-    cache.set(email, result)
-    return result
+function isInternalUser(email) {
+  if (!email) return false
+  if (internalUserCache.has(email)) {
+    return internalUserCache.get(email)
   }
-})()
+  const result = INTERNAL_USER_EMAIL_PATTERNS.some((pattern) => pattern.test(email))
+  internalUserCache.set(email, result)
+  return result
+}
 
 const readSession = () => {
   try {
@@ -142,7 +174,7 @@ const watchForSession = () => {
   poll()
 }
 
-if (!isLocalhost && !isNetlify) {
+if (!isNonProdHost) {
   !(function (t, e) {
     var o, n, p, r
     e.__SV ||
@@ -196,7 +228,7 @@ if (!isLocalhost && !isNetlify) {
   watchForSession()
 }
 
-if (ENABLE_NON_PROD_ANALYTICS && (isNetlify || isLocalhost)) {
+if (ENABLE_NON_PROD_ANALYTICS) {
   !(function (t, e) {
     var o, n, p, r
     e.__SV ||
@@ -245,7 +277,10 @@ if (ENABLE_NON_PROD_ANALYTICS && (isNetlify || isLocalhost)) {
     defaults: '2025-05-24',
     person_profiles: 'identified_only',
   })
-  console.log('PostHog initialized - Staging')
+  console.log(
+    '%c[PostHog] Staging project initialized (non-prod). Disable with: localStorage.removeItem("enableBeaconStaging") + reload',
+    'color:#f59e0b',
+  )
   watchForSession()
 }
 

--- a/public/js/posthog.js
+++ b/public/js/posthog.js
@@ -193,58 +193,6 @@ if (!isLocalhost && !isNetlify) {
   watchForSession()
 }
 
-if (isNetlify || isLocalhost) {
-  !(function (t, e) {
-    var o, n, p, r
-    e.__SV ||
-      ((window.posthog = e),
-      (e._i = []),
-      (e.init = function (i, s, a) {
-        function g(t, e) {
-          var o = e.split('.')
-          ;(2 == o.length && ((t = t[o[0]]), (e = o[1])),
-            (t[e] = function () {
-              t.push([e].concat(Array.prototype.slice.call(arguments, 0)))
-            }))
-        }
-        ;(((p = t.createElement('script')).type = 'text/javascript'),
-          (p.crossOrigin = 'anonymous'),
-          (p.async = !0),
-          (p.src =
-            s.api_host.replace('.i.posthog.com', '-assets.i.posthog.com') + '/static/array.js'),
-          (r = t.getElementsByTagName('script')[0]).parentNode.insertBefore(p, r))
-        var u = e
-        for (
-          void 0 !== a ? (u = e[a] = []) : (a = 'posthog'),
-            u.people = u.people || [],
-            u.toString = function (t) {
-              var e = 'posthog'
-              return ('posthog' !== a && (e += '.' + a), t || (e += ' (stub)'), e)
-            },
-            u.people.toString = function () {
-              return u.toString(1) + '.people (stub)'
-            },
-            o =
-              'init Re Ms Fs Pe Rs Cs capture Ve calculateEventProperties Ds register register_once register_for_session unregister unregister_for_session zs getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty Ls As createPersonProfile Ns Is Us opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing is_capturing clear_opt_in_out_capturing Os debug I js getPageViewId captureTraceFeedback captureTraceMetric'.split(
-                ' ',
-              ),
-            n = 0;
-          n < o.length;
-          n++
-        )
-          g(u, o[n])
-        e._i.push([i, s, a])
-      }),
-      (e.__SV = 1))
-  })(document, window.posthog || [])
-  posthog.init('phc_KUlqDD4PiELsO4iZiYdTI3syM4m9FfWcA9sTKgxfC0m', {
-    api_host: 'https://ph.scalekit.com',
-    defaults: '2025-05-24',
-    person_profiles: 'identified_only', // or 'always' to create profiles for anonymous users as well
-  })
-  console.log('PostHog initialized - Staging')
-  watchForSession()
-}
 
 window.addEventListener('storage', (event) => {
   if (event.key === SESSION_STORAGE_KEY) {


### PR DESCRIPTION
## Summary

Updates `public/js/posthog.js` to prevent analytics events from being sent to PostHog in localhost and Netlify preview environments, and keeps the staging analytics code in the repo behind a toggle for when it's needed.

**Changes:**

- Added three new patterns to `INTERNAL_USER_EMAIL_PATTERNS` to filter test/internal accounts: `/testscalekit/i`, `/skituser/i`, `/@scalekit\.cloud$/i`
- Added `ENABLE_NON_PROD_ANALYTICS` flag (defaults to `false`) that gates PostHog initialization on localhost and Netlify previews
- The staging PostHog project init block is preserved in code — flip the flag to `true` locally to test analytics, then revert before merging

**Behavior after this change:**

| Environment | Analytics |
|---|---|
| Production (`docs.scalekit.com`) | Fires to production PostHog project (unchanged) |
| Netlify preview (`*.netlify.app`) | Suppressed by default |
| Localhost | Suppressed by default |

To temporarily enable non-prod analytics for testing, set `ENABLE_NON_PROD_ANALYTICS = true` in `public/js/posthog.js` — **must be reverted to `false` before merging**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnxmzqDMKWr6FqjQ9S5WUx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated analytics initialization so non-production hosts (like localhost and Netlify) no longer start analytics automatically.
  * Added a runtime “escape hatch” to allow enabling staging analytics only when explicitly toggled.
  * Improved internal-user detection for more reliable analytics opt-out behavior.
  * Kept user profile tracking behavior consistent, while clarifying the staging-disable message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->