### PR TITLE
[SK-1206] docs: show all enum values for status and old_status in status_updated webhook

### DIFF
--- a/openapi/scalekit.yaml
+++ b/openapi/scalekit.yaml
@@ -10881,15 +10881,39 @@ components:
           example: GMAIL
           description: The provider of the connected account
         authorization_type:
-          $ref: '#/components/schemas/connected_accountsConnectorType'
+          type: string
+          enum:
+            - OAUTH
+            - API_KEY
+            - BASIC_AUTH
+            - BEARER_TOKEN
+            - CUSTOM
+            - BASIC
+            - OAUTH_M2M
+            - TRELLO_OAUTH1
+            - GOOGLE_DWD
+            - TRUSTED_IDP
+            - SMART_FHIR
           example: OAUTH
           description: The authorization type of the connected account
         status:
-          $ref: '#/components/schemas/connected_accountsConnectorStatus'
+          type: string
+          enum:
+            - ACTIVE
+            - EXPIRED
+            - PENDING_AUTH
+            - PENDING_VERIFICATION
+            - DISCONNECTED
           example: EXPIRED
           description: The new status of the connected account
         old_status:
-          $ref: '#/components/schemas/connected_accountsConnectorStatus'
+          type: string
+          enum:
+            - ACTIVE
+            - EXPIRED
+            - PENDING_AUTH
+            - PENDING_VERIFICATION
+            - DISCONNECTED
           example: ACTIVE
           description: The previous status of the connected account
   securitySchemes:

--- a/openapi/scalekit.yaml
+++ b/openapi/scalekit.yaml
@@ -10887,7 +10887,6 @@ components:
             - API_KEY
             - BASIC_AUTH
             - BEARER_TOKEN
-            - CUSTOM
             - BASIC
             - OAUTH_M2M
             - TRELLO_OAUTH1


### PR DESCRIPTION
## What

Inline the full enum value lists on the `data.status`, `data.old_status`, and `data.authorization_type` attributes of the `ConnectedAccountStatusUpdatedEventData` schema in the **Connected Account Status Updated** webhook reference.

## Why

Under the webhook's `data` object → child attributes, only `authorization_type` was rendering its enum values. `status` and `old_status` both referenced a shared component schema (`connected_accountsConnectorStatus`) via `$ref`. Scalar renders a shared `$ref` enum inline only on its first appearance and shows subsequent usages as a bare type — so `status` and `old_status` showed no possible values.

Inlining each attribute's enum makes all possible values render for every attribute.

## Result

Under `data` → child attributes, all three now list their possible values:

- **status** / **old_status**: `ACTIVE`, `EXPIRED`, `PENDING_AUTH`, `PENDING_VERIFICATION`, `DISCONNECTED`
- **authorization_type**: `OAUTH`, `API_KEY`, `BASIC_AUTH`, `BEARER_TOKEN`, `CUSTOM`, `BASIC`, `OAUTH_M2M`, `TRELLO_OAUTH1`, `GOOGLE_DWD`, `TRUSTED_IDP`, `SMART_FHIR`

Only the `connected_account.status_updated` webhook schema is affected; all other webhooks are unchanged.

## Notes

- Source-only change (`openapi/scalekit.yaml`). The `public/api/*` bundles are regenerated by `bundle:apis` at build time, so they are not committed here to avoid unrelated redocly-version formatting churn.
- Verified locally by rendering the bundled spec in Scalar and confirming all enum values appear under the `data` object's child attributes.

Preview: https://deploy-preview-864--scalekit-starlight.netlify.app/agentkit/apis/#webhook/connectedaccountstatusupdated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the webhook API schema for connected account status events.
  * Explicitly documents the supported `authorization_type` values plus `status` and `old_status` values directly in the event payload contract.
  * Improves contract clarity for clients by enumerating the allowed authorization and lifecycle statuses, including prior status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->