### PR TITLE
chore: CODEOWNERS for public agent tools index

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,8 @@
 #
 # Order matters: the last matching pattern wins. * is @saif-at-scalekit; *.mdx
 # adds amit, ravi, and akshay; integrations/ and agent-connectors/ override below.
+# public/data/agent-tools-index.json is owned with agent connectors so connector
+# sync PRs can merge with an Akshay/Avinash approval (not saif-only via *).
 
 # Default owners for everything in the repo
 * @saif-at-scalekit
@@ -14,7 +16,8 @@
 # Folder specific owners (last so this path takes precedence)
 /src/content/docs/guides/integrations/ @amitash1912 @saravanan2003-hub
 
-# Agent connector docs (overrides *.mdx for these trees)
+# Agent connector docs + generated tool indexes (overrides *.mdx / * for these paths)
 /src/components/templates/agent-connectors/ @AkshayParihar33 @Avinash-Kamath @saif-at-scalekit
 /src/content/docs/agentkit/connectors/ @AkshayParihar33 @Avinash-Kamath @saif-at-scalekit
 /src/data/agent-connectors/ @AkshayParihar33 @Avinash-Kamath @saif-at-scalekit
+/public/data/agent-tools-index.json @AkshayParihar33 @Avinash-Kamath @saif-at-scalekit


### PR DESCRIPTION
## Summary
- Add `/public/data/agent-tools-index.json` to the agent-connector CODEOWNERS set (`@AkshayParihar33`, `@Avinash-Kamath`, `@saif-at-scalekit`)
- Unblocks connector sync PRs (e.g. #844) from requiring a saif-only approval just because the generated public tools index was under `*`

## Context
Connector syncs update both:
- `src/data/agent-connectors/tools-index.json` (already agent-connector owned)
- `public/data/agent-tools-index.json` (was default `*` → saif only)

With require-code-owner-review, that second path forced `@saif-at-scalekit` even after Akshay approved the rest.

## Test plan
- [ ] After merge, open a PR that only changes connector paths + `public/data/agent-tools-index.json`
- [ ] Confirm GitHub requests Akshay/Avinash/saif as owners for that file
- [ ] Confirm Akshay approval alone satisfies code-owner requirement for those paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ownership rules for the public tool index file so future changes are routed to the appropriate reviewers.
  * Added a note clarifying the review assignment for that file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->