### PR TITLE
content(hackathon): make footer more professional

### DIFF
--- a/public/hackathon/index.html
+++ b/public/hackathon/index.html
@@ -124,6 +124,27 @@
         font-size: 0.875rem;
         color: var(--muted);
       }
+      .footer-row {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem 1.5rem;
+      }
+      .footer-links {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem 1.25rem;
+      }
+      .footer-links a {
+        color: var(--muted);
+        text-decoration: none;
+        border-bottom: 1px solid transparent;
+      }
+      .footer-links a:hover {
+        color: var(--fg);
+        border-bottom-color: var(--fg);
+      }
     </style>
   </head>
   <body>
@@ -146,7 +167,14 @@
         </div>
       </main>
       <footer>
-        <strong>Scalekit Hackathon Hub</strong> · Placeholder until the full hub ships
+        <div class="footer-row">
+          <span>&copy; 2026 Scalekit, Inc.</span>
+          <nav class="footer-links">
+            <a href="https://docs.scalekit.com/">Docs</a>
+            <a href="https://scalekit.com/">Scalekit</a>
+            <a href="mailto:support@scalekit.com">Contact support</a>
+          </nav>
+        </div>
       </footer>
     </div>
   </body>


### PR DESCRIPTION
## Summary
- Replaced placeholder footer text ("Placeholder until the full hub ships") with a standard footer: copyright line + Docs / Scalekit / Contact support links.

## Preview
- Self-contained change, single file: `public/hackathon/index.html`.
- Local preview: `pnpm start` → http://localhost:4321/hackathon/

## Test plan
- [x] Verified locally in browser — footer renders with copyright and links, no layout regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the hackathon hub footer with a structured, responsive layout.
  - Added navigation links for Docs, Scalekit, and support.
  - Improved link styling, including hover interactions and visual hierarchy.
  - Added a copyright notice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->