### PR TITLE
docs: host /hackathon with coming-soon shell (SK-1255)

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,7 @@
+# Hackathon hub — clean URL for self-contained public/hackathon/index.html
+/hackathon                             /hackathon/index.html                    200
+/hackathon/                            /hackathon/index.html                    200
+
 # AgentKit redirects - specific rules first, then wildcards
 /agent-auth/tools/execute              /agentkit/tools/agent-tools-quickstart/  301
 /agent-auth/tools/modifiers            /agentkit/tools/agent-tools-quickstart/  301

--- a/public/hackathon/README.md
+++ b/public/hackathon/README.md
@@ -1,0 +1,47 @@
+# Hackathon hub (`/hackathon`)
+
+Self-contained landing page for hackathon participants.
+
+**Live path:** `https://docs.scalekit.com/hackathon/`
+
+## How to update this page
+
+This page is **one full HTML file**. Anyone (including Claude, Cursor, or another coding agent) can regenerate it and replace the file wholesale.
+
+1. Generate or edit a **complete self-contained HTML document** (all CSS, markup, and JS in one file).
+2. **Replace** `public/hackathon/index.html` entirely — paste the whole file over the old one.
+3. Open a PR against `main`.
+
+No MDX, no Astro components, no build config, and no companion CSS/JS files.
+
+`src/pages/hackathon.ts` only serves this HTML at `/hackathon`. Do not put page content there — replace `index.html` only.
+
+### Self-contained rules
+
+Keep these so a full-file paste still works:
+
+- Inline `<style>` and `<script>` in the same file
+- No sibling assets required (logo must be inline SVG or an absolute URL)
+- Fonts via CDN `<link>` only (optional)
+- Prefer absolute links for docs, app, Slack, and pricing
+
+### Product constraints
+
+Do not remove free-plan / no-coupon messaging without product sign-off.
+
+## Preview
+
+```bash
+pnpm start
+# open http://localhost:4321/hackathon/
+```
+
+You can also open `index.html` directly in a browser (file open / drag-and-drop) to verify the page works without the docs app.
+
+Deploy preview after a PR:
+
+`https://deploy-preview-{PR_NUMBER}--scalekit-starlight.netlify.app/hackathon/`
+
+## Current state
+
+Placeholder **coming soon** page. Full hub content ships in a follow-up PR (SK-1256).

--- a/public/hackathon/index.html
+++ b/public/hackathon/index.html
@@ -1,0 +1,166 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Hackathon Hub | Scalekit</title>
+    <meta
+      name="description"
+      content="Scalekit hackathon resources are coming soon. Build agents with real accounts using AgentKit."
+    />
+    <!--
+      Self-contained hackathon hub for docs.scalekit.com/hackathon
+      Edit model: replace this entire file with a new full HTML document (CSS + markup + JS).
+    -->
+    <style>
+      :root {
+        --bg: #ffffff;
+        --fg: #0a0a0a;
+        --muted: #525252;
+        --border-soft: #e5e5e5;
+        --surface: #fafafa;
+        --font:
+          ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+      }
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: var(--font);
+        font-size: 16px;
+        line-height: 1.55;
+        color: var(--fg);
+        background: var(--bg);
+        -webkit-font-smoothing: antialiased;
+        display: flex;
+        flex-direction: column;
+      }
+      a {
+        color: inherit;
+        text-underline-offset: 3px;
+      }
+      a:hover {
+        text-decoration-thickness: 2px;
+      }
+      .shell {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        max-width: 40rem;
+        margin: 0 auto;
+        padding: 2rem 1.25rem 3rem;
+        width: 100%;
+      }
+      header {
+        padding-bottom: 1.5rem;
+        border-bottom: 1px solid var(--border-soft);
+        margin-bottom: 2.5rem;
+      }
+      .brand {
+        font-size: 0.875rem;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+      }
+      main {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        gap: 1rem;
+      }
+      .eyebrow {
+        margin: 0;
+        font-size: 0.8125rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--muted);
+      }
+      h1 {
+        margin: 0;
+        font-size: clamp(1.75rem, 4vw, 2.25rem);
+        font-weight: 700;
+        line-height: 1.2;
+        letter-spacing: -0.02em;
+      }
+      .lede {
+        margin: 0;
+        color: var(--muted);
+        font-size: 1.0625rem;
+        max-width: 32rem;
+      }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem 1.25rem;
+        margin-top: 1rem;
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.625rem 1rem;
+        font-size: 0.9375rem;
+        font-weight: 600;
+        text-decoration: none;
+        border: 1px solid var(--fg);
+        background: var(--fg);
+        color: var(--bg);
+      }
+      .btn:hover {
+        opacity: 0.9;
+      }
+      .btn-secondary {
+        background: var(--bg);
+        color: var(--fg);
+      }
+      footer {
+        margin-top: 3rem;
+        padding-top: 1.25rem;
+        border-top: 1px solid var(--border-soft);
+        font-size: 0.875rem;
+        color: var(--muted);
+      }
+      .note {
+        margin: 1.5rem 0 0;
+        padding: 0.875rem 1rem;
+        background: var(--surface);
+        border: 1px solid var(--border-soft);
+        font-size: 0.875rem;
+        color: var(--muted);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="shell">
+      <header>
+        <div class="brand">Scalekit · Hackathon Hub</div>
+      </header>
+      <main>
+        <p class="eyebrow">Coming soon</p>
+        <h1>Hackathon resources are on the way</h1>
+        <p class="lede">
+          This page will host quickstarts, templates, and support links for Scalekit AgentKit
+          hackathons. Check back soon, or explore the docs while we finish the hub.
+        </p>
+        <div class="actions">
+          <a class="btn" href="https://docs.scalekit.com/agentkit/quickstart/"
+            >AgentKit quickstart</a
+          >
+          <a class="btn btn-secondary" href="https://docs.scalekit.com/">Docs home</a>
+        </div>
+        <p class="note">
+          Maintainers: replace <code>public/hackathon/index.html</code> wholesale with a full
+          self-contained HTML document. See <code>public/hackathon/README.md</code>.
+        </p>
+      </main>
+      <footer>
+        <strong>Scalekit Hackathon Hub</strong> · Placeholder until the full hub ships
+      </footer>
+    </div>
+  </body>
+</html>

--- a/public/hackathon/index.html
+++ b/public/hackathon/index.html
@@ -18,7 +18,6 @@
         --fg: #0a0a0a;
         --muted: #525252;
         --border-soft: #e5e5e5;
-        --surface: #fafafa;
         --font:
           ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
       }
