### PR TITLE
[SK-1265] Fix OpenAPI code samples across all four SDKs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,12 +16,8 @@ STARLIGHT_CHANGELOG_90DAY_ACCESS=
 GITHUB_TOKEN=
 
 # ==============================================================================
-# Sample App & Chat Widget
+# Chat Widget
 # ==============================================================================
-
-# API key for external sample application
-# Status: NOT CURRENTLY USED in the codebase
-PUBLIC_SAMPLEAPP_API_KEY=
 
 # Pylon chat widget application ID
 # Status: Currently HARDCODED in public/js/pylon-widget.js — this env var is not read at runtime

--- a/openapi/code_samples/go/api_v1_connected_accounts/get.go
+++ b/openapi/code_samples/go/api_v1_connected_accounts/get.go
@@ -1,0 +1,2 @@
+// Connected Accounts are not available in the Go SDK public API yet.
+// Use the REST API (GET /api/v1/connected_accounts) or the Node.js/Python SDKs.

--- a/openapi/code_samples/go/api_v1_execute_tool/post.go
+++ b/openapi/code_samples/go/api_v1_execute_tool/post.go
@@ -1,0 +1,2 @@
+// Tool calling (execute_tool) is not available in the Go SDK public API yet.
+// Use the REST API (POST /api/v1/execute_tool) or the Node.js/Python SDKs.

--- a/openapi/code_samples/go/api_v1_memberships_organizations_{organization_id}_users_{id}/delete.go
+++ b/openapi/code_samples/go/api_v1_memberships_organizations_{organization_id}_users_{id}/delete.go
@@ -1,0 +1,10 @@
+err := scalekitClient.User().DeleteMembership(
+  ctx,
+  "org_123",
+  "usr_123",
+  false, // cascade: also remove from nested groups when true
+)
+if err != nil {
+  // handle error
+  return
+}

