### PR TITLE
[SK-928]Publish MCP connectors to Claude & ChatGPT directories

### DIFF
--- a/src/configs/sidebar.config.ts
+++ b/src/configs/sidebar.config.ts
@@ -440,7 +440,10 @@ export const sidebar = [
       },
       {
         label: 'Go live',
-        items: ['authenticate/mcp/launch-checklist'],
+        items: [
+          'authenticate/mcp/launch-checklist',
+          'authenticate/mcp/directory-submission-test-credentials',
+        ],
       },
     ],
   },

--- a/src/content/docs/authenticate/mcp/directory-submission-test-credentials.mdx
+++ b/src/content/docs/authenticate/mcp/directory-submission-test-credentials.mdx
@@ -1,0 +1,180 @@
+---
+title: Publish your MCP connector to Claude & ChatGPT
+description: Give MCP connector directory reviewers a test user and static code so they can authenticate and test your server end to end.
+tags: [mcp-auth, go-live, connector-directory, test-users, submission, claude, chatgpt]
+tableOfContents: true
+sidebar:
+  label: Publish on Claude/ChatGPT
+prev:
+  label: Production readiness checklist
+  link: /authenticate/mcp/launch-checklist
+next: false
+---
+
+import { Steps, Aside, Tabs, TabItem } from '@astrojs/starlight/components'
+
+To list your MCP connector in the [Claude connector directory](https://claude.com/docs/connectors/building/submission) or the [ChatGPT app directory](https://developers.openai.com/apps-sdk/deploy/submission#review-and-approval-faqs), a reviewer must sign in to your server and run every tool end to end. Both submission forms have a testing-access step that expects every credential and step needed to reach a fully-populated account.
+
+Scalekit's [Test Users](/authenticate/run-e2e-tests/) feature makes this possible without handing over a real inbox: allowlist a reviewer email and set a **static 6-digit code**, and the reviewer signs in through Scalekit's hosted login using that code. This page shows how to prepare the credential and write the instructions to paste into the submission form.
+
+<Aside type="caution" title="Works only with Scalekit-managed auth">
+Test Users works only when **Scalekit manages your app's login, sessions, and user management** (Full Stack Auth / SaaSKit), because it intercepts Scalekit's own Magic Link/OTP delivery.
+
+It does **not** work when your MCP server runs in [Bring Your Own Auth](/mcp/auth-methods/custom-auth/) mode. In that mode Scalekit federates to your own identity provider and never owns the login screen or the OTP, so there is no static code to hand a reviewer. For Bring Your Own Auth, create a reviewer account directly in your identity provider and share those credentials instead.
+</Aside>
+
+## Prerequisites
+
+- An MCP connector already protected with Scalekit MCP Auth using Scalekit-managed auth. See the [MCP Auth quickstart](/authenticate/mcp/quickstart/).
+- The **Magic Link & OTP** auth method enabled, with delivery set to `Verification Code` or `Magic Link + Verification Code`. `Magic Link`-only delivery is not supported. See the [Test Users prerequisite](/authenticate/run-e2e-tests/#prerequisites).
+
+## How reviewer sign-in works
+
+The reviewer follows the same OAuth 2.1 flow as any [human interacting with your MCP server](/authenticate/mcp/overview/#the-authorization-flow-in-practice):
+
+1. The MCP client (MCP Inspector or Claude as a custom connector) calls your protected server and receives a `401` pointing to Scalekit.
+2. The client redirects the reviewer to Scalekit's hosted login.
+3. The reviewer enters the **test email** and the **static code** you configured — no inbox required.
+4. The reviewer approves the consent screen, Scalekit issues an access token, and the client runs your tools.
+
+## Prepare the reviewer credential
+
+<Steps>
+1. ## Enable Test Users and add a reviewer email
+
+   In **Dashboard > Environment settings > Test users**, toggle **Enable test users** and add a reviewer address. The email must contain `+sktest` in the local part — for example `reviewer+sktest@yourapp.com`. Set the **Static confirmation code** (the default is `424242`).
+
+   For the full field-by-field reference, see [Configure test users](/authenticate/run-e2e-tests/#configure-test-users).
+
+2. ## Create the reviewer inside a fully-populated organization
+
+   Reviewers expect your tools to return real data, so add the reviewer user to an organization that already has representative content. Create the user with `sendInvitationEmail: false` so no email goes out, then confirm the same email is on the Test Users allowlist.
+
+   <Tabs syncKey="tech-stack">
+     <TabItem label="Node.js">
+   ```ts title="Create the reviewer user"
+   import { ScalekitClient } from '@scalekit-sdk/node'
+
+   const scalekit = new ScalekitClient(
+     process.env.SCALEKIT_ENVIRONMENT_URL!,
+     process.env.SCALEKIT_CLIENT_ID!,
+     process.env.SCALEKIT_CLIENT_SECRET!
+   )
+
+   // Add the reviewer to a populated org so tools return real data during review.
+   const { user } = await scalekit.user.createUserAndMembership(orgId, {
+     email: 'reviewer+sktest@yourapp.com',
+     sendInvitationEmail: false,
+   })
+   ```
+     </TabItem>
+     <TabItem label="Python">
+   ```python title="Create the reviewer user"
+   import os
+   from scalekit import ScalekitClient
+   from scalekit.v1.users.users_pb2 import CreateUser
+
+   scalekit_client = ScalekitClient(
+     env_url=os.environ["SCALEKIT_ENVIRONMENT_URL"],
+     client_id=os.environ["SCALEKIT_CLIENT_ID"],
+     client_secret=os.environ["SCALEKIT_CLIENT_SECRET"],
+   )
+
+   # Add the reviewer to a populated org so tools return real data during review.
+   user_response = scalekit_client.users.create_user_and_membership(
+     org_id,
+     CreateUser(email="reviewer+sktest@yourapp.com"),
+     send_invitation_email=False,
+   )
+   ```
+     </TabItem>
+     <TabItem label="Go">
+   ```go title="Create the reviewer user"
+   import usersv1 "github.com/scalekit-inc/scalekit-sdk-go/v2/pkg/grpc/scalekit/v1/users"
+
+   scalekitClient := scalekit.NewScalekitClient(
+     os.Getenv("SCALEKIT_ENVIRONMENT_URL"),
+     os.Getenv("SCALEKIT_CLIENT_ID"),
+     os.Getenv("SCALEKIT_CLIENT_SECRET"),
+   )
+
+   // Add the reviewer to a populated org so tools return real data during review.
+   userResp, err := scalekitClient.User().CreateUserAndMembership(ctx, orgID,
+     &usersv1.CreateUser{Email: "reviewer+sktest@yourapp.com"},
+     false,
+   )
+   if err != nil {
+     log.Fatalf("failed to create reviewer user: %v", err)
+   }
+   ```
+     </TabItem>
+     <TabItem label="Java">
+   ```java title="Create the reviewer user"
+   import com.scalekit.grpc.scalekit.v1.users.*;
+
+   ScalekitClient scalekitClient = new ScalekitClient(
+     System.getenv("SCALEKIT_ENVIRONMENT_URL"),
+     System.getenv("SCALEKIT_CLIENT_ID"),
+     System.getenv("SCALEKIT_CLIENT_SECRET")
+   );
+
+   // Add the reviewer to a populated org so tools return real data during review.
+   CreateUserAndMembershipRequest request = CreateUserAndMembershipRequest.newBuilder()
+     .setUser(CreateUser.newBuilder().setEmail("reviewer+sktest@yourapp.com").build())
+     .setSendInvitationEmail(false)
+     .build();
+
+   CreateUserAndMembershipResponse userResp = scalekitClient.users()
+     .createUserAndMembership(orgId, request);
+   ```
+     </TabItem>
+   </Tabs>
+
+3. ## Self-test the connection as a reviewer will
+
+   Connect to your server the same way the reviewer will — via [MCP Inspector](https://github.com/modelcontextprotocol/inspector) or as a custom connector in Claude — and sign in with the reviewer email and static code. Run every tool once to surface any gaps before you submit.
+</Steps>
+
+## Write the test setup instructions
+
+Paste instructions into the submission form's testing-access field — the **Test setup instructions** box on Claude's **Test & launch** step, or the equivalent testing-instructions field in the ChatGPT app submission. Give the reviewer everything needed to authenticate autonomously:
+
+```text title="Test setup instructions (paste-ready)" frame="terminal" showLineNumbers=false
+Connector URL: https://mcp.yourapp.com/mcp
+
+Authentication: OAuth 2.0 (hosted login). When prompted to connect, use the
+test account below — no email inbox is required.
+
+  Email: reviewer+sktest@yourapp.com
+  Verification code: 424242
+
+Steps:
+  1. Add the connector and start the OAuth sign-in.
+  2. On the login screen, enter the email above and continue.
+  3. At the verification-code prompt, enter 424242 and continue.
+  4. Approve the consent screen.
+  5. The account belongs to a fully-populated organization, so every tool
+     returns representative data.
+```
+
+Replace the URL, email, and code with your own values. Keep the code identical to the **Static confirmation code** configured in the dashboard. After your connector is approved, remove the reviewer email from the allowlist or rotate the static code.
+
+## Common scenarios
+
+<details>
+<summary>The reviewer still receives a real verification email</summary>
+
+All three conditions must be true for Test Users to apply:
+
+- **Test Users** is enabled in the environment.
+- The reviewer email is on the allowlist (case-insensitive match).
+- **Magic Link & OTP** is enabled with delivery set to `Verification Code` or `Magic Link + Verification Code`.
+
+</details>
+
+<details>
+<summary>My connector uses Bring Your Own Auth — can I still do this?</summary>
+
+No. Test Users only affects Scalekit's own Magic Link/OTP delivery. In [Bring Your Own Auth](/mcp/auth-methods/custom-auth/) mode, Scalekit federates to your identity provider, which owns the login and any verification codes. Create a dedicated reviewer account in your identity provider and share those credentials in the test setup instructions instead.
+
+</details>

--- a/src/content/docs/authenticate/mcp/directory-submission-test-credentials.mdx
+++ b/src/content/docs/authenticate/mcp/directory-submission-test-credentials.mdx
@@ -61,11 +61,15 @@ The reviewer follows the same OAuth 2.1 flow as any [human interacting with your
      process.env.SCALEKIT_CLIENT_SECRET!
    )
 
-   // Add the reviewer to a populated org so tools return real data during review.
-   const { user } = await scalekit.user.createUserAndMembership(orgId, {
-     email: 'reviewer+sktest@yourapp.com',
-     sendInvitationEmail: false,
-   })
+   try {
+     // Add the reviewer to a populated org so tools return real data during review.
+     const { user } = await scalekit.user.createUserAndMembership(orgId, {
+       email: 'reviewer+sktest@yourapp.com',
+       sendInvitationEmail: false,
+     })
+   } catch (error) {
+     console.error('Failed to create reviewer user:', error)
+   }
    ```
      </TabItem>
      <TabItem label="Python">
@@ -80,12 +84,15 @@ The reviewer follows the same OAuth 2.1 flow as any [human interacting with your
      client_secret=os.environ["SCALEKIT_CLIENT_SECRET"],
    )
 
-   # Add the reviewer to a populated org so tools return real data during review.
-   user_response = scalekit_client.users.create_user_and_membership(
-     org_id,
-     CreateUser(email="reviewer+sktest@yourapp.com"),
-     send_invitation_email=False,
-   )
+   try:
+     # Add the reviewer to a populated org so tools return real data during review.
+     user_response = scalekit_client.users.create_user_and_membership(
+       org_id,
+       CreateUser(email="reviewer+sktest@yourapp.com"),
+       send_invitation_email=False,
+     )
+   except Exception as error:
+     print(f"Failed to create reviewer user: {error}")
    ```
      </TabItem>
      <TabItem label="Go">
@@ -118,22 +125,34 @@ The reviewer follows the same OAuth 2.1 flow as any [human interacting with your
      System.getenv("SCALEKIT_CLIENT_SECRET")
    );
 
-   // Add the reviewer to a populated org so tools return real data during review.
-   CreateUserAndMembershipRequest request = CreateUserAndMembershipRequest.newBuilder()
-     .setUser(CreateUser.newBuilder().setEmail("reviewer+sktest@yourapp.com").build())
-     .setSendInvitationEmail(false)
-     .build();
+   try {
+     // Add the reviewer to a populated org so tools return real data during review.
+     CreateUserAndMembershipRequest request = CreateUserAndMembershipRequest.newBuilder()
+       .setUser(CreateUser.newBuilder().setEmail("reviewer+sktest@yourapp.com").build())
+       .setSendInvitationEmail(false)
+       .build();
 
-   CreateUserAndMembershipResponse userResp = scalekitClient.users()
-     .createUserAndMembership(orgId, request);
+     CreateUserAndMembershipResponse userResp = scalekitClient.users()
+       .createUserAndMembership(orgId, request);
+   } catch (Exception error) {
+     System.err.println("Failed to create reviewer user: " + error.getMessage());
+   }
    ```
      </TabItem>
    </Tabs>
 
-3. ## Self-test the connection as a reviewer will
-
-   Connect to your server the same way the reviewer will — via [MCP Inspector](https://github.com/modelcontextprotocol/inspector) or as a custom connector in Claude — and sign in with the reviewer email and static code. Run every tool once to surface any gaps before you submit.
 </Steps>
+
+## Verify
+
+Connect to your server the same way the reviewer will — via [MCP Inspector](https://github.com/modelcontextprotocol/inspector) or as a custom connector in Claude — and sign in with the reviewer email and static code.
+
+Verification succeeds when:
+
+- Sign-in completes with the static code and no real verification email is sent.
+- Every tool runs successfully and returns representative data from the populated organization.
+
+Fix any gaps before you submit to a directory.
 
 ## Write the test setup instructions
 
@@ -157,7 +176,11 @@ Steps:
      returns representative data.
 ```
 
-Replace the URL, email, and code with your own values. Keep the code identical to the **Static confirmation code** configured in the dashboard. After your connector is approved, remove the reviewer email from the allowlist or rotate the static code.
+Replace the URL, email, and code with your own values. Keep the code identical to the **Static confirmation code** configured in the dashboard.
+
+## Next steps
+
+Once your connector is approved, remove the reviewer email from the allowlist or rotate the static code — see [Configure test users](/authenticate/run-e2e-tests/#configure-test-users) for how to manage the allowlist.
 
 ## Common scenarios
 


### PR DESCRIPTION
## What
Adds a new MCP Auth guide: **Publish your MCP connector to Claude & ChatGPT** (`/authenticate/mcp/directory-submission-test-credentials/`), placed under **MCP Auth > Go live**.

The page explains how to give Claude connector directory and ChatGPT app directory reviewers a **test user + static verification code** using Scalekit's [Test Users](/authenticate/run-e2e-tests/) feature, so reviewers can authenticate and run every tool end to end without a real inbox. It includes:
- The Scalekit-managed-auth requirement and the **Bring Your Own Auth** limitation
- Steps to enable Test Users, create a reviewer in a fully-populated org (all 4 SDKs), and self-test
- A paste-ready **test setup instructions** template for the submission form

## Changes
- New page: `src/content/docs/authenticate/mcp/directory-submission-test-credentials.mdx`
- Sidebar: added the page to the MCP Auth "Go live" group in `src/configs/sidebar.config.ts`

## Preview
https://deploy-preview-873--scalekit-starlight.netlify.app/authenticate/mcp/directory-submission-test-credentials/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new guide for publishing an MCP connector to the Claude connector directory and the ChatGPT app directory using Scalekit Test Users.
  * Includes prerequisites, reviewer sign-in flow using a preconfigured static code (Magic Link + verification code / verification code), and end-to-end verification steps.
  * Added paste-ready submission instructions and a “next steps” section covering post-approval allowlist/code rotation.
  * Linked the guide in the MCP “Go live” sidebar section under the updated checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->