### PR TITLE
Update AgentKit Node and Python SDK docs

### DIFF
--- a/src/content/docs/agentkit/advanced/migrate-from-composio.mdx
+++ b/src/content/docs/agentkit/advanced/migrate-from-composio.mdx
@@ -98,11 +98,11 @@ This guide maps Composio concepts to their Scalekit AgentKit equivalents and wal
    ```typescript
    import { ScalekitClient } from '@scalekit-sdk/node';
 
-   const scalekit = new ScalekitClient({
-     clientId: process.env.SCALEKIT_CLIENT_ID!,
-     clientSecret: process.env.SCALEKIT_CLIENT_SECRET!,
-     envUrl: process.env.SCALEKIT_ENV_URL!,
-   });
+   const scalekit = new ScalekitClient(
+     process.env.SCALEKIT_ENV_URL!,
+     process.env.SCALEKIT_CLIENT_ID!,
+     process.env.SCALEKIT_CLIENT_SECRET!
+   );
    ```
      </TabItem>
    </Tabs>

--- a/src/content/docs/agentkit/examples/mastra.mdx
+++ b/src/content/docs/agentkit/examples/mastra.mdx
@@ -30,7 +30,7 @@ npm install @scalekit-sdk/node @mastra/core @mastra/mcp @ai-sdk/openai
 
 ## Get a per-user MCP URL
 
-Generate a Scalekit MCP URL for the user. This requires the Python SDK. Call this from your backend and pass the URL to your Mastra application:
+Generate a Scalekit MCP URL for the user. This requires the Python SDK. Call this from your backend for the **current user**, then pass that URL into your Mastra app (API response, session store, or request-scoped config).
 
 ```python
 # Backend (Python): generate once per user session
@@ -39,21 +39,26 @@ inst_response = actions.mcp.ensure_instance(
     user_identifier="user_123",
 )
 mcp_url = inst_response.instance.url
-# Pass mcp_url to your Mastra app (e.g. via environment variable or API response)
+# Return mcp_url to the Mastra app for this user only
 ```
 
 See [Virtual MCP Servers](/agentkit/mcp/overview/) to set up the config and generate the URL.
 
+<Aside type="caution" title="Do not share one MCP URL across users">
+  Each URL is pre-authenticated for a single user. In multi-user deployments, look up the URL for the authenticated user on the server. A process-wide `SCALEKIT_MCP_URL` is only safe for single-user demos; sharing it runs every request as that user.
+</Aside>
+
 ## Build the agent
 
-Pass the MCP URL to `MCPClient`. Mastra fetches the tool list and schemas automatically:
+Pass the **current user's** MCP URL to `MCPClient`. Mastra fetches the tool list and schemas automatically:
 
 ```typescript
 import { Agent } from '@mastra/core/agent';
 import { MCPClient } from '@mastra/mcp';
 import { openai } from '@ai-sdk/openai';
 
-const mcpUrl = process.env.SCALEKIT_MCP_URL!; // set from your backend
+// From your backend for the authenticated user — not a shared process-wide secret
+const mcpUrl = await getMcpUrlForUser(currentUserId);
 
 const mcp = new MCPClient({
   servers: {

--- a/src/content/docs/agentkit/examples/mastra.mdx
+++ b/src/content/docs/agentkit/examples/mastra.mdx
@@ -42,7 +42,7 @@ mcp_url = inst_response.instance.url
 # Pass mcp_url to your Mastra app (e.g. via environment variable or API response)
 ```
 
