### PR TITLE
SK-1159: Fix 404 links on Monday.com connector docs page

### DIFF
--- a/src/components/templates/agent-connectors/_setup-monday.mdx
+++ b/src/components/templates/agent-connectors/_setup-monday.mdx
@@ -1,6 +1,6 @@
 import { Steps, Aside } from '@astrojs/starlight/components'
 
-Register your Scalekit environment with the Monday.com connector so Scalekit handles the authentication flow and token lifecycle for you. The connection name you create will be used to identify and invoke the connection programmatically. You'll need your app credentials from the [Monday.com Developer Center](https://monday.com/developers/apps).
+Register your Scalekit environment with the Monday.com connector so Scalekit handles the authentication flow and token lifecycle for you. The connection name you create will be used to identify and invoke the connection programmatically. You'll need your app credentials from the [Monday.com Developer Center](https://developer.monday.com/).
 
 <Steps>
 1. ### Set up auth redirects
@@ -11,7 +11,7 @@ Register your Scalekit environment with the Monday.com connector so Scalekit han
 
       ![Copy redirect URI from Scalekit dashboard](@/assets/docs/agent-connectors/monday/use-own-credentials-redirect-uri.png)
 
-    - In the [Monday.com Developer Center](https://monday.com/developers/apps), open your app and go to the **OAuth** tab.
+    - In the [Monday.com Developer Center](https://developer.monday.com/), open your app and go to the **OAuth** tab.
 
     - Add the copied URI under **Redirect URLs** and save.
 
@@ -19,7 +19,7 @@ Register your Scalekit environment with the Monday.com connector so Scalekit han
 
 2. ### Get client credentials
 
-    - In the [Monday.com Developer Center](https://monday.com/developers/apps), open your app and go to the **Basic Information** tab:
+    - In the [Monday.com Developer Center](https://developer.monday.com/), open your app and go to the **Basic Information** tab:
       - **Client ID** — listed under **Client ID**
       - **Client Secret** — listed under **Client Secret**
 
@@ -30,7 +30,7 @@ Register your Scalekit environment with the Monday.com connector so Scalekit han
     - Enter your credentials:
       - Client ID (from your Monday.com app)
       - Client Secret (from your Monday.com app)
-      - Permissions — select the scopes your app needs (see [Monday.com OAuth scopes](https://developer.monday.com/apps/docs/oauth-scopes))
+      - Permissions — select the scopes your app needs (see [Monday.com OAuth scopes](https://developer.monday.com/apps/docs/oauth))
 
       ![Add credentials in Scalekit dashboard](@/assets/docs/agent-connectors/monday/add-credentials.png)
     - Click **Save**.


### PR DESCRIPTION
## Summary

Fixes [SK-1159](https://linear.app/scalekit/issue/SK-1159/fix-404-links-on-mondaycom-connector-docs-page). Several outgoing links on the [Monday.com connector docs page](https://docs.scalekit.com/agentkit/connectors/monday/) returned 404, including the highlighted link to the Monday.com Developer Center.

All the broken links live in the shared setup template `src/components/templates/agent-connectors/_setup-monday.mdx`, which the connector page renders.

## Changes

| Old link (404) | Fixed link | Occurrences |
|---|---|---|
| `https://monday.com/developers/apps` | `https://developer.monday.com/` | 3 (Developer Center) |
| `https://developer.monday.com/apps/docs/oauth-scopes` | `https://developer.monday.com/apps/docs/oauth` | 1 (OAuth scopes) |

- The Monday.com Developer Center now lives at `developer.monday.com`.
- Monday's scopes documentation moved from `/oauth-scopes` to the **OAuth and Permissions** page at `/apps/docs/oauth`.

The other links on the page (`app.scalekit.com`, `mcp.monday.com`, the board-URL example) are valid and were left unchanged.

## Preview

https://deploy-preview-847--scalekit-starlight.netlify.app/agentkit/connectors/monday/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Monday.com setup instructions to reflect the latest Developer Center URLs and navigation labels.
  * Added clearer guidance for configuring the redirect URI in the app’s OAuth settings, including the relevant screenshot.
  * Refreshed the link to Monday.com OAuth scopes documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->