--- a/openapi/code_samples/go/api_v1_memberships_organizations_{organization_id}_users_{id}/post.go
+++ b/openapi/code_samples/go/api_v1_memberships_organizations_{organization_id}_users_{id}/post.go
@@ -1,21 +1,19 @@
-func main() {
-    scalekitClient := scalekit.NewScalekitClient(
-        os.Getenv("SCALEKIT_ENV_URL"),
-        os.Getenv("SCALEKIT_CLIENT_ID"),
-        os.Getenv("SCALEKIT_CLIENT_SECRET"),
-    )
-    membership := &usersv1.CreateMembership{
-        Roles: []*usersv1.Role{{Name: "admin"}},
-        Metadata: map[string]string{
-            "department": "engineering",
-            "location":   "nyc-office",
-        },
-    }
-    resp, 
-      err := scalekitClient.User().CreateMembership(
-        context.Background(), "org_123", 
-          "usr_123", membership, false)
-    if err != nil {
-        panic(err)
-    }
+membership := &usersv1.CreateMembership{
+  Roles: []*usersv1.Role{{Name: "admin"}},
+  Metadata: map[string]string{
+    "department": "engineering",
+    "location":   "nyc-office",
+  },
 }
+resp, err := scalekitClient.User().CreateMembership(
+  ctx,
+  "org_123",
+  "usr_123",
+  membership,
+  false,
+)
+if err != nil {
+  // handle error
+  return
+}
+_ = resp

--- a/openapi/code_samples/go/api_v1_organizations/get.go
+++ b/openapi/code_samples/go/api_v1_organizations/get.go
@@ -1,6 +1,6 @@
-organizations, err := scalekitClient.Organization.ListOrganizations(
+organizations, err := scalekitClient.Organization().ListOrganization(
   ctx,
   &scalekit.ListOrganizationOptions{
     PageSize: 10,
-  }
+  },
 )

--- a/openapi/code_samples/go/api_v1_organizations/post.go
+++ b/openapi/code_samples/go/api_v1_organizations/post.go
@@ -1,7 +1,7 @@
-organization, err := ScalekitClient.Organization.CreateOrganization(
+organization, err := scalekitClient.Organization().CreateOrganization(
   ctx,
   name,
   scalekit.CreateOrganizationOptions{
-    ExternalID: "externalId",
+    ExternalId: "externalId",
   },
 )

--- a/openapi/code_samples/go/api_v1_organizations_{id}/delete.go
+++ b/openapi/code_samples/go/api_v1_organizations_{id}/delete.go
@@ -1,4 +1,4 @@
-err := scalekitClient.Organization.DeleteOrganization(
+err := scalekitClient.Organization().DeleteOrganization(
   ctx,
-  organizationId
+  organizationId,
 )

--- a/openapi/code_samples/go/api_v1_organizations_{id}/get.go
+++ b/openapi/code_samples/go/api_v1_organizations_{id}/get.go
@@ -1,10 +1,4 @@
-scalekitClient := scalekit.NewScalekitClient(
-  <SCALEKIT_ENVIRONMENT_URL>,
-  <SCALEKIT_CLIENT_ID>,
-  <SCALEKIT_CLIENT_SECRET>
-)
-
-organization, err := scalekitClient.Organization.GetOrganization(
+organization, err := scalekitClient.Organization().GetOrganization(
   ctx,
-  organizationId
+  organizationId,
 )

--- a/openapi/code_samples/go/api_v1_organizations_{id}/patch.go
+++ b/openapi/code_samples/go/api_v1_organizations_{id}/patch.go
@@ -1,8 +1,8 @@
-organization, err := scalekitClient.Organization.UpdateOrganization(
+organization, err := scalekitClient.Organization().UpdateOrganization(
   ctx,
   organizationId,
   &scalekit.UpdateOrganization{
     DisplayName: "displayName",
-    ExternalId: "externalId",
+    ExternalId:  "externalId",
   },
 )

--- a/openapi/code_samples/go/api_v1_organizations_{id}_portal_links/put.go
+++ b/openapi/code_samples/go/api_v1_organizations_{id}_portal_links/put.go
@@ -1,4 +1,4 @@
-link, err := scalekitClient.Organization.GeneratePortalLink(
+link, err := scalekitClient.Organization().GeneratePortalLink(
   ctx,
-  organizationId
+  organizationId,
 )

--- a/openapi/code_samples/go/api_v1_organizations_{organization_id}_clients/get.go
+++ b/openapi/code_samples/go/api_v1_organizations_{organization_id}_clients/get.go
@@ -1,0 +1,12 @@
+response, err := scalekitClient.M2M().ListOrganizationClients(
+  ctx,
+  "org_123",
+  scalekit.ListOrganizationClientsOptions{
+    PageSize: 30,
+  },
+)
+if err != nil {
+  // handle error
+  return
+}
+_ = response

--- a/openapi/code_samples/go/api_v1_organizations_{organization_id}_clients/post.go
+++ b/openapi/code_samples/go/api_v1_organizations_{organization_id}_clients/post.go
@@ -1,0 +1,15 @@
+response, err := scalekitClient.M2M().CreateOrganizationClient(
+  ctx,
+  "org_123",
+  scalekit.CreateOrganizationClientOptions{
+    Name:        "GitHub Actions Deployment Service",
+    Description: "Service account for GitHub Actions to deploy applications to production",
+    Scopes:      []string{"deploy:applications", "read:deployments"},
+    Audience:    []string{"deployment-api.acmecorp.com"},
+  },
+)
+if err != nil {
+  // handle error
+  return
+}
+_ = response

--- a/openapi/code_samples/go/api_v1_organizations_{organization_id}_clients_{client_id}/delete.go
+++ b/openapi/code_samples/go/api_v1_organizations_{organization_id}_clients_{client_id}/delete.go
@@ -1,0 +1,9 @@
+err := scalekitClient.M2M().DeleteOrganizationClient(
+  ctx,
+  "org_123",
+  "skc_xxxxx",
+)
+if err != nil {
+  // handle error
+  return
+}

--- a/openapi/code_samples/go/api_v1_organizations_{organization_id}_clients_{client_id}/get.go
+++ b/openapi/code_samples/go/api_v1_organizations_{organization_id}_clients_{client_id}/get.go
@@ -1,0 +1,10 @@
+response, err := scalekitClient.M2M().GetOrganizationClient(
+  ctx,
+  "org_123",
+  "skc_xxxxx",
+)
+if err != nil {
+  // handle error
+  return
+}
+_ = response

--- a/openapi/code_samples/go/api_v1_organizations_{organization_id}_clients_{client_id}/patch.go
+++ b/openapi/code_samples/go/api_v1_organizations_{organization_id}_clients_{client_id}/patch.go
@@ -1,0 +1,13 @@
+response, err := scalekitClient.M2M().UpdateOrganizationClient(
+  ctx,
+  "org_123",
+  "skc_xxxxx",
+  scalekit.UpdateOrganizationClientOptions{
+    Description: "Service account for GitHub Actions to deploy applications to production_eu",
+  },
+)
+if err != nil {
+  // handle error
+  return
+}
+_ = response

--- a/openapi/code_samples/go/api_v1_organizations_{organization_id}_clients_{client_id}_secrets/post.go
+++ b/openapi/code_samples/go/api_v1_organizations_{organization_id}_clients_{client_id}_secrets/post.go
@@ -1,0 +1,10 @@
+response, err := scalekitClient.M2M().CreateOrganizationClientSecret(
+  ctx,
+  "org_123",
+  "skc_xxxxx",
+)
+if err != nil {
+  // handle error
+  return
+}
+_ = response

--- a/openapi/code_samples/go/api_v1_organizations_{organization_id}_clients_{client_id}_secrets_{secret_id}/delete.go
+++ b/openapi/code_samples/go/api_v1_organizations_{organization_id}_clients_{client_id}_secrets_{secret_id}/delete.go
@@ -1,0 +1,10 @@
+err := scalekitClient.M2M().DeleteOrganizationClientSecret(
+  ctx,
+  "org_123",
+  "skc_xxxxx",
+  "sks_xxxxx",
+)
+if err != nil {
+  // handle error
+  return
+}

--- a/openapi/code_samples/go/api_v1_organizations_{organization_id}_connections_{id}/delete.go
+++ b/openapi/code_samples/go/api_v1_organizations_{organization_id}_connections_{id}/delete.go
@@ -1,4 +1,4 @@
-err := scalekitClient.Connection.DeleteConnection(
+err := scalekitClient.Connection().DeleteConnection(
   ctx,
   organizationId,
   connectionId,

--- a/openapi/code_samples/go/api_v1_organizations_{organization_id}_connections_{id}/get.go
+++ b/openapi/code_samples/go/api_v1_organizations_{organization_id}_connections_{id}/get.go
@@ -1,4 +1,4 @@
-connection, err := scalekitClient.Connection.GetConnection(
+connection, err := scalekitClient.Connection().GetConnection(
   ctx,
   organizationId,
   connectionId,

--- a/openapi/code_samples/go/api_v1_organizations_{organization_id}_connections_{id}:disable/patch.go
+++ b/openapi/code_samples/go/api_v1_organizations_{organization_id}_connections_{id}:disable/patch.go
@@ -1,4 +1,4 @@
-err := scalekitClient.Connection.DisableConnection(
+err := scalekitClient.Connection().DisableConnection(
   ctx,
   organizationId,
   connectionId,

--- a/openapi/code_samples/go/api_v1_organizations_{organization_id}_connections_{id}:enable/patch.go
+++ b/openapi/code_samples/go/api_v1_organizations_{organization_id}_connections_{id}:enable/patch.go
@@ -1,4 +1,4 @@
-err := scalekitClient.Connection.EnableConnection(
+err := scalekitClient.Connection().EnableConnection(
   ctx,
   organizationId,
   connectionId,

--- a/openapi/code_samples/go/api_v1_passwordless_email_send/post.go
+++ b/openapi/code_samples/go/api_v1_passwordless_email_send/post.go
@@ -1,22 +1,20 @@
 templateType := scalekit.TemplateTypeSignin
 response, err := scalekitClient.Passwordless().SendPasswordlessEmail(
-    ctx,
-    "john.doe@example.com",
-    &scalekit.SendPasswordlessOptions{
-        Template:         &templateType,
-        ExpiresIn:        100,
-        MagiclinkAuthUri: "https://www.google.com",
-        TemplateVariables: map[string]string{
-            "employeeID":    "EMP523",
-            "teamName":      "Alpha Team",
-            "supportEmail":  "support@yourcompany.com",
-        },
+  ctx,
+  "john.doe@example.com",
+  &scalekit.SendPasswordlessOptions{
+    Template:         &templateType,
+    ExpiresIn:        100,
+    MagiclinkAuthUri: "https://yourapp.com/auth/passwordless/callback",
+    TemplateVariables: map[string]string{
+      "employeeID":   "EMP523",
+      "teamName":     "Alpha Team",
+      "supportEmail": "support@yourcompany.com",
     },
+  },
 )
-
 if err != nil {
-    // Handle error
-    return
+  // handle error
+  return
 }
-
 authRequestId := response.AuthRequestId

--- a/openapi/code_samples/java/api_v1_connected_accounts/get.java
+++ b/openapi/code_samples/java/api_v1_connected_accounts/get.java
@@ -1,0 +1,2 @@
+// Connected Accounts are not part of the Java SDK public API yet.
+// Use the REST API (GET /api/v1/connected_accounts) or the Node.js/Python SDKs.

--- a/openapi/code_samples/java/api_v1_execute_tool/post.java
+++ b/openapi/code_samples/java/api_v1_execute_tool/post.java
@@ -1,0 +1,2 @@
+// Tool calling (execute_tool) is not part of the Java SDK public API yet.
+// Use the REST API (POST /api/v1/execute_tool) or the Node.js/Python SDKs.

--- a/openapi/code_samples/java/api_v1_memberships_organizations_{organization_id}_users_{id}/delete.java
+++ b/openapi/code_samples/java/api_v1_memberships_organizations_{organization_id}_users_{id}/delete.java
@@ -1,0 +1,1 @@
+scalekitClient.users().deleteMembership("org_123", "usr_123");

--- a/openapi/code_samples/java/api_v1_memberships_organizations_{organization_id}_users_{id}/post.java
+++ b/openapi/code_samples/java/api_v1_memberships_organizations_{organization_id}_users_{id}/post.java
@@ -1,22 +1,13 @@
-import com.scalekit.ScalekitClient;
-import com.scalekit.api.UserClient;
-import com.scalekit.grpc.scalekit.v1.users.*;
-ScalekitClient scalekitClient = new ScalekitClient(
-    System.getenv("SCALEKIT_ENV_URL"),
-    System.getenv("SCALEKIT_CLIENT_ID"),
-    System.getenv("SCALEKIT_CLIENT_SECRET")
+CreateMembershipRequest membershipReq = CreateMembershipRequest.newBuilder()
+    .setMembership(
+        CreateMembership.newBuilder()
+            .addRoles(Role.newBuilder().setName("admin").build())
+            .putMetadata("department", "engineering")
+            .putMetadata("location", "nyc-office")
+            .build())
+    .build();
+CreateMembershipResponse res = scalekitClient.users().createMembership(
+    "org_123",
+    "usr_123",
+    membershipReq
 );
-UserClient users = scalekitClient.users();
-CreateMembershipRequest membershipReq = CreateMemb
-  ershipRequest.newBuilder()
-        .setMembership(
-          CreateMembership.newBuilder()
-                .addRoles(Role.newBuilder(
-                  ).setName("admin").build())
-                .putMetadata("department", "engineering")
-                .putMetadata("location", "nyc-office")
-                .build())
-        .build();
-CreateMembershipResponse res = users.
-  createMembership("org_123", "usr_123", 
-    membershipReq);

--- a/openapi/code_samples/java/api_v1_organizations_{organization_id}_clients/get.java
+++ b/openapi/code_samples/java/api_v1_organizations_{organization_id}_clients/get.java
@@ -1,0 +1,2 @@
+ListOrganizationClientsResponse response = scalekitClient.m2m()
+    .listOrganizationClients("org_123", 30, "");

--- a/openapi/code_samples/java/api_v1_organizations_{organization_id}_clients/post.java
+++ b/openapi/code_samples/java/api_v1_organizations_{organization_id}_clients/post.java
@@ -1,0 +1,12 @@
+import com.scalekit.grpc.scalekit.v1.clients.OrganizationClient;
+
+OrganizationClient orgClient = OrganizationClient.newBuilder()
+    .setName("GitHub Actions Deployment Service")
+    .setDescription("Service account for GitHub Actions to deploy applications to production")
+    .addScopes("deploy:applications")
+    .addScopes("read:deployments")
+    .addAudience("deployment-api.acmecorp.com")
+    .build();
+
+CreateOrganizationClientResponse response = scalekitClient.m2m()
+    .createOrganizationClient("org_123", orgClient);

--- a/openapi/code_samples/java/api_v1_organizations_{organization_id}_clients_{client_id}/delete.java
+++ b/openapi/code_samples/java/api_v1_organizations_{organization_id}_clients_{client_id}/delete.java
@@ -1,0 +1,1 @@
+scalekitClient.m2m().deleteOrganizationClient("org_123", "skc_xxxxx");

--- a/openapi/code_samples/java/api_v1_organizations_{organization_id}_clients_{client_id}/get.java
+++ b/openapi/code_samples/java/api_v1_organizations_{organization_id}_clients_{client_id}/get.java
@@ -1,0 +1,2 @@
+GetOrganizationClientResponse response = scalekitClient.m2m()
+    .getOrganizationClient("org_123", "skc_xxxxx");

--- a/openapi/code_samples/java/api_v1_organizations_{organization_id}_clients_{client_id}/patch.java
+++ b/openapi/code_samples/java/api_v1_organizations_{organization_id}_clients_{client_id}/patch.java
@@ -1,0 +1,8 @@
+import com.scalekit.grpc.scalekit.v1.clients.OrganizationClient;
+
+OrganizationClient updates = OrganizationClient.newBuilder()
+    .setDescription("Service account for GitHub Actions to deploy applications to production_eu")
+    .build();
+
+UpdateOrganizationClientResponse response = scalekitClient.m2m()
+    .updateOrganizationClient("org_123", "skc_xxxxx", updates);

--- a/openapi/code_samples/java/api_v1_organizations_{organization_id}_clients_{client_id}_secrets/post.java
+++ b/openapi/code_samples/java/api_v1_organizations_{organization_id}_clients_{client_id}_secrets/post.java
@@ -1,0 +1,2 @@
+CreateOrganizationClientSecretResponse response = scalekitClient.m2m()
+    .createOrganizationClientSecret("org_123", "skc_xxxxx");

--- a/openapi/code_samples/java/api_v1_organizations_{organization_id}_clients_{client_id}_secrets_{secret_id}/delete.java
+++ b/openapi/code_samples/java/api_v1_organizations_{organization_id}_clients_{client_id}_secrets_{secret_id}/delete.java
@@ -1,0 +1,5 @@
+scalekitClient.m2m().deleteOrganizationClientSecret(
+    "org_123",
+    "skc_xxxxx",
+    "sks_xxxxx"
+);

--- a/openapi/code_samples/java/api_v1_passwordless_email_resend/post.java
+++ b/openapi/code_samples/java/api_v1_passwordless_email_resend/post.java
@@ -1,1 +1,2 @@
-SendPasswordlessResponse resendResponse = passwordlessClient.resendPasswordlessEmail(authRequestId);
+SendPasswordlessResponse resendResponse = scalekitClient.passwordless()
+    .resendPasswordlessEmail(authRequestId);

--- a/openapi/code_samples/java/api_v1_passwordless_email_send/post.java
+++ b/openapi/code_samples/java/api_v1_passwordless_email_send/post.java
@@ -7,10 +7,10 @@ templateVariables.put("supportEmail", "support@yourcompany.com");
 SendPasswordlessOptions options = new SendPasswordlessOptions();
 options.setTemplate(templateType);
 options.setExpiresIn(100);
-options.setMagiclinkAuthUri("https://www.example.com");
+options.setMagiclinkAuthUri("https://yourapp.com/auth/passwordless/callback");
 options.setTemplateVariables(templateVariables);
 
-SendPasswordlessResponse response = passwordlessClient.sendPasswordlessEmail(
+SendPasswordlessResponse response = scalekitClient.passwordless().sendPasswordlessEmail(
     "john.doe@example.com",
     options
 );

--- a/openapi/code_samples/java/api_v1_passwordless_email_verify/post.java
+++ b/openapi/code_samples/java/api_v1_passwordless_email_verify/post.java
@@ -3,16 +3,17 @@ VerifyPasswordlessOptions verifyOptions = new VerifyPasswordlessOptions();
 verifyOptions.setCode("123456"); // OTP code
 verifyOptions.setAuthRequestId(authRequestId);
 
-VerifyPasswordLessResponse verifyResponse = passwordlessClient.verifyPasswordlessEmail(verifyOptions);
+VerifyPasswordLessResponse verifyResponse = scalekitClient.passwordless()
+    .verifyPasswordlessEmail(verifyOptions);
 
 // User verified successfully
 String userEmail = verifyResponse.getEmail();
 
 // Verify with magic link token
-VerifyPasswordlessOptions verifyOptions = new VerifyPasswordlessOptions();
-verifyOptions.setLinkToken(linkToken); // Magic link token
+VerifyPasswordlessOptions linkVerifyOptions = new VerifyPasswordlessOptions();
+linkVerifyOptions.setLinkToken(linkToken); // Magic link token
 
-VerifyPasswordLessResponse verifyResponse = passwordlessClient.verifyPasswordlessEmail(verifyOptions);
+VerifyPasswordLessResponse linkVerifyResponse = scalekitClient.passwordless()
+    .verifyPasswordlessEmail(linkVerifyOptions);
 
-// User verified successfully
-String userEmail = verifyResponse.getEmail();
+String verifiedEmail = linkVerifyResponse.getEmail();

--- a/openapi/code_samples/java/api_v1_users/get.java
+++ b/openapi/code_samples/java/api_v1_users/get.java
@@ -1,3 +1,4 @@
-ListUsersRequest lur = ListUsersRequest.
-  newBuilder().setPageSize(100).build();
-ListUsersResponse allUsers = users.listUsers(lur);
+ListUsersRequest lur = ListUsersRequest.newBuilder()
+    .setPageSize(100)
+    .build();
+ListUsersResponse allUsers = scalekitClient.users().listUsers(lur);

--- a/openapi/code_samples/java/api_v1_users_{id}/delete.java
+++ b/openapi/code_samples/java/api_v1_users_{id}/delete.java
@@ -1,1 +1,1 @@
-users.deleteUser("usr_123");
+scalekitClient.users().deleteUser("usr_123");

--- a/openapi/code_samples/java/api_v1_users_{id}/patch.java
+++ b/openapi/code_samples/java/api_v1_users_{id}/patch.java
@@ -1,11 +1,12 @@
 UpdateUser upd = UpdateUser.newBuilder()
-        .setUserProfile(
-          UpdateUserProfile.newBuilder()
-                .setFirstName("John")
-                .setLastName("Smith")
-                .build())
-        .putMetadata("department", "sales")
-        .build();
-UpdateUserRequest updReq = UpdateUserRequest.
-  newBuilder().setUser(upd).build();
-users.updateUser("usr_123", updReq);
+    .setUserProfile(
+        UpdateUserProfile.newBuilder()
+            .setFirstName("John")
+            .setLastName("Smith")
+            .build())
+    .putMetadata("department", "sales")
+    .build();
+UpdateUserRequest updReq = UpdateUserRequest.newBuilder()
+    .setUser(upd)
+    .build();
+scalekitClient.users().updateUser("usr_123", updReq);

--- a/openapi/code_samples/java/api_v1_webauthn_credentials/get.java
+++ b/openapi/code_samples/java/api_v1_webauthn_credentials/get.java
@@ -1,1 +1,1 @@
-ListCredentialsResponse res = scalekitClient.webauthn().listCredentials("user_123");
+ListCredentialsResponse res = scalekitClient.webAuthn().listCredentials("user_123");

--- a/openapi/code_samples/java/api_v1_webauthn_credentials_{credential_id}/delete.java
+++ b/openapi/code_samples/java/api_v1_webauthn_credentials_{credential_id}/delete.java
@@ -1,1 +1,1 @@
-DeleteCredentialResponse res = scalekitClient.webauthn().deleteCredential("wac_123");
+DeleteCredentialResponse res = scalekitClient.webAuthn().deleteCredential("wac_123");

--- a/openapi/code_samples/java/api_v1_webauthn_credentials_{credential_id}/patch.java
+++ b/openapi/code_samples/java/api_v1_webauthn_credentials_{credential_id}/patch.java
@@ -1,2 +1,2 @@
-UpdateCredentialResponse res = scalekitClient.webauthn()
+UpdateCredentialResponse res = scalekitClient.webAuthn()
     .updateCredential("wac_123", "Work Laptop Passkey");

--- a/openapi/code_samples/javascript/api_v1_connected_accounts/get.js
+++ b/openapi/code_samples/javascript/api_v1_connected_accounts/get.js
@@ -1,1 +1,5 @@
-// Coming soon — accurate SDK snippets for List connected accounts will be added via scalekit-code-doctor (SK-399)
+const response = await scalekit.connectedAccounts.listConnectedAccounts({
+  organizationId: 'org_123',
+  pageSize: 20,
+})
+const connectedAccounts = response.connectedAccounts

--- a/openapi/code_samples/javascript/api_v1_execute_tool/post.js
+++ b/openapi/code_samples/javascript/api_v1_execute_tool/post.js
@@ -1,1 +1,9 @@
-// Coming soon — accurate SDK snippets for Execute tool (Tool Calling) will be added via scalekit-code-doctor (SK-399)
+const response = await scalekit.tools.executeTool({
+  toolName: 'gmail_send_email',
+  identifier: 'user@example.com',
+  params: {
+    to: 'team@example.com',
+    subject: 'Hello from Scalekit',
+    body: 'Tool execution succeeded.',
+  },
+})

--- a/openapi/code_samples/javascript/api_v1_memberships_organizations_{organization_id}_users_{id}/delete.js
+++ b/openapi/code_samples/javascript/api_v1_memberships_organizations_{organization_id}_users_{id}/delete.js
@@ -1,0 +1,1 @@
+await scalekit.user.deleteMembership('org_123', 'usr_123')

--- a/openapi/code_samples/javascript/api_v1_memberships_organizations_{organization_id}_users_{id}/post.js
+++ b/openapi/code_samples/javascript/api_v1_memberships_organizations_{organization_id}_users_{id}/post.js
@@ -1,9 +1,3 @@
-import { ScalekitClient } from '@scalekit-sdk/node'
-const scalekit = new ScalekitClient(
-  process.env.SCALEKIT_ENV_URL,
-  process.env.SCALEKIT_CLIENT_ID,
-  process.env.SCALEKIT_CLIENT_SECRET,
-)
 await scalekit.user.createMembership('org_123', 'usr_123', {
   roles: ['admin'],
   metadata: {

--- a/openapi/code_samples/javascript/api_v1_organizations_{id}/get.js
+++ b/openapi/code_samples/javascript/api_v1_organizations_{id}/get.js
@@ -1,7 +1,1 @@
-import { ScalekitClient } from '@scalekit-sdk/node'
-const scalekit = new ScalekitClient(
-  process.env.SCALEKIT_ENV_URL,
-  process.env.SCALEKIT_CLIENT_ID,
-  process.env.SCALEKIT_CLIENT_SECRET,
-)
-const organization = await scalekit.organization.getOrganization(organization_id)
+const organization = await scalekit.organization.getOrganization(organizationId)

--- a/openapi/code_samples/javascript/api_v1_organizations_{organization_id}_clients/get.js
+++ b/openapi/code_samples/javascript/api_v1_organizations_{organization_id}_clients/get.js
@@ -1,0 +1,4 @@
+const response = await scalekit.m2m.listOrganizationClients('org_123', {
+  pageSize: 30,
+})
+const clients = response.clients

--- a/openapi/code_samples/javascript/api_v1_organizations_{organization_id}_clients/post.js
+++ b/openapi/code_samples/javascript/api_v1_organizations_{organization_id}_clients/post.js
@@ -1,0 +1,6 @@
+const response = await scalekit.m2m.createOrganizationClient('org_123', {
+  name: 'GitHub Actions Deployment Service',
+  description: 'Service account for GitHub Actions to deploy applications to production',
+  scopes: ['deploy:applications', 'read:deployments'],
+  audience: ['deployment-api.acmecorp.com'],
+})

--- a/openapi/code_samples/javascript/api_v1_organizations_{organization_id}_clients_{client_id}/delete.js
+++ b/openapi/code_samples/javascript/api_v1_organizations_{organization_id}_clients_{client_id}/delete.js
@@ -1,0 +1,1 @@
+await scalekit.m2m.deleteOrganizationClient('org_123', 'skc_xxxxx')

--- a/openapi/code_samples/javascript/api_v1_organizations_{organization_id}_clients_{client_id}/get.js
+++ b/openapi/code_samples/javascript/api_v1_organizations_{organization_id}_clients_{client_id}/get.js
@@ -1,0 +1,1 @@
+const response = await scalekit.m2m.getOrganizationClient('org_123', 'skc_xxxxx')

--- a/openapi/code_samples/javascript/api_v1_organizations_{organization_id}_clients_{client_id}/patch.js
+++ b/openapi/code_samples/javascript/api_v1_organizations_{organization_id}_clients_{client_id}/patch.js
@@ -1,0 +1,3 @@
+const response = await scalekit.m2m.updateOrganizationClient('org_123', 'skc_xxxxx', {
+  description: 'Service account for GitHub Actions to deploy applications to production_eu',
+})

--- a/openapi/code_samples/javascript/api_v1_organizations_{organization_id}_clients_{client_id}_secrets/post.js
+++ b/openapi/code_samples/javascript/api_v1_organizations_{organization_id}_clients_{client_id}_secrets/post.js
@@ -1,0 +1,2 @@
+const response = await scalekit.m2m.addOrganizationClientSecret('org_123', 'skc_xxxxx')
+const secretId = response.secret?.id

--- a/openapi/code_samples/javascript/api_v1_organizations_{organization_id}_clients_{client_id}_secrets_{secret_id}/delete.js
+++ b/openapi/code_samples/javascript/api_v1_organizations_{organization_id}_clients_{client_id}_secrets_{secret_id}/delete.js
@@ -1,0 +1,1 @@
+await scalekit.m2m.removeOrganizationClientSecret('org_123', 'skc_xxxxx', 'sks_xxxxx')

--- a/openapi/code_samples/javascript/api_v1_passwordless_email_send/post.js
+++ b/openapi/code_samples/javascript/api_v1_passwordless_email_send/post.js
@@ -1,7 +1,7 @@
 const response = await scalekit.passwordless.sendPasswordlessEmail('john.doe@example.com', {
   template: 'SIGNIN',
   expiresIn: 100,
-  magiclinkAuthUri: 'https://www.google.com',
+  magiclinkAuthUri: 'https://yourapp.com/auth/passwordless/callback',
   templateVariables: {
     employeeID: 'EMP523',
     teamName: 'Alpha Team',

--- a/openapi/code_samples/javascript/api_v1_passwordless_email_verify/post.js
+++ b/openapi/code_samples/javascript/api_v1_passwordless_email_verify/post.js
@@ -1,12 +1,12 @@
 const { authRequestId } = sendResponse
+
+// Verify with OTP code
 const verifyResponse = await scalekit.passwordless.verifyPasswordlessEmail(
-  // Verification Code (OTP)
-
   { code: '123456' },
-
-  // Magic Link Token
-
-  { linkToken: link_token },
-
   authRequestId,
 )
+
+// Or verify with magic link token
+const linkVerifyResponse = await scalekit.passwordless.verifyPasswordlessEmail({
+  linkToken: linkToken,
+})

--- a/openapi/code_samples/python/api_v1_connected_accounts/get.py
+++ b/openapi/code_samples/python/api_v1_connected_accounts/get.py
@@ -1,1 +1,6 @@
-# Coming soon — accurate SDK snippets for List connected accounts will be added via scalekit-code-doctor (SK-399)
+response = scalekit_client.connected_accounts.list_connected_accounts(
+    organization_id="org_123",
+    page_size=20,
+)
+# with_call returns (response, call)
+connected_accounts = response[0].connected_accounts

--- a/openapi/code_samples/python/api_v1_execute_tool/post.py
+++ b/openapi/code_samples/python/api_v1_execute_tool/post.py
@@ -1,1 +1,9 @@
-# Coming soon — accurate SDK snippets for Execute tool (Tool Calling) will be added via scalekit-code-doctor (SK-399)
+response = scalekit_client.tools.execute_tool(
+    tool_name="gmail_send_email",
+    identifier="user@example.com",
+    params={
+        "to": "team@example.com",
+        "subject": "Hello from Scalekit",
+        "body": "Tool execution succeeded.",
+    },
+)

--- a/openapi/code_samples/python/api_v1_memberships_organizations_{organization_id}_users_{id}/delete.py
+++ b/openapi/code_samples/python/api_v1_memberships_organizations_{organization_id}_users_{id}/delete.py
@@ -1,3 +1,4 @@
-response = scalekit_client.users.delete_membership(
-  organization_id=org_id,user_id=user_id
+scalekit_client.users.delete_membership(
+    organization_id="org_123",
+    user_id="usr_123",
 )

--- a/openapi/code_samples/python/api_v1_organizations_{id}/get.py
+++ b/openapi/code_samples/python/api_v1_organizations_{id}/get.py
@@ -1,9 +1,1 @@
-scalekit_client = ScalekitClient(
-  <SCALEKIT_ENVIRONMENT_URL>,
-  <SCALEKIT_CLIENT_ID>,
-  <SCALEKIT_CLIENT_SECRET>
-)
-
-organization = scalekit_client.organization.get_organization(
-  organization_id
-)
+organization = scalekit_client.organization.get_organization(organization_id)

--- a/openapi/code_samples/python/api_v1_organizations_{organization_id}_clients/get.py
+++ b/openapi/code_samples/python/api_v1_organizations_{organization_id}_clients/get.py
@@ -1,13 +1,11 @@
 # List clients for a specific organization
-org_id = 'SCALEKIT_ORGANIZATION_ID'
+org_id = "org_123"
 
-# Retrieve all clients with default pagination
 response = scalekit_client.m2m_client.list_organization_clients(
     organization_id=org_id,
-    page_size=30
+    page_size=30,
 )
 
-# Access the clients list
 clients = response.clients
 for client in clients:
-    print(f"Client ID: {scalekit_client.id}, Name: {scalekit_client.name}")
+    print(f"Client ID: {client.id}, Name: {client.name}")

--- a/openapi/code_samples/python/api_v1_organizations_{organization_id}_clients/post.py
+++ b/openapi/code_samples/python/api_v1_organizations_{organization_id}_clients/post.py
@@ -2,18 +2,17 @@ from scalekit.v1.clients.clients_pb2 import OrganizationClient
 
 m2m_client = OrganizationClient(
     name="GitHub Actions Deployment Service",
-    description="Service account for GitHub Actions to deploy applications
-to production",
+    description="Service account for GitHub Actions to deploy applications to production",
     custom_claims=[
         {"key": "github_repository", "value": "acmecorp/inventory-service"},
-        {"key": "environment", "value": "production_us"}
+        {"key": "environment", "value": "production_us"},
     ],
     scopes=["deploy:applications", "read:deployments"],
     audience=["deployment-api.acmecorp.com"],
-    expiry=3600
+    expiry=3600,
 )
 
 response = scalekit_client.m2m_client.create_organization_client(
-    organization_id="SCALEKIT_ORGANIZATION_ID",
-    m2m_client=m2m_client
+    organization_id="org_123",
+    m2m_client=m2m_client,
 )

--- a/openapi/code_samples/python/api_v1_organizations_{organization_id}_clients_{client_id}/delete.py
+++ b/openapi/code_samples/python/api_v1_organizations_{organization_id}_clients_{client_id}/delete.py
@@ -1,9 +1,9 @@
-# Get client ID from environment variables
-org_id = '<SCALEKIT_ORGANIZATION_ID>'
-client_id = os.environ['M2M_CLIENT_ID']
+import os
 
-# Delete the specified client from the organization
-response = scalekit_client.m2m_client.delete_organization_client(
+org_id = "org_123"
+client_id = os.environ["M2M_CLIENT_ID"]
+
+scalekit_client.m2m_client.delete_organization_client(
     organization_id=org_id,
-    client_id=client_id
+    client_id=client_id,
 )

--- a/openapi/code_samples/python/api_v1_organizations_{organization_id}_clients_{client_id}/get.py
+++ b/openapi/code_samples/python/api_v1_organizations_{organization_id}_clients_{client_id}/get.py
@@ -1,9 +1,9 @@
-# Get client ID from environment variables
-org_id = 'SCALEKIT_ORGANIZATION_ID'
-client_id = os.environ['M2M_CLIENT_ID']
+import os
 
-# Fetch client details for the specified organization
+org_id = "org_123"
+client_id = os.environ["M2M_CLIENT_ID"]
+
 response = scalekit_client.m2m_client.get_organization_client(
     organization_id=org_id,
-    client_id=client_id
+    client_id=client_id,
 )

--- a/openapi/code_samples/python/api_v1_organizations_{organization_id}_clients_{client_id}/patch.py
+++ b/openapi/code_samples/python/api_v1_organizations_{organization_id}_clients_{client_id}/patch.py
@@ -1,19 +1,19 @@
+import os
 from scalekit.v1.clients.clients_pb2 import OrganizationClient
 
-org_id = '<SCALEKIT_ORGANIZATION_ID>'
-client_id = os.environ['M2M_CLIENT_ID']
+org_id = "org_123"
+client_id = os.environ["M2M_CLIENT_ID"]
 
 update_m2m_client = OrganizationClient(
-    description="Service account for GitHub Actions to deploy applications
-to production_eu",
+    description="Service account for GitHub Actions to deploy applications to production_eu",
     custom_claims=[
         {"key": "github_repository", "value": "acmecorp/inventory"},
-        {"key": "environment", "value": "production_eu"}
-    ]
+        {"key": "environment", "value": "production_eu"},
+    ],
 )
 
 response = scalekit_client.m2m_client.update_organization_client(
     organization_id=org_id,
     client_id=client_id,
-    m2m_client=update_m2m_client
+    m2m_client=update_m2m_client,
 )

--- a/openapi/code_samples/python/api_v1_organizations_{organization_id}_clients_{client_id}_secrets/post.py
+++ b/openapi/code_samples/python/api_v1_organizations_{organization_id}_clients_{client_id}_secrets/post.py
@@ -1,12 +1,12 @@
-# Get client ID from environment variables
-org_id = 'SCALEKIT_ORGANIZATION_ID'
-client_id = os.environ['M2M_CLIENT_ID']
+import os
 
-# Add a new secret to the specified client
+org_id = "org_123"
+client_id = os.environ["M2M_CLIENT_ID"]
+
 response = scalekit_client.m2m_client.add_organization_client_secret(
     organization_id=org_id,
-    client_id=client_id
+    client_id=client_id,
 )
 
-# Extract the secret ID from the response
+# with_call returns (response, call)
 secret_id = response[0].secret.id

--- a/openapi/code_samples/python/api_v1_organizations_{organization_id}_clients_{client_id}_secrets_{secret_id}/delete.py
+++ b/openapi/code_samples/python/api_v1_organizations_{organization_id}_clients_{client_id}_secrets_{secret_id}/delete.py
@@ -1,11 +1,11 @@
-# Get client and secret IDs from environment variables
-org_id = '<SCALEKIT_ORGANIZATION_ID>'
-client_id = os.environ['M2M_CLIENT_ID']
-secret_id = os.environ['M2M_SECRET_ID']
+import os
 
-# Remove the specified secret from the client
-response = scalekit_client.m2m_client.remove_organization_client_secret(
+org_id = "org_123"
+client_id = os.environ["M2M_CLIENT_ID"]
+secret_id = os.environ["M2M_SECRET_ID"]
+
+scalekit_client.m2m_client.remove_organization_client_secret(
     organization_id=org_id,
     client_id=client_id,
-    secret_id=secret_id
+    secret_id=secret_id,
 )

--- a/openapi/code_samples/python/api_v1_organizations_{organization_id}_users/get.py
+++ b/openapi/code_samples/python/api_v1_organizations_{organization_id}_users/get.py
@@ -1,1 +1,4 @@
-resp, _ = scalekit_client.users.list_users(organization_id="org_123", page_size=50)
+response = scalekit_client.users.list_organization_users(
+    organization_id="org_123",
+    page_size=50,
+)

--- a/openapi/code_samples/python/api_v1_passwordless_email_send/post.py
+++ b/openapi/code_samples/python/api_v1_passwordless_email_send/post.py
@@ -2,7 +2,7 @@ response = scalekit_client.passwordless.send_passwordless_email(
     email="john.doe@example.com",
     template="SIGNIN",  # or "SIGNUP", "UNSPECIFIED"
     expires_in=100,
-    magiclink_auth_uri="https://www.google.com",
+    magiclink_auth_uri="https://yourapp.com/auth/passwordless/callback",
     template_variables={
         "employeeID": "EMP523",
         "teamName": "Alpha Team",
@@ -10,5 +10,5 @@ response = scalekit_client.passwordless.send_passwordless_email(
     },
 )
 
-# Extract auth request ID from response
+# with_call returns (response, call)
 auth_request_id = response[0].auth_request_id

--- a/openapi/code_samples/python/api_v1_users/get.py
+++ b/openapi/code_samples/python/api_v1_users/get.py
@@ -1,2 +1,2 @@
-# pass empty org to fetch all users in environment
-resp,_ = scalekit_client.users.list_users(organization_id="", page_size=100)
+# List all users in the environment
+response = scalekit_client.users.list_users(page_size=100)

--- a/openapi/code_samples/python/api_v1_users_{id}/delete.py
+++ b/openapi/code_samples/python/api_v1_users_{id}/delete.py
@@ -1,2 +1,1 @@
-scalekit_client.users.delete_user(organization_id="org_123", 
-  user_id="usr_123")
+scalekit_client.users.delete_user("usr_123")

--- a/openapi/code_samples/python/api_v1_users_{id}/patch.py
+++ b/openapi/code_samples/python/api_v1_users_{id}/patch.py
@@ -1,18 +1,11 @@
-import os
-from scalekit import ScalekitClient
 from scalekit.v1.users.users_pb2 import UpdateUser
 from scalekit.v1.commons.commons_pb2 import UserProfile
-scalekit_client = ScalekitClient(
-    env_url=os.getenv("SCALEKIT_ENV_URL"),
-    client_id=os.getenv("SCALEKIT_CLIENT_ID"),
-    client_secret=os.getenv("SCALEKIT_CLIENT_SECRET"),
-)
+
 update_user = UpdateUser(
     user_profile=UserProfile(
         first_name="John",
-        last_name="Smith"
+        last_name="Smith",
     ),
-    metadata={"department": "sales"}
+    metadata={"department": "sales"},
 )
-scalekit_client.users.update_user(organization_id="org_123", 
-  user=update_user)
+response = scalekit_client.users.update_user("usr_123", update_user)

--- a/project-docs/.env.template
+++ b/project-docs/.env.template
@@ -11,7 +11,6 @@
 STARLIGHT_CHANGELOG_90DAY_ACCESS=github_pat_***xpM0nMNLBLQKST6bezO94W
 # this is access to public repositories (forever)
 GITHUB_TOKEN=gh****pKRm1TviLJ
-PUBLIC_SAMPLEAPP_API_KEY=3ZbW8*****Sgd
 PUBLIC_PYLON_APP_ID=32a5*****f9deb8a6
 
 # Authentication


### PR DESCRIPTION
## Summary

- Audit and correct Scalar API reference code samples across Node.js, Python, Go, and Java
- Fix SDK method names, client accessors (e.g. `Organization()` vs field access), and M2M client samples
- Add missing membership delete samples and AgentKit stubs (connected accounts, execute tool)
- Align passwordless send/verify samples and user/org listing method signatures
- Remove unused `PUBLIC_SAMPLEAPP_API_KEY` from `.env.example` and `project-docs/.env.template`

## Linear

https://linear.app/scalekit/issue/SK-1265/audit-and-fix-openapi-code-samples-across-all-four-sdks

## Deploy preview

https://deploy-preview-875--scalekit-starlight.netlify.app/

## Test plan

- [ ] Spot-check API reference pages for Organizations, Users, Memberships, M2M clients, Passwordless, and AgentKit endpoints
- [ ] Confirm Node, Python, Go, and Java samples render correctly in Scalar for touched operations
- [ ] Verify membership delete and M2M client CRUD samples appear for all four languages
- [ ] Confirm `PUBLIC_SAMPLEAPP_API_KEY` is no longer present in env templates
- [ ] Run local docs preview if needed for sample injection via `pnpm run bundle:apis`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded runnable JavaScript, Python, Go, and Java examples for connected accounts, tool execution, memberships, organizations, clients, secrets, users, and passwordless authentication.
  * Updated SDK examples to reflect current client access patterns and request formats.
  * Added guidance where certain capabilities are unavailable in specific SDKs.
  * Improved examples with clearer callbacks, identifiers, pagination, and error-handling patterns.
  * Refreshed environment templates with chat widget configuration and GitHub access token placeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->