@@ -125,14 +124,6 @@
         font-size: 0.875rem;
         color: var(--muted);
       }
-      .note {
-        margin: 1.5rem 0 0;
-        padding: 0.875rem 1rem;
-        background: var(--surface);
-        border: 1px solid var(--border-soft);
-        font-size: 0.875rem;
-        color: var(--muted);
-      }
     </style>
   </head>
   <body>
@@ -153,10 +144,6 @@
           >
           <a class="btn btn-secondary" href="https://docs.scalekit.com/">Docs home</a>
         </div>
-        <p class="note">
-          Maintainers: replace <code>public/hackathon/index.html</code> wholesale with a full
-          self-contained HTML document. See <code>public/hackathon/README.md</code>.
-        </p>
       </main>
       <footer>
         <strong>Scalekit Hackathon Hub</strong> · Placeholder until the full hub ships

--- a/src/pages/hackathon.ts
+++ b/src/pages/hackathon.ts
@@ -1,0 +1,25 @@
+import type { APIRoute } from 'astro'
+import fs from 'node:fs'
+import path from 'node:path'
+
+/**
+ * Serves the self-contained hackathon hub at /hackathon.
+ *
+ * Source of truth for content/design: public/hackathon/index.html
+ * Editors and coding agents should replace that HTML file wholesale —
+ * do not put page content in this route.
+ */
+export const prerender = true
+
+export const GET: APIRoute = async () => {
+  const filePath = path.join(process.cwd(), 'public/hackathon/index.html')
+  const html = fs.readFileSync(filePath, 'utf-8')
+
+  return new Response(html, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'public, max-age=0, must-revalidate',
+    },
+  })
+}


### PR DESCRIPTION
## Summary

Hosts a stable public URL at `/hackathon` with a minimal self-contained coming-soon shell so the path is reserved and ready for the full hub.

- Add Astro serve route (`src/pages/hackathon.ts`) that returns `public/hackathon/index.html`
- Add Netlify rewrites for `/hackathon` and `/hackathon/` → `index.html`
- Add edit-model README for wholesale HTML replacement by humans/agents
- Ship a minimal self-contained coming-soon page (inline CSS, no sibling assets)

**Full hub content is out of scope** and ships in follow-up **SK-1256**.

## Related

- Linear: [SK-1255](https://linear.app/scalekit/issue/SK-1255)
- Parent: [SK-1154](https://linear.app/scalekit/issue/SK-1154)
- Follow-up: SK-1256 (full hub content)

## Preview

https://deploy-preview-867--scalekit-starlight.netlify.app/hackathon/

## Test plan

- [ ] Deploy preview loads `/hackathon` and `/hackathon/`
- [ ] Page shows coming soon content
- [ ] Opening `public/hackathon/index.html` alone still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Hackathon Hub at `/hackathon`.
  * Introduced a “Coming soon” landing page with links to the AgentKit quickstart and documentation.
  * Added clean URL handling for both `/hackathon` and `/hackathon/`.

* **Documentation**
  * Added guidance for updating, previewing, and deploying the Hackathon Hub page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->