-See [Virtual MCP Servers](/agentkit/mcp/overview/) to set up the config and generate the URL.
+See [Virtual MCP Servers](/agentkit/mcp/overview/) to set up the config, and [`actions.mcp.ensure_instance`](/agentkit/sdks/python/#actionsmcpensure_instance) in the Python SDK reference.
 
 ## Build the agent
 

--- a/src/content/docs/agentkit/examples/mastra.mdx
+++ b/src/content/docs/agentkit/examples/mastra.mdx
@@ -42,7 +42,7 @@ mcp_url = inst_response.instance.url
 # Pass mcp_url to your Mastra app (e.g. via environment variable or API response)
 ```
 
-See [Virtual MCP Servers](/agentkit/mcp/overview/) to set up the config, and [`actions.mcp.ensure_instance`](/agentkit/sdks/python/#actionsmcpensure_instance) in the Python SDK reference.
+See [Virtual MCP Servers](/agentkit/mcp/overview/) to set up the config and generate the URL.
 
 ## Build the agent
 

--- a/src/content/docs/agentkit/sdks/node/index.mdx
+++ b/src/content/docs/agentkit/sdks/node/index.mdx
@@ -28,11 +28,11 @@ npm install @scalekit-sdk/node
 ```ts
 import { ScalekitClient } from '@scalekit-sdk/node';
 
-const scalekit = new ScalekitClient({
-  clientId: process.env.SCALEKIT_CLIENT_ID!,
-  clientSecret: process.env.SCALEKIT_CLIENT_SECRET!,
-  envUrl: process.env.SCALEKIT_ENV_URL!,
-});
+const scalekit = new ScalekitClient(
+  process.env.SCALEKIT_ENV_URL!,
+  process.env.SCALEKIT_CLIENT_ID!,
+  process.env.SCALEKIT_CLIENT_SECRET!
+);
 ```
 
 ---
@@ -121,6 +121,8 @@ const { connectedAccount } = await scalekit.actions.getOrCreateConnectedAccount(
 });
 console.log(connectedAccount.id);
 ```
+
+`upsertConnectedAccount` is an alias of `getOrCreateConnectedAccount`. Prefer the upsert name when you mean create-or-update credential semantics.
 
 #### getConnectedAccount
 
@@ -212,6 +214,39 @@ Deletes a connected account and revokes its credentials. Requires `connectedAcco
 ]} />
 
 Returns DeleteConnectedAccountResponse.
+
+#### listConnections
+
+Lists **app-level** AgentKit connections (tool/provider integrations for the environment). This is not the same as SSO organization connections on `scalekit.connection`.
+
+<MethodParams label="Input schema" params={[
+  { name: 'pageSize', type: 'number', required: false, description: 'Maximum connections per page (max 30)' },
+  { name: 'pageToken', type: 'string', required: false, description: 'Opaque cursor from a previous list response' },
+  { name: 'provider', type: 'string', required: false, description: 'Filter by provider key (case-sensitive, e.g. GMAIL, SALESFORCE)' },
+]} />
+
+<MethodReturns type="ListAppConnectionsResult" fields={[
+  { name: 'connections', type: 'array', description: 'Normalized AppConnection objects' },
+  { name: 'connections[].id', type: 'string', description: 'Connection ID (conn_...)' },
+  { name: 'connections[].connectionName', type: 'string', description: 'Connection name / key identifier' },
+  { name: 'connections[].provider', type: 'string', description: 'Provider key (e.g. GMAIL)' },
+  { name: 'connections[].type', type: 'string', description: 'Connection type (e.g. OAUTH)' },
+  { name: 'connections[].status', type: 'string', description: 'Connection status (e.g. COMPLETED, DRAFT)' },
+  { name: 'connections[].enabled', type: 'boolean', description: 'Whether the connection is enabled' },
+  { name: 'totalSize', type: 'number', description: 'Total number of matching connections' },
+  { name: 'nextPageToken', type: 'string', description: 'Token for the next page, if any' },
+  { name: 'prevPageToken', type: 'string', description: 'Token for the previous page, if any' },
+]} />
+
+```ts title="Example"
+const { connections } = await scalekit.actions.listConnections({
+  pageSize: 30,
+  provider: 'GMAIL',
+});
+for (const conn of connections) {
+  console.log(conn.id, conn.connectionName, conn.enabled);
+}
+```
 
 ---
 

--- a/src/content/docs/agentkit/sdks/node/index.mdx
+++ b/src/content/docs/agentkit/sdks/node/index.mdx
@@ -238,13 +238,17 @@ Lists **app-level** AgentKit connections (tool/provider integrations for the env
   { name: 'prevPageToken', type: 'string', description: 'Token for the previous page, if any' },
 ]} />
 
-```ts title="Example"
-const { connections } = await scalekit.actions.listConnections({
-  pageSize: 30,
-  provider: 'GMAIL',
-});
-for (const conn of connections) {
-  console.log(conn.id, conn.connectionName, conn.enabled);
+```ts title="list-connections.ts"
+try {
+  const { connections } = await scalekit.actions.listConnections({
+    pageSize: 30,
+    provider: 'GMAIL',
+  });
+  for (const conn of connections) {
+    console.log(conn.id, conn.connectionName, conn.enabled);
+  }
+} catch (error) {
+  console.error('Failed to list connections', error);
 }
 ```
 

--- a/src/content/docs/agentkit/sdks/python/index.mdx
+++ b/src/content/docs/agentkit/sdks/python/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Python SDK reference'
-description: 'Complete API reference for the Scalekit Python SDK: actions client, MCP server provisioning, framework adapters, tools client, and modifiers.'
+description: 'Complete API reference for the Scalekit Python SDK: actions client, MCP configs/instances/session tokens, custom providers, framework adapters, tools, and modifiers.'
 sidebar:
   label: 'Python SDK'
 tableOfContents:
@@ -153,12 +153,44 @@ Requires `connected_account_id` **or** `connection_name` + `identifier`.
   { name: 'connected_account.updated_at', type: 'datetime', description: 'Last update timestamp' },
 ]} />
 
