### PR TITLE
chore: add Akshay as CODEOWNER on all paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,19 +2,20 @@
 # Each line is a file pattern followed by one or more owners.
 # Owners will be automatically requested for review when someone opens a pull request.
 #
-# Order matters: the last matching pattern wins. * is @saif-at-scalekit and
-# @ravibits; *.mdx adds amit and akshay; integrations/ and agent-connectors/
-# override below. public/data/agent-tools-index.json is owned with agent
-# connectors so connector sync PRs can merge without default-only ownership.
+# Order matters: the last matching pattern wins. * is shared across docs
+# reviewers including Akshay; *.mdx adds amit; integrations/ and
+# agent-connectors/ override below. public/data/agent-tools-index.json is
+# owned with agent connectors so connector sync PRs can merge without
+# default-only ownership.
 
 # Default owners for everything in the repo
-* @saif-at-scalekit @ravibits
+* @saif-at-scalekit @ravibits @AkshayParihar33
 
 # MDX files: all docs reviewers
 *.mdx @saif-at-scalekit @amitash1912 @ravibits @AkshayParihar33
 
 # Folder specific owners (last so this path takes precedence)
-/src/content/docs/guides/integrations/ @amitash1912 @saravanan2003-hub
+/src/content/docs/guides/integrations/ @amitash1912 @saravanan2003-hub @AkshayParihar33
 
 # Agent connector docs + generated tool indexes (overrides *.mdx / * for these paths)
 /src/components/templates/agent-connectors/ @AkshayParihar33 @Avinash-Kamath @saif-at-scalekit @ravibits


### PR DESCRIPTION
## Summary
- Add Akshay as a CODEOWNER on all paths in `.github/CODEOWNERS`

## Notes
- Hackathon hub page work was moved out of this PR to branch `saifshaik/sk-1154-create-hackathon-page-on-the-docs` (SK-1154)

## Test plan
- [ ] Confirm CODEOWNERS review routing includes Akshay on sample paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership and review assignment rules.
  * Clarified how ownership rules are applied and overridden for specific content and agent connector areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->