### PR TITLE
chore: give ravibits same CODEOWNERS access as saif

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,13 +2,13 @@
 # Each line is a file pattern followed by one or more owners.
 # Owners will be automatically requested for review when someone opens a pull request.
 #
-# Order matters: the last matching pattern wins. * is @saif-at-scalekit; *.mdx
-# adds amit, ravi, and akshay; integrations/ and agent-connectors/ override below.
-# public/data/agent-tools-index.json is owned with agent connectors so connector
-# sync PRs can merge with an Akshay/Avinash approval (not saif-only via *).
+# Order matters: the last matching pattern wins. * is @saif-at-scalekit and
+# @ravibits; *.mdx adds amit and akshay; integrations/ and agent-connectors/
+# override below. public/data/agent-tools-index.json is owned with agent
+# connectors so connector sync PRs can merge without default-only ownership.
 
 # Default owners for everything in the repo
-* @saif-at-scalekit
+* @saif-at-scalekit @ravibits
 
 # MDX files: all docs reviewers
 *.mdx @saif-at-scalekit @amitash1912 @ravibits @AkshayParihar33
@@ -17,7 +17,7 @@
 /src/content/docs/guides/integrations/ @amitash1912 @saravanan2003-hub
 
 # Agent connector docs + generated tool indexes (overrides *.mdx / * for these paths)
-/src/components/templates/agent-connectors/ @AkshayParihar33 @Avinash-Kamath @saif-at-scalekit
-/src/content/docs/agentkit/connectors/ @AkshayParihar33 @Avinash-Kamath @saif-at-scalekit
-/src/data/agent-connectors/ @AkshayParihar33 @Avinash-Kamath @saif-at-scalekit
-/public/data/agent-tools-index.json @AkshayParihar33 @Avinash-Kamath @saif-at-scalekit
+/src/components/templates/agent-connectors/ @AkshayParihar33 @Avinash-Kamath @saif-at-scalekit @ravibits
+/src/content/docs/agentkit/connectors/ @AkshayParihar33 @Avinash-Kamath @saif-at-scalekit @ravibits
+/src/data/agent-connectors/ @AkshayParihar33 @Avinash-Kamath @saif-at-scalekit @ravibits
+/public/data/agent-tools-index.json @AkshayParihar33 @Avinash-Kamath @saif-at-scalekit @ravibits


### PR DESCRIPTION
## Summary
- Add `@ravibits` alongside `@saif-at-scalekit` on the default `*` CODEOWNERS rule
- Add `@ravibits` to agent-connector paths (templates, docs, data, public tools index)
- `@ravibits` was already on `*.mdx`; integrations path unchanged (saif is not an owner there)

## Why
Give Ravi the same code-owner approval power as Saif so PRs that match `*` or agent-connector ownership can merge without requiring Saif specifically.

## Test plan
- [ ] After merge, open a PR that only changes a non-mdx, non-special-path file
- [ ] Confirm GitHub requests both `@saif-at-scalekit` and `@ravibits` as owners
- [ ] Confirm Ravi approval alone satisfies code-owner requirement for that path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership assignments to include additional reviewers for general changes and agent connector–related areas.
  * Expanded coverage for connector documentation, templates, data, and generated index updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->