+#### get_connected_account_details
+
+Fetches connected account metadata **without** auth credentials. Use this when you need status, connector, or `api_config` and do not need access or refresh tokens.
+
+Requires `connected_account_id` **or** `connection_name` + `identifier`.
+
+<MethodParams label="Input schema" params={[
+  { name: 'connection_name', type: 'str', required: false, description: 'Connector slug. Use with identifier when you do not pass connected_account_id.' },
+  { name: 'identifier', type: 'str', required: false, description: 'End-user or workspace identifier. Use with connection_name.' },
+  { name: 'connected_account_id', type: 'str', required: false, description: 'Connected account ID (ca_...) when resolving by ID instead of name + identifier' },
+]} />
+
+<MethodReturns type="GetConnectedAccountDetailsResponse" fields={[
+  { name: 'connected_account.id', type: 'str', description: 'Account ID (ca_...)' },
+  { name: 'connected_account.identifier', type: 'str', description: "User's identifier" },
+  { name: 'connected_account.provider', type: 'str', description: 'Provider slug' },
+  { name: 'connected_account.status', type: 'str', description: 'ACTIVE, INACTIVE, or PENDING' },
+  { name: 'connected_account.authorization_type', type: 'str', description: 'OAuth, API_KEY, etc.' },
+  { name: 'connected_account.token_expires_at', type: 'datetime', description: 'OAuth token expiry when known' },
+  { name: 'connected_account.last_used_at', type: 'datetime', description: 'Last time this account was used' },
+  { name: 'connected_account.updated_at', type: 'datetime', description: 'Last update timestamp' },
+]} />
+
+```python title="Example"
+details = actions.get_connected_account_details(
+    connection_name="gmail",
+    identifier="user@example.com",
+)
+print(details.connected_account.status)
+```
+
 #### list_connected_accounts
 
 <MethodParams label="Input schema" params={[
-  { name: 'connection_name', type: 'str', required: false, description: 'Filter by connector' },
+  { name: 'connection_name', type: 'str', required: false, description: 'Filter by a single connector slug' },
   { name: 'identifier', type: 'str', required: false, description: 'Filter by user identifier' },
   { name: 'provider', type: 'str', required: false, description: 'Filter by provider' },
+  { name: 'connection_names', type: 'list', required: false, description: 'Filter to accounts for any of these connector slugs (e.g. ["gmail", "slack"])' },
 ]} />
 
 <MethodReturns type="ListConnectedAccountsResponse" fields={[
@@ -277,7 +309,7 @@ messages = response.json()["messages"]
 
 `actions.mcp` manages Virtual MCP Servers. Any MCP-compatible agent framework (LangChain, Google ADK, Anthropic, OpenAI, and others) can connect to these servers directly.
 
-**Two-step model:** Create a **config** once (defines which connectors and tools to expose) to get a static Virtual MCP Server URL. Before each agent run, mint a short-lived session token to authenticate the user.
+**Common model:** Create a **config** once (defines which connectors and tools to expose). For a static Virtual MCP Server URL, mint a short-lived **session token** before each agent run. For frameworks that need a per-user MCP endpoint URL, call **`ensure_instance`** instead (or in addition) and use `instance.url`.
 
 ### Configs
 
@@ -314,8 +346,10 @@ config = actions.mcp.create_config(
 <MethodParams label="Input schema" params={[
   { name: 'page_size', type: 'int', required: false, description: 'Maximum configs per page (server default if omitted)' },
   { name: 'page_token', type: 'str', required: false, description: 'Opaque cursor from a previous list response' },
+  { name: 'filter_id', type: 'str', required: false, description: 'Filter by config ID' },
   { name: 'filter_name', type: 'str', required: false, description: 'Filter by exact name' },
   { name: 'filter_provider', type: 'str', required: false, description: 'Filter by provider slug' },
+  { name: 'filter_mcp_server_url', type: 'str', required: false, description: 'Filter by MCP server URL' },
   { name: 'search', type: 'str', required: false, description: 'Free-text search on name' },
 ]} />
 
@@ -339,30 +373,112 @@ Returns UpdateMcpConfigResponse.
 
 Returns DeleteMcpConfigResponse.
 
+### Instances
+
+Use instances when you need a per-user MCP endpoint URL (for example Mastra or other MCP clients). Prefer configs + session tokens for the static Virtual MCP Server URL model; use `ensure_instance` when the framework needs an instance URL.
+
+#### actions.mcp.ensure_instance
+
+Creates or returns an MCP instance for a config and user.
+
+<MethodParams label="Input schema" params={[
+  { name: 'config_name', type: 'str', required: true, description: 'MCP config name to bind the instance to' },
+  { name: 'user_identifier', type: 'str', required: true, description: 'End-user identifier (email or opaque user ID)' },
+  { name: 'name', type: 'str', required: false, description: 'Optional display name for the instance' },
+]} />
+
+<MethodReturns type="EnsureMcpInstanceResponse" fields={[
+  { name: 'instance.id', type: 'str', description: 'Instance ID' },
+  { name: 'instance.url', type: 'str', description: 'MCP endpoint URL for this user instance' },
+  { name: 'instance.name', type: 'str', description: 'Display name' },
+  { name: 'instance.user_identifier', type: 'str', description: 'User identifier bound to the instance' },
+]} />
+
+```python title="Example"
+inst_response = actions.mcp.ensure_instance(
+    config_name="email-agent",
+    user_identifier="user@example.com",
+)
+mcp_url = inst_response.instance.url
+```
+
+#### actions.mcp.get_instance
+
+<MethodParams label="Input schema" params={[
+  { name: 'instance_id', type: 'str', required: true, description: 'MCP instance ID from ensure_instance or list_instances' },
+]} />
+
+Returns GetMcpInstanceResponse with the same `instance` shape as `ensure_instance`.
+
+#### actions.mcp.list_instances
+
+<MethodParams label="Input schema" params={[
+  { name: 'page_size', type: 'int', required: false, description: 'Maximum instances per page' },
+  { name: 'page_token', type: 'str', required: false, description: 'Opaque cursor from a previous list response' },
+  { name: 'filter_id', type: 'str', required: false, description: 'Filter by instance ID' },
+  { name: 'filter_name', type: 'str', required: false, description: 'Filter by instance name' },
+  { name: 'filter_config_name', type: 'str', required: false, description: 'Filter by MCP config name' },
+  { name: 'filter_user_identifier', type: 'str', required: false, description: 'Filter by user identifier' },
+]} />
+
+Returns ListMcpInstancesResponse.
+
+#### actions.mcp.update_instance
+
+<MethodParams label="Input schema" params={[
+  { name: 'instance_id', type: 'str', required: true, description: 'MCP instance ID to update' },
+  { name: 'name', type: 'str', required: false, description: 'New display name' },
+  { name: 'config_name', type: 'str', required: false, description: 'Rebind the instance to another config name' },
+]} />
+
+Returns UpdateMcpInstanceResponse.
+
+#### actions.mcp.delete_instance
+
+<MethodParams label="Input schema" params={[
+  { name: 'instance_id', type: 'str', required: true, description: 'MCP instance ID to delete' },
+]} />
+
+Returns DeleteMcpInstanceResponse.
+
+#### actions.mcp.get_instance_auth_state
+
+Returns authorization health for connectors used by an instance. Optionally mint fresh auth links.
+
+<MethodParams label="Input schema" params={[
+  { name: 'instance_id', type: 'str', required: true, description: 'MCP instance ID' },
+  { name: 'include_auth_links', type: 'bool', required: false, description: 'When True, include fresh auth/re-auth links for connections' },
+]} />
+
+Returns GetMcpInstanceAuthStateResponse.
+
 ### Session tokens
 
 #### actions.mcp.list_mcp_connected_accounts
 
-Returns the connection status for each connector configured in a Virtual MCP Server, for a specific user. Call this before minting a session token to verify all connections are `ACTIVE`.
+Returns the connection status for each connector configured in a Virtual MCP Server, for a specific user. Call this before minting a session token to verify all connections are active.
 
 <MethodParams label="Input schema" params={[
   { name: 'config_id', type: 'str', required: true, description: 'Virtual MCP Server config ID from list_configs or create_config' },
   { name: 'identifier', type: 'str', required: true, description: 'User identifier' },
+  { name: 'include_auth_link', type: 'bool', required: false, description: 'When True, include one-minute auth/re-auth URLs for each connection' },
 ]} />
 
 <MethodReturns type="ListMcpConnectedAccountsResponse" fields={[
   { name: 'connected_accounts', type: 'list', description: 'One entry per connector configured in the Virtual MCP Server' },
   { name: 'connected_accounts[].connection_name', type: 'str', description: 'Connector slug' },
-  { name: 'connected_accounts[].connected_account_status', type: 'str', description: 'ACTIVE, PENDING, EXPIRED, REVOKED, or ERROR' },
+  { name: 'connected_accounts[].connected_account_status', type: 'str', description: 'Auth status for this user and connector (for example active, expired, disconnected)' },
+  { name: 'connected_accounts[].authentication_link', type: 'str', description: 'Present when include_auth_link is True; valid for about one minute' },
 ]} />
 
 ```python title="Example"
 accounts_response = scalekit_client.actions.mcp.list_mcp_connected_accounts(
     config_id=mcp_id,
     identifier="user@example.com",
+    include_auth_link=True,
 )
 for account in accounts_response.connected_accounts:
-    if account.connected_account_status != "ACTIVE":
+    if account.connected_account_status != "active":
         print(f"{account.connection_name} is not active — prompt user to authorize")
 ```
 
@@ -373,11 +489,12 @@ Mints a short-lived session token scoped to a user and a Virtual MCP Server conf
 <MethodParams label="Input schema" params={[
   { name: 'mcp_config_id', type: 'str', required: true, description: 'Virtual MCP Server config ID' },
   { name: 'identifier', type: 'str', required: true, description: 'User identifier' },
-  { name: 'expiry', type: 'timedelta', required: false, description: 'Token lifetime (default: 1 hour). Set longer than the expected agent run duration.' },
+  { name: 'expiry', type: 'timedelta', required: false, description: 'Token lifetime (server default if omitted, typically 1 hour). Set longer than the expected agent run duration.' },
 ]} />
 
 <MethodReturns type="CreateMcpSessionTokenResponse" fields={[
   { name: 'token', type: 'str', description: 'Bearer token to pass as Authorization header' },
+  { name: 'expires_at', type: 'datetime', description: 'UTC expiry timestamp for the token' },
 ]} />
 
 ```python title="Example"
@@ -391,6 +508,61 @@ token_response = scalekit_client.actions.mcp.create_session_token(
 token = token_response.token
 # Pass as: {"Authorization": f"Bearer {token}"}
 ```
+
+---
+
+## Custom providers
+
+`actions.providers` manages custom providers used with bring-your-own connectors. Methods take typed request objects and return typed responses.
+
+See [Bring your own connector](/agentkit/bring-your-own-connector/overview/) for the product flow.
+
+#### actions.providers.create_custom_provider
+
+<MethodParams label="Input schema" params={[
+  { name: 'request', type: 'CreateCustomProviderRequest', required: true, description: 'display_name and proxy_url required; optional description, proxy_enabled, auth_patterns' },
+]} />
+
+Returns CreateCustomProviderResponse with the created provider (including server-assigned identifier).
+
+```python title="Example"
+from scalekit.actions.types import CreateCustomProviderRequest
+
+response = actions.providers.create_custom_provider(
+    CreateCustomProviderRequest(
+        display_name="My API",
+        proxy_url="https://api.example.com",
+    )
+)
+```
+
+#### actions.providers.update_custom_provider
+
+Partial update. Only non-`None` fields on the request are applied.
+
+<MethodParams label="Input schema" params={[
+  { name: 'request', type: 'UpdateCustomProviderRequest', required: true, description: 'identifier required; optional display_name, description, proxy_url, auth_patterns' },
+]} />
+
+Returns UpdateCustomProviderResponse.
+
+#### actions.providers.list_providers
+
+<MethodParams label="Input schema" params={[
+  { name: 'request', type: 'ListProvidersRequest', required: true, description: 'All fields optional: provider_type, page_size, page_token, identifier. Empty request lists all.' },
+]} />
+
+Returns ListProvidersResponse with a page of providers and `next_page_token`.
+
+#### actions.providers.delete_custom_provider
+
+Permanent delete by identifier.
+
+<MethodParams label="Input schema" params={[
+  { name: 'request', type: 'DeleteCustomProviderRequest', required: true, description: 'identifier of the custom provider to delete' },
+]} />
+
+Returns DeleteCustomProviderResponse.
 
 ---
 

--- a/src/content/docs/agentkit/sdks/python/index.mdx
+++ b/src/content/docs/agentkit/sdks/python/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Python SDK reference'
-description: 'Complete API reference for the Scalekit Python SDK: actions client, MCP configs/instances/session tokens, custom providers, framework adapters, tools, and modifiers.'
+description: 'Python SDK reference for actions, MCP configs and session tokens, custom providers, framework adapters, tools, and modifiers.'
 sidebar:
   label: 'Python SDK'
 tableOfContents:
@@ -171,6 +171,7 @@ Requires `connected_account_id` **or** `connection_name` + `identifier`.
   { name: 'connected_account.provider', type: 'str', description: 'Provider slug' },
   { name: 'connected_account.status', type: 'str', description: 'ACTIVE, INACTIVE, or PENDING' },
   { name: 'connected_account.authorization_type', type: 'str', description: 'OAuth, API_KEY, etc.' },
+  { name: 'connected_account.api_config', type: 'dict', description: 'API configuration metadata for the connected account when present' },
   { name: 'connected_account.token_expires_at', type: 'datetime', description: 'OAuth token expiry when known' },
   { name: 'connected_account.last_used_at', type: 'datetime', description: 'Last time this account was used' },
   { name: 'connected_account.updated_at', type: 'datetime', description: 'Last update timestamp' },
@@ -309,7 +310,7 @@ messages = response.json()["messages"]
 
 `actions.mcp` manages Virtual MCP Servers. Any MCP-compatible agent framework (LangChain, Google ADK, Anthropic, OpenAI, and others) can connect to these servers directly.
 
-**Common model:** Create a **config** once (defines which connectors and tools to expose). For a static Virtual MCP Server URL, mint a short-lived **session token** before each agent run. For frameworks that need a per-user MCP endpoint URL, call **`ensure_instance`** instead (or in addition) and use `instance.url`.
+**Two-step model:** Create a **config** once (defines which connectors and tools to expose) to get a static Virtual MCP Server URL. Before each agent run, mint a short-lived session token to authenticate the user.
 
 ### Configs
 
@@ -373,85 +374,6 @@ Returns UpdateMcpConfigResponse.
 
 Returns DeleteMcpConfigResponse.
 
-### Instances
-
-Use instances when you need a per-user MCP endpoint URL (for example Mastra or other MCP clients). Prefer configs + session tokens for the static Virtual MCP Server URL model; use `ensure_instance` when the framework needs an instance URL.
-
-#### actions.mcp.ensure_instance
-
-Creates or returns an MCP instance for a config and user.
-
-<MethodParams label="Input schema" params={[
-  { name: 'config_name', type: 'str', required: true, description: 'MCP config name to bind the instance to' },
-  { name: 'user_identifier', type: 'str', required: true, description: 'End-user identifier (email or opaque user ID)' },
-  { name: 'name', type: 'str', required: false, description: 'Optional display name for the instance' },
-]} />
-
-<MethodReturns type="EnsureMcpInstanceResponse" fields={[
-  { name: 'instance.id', type: 'str', description: 'Instance ID' },
-  { name: 'instance.url', type: 'str', description: 'MCP endpoint URL for this user instance' },
-  { name: 'instance.name', type: 'str', description: 'Display name' },
-  { name: 'instance.user_identifier', type: 'str', description: 'User identifier bound to the instance' },
-]} />
-
-```python title="Example"
-inst_response = actions.mcp.ensure_instance(
-    config_name="email-agent",
-    user_identifier="user@example.com",
-)
-mcp_url = inst_response.instance.url
-```
-
-#### actions.mcp.get_instance
-
-<MethodParams label="Input schema" params={[
-  { name: 'instance_id', type: 'str', required: true, description: 'MCP instance ID from ensure_instance or list_instances' },
-]} />
-
-Returns GetMcpInstanceResponse with the same `instance` shape as `ensure_instance`.
-
-#### actions.mcp.list_instances
-
-<MethodParams label="Input schema" params={[
-  { name: 'page_size', type: 'int', required: false, description: 'Maximum instances per page' },
-  { name: 'page_token', type: 'str', required: false, description: 'Opaque cursor from a previous list response' },
-  { name: 'filter_id', type: 'str', required: false, description: 'Filter by instance ID' },
-  { name: 'filter_name', type: 'str', required: false, description: 'Filter by instance name' },
-  { name: 'filter_config_name', type: 'str', required: false, description: 'Filter by MCP config name' },
-  { name: 'filter_user_identifier', type: 'str', required: false, description: 'Filter by user identifier' },
-]} />
-
-Returns ListMcpInstancesResponse.
-
-#### actions.mcp.update_instance
-
-<MethodParams label="Input schema" params={[
-  { name: 'instance_id', type: 'str', required: true, description: 'MCP instance ID to update' },
-  { name: 'name', type: 'str', required: false, description: 'New display name' },
-  { name: 'config_name', type: 'str', required: false, description: 'Rebind the instance to another config name' },
-]} />
-
-Returns UpdateMcpInstanceResponse.
-
-#### actions.mcp.delete_instance
-
-<MethodParams label="Input schema" params={[
-  { name: 'instance_id', type: 'str', required: true, description: 'MCP instance ID to delete' },
-]} />
-
-Returns DeleteMcpInstanceResponse.
-
-#### actions.mcp.get_instance_auth_state
-
-Returns authorization health for connectors used by an instance. Optionally mint fresh auth links.
-
-<MethodParams label="Input schema" params={[
-  { name: 'instance_id', type: 'str', required: true, description: 'MCP instance ID' },
-  { name: 'include_auth_links', type: 'bool', required: false, description: 'When True, include fresh auth/re-auth links for connections' },
-]} />
-
-Returns GetMcpInstanceAuthStateResponse.
-
 ### Session tokens
 
 #### actions.mcp.list_mcp_connected_accounts
@@ -461,14 +383,14 @@ Returns the connection status for each connector configured in a Virtual MCP Ser
 <MethodParams label="Input schema" params={[
   { name: 'config_id', type: 'str', required: true, description: 'Virtual MCP Server config ID from list_configs or create_config' },
   { name: 'identifier', type: 'str', required: true, description: 'User identifier' },
-  { name: 'include_auth_link', type: 'bool', required: false, description: 'When True, include one-minute auth/re-auth URLs for each connection' },
+  { name: 'include_auth_link', type: 'bool', required: false, description: 'When True, creates missing connected accounts if needed and returns short-lived auth/re-auth URLs. When False or omitted, reports existing accounts only and returns no links. Links are empty when a connection has no associated key.' },
 ]} />
 
 <MethodReturns type="ListMcpConnectedAccountsResponse" fields={[
   { name: 'connected_accounts', type: 'list', description: 'One entry per connector configured in the Virtual MCP Server' },
   { name: 'connected_accounts[].connection_name', type: 'str', description: 'Connector slug' },
   { name: 'connected_accounts[].connected_account_status', type: 'str', description: 'Auth status for this user and connector (for example active, expired, disconnected)' },
-  { name: 'connected_accounts[].authentication_link', type: 'str', description: 'Present when include_auth_link is True; valid for about one minute' },
+  { name: 'connected_accounts[].authentication_link', type: 'str', description: 'Auth/re-auth URL when include_auth_link is True and a link can be minted; valid for about one minute' },
 ]} />
 
 ```python title="Example"
@@ -515,54 +437,16 @@ token = token_response.token
 
 `actions.providers` manages custom providers used with bring-your-own connectors. Methods take typed request objects and return typed responses.
 
+Working end-to-end examples for OAuth, API key, bearer, and other auth types live in the [custom connectors demos](https://github.com/scalekit-inc/python-connect-demos/tree/main/custom-connectors) repo. Use those samples for field-complete setup rather than partial request shapes here.
+
 See [Bring your own connector](/agentkit/bring-your-own-connector/overview/) for the product flow.
 
-#### actions.providers.create_custom_provider
-
-<MethodParams label="Input schema" params={[
-  { name: 'request', type: 'CreateCustomProviderRequest', required: true, description: 'display_name and proxy_url required; optional description, proxy_enabled, auth_patterns' },
-]} />
-
-Returns CreateCustomProviderResponse with the created provider (including server-assigned identifier).
-
-```python title="Example"
-from scalekit.actions.types import CreateCustomProviderRequest
-
-response = actions.providers.create_custom_provider(
-    CreateCustomProviderRequest(
-        display_name="My API",
-        proxy_url="https://api.example.com",
-    )
-)
-```
-
-#### actions.providers.update_custom_provider
-
-Partial update. Only non-`None` fields on the request are applied.
-
-<MethodParams label="Input schema" params={[
-  { name: 'request', type: 'UpdateCustomProviderRequest', required: true, description: 'identifier required; optional display_name, description, proxy_url, auth_patterns' },
-]} />
-
-Returns UpdateCustomProviderResponse.
-
-#### actions.providers.list_providers
-
-<MethodParams label="Input schema" params={[
-  { name: 'request', type: 'ListProvidersRequest', required: true, description: 'All fields optional: provider_type, page_size, page_token, identifier. Empty request lists all.' },
-]} />
-
-Returns ListProvidersResponse with a page of providers and `next_page_token`.
-
-#### actions.providers.delete_custom_provider
-
-Permanent delete by identifier.
-
-<MethodParams label="Input schema" params={[
-  { name: 'request', type: 'DeleteCustomProviderRequest', required: true, description: 'identifier of the custom provider to delete' },
-]} />
-
-Returns DeleteCustomProviderResponse.
+| Method | Purpose |
+| --- | --- |
+| `actions.providers.create_custom_provider` | Create a custom provider (`CreateCustomProviderRequest`) |
+| `actions.providers.update_custom_provider` | Partial update (`UpdateCustomProviderRequest`; only non-`None` fields apply) |
+| `actions.providers.list_providers` | List or filter providers (`ListProvidersRequest`) |
+| `actions.providers.delete_custom_provider` | Permanent delete by identifier (`DeleteCustomProviderRequest`) |
 
 ---
 


### PR DESCRIPTION
## Summary

Close AgentKit Node/Python SDK reference gaps against live SDK main.

Linear: [SK-1269](https://linear.app/scalekit/issue/SK-1269/close-agentkit-nodepython-sdk-reference-gaps)

- Align ScalekitClient constructor examples with positional args
- Document MCP instances and custom provider APIs
- Add listConnections method and upsert alias notes
- Expand connected account and config filtering options

## Preview

https://deploy-preview-876--scalekit-starlight.netlify.app/agentkit/sdks/node/

## Test plan

- [ ] Spot-check Node SDK reference constructor and listConnections
- [ ] Spot-check Python MCP instances / providers sections
- [ ] Confirm deploy preview builds cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Node.js SDK and migration guidance to initialize `ScalekitClient` using environment variables.
  * Improved Node.js API docs: fully documented `listConnections` (inputs, response shape, and TypeScript example) and clarified `upsertConnectedAccount` as an alias for create-or-update semantics.
  * Expanded Python SDK reference for connected account metadata access, account filtering, MCP config/session token helpers, and provider operations.
  * Updated the Mastra example to generate and use user-scoped MCP URLs, with guidance against sharing across users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->