### PR TITLE
sync: reconcile 3 connectors with new tools

### DIFF
--- a/public/data/agent-tools-index.json
+++ b/public/data/agent-tools-index.json
@@ -316,6 +316,26 @@
   },
   {
     "slug": "advancedmd",
+    "name": "advancedmd_care_plan_read",
+    "description": "Retrieve a single FHIR CarePlan resource by its logical ID. Care plans describe planned activities to manage a patient's health issues."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_care_plan_search",
+    "description": "Search for FHIR CarePlan resources describing planned patient care activities using parameters like patient, category, status, and date."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_care_team_read",
+    "description": "Retrieve a single FHIR CareTeam resource by its logical ID. Care teams represent the group of practitioners involved in a patient's care."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_care_team_search",
+    "description": "Search for FHIR CareTeam resources representing groups of practitioners involved in patient care, filtered by patient and status."
+  },
+  {
+    "slug": "advancedmd",
     "name": "advancedmd_condition_create",
     "description": "Create a new FHIR Condition resource representing a diagnosis or health problem for a patient."
   },
@@ -338,6 +358,26 @@
     "slug": "advancedmd",
     "name": "advancedmd_condition_update",
     "description": "Update an existing FHIR Condition resource by its ID. Replaces the resource with the provided data."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_coverage_read",
+    "description": "Retrieve a single FHIR Coverage resource by its logical ID. Coverage resources describe a patient's insurance or payment details."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_coverage_search",
+    "description": "Search for FHIR Coverage resources describing a patient's insurance or payment details, filtered by patient."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_device_read",
+    "description": "Retrieve a single FHIR Device resource by its logical ID. Devices represent implantable medical devices associated with a patient."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_device_search",
+    "description": "Search for FHIR Device resources representing implantable medical devices using parameters like patient and device type."
   },
   {
     "slug": "advancedmd",
@@ -366,6 +406,16 @@
   },
   {
     "slug": "advancedmd",
+    "name": "advancedmd_document_reference_read",
+    "description": "Retrieve a single FHIR DocumentReference resource by its logical ID. Document references index clinical documents such as summaries and notes."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_document_reference_search",
+    "description": "Search for FHIR DocumentReference resources indexing clinical documents using parameters like patient, status, category, type, date, and period."
+  },
+  {
+    "slug": "advancedmd",
     "name": "advancedmd_encounter_create",
     "description": "Create a new FHIR Encounter resource representing a patient visit or admission."
   },
@@ -391,6 +441,26 @@
   },
   {
     "slug": "advancedmd",
+    "name": "advancedmd_endpoint_read",
+    "description": "Retrieve a single FHIR Endpoint resource by its logical ID. Endpoints describe technical details of a service endpoint used for exchanging data."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_endpoint_search",
+    "description": "Search for FHIR Endpoint resources describing service endpoints for data exchange, filtered by category, status, patient, and date."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_goal_read",
+    "description": "Retrieve a single FHIR Goal resource by its logical ID. Goals describe desired health outcomes for a patient."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_goal_search",
+    "description": "Search for FHIR Goal resources describing desired patient health outcomes using parameters like patient, lifecycle status, and target date."
+  },
+  {
+    "slug": "advancedmd",
     "name": "advancedmd_immunization_create",
     "description": "Create a new FHIR Immunization resource recording a vaccination event for a patient."
   },
@@ -413,6 +483,26 @@
     "slug": "advancedmd",
     "name": "advancedmd_immunization_update",
     "description": "Update an existing FHIR Immunization resource by its ID."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_location_read",
+    "description": "Retrieve a single FHIR Location resource by its logical ID. Locations represent physical places where care is delivered, such as clinics or rooms."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_location_search",
+    "description": "Search for FHIR Location resources representing care facilities using parameters like name and address."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_medication_dispense_read",
+    "description": "Retrieve a single FHIR MedicationDispense resource by its logical ID. Medication dispenses record medications that have been provided to a patient."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_medication_dispense_search",
+    "description": "Search for FHIR MedicationDispense resources recording medications provided to a patient using parameters like status, type, patient, and medication."
   },
   {
     "slug": "advancedmd",
@@ -568,6 +658,41 @@
     "slug": "advancedmd",
     "name": "advancedmd_procedure_update",
     "description": "Update an existing FHIR Procedure resource by its ID."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_provenance_read",
+    "description": "Retrieve a single FHIR Provenance resource by its logical ID. Provenance records who created or changed a resource and when."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_related_person_read",
+    "description": "Retrieve a single FHIR RelatedPerson resource by its logical ID. Related persons represent individuals connected to a patient, such as family members or caregivers."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_related_person_search",
+    "description": "Search for FHIR RelatedPerson resources representing individuals connected to a patient, such as family members or caregivers, filtered by patient and name."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_service_request_read",
+    "description": "Retrieve a single FHIR ServiceRequest resource by its logical ID. Service requests represent orders for services such as lab tests or referrals."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_service_request_search",
+    "description": "Search for FHIR ServiceRequest resources representing orders for services such as lab tests or referrals, filtered by patient."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_specimen_read",
+    "description": "Retrieve a single FHIR Specimen resource by its logical ID. Specimens represent samples collected from a patient for laboratory analysis."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_specimen_search",
+    "description": "Search for FHIR Specimen resources representing laboratory samples collected from a patient, filtered by patient."
   },
   {
     "slug": "adzvisermcp",
@@ -12524,6 +12649,11 @@
     "description": "Recall data previously saved to Cognee memory. Runs a semantic search over the knowledge graph (and, optionally, session memory) and returns an answer or matching context. Use searchType to control the retrieval strategy."
   },
   {
+    "slug": "cognee",
+    "name": "cognee_remember",
+    "description": "Save data to Cognee memory. Ingests the provided content into a dataset and builds a knowledge graph from it in a single operation, so it can be recalled later with semantic search. Creates the dataset if it does not already exist. NOTE: Coming soon — Cognee's ingest endpoint (P…"
+  },
+  {
     "slug": "coinmarketcapmcp",
     "name": "coinmarketcapmcp_get_crypto_info",
     "description": "Get static metadata for one or more cryptocurrencies, including logo, description, website, social links, and technical documentation URLs."
@@ -23963,8 +24093,83 @@
   },
   {
     "slug": "googledocs",
+    "name": "googledocs_apply_text_style",
+    "description": "Apply character formatting (bold, italic, underline, strikethrough, font size) to a range of text in a Google Doc. Only the attributes you set are changed."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_copy_document",
+    "description": "Duplicate a Google Doc. Optionally rename the copy or place it in a specific Drive folder. Uses the Drive API and returns the new document's metadata."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_create_comment",
+    "description": "Add a comment to a Google Doc. Comments are managed through the Drive API. Optionally anchor the comment to a quoted section of the document."
+  },
+  {
+    "slug": "googledocs",
     "name": "googledocs_create_document",
     "description": "Create a new blank Google Doc with an optional title. Returns the new document's ID and metadata."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_create_named_range",
+    "description": "Create a named range over a span of content in a Google Doc. Named ranges let you reference and update a region of the document later by name."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_create_paragraph_bullets",
+    "description": "Turn the paragraphs in a range into a bulleted or numbered list using a preset glyph pattern."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_delete_comment",
+    "description": "Permanently delete a comment from a Google Doc. Comments are managed through the Drive API. This cannot be undone."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_delete_content_range",
+    "description": "Delete content between two character indexes in a Google Doc. The start index is inclusive and the end index is exclusive."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_delete_named_range",
+    "description": "Delete named ranges from a Google Doc. Provide a named range ID to remove one specific range, or a name to remove all ranges sharing that name. The underlying document content is not deleted."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_delete_paragraph_bullets",
+    "description": "Remove list bullets or numbering from the paragraphs in a range, converting them back to normal paragraphs."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_export_document",
+    "description": "Export a Google Doc to another format such as PDF, plain text, HTML, Word (.docx), RTF, or EPUB. Uses the Drive API export endpoint. Exported files are limited to 10 MB."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_insert_inline_image",
+    "description": "Insert an inline image from a publicly accessible URL into a Google Doc. Optionally set the image width and height in points. Provide an index to insert at that position, or omit it to append at the end of the document body."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_insert_page_break",
+    "description": "Insert a page break into a Google Doc. Provide an index to insert at that position, or omit it to append at the end of the document body."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_insert_table",
+    "description": "Insert an empty table with the given number of rows and columns into a Google Doc. Provide an index to insert at that position, or omit it to append at the end of the document body."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_insert_text",
+    "description": "Insert text into a Google Doc at a specific location. Provide an index to insert at that position, or omit it to append at the end of the document body."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_list_comments",
+    "description": "List the comments on a Google Doc, including their replies and resolved status. Comments are managed through the Drive API. Supports pagination."
   },
   {
     "slug": "googledocs",
@@ -23978,8 +24183,28 @@
   },
   {
     "slug": "googledocs",
+    "name": "googledocs_replace_all_text",
+    "description": "Find every occurrence of a text string in a Google Doc and replace it with new text. Useful for templating and bulk edits."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_reply_to_comment",
+    "description": "Post a reply to an existing comment on a Google Doc. Comments and replies are managed through the Drive API."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_resolve_comment",
+    "description": "Resolve an open comment on a Google Doc by posting a resolving reply. Comments are managed through the Drive API. Optionally include reply text alongside the resolution."
+  },
+  {
+    "slug": "googledocs",
     "name": "googledocs_update_document",
     "description": "Update the content of an existing Google Doc using batch update requests. Supports inserting and deleting text, formatting, tables, and other document elements."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_update_paragraph_style",
+    "description": "Apply paragraph-level formatting to a range: set a named style such as a heading or title, and/or set text alignment. Use this to turn text into a heading."
   },
   {
     "slug": "googledrive",

--- a/src/content/docs/agentkit/connectors/cognee.mdx
+++ b/src/content/docs/agentkit/connectors/cognee.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Cognee connector'
 tableOfContents: true
-description: "Use Cognee to recall, enrich, and manage your AI agent's memory in a knowledge graph."
+description: 'Connect to Cognee, an AI memory engine for agents. Remember data into a knowledge graph, recall it with semantic search, improve stored memory, and forget...'
 sidebar:
   label: 'Cognee'
 overviewTitle: 'Quickstart'
@@ -21,7 +21,7 @@ head:
 
 import ToolList from '@/components/ToolList.astro'
 import { tools } from '@/data/agent-connectors/cognee'
-import { Steps, Tabs, TabItem, Aside } from '@astrojs/starlight/components'
+import { Steps, Tabs, TabItem } from '@astrojs/starlight/components'
 import { AgentKitCredentials } from '@components/templates'
 import { SetupCogneeSection } from '@components/templates'
 import { QuickstartGenericApikeySection } from '@components/templates'
@@ -63,7 +63,7 @@ import { SectionAfterSetupCogneeCommonWorkflows } from '@components/templates'
 
 4. ### Make your first call
 
-   <QuickstartGenericApikeySection connector="cognee" toolName="cognee_list_datasets" providerName="Cognee" />
+   <QuickstartGenericApikeySection connector="cognee" toolName="cognee_check_status" providerName="Cognee" />
 
 </Steps>
 
@@ -71,17 +71,12 @@ import { SectionAfterSetupCogneeCommonWorkflows } from '@components/templates'
 
 Connect this agent connector to let your agent:
 
-- **Recall records** — Search Cognee's knowledge graph by meaning and get back an answer or matching context
-- **Improve records** — Enrich a dataset's knowledge graph with new text, or reprocess the existing graph to sharpen later recall
-- **Forget records** — Permanently delete a dataset (by name or ID), a single data item, or just its memory graph
-- **List datasets** — Discover the dataset names and UUIDs accessible to the connected account
-- **List dataset data** — Inspect the individual data items stored in a dataset, with their UUIDs
-- **Check status** — Check the processing status of a dataset's ingestion or enrichment pipeline
-- **Create dataset** — Provision a new, empty dataset up front by name
-
-<Aside type="note" title="Remember is coming soon">
-  Cognee's ingest endpoint (`POST /api/v1/remember`) requires a `multipart/form-data` request, which the Scalekit tool proxy doesn't support yet (JSON bodies only). Track backend support in **SK-1178**. Until then, use `cognee_improve` with the `data` field to add text into a dataset.
-</Aside>
+- **Status check** — Check the processing status of Cognee datasets' pipelines
+- **Create dataset** — Create a new, empty Cognee dataset by name
+- **Forget records** — Forget stored data in Cognee memory
+- **Improve records** — Improve stored memory by running Cognee's enrichment pipeline (the 'memify'/cognify step) over a dataset
+- **List dataset data, datasets** — List the individual data items stored in a Cognee dataset, with their UUIDs
+- **Recall records** — Recall data previously saved to Cognee memory
 
 ## Common workflows
 

--- a/src/content/docs/agentkit/connectors/googledocs.mdx
+++ b/src/content/docs/agentkit/connectors/googledocs.mdx
@@ -71,10 +71,12 @@ import { SectionAfterSetupGoogledocsCommonWorkflows } from '@components/template
 
 Connect this agent connector to let your agent:
 
-- **List documents** — List all Google Docs documents in the user's Drive
-- **Update document** — Update the content of an existing Google Doc using batch update requests
-- **Read document** — Read the complete content and structure of a Google Doc including text, formatting, tables, and metadata
-- **Create document** — Create a new blank Google Doc with an optional title
+- **Style apply text** — Apply character formatting (bold, italic, underline, strikethrough, font size) to a range of text in a Google Doc
+- **Document copy, export** — Duplicate a Google Doc
+- **Create comment, document, named range** — Add a comment to a Google Doc
+- **Delete comment, content range, named range** — Permanently delete a comment from a Google Doc
+- **Image insert inline** — Insert an inline image from a publicly accessible URL into a Google Doc
+- **Break insert page** — Insert a page break into a Google Doc
 
 ## Common workflows
 

--- a/src/data/agent-connectors/advancedmd.ts
+++ b/src/data/agent-connectors/advancedmd.ts
@@ -392,6 +392,102 @@ export const tools: Tool[] = [
     ],
   },
   {
+    name: 'advancedmd_care_plan_read',
+    description: `Retrieve a single FHIR CarePlan resource by its logical ID. Care plans describe planned activities to manage a patient's health issues.`,
+    params: [
+      {
+        name: 'care_plan_id',
+        type: 'string',
+        required: true,
+        description: `The logical ID of the CarePlan resource`,
+      },
+    ],
+  },
+  {
+    name: 'advancedmd_care_plan_search',
+    description: `Search for FHIR CarePlan resources describing planned patient care activities using parameters like patient, category, status, and date.`,
+    params: [
+      {
+        name: '_count',
+        type: 'number',
+        required: false,
+        description: `Maximum number of results to return per page`,
+      },
+      {
+        name: '_offset',
+        type: 'number',
+        required: false,
+        description: `Number of results to skip for pagination`,
+      },
+      {
+        name: 'category',
+        type: 'string',
+        required: false,
+        description: `Category of the care plan, e.g. assess-plan`,
+      },
+      {
+        name: 'date',
+        type: 'string',
+        required: false,
+        description: `Filter by care plan period date (YYYY-MM-DD or range with prefix)`,
+      },
+      {
+        name: 'patient',
+        type: 'string',
+        required: false,
+        description: `Patient ID to filter care plans by`,
+      },
+      {
+        name: 'status',
+        type: 'string',
+        required: false,
+        description: `Care plan status: draft, active, on-hold, revoked, completed, entered-in-error, unknown`,
+      },
+    ],
+  },
+  {
+    name: 'advancedmd_care_team_read',
+    description: `Retrieve a single FHIR CareTeam resource by its logical ID. Care teams represent the group of practitioners involved in a patient's care.`,
+    params: [
+      {
+        name: 'care_team_id',
+        type: 'string',
+        required: true,
+        description: `The logical ID of the CareTeam resource`,
+      },
+    ],
+  },
+  {
+    name: 'advancedmd_care_team_search',
+    description: `Search for FHIR CareTeam resources representing groups of practitioners involved in patient care, filtered by patient and status.`,
+    params: [
+      {
+        name: '_count',
+        type: 'number',
+        required: false,
+        description: `Maximum number of results to return per page`,
+      },
+      {
+        name: '_offset',
+        type: 'number',
+        required: false,
+        description: `Number of results to skip for pagination`,
+      },
+      {
+        name: 'patient',
+        type: 'string',
+        required: false,
+        description: `Patient ID to filter care teams by`,
+      },
+      {
+        name: 'status',
+        type: 'string',
+        required: false,
+        description: `Care team status: proposed, active, suspended, inactive, entered-in-error`,
+      },
+    ],
+  },
+  {
     name: 'advancedmd_condition_create',
     description: `Create a new FHIR Condition resource representing a diagnosis or health problem for a patient.`,
     params: [
@@ -576,6 +672,84 @@ export const tools: Tool[] = [
         type: 'string',
         required: false,
         description: `Verification status: unconfirmed, provisional, differential, confirmed, refuted, entered-in-error`,
+      },
+    ],
+  },
+  {
+    name: 'advancedmd_coverage_read',
+    description: `Retrieve a single FHIR Coverage resource by its logical ID. Coverage resources describe a patient's insurance or payment details.`,
+    params: [
+      {
+        name: 'coverage_id',
+        type: 'string',
+        required: true,
+        description: `The logical ID of the Coverage resource`,
+      },
+    ],
+  },
+  {
+    name: 'advancedmd_coverage_search',
+    description: `Search for FHIR Coverage resources describing a patient's insurance or payment details, filtered by patient.`,
+    params: [
+      {
+        name: '_count',
+        type: 'number',
+        required: false,
+        description: `Maximum number of results to return per page`,
+      },
+      {
+        name: '_offset',
+        type: 'number',
+        required: false,
+        description: `Number of results to skip for pagination`,
+      },
+      {
+        name: 'patient',
+        type: 'string',
+        required: false,
+        description: `Patient ID to filter coverage records by`,
+      },
+    ],
+  },
+  {
+    name: 'advancedmd_device_read',
+    description: `Retrieve a single FHIR Device resource by its logical ID. Devices represent implantable medical devices associated with a patient.`,
+    params: [
+      {
+        name: 'device_id',
+        type: 'string',
+        required: true,
+        description: `The logical ID of the Device resource`,
+      },
+    ],
+  },
+  {
+    name: 'advancedmd_device_search',
+    description: `Search for FHIR Device resources representing implantable medical devices using parameters like patient and device type.`,
+    params: [
+      {
+        name: '_count',
+        type: 'number',
+        required: false,
+        description: `Maximum number of results to return per page`,
+      },
+      {
+        name: '_offset',
+        type: 'number',
+        required: false,
+        description: `Number of results to skip for pagination`,
+      },
+      {
+        name: 'patient',
+        type: 'string',
+        required: false,
+        description: `Patient ID to filter devices by`,
+      },
+      {
+        name: 'type',
+        type: 'string',
+        required: false,
+        description: `Device type code, e.g. SNOMED code for the device type`,
       },
     ],
   },
@@ -766,6 +940,72 @@ export const tools: Tool[] = [
     ],
   },
   {
+    name: 'advancedmd_document_reference_read',
+    description: `Retrieve a single FHIR DocumentReference resource by its logical ID. Document references index clinical documents such as summaries and notes.`,
+    params: [
+      {
+        name: 'document_reference_id',
+        type: 'string',
+        required: true,
+        description: `The logical ID of the DocumentReference resource`,
+      },
+    ],
+  },
+  {
+    name: 'advancedmd_document_reference_search',
+    description: `Search for FHIR DocumentReference resources indexing clinical documents using parameters like patient, status, category, type, date, and period.`,
+    params: [
+      {
+        name: '_count',
+        type: 'number',
+        required: false,
+        description: `Maximum number of results to return per page`,
+      },
+      {
+        name: '_offset',
+        type: 'number',
+        required: false,
+        description: `Number of results to skip for pagination`,
+      },
+      {
+        name: 'category',
+        type: 'string',
+        required: false,
+        description: `Document category, e.g. clinical-note`,
+      },
+      {
+        name: 'date',
+        type: 'string',
+        required: false,
+        description: `Filter by document creation date (YYYY-MM-DD or range with prefix)`,
+      },
+      {
+        name: 'patient',
+        type: 'string',
+        required: false,
+        description: `Patient ID to filter document references by`,
+      },
+      {
+        name: 'period',
+        type: 'string',
+        required: false,
+        description: `Filter by the time period the document content covers`,
+      },
+      {
+        name: 'status',
+        type: 'string',
+        required: false,
+        description: `Document status: current, superseded, entered-in-error`,
+      },
+      {
+        name: 'type',
+        type: 'string',
+        required: false,
+        description: `Document type code, e.g. LOINC code for a discharge summary`,
+      },
+    ],
+  },
+  {
     name: 'advancedmd_encounter_create',
     description: `Create a new FHIR Encounter resource representing a patient visit or admission.`,
     params: [
@@ -952,6 +1192,108 @@ export const tools: Tool[] = [
     ],
   },
   {
+    name: 'advancedmd_endpoint_read',
+    description: `Retrieve a single FHIR Endpoint resource by its logical ID. Endpoints describe technical details of a service endpoint used for exchanging data.`,
+    params: [
+      {
+        name: 'endpoint_id',
+        type: 'string',
+        required: true,
+        description: `The logical ID of the Endpoint resource`,
+      },
+    ],
+  },
+  {
+    name: 'advancedmd_endpoint_search',
+    description: `Search for FHIR Endpoint resources describing service endpoints for data exchange, filtered by category, status, patient, and date.`,
+    params: [
+      {
+        name: '_count',
+        type: 'number',
+        required: false,
+        description: `Maximum number of results to return per page`,
+      },
+      {
+        name: '_offset',
+        type: 'number',
+        required: false,
+        description: `Number of results to skip for pagination`,
+      },
+      {
+        name: 'category',
+        type: 'string',
+        required: false,
+        description: `Connection type category for the endpoint`,
+      },
+      {
+        name: 'date',
+        type: 'string',
+        required: false,
+        description: `Filter by endpoint record date (YYYY-MM-DD or range with prefix)`,
+      },
+      {
+        name: 'patient',
+        type: 'string',
+        required: false,
+        description: `Patient ID to filter endpoints by`,
+      },
+      {
+        name: 'status',
+        type: 'string',
+        required: false,
+        description: `Endpoint status: active, suspended, error, off, entered-in-error, test`,
+      },
+    ],
+  },
+  {
+    name: 'advancedmd_goal_read',
+    description: `Retrieve a single FHIR Goal resource by its logical ID. Goals describe desired health outcomes for a patient.`,
+    params: [
+      {
+        name: 'goal_id',
+        type: 'string',
+        required: true,
+        description: `The logical ID of the Goal resource`,
+      },
+    ],
+  },
+  {
+    name: 'advancedmd_goal_search',
+    description: `Search for FHIR Goal resources describing desired patient health outcomes using parameters like patient, lifecycle status, and target date.`,
+    params: [
+      {
+        name: '_count',
+        type: 'number',
+        required: false,
+        description: `Maximum number of results to return per page`,
+      },
+      {
+        name: '_offset',
+        type: 'number',
+        required: false,
+        description: `Number of results to skip for pagination`,
+      },
+      {
+        name: 'lifecycle_status',
+        type: 'string',
+        required: false,
+        description: `Goal lifecycle status: proposed, planned, accepted, active, on-hold, completed, cancelled, entered-in-error, rejected`,
+      },
+      {
+        name: 'patient',
+        type: 'string',
+        required: false,
+        description: `Patient ID to filter goals by`,
+      },
+      {
+        name: 'target_date',
+        type: 'string',
+        required: false,
+        description: `Filter by the goal's target date (YYYY-MM-DD or range with prefix)`,
+      },
+    ],
+  },
+  {
     name: 'advancedmd_immunization_create',
     description: `Create a new FHIR Immunization resource recording a vaccination event for a patient.`,
     params: [
@@ -1103,6 +1445,115 @@ export const tools: Tool[] = [
         type: 'string',
         required: false,
         description: `Human-readable display for the vaccine`,
+      },
+    ],
+  },
+  {
+    name: 'advancedmd_location_read',
+    description: `Retrieve a single FHIR Location resource by its logical ID. Locations represent physical places where care is delivered, such as clinics or rooms.`,
+    params: [
+      {
+        name: 'location_id',
+        type: 'string',
+        required: true,
+        description: `The logical ID of the Location resource`,
+      },
+    ],
+  },
+  {
+    name: 'advancedmd_location_search',
+    description: `Search for FHIR Location resources representing care facilities using parameters like name and address.`,
+    params: [
+      {
+        name: '_count',
+        type: 'number',
+        required: false,
+        description: `Maximum number of results to return per page`,
+      },
+      {
+        name: '_offset',
+        type: 'number',
+        required: false,
+        description: `Number of results to skip for pagination`,
+      },
+      {
+        name: 'address',
+        type: 'string',
+        required: false,
+        description: `Any part of the location's address`,
+      },
+      {
+        name: 'address_city',
+        type: 'string',
+        required: false,
+        description: `City of the location's address`,
+      },
+      {
+        name: 'address_postalcode',
+        type: 'string',
+        required: false,
+        description: `Postal code of the location's address`,
+      },
+      {
+        name: 'address_state',
+        type: 'string',
+        required: false,
+        description: `State of the location's address`,
+      },
+      { name: 'name', type: 'string', required: false, description: `Name of the location` },
+    ],
+  },
+  {
+    name: 'advancedmd_medication_dispense_read',
+    description: `Retrieve a single FHIR MedicationDispense resource by its logical ID. Medication dispenses record medications that have been provided to a patient.`,
+    params: [
+      {
+        name: 'medication_dispense_id',
+        type: 'string',
+        required: true,
+        description: `The logical ID of the MedicationDispense resource`,
+      },
+    ],
+  },
+  {
+    name: 'advancedmd_medication_dispense_search',
+    description: `Search for FHIR MedicationDispense resources recording medications provided to a patient using parameters like status, type, patient, and medication.`,
+    params: [
+      {
+        name: '_count',
+        type: 'number',
+        required: false,
+        description: `Maximum number of results to return per page`,
+      },
+      {
+        name: '_offset',
+        type: 'number',
+        required: false,
+        description: `Number of results to skip for pagination`,
+      },
+      {
+        name: 'medication',
+        type: 'string',
+        required: false,
+        description: `Medication code or reference dispensed`,
+      },
+      {
+        name: 'patient',
+        type: 'string',
+        required: false,
+        description: `Patient ID to filter medication dispenses by`,
+      },
+      {
+        name: 'status',
+        type: 'string',
+        required: false,
+        description: `Dispense status: preparation, in-progress, completed, entered-in-error, stopped`,
+      },
+      {
+        name: 'type',
+        type: 'string',
+        required: false,
+        description: `Dispense type code, e.g. RFP for a refill`,
       },
     ],
   },
@@ -2168,6 +2619,127 @@ export const tools: Tool[] = [
         type: 'string',
         required: false,
         description: `SNOMED code for the reason the procedure was performed`,
+      },
+    ],
+  },
+  {
+    name: 'advancedmd_provenance_read',
+    description: `Retrieve a single FHIR Provenance resource by its logical ID. Provenance records who created or changed a resource and when.`,
+    params: [
+      {
+        name: 'provenance_id',
+        type: 'string',
+        required: true,
+        description: `The logical ID of the Provenance resource`,
+      },
+    ],
+  },
+  {
+    name: 'advancedmd_related_person_read',
+    description: `Retrieve a single FHIR RelatedPerson resource by its logical ID. Related persons represent individuals connected to a patient, such as family members or caregivers.`,
+    params: [
+      {
+        name: 'related_person_id',
+        type: 'string',
+        required: true,
+        description: `The logical ID of the RelatedPerson resource`,
+      },
+    ],
+  },
+  {
+    name: 'advancedmd_related_person_search',
+    description: `Search for FHIR RelatedPerson resources representing individuals connected to a patient, such as family members or caregivers, filtered by patient and name.`,
+    params: [
+      {
+        name: '_count',
+        type: 'number',
+        required: false,
+        description: `Maximum number of results to return per page`,
+      },
+      {
+        name: '_offset',
+        type: 'number',
+        required: false,
+        description: `Number of results to skip for pagination`,
+      },
+      { name: 'name', type: 'string', required: false, description: `Name of the related person` },
+      {
+        name: 'patient',
+        type: 'string',
+        required: false,
+        description: `Patient ID to filter related persons by`,
+      },
+    ],
+  },
+  {
+    name: 'advancedmd_service_request_read',
+    description: `Retrieve a single FHIR ServiceRequest resource by its logical ID. Service requests represent orders for services such as lab tests or referrals.`,
+    params: [
+      {
+        name: 'service_request_id',
+        type: 'string',
+        required: true,
+        description: `The logical ID of the ServiceRequest resource`,
+      },
+    ],
+  },
+  {
+    name: 'advancedmd_service_request_search',
+    description: `Search for FHIR ServiceRequest resources representing orders for services such as lab tests or referrals, filtered by patient.`,
+    params: [
+      {
+        name: '_count',
+        type: 'number',
+        required: false,
+        description: `Maximum number of results to return per page`,
+      },
+      {
+        name: '_offset',
+        type: 'number',
+        required: false,
+        description: `Number of results to skip for pagination`,
+      },
+      {
+        name: 'patient',
+        type: 'string',
+        required: false,
+        description: `Patient ID to filter service requests by`,
+      },
+    ],
+  },
+  {
+    name: 'advancedmd_specimen_read',
+    description: `Retrieve a single FHIR Specimen resource by its logical ID. Specimens represent samples collected from a patient for laboratory analysis.`,
+    params: [
+      {
+        name: 'specimen_id',
+        type: 'string',
+        required: true,
+        description: `The logical ID of the Specimen resource`,
+      },
+    ],
+  },
+  {
+    name: 'advancedmd_specimen_search',
+    description: `Search for FHIR Specimen resources representing laboratory samples collected from a patient, filtered by patient.`,
+    params: [
+      {
+        name: '_count',
+        type: 'number',
+        required: false,
+        description: `Maximum number of results to return per page`,
+      },
+      {
+        name: '_offset',
+        type: 'number',
+        required: false,
+        description: `Number of results to skip for pagination`,
+      },
+      {
+        name: 'patient',
+        type: 'string',
+        required: false,
+        description: `Patient ID to filter specimens by`,
       },
     ],
   },

--- a/src/data/agent-connectors/cognee.ts
+++ b/src/data/agent-connectors/cognee.ts
@@ -180,8 +180,46 @@ export const tools: Tool[] = [
       },
     ],
   },
-  // cognee_remember is intentionally omitted: visibility is "internal" (coming soon).
-  // Cognee's ingest endpoint requires multipart/form-data, which the Scalekit tool
-  // proxy doesn't support yet (JSON bodies only). Tracked in SK-1178. See the
-  // "Remember is coming soon" note on the connector page for the workaround.
+  {
+    name: 'cognee_remember',
+    description: `Save data to Cognee memory. Ingests the provided content into a dataset and builds a knowledge graph from it in a single operation, so it can be recalled later with semantic search. Creates the dataset if it does not already exist. NOTE: Coming soon — Cognee's ingest endpoint (POST /api/v1/remember) uses multipart/form-data, which the Scalekit tool proxy does not yet support (JSON bodies only). Kept internal until multipart proxy support lands; see backend feature request. Until then, use Improve with the data field to add text into a dataset.`,
+    params: [
+      {
+        name: 'data',
+        type: 'string',
+        required: true,
+        description: `The content to remember. Free-form text that Cognee ingests and turns into knowledge-graph memory.`,
+      },
+      {
+        name: 'custom_prompt',
+        type: 'string',
+        required: false,
+        description: `Overrides the default entity-extraction prompt used during graph building. Use it to steer which entities and relationships get extracted. Leave empty for the default.`,
+      },
+      {
+        name: 'datasetName',
+        type: 'string',
+        required: false,
+        description: `Name of the target dataset. Created automatically if it does not exist. Defaults to 'main_dataset'.`,
+      },
+      {
+        name: 'node_set',
+        type: 'array',
+        required: false,
+        description: `JSON array of named node-set tags to attach to the ingested data (e.g. per-agent or per-project groups). Recall can later be restricted to these tags. Leave empty to skip tagging.`,
+      },
+      {
+        name: 'run_in_background',
+        type: 'boolean',
+        required: false,
+        description: `If true, the request returns immediately while ingestion and graph building continue server-side. If false (default), the request blocks until the knowledge graph is fully built, which can take minutes for large inputs.`,
+      },
+      {
+        name: 'session_id',
+        type: 'string',
+        required: false,
+        description: `Optional session to attribute this memory to (e.g. agent-run-1718000000). When set, the data is stored in the session cache and bridged into the permanent graph in the background. Leave empty for a direct add and build.`,
+      },
+    ],
+  },
 ]

--- a/src/data/agent-connectors/googledocs.ts
+++ b/src/data/agent-connectors/googledocs.ts
@@ -2,6 +2,133 @@ import type { Tool } from '../../types/agent-connectors'
 
 export const tools: Tool[] = [
   {
+    name: 'googledocs_apply_text_style',
+    description: `Apply character formatting (bold, italic, underline, strikethrough, font size) to a range of text in a Google Doc. Only the attributes you set are changed.`,
+    params: [
+      {
+        name: 'document_id',
+        type: 'string',
+        required: true,
+        description: `The ID of the Google Doc to edit`,
+      },
+      {
+        name: 'end_index',
+        type: 'integer',
+        required: true,
+        description: `End index of the range to format (exclusive)`,
+      },
+      {
+        name: 'start_index',
+        type: 'integer',
+        required: true,
+        description: `Zero-based start index of the range to format (inclusive)`,
+      },
+      {
+        name: 'bold',
+        type: 'boolean',
+        required: false,
+        description: `Set text to bold (true) or non-bold (false)`,
+      },
+      { name: 'font_size_pt', type: 'number', required: false, description: `Font size in points` },
+      {
+        name: 'italic',
+        type: 'boolean',
+        required: false,
+        description: `Set text to italic (true) or non-italic (false)`,
+      },
+      {
+        name: 'schema_version',
+        type: 'string',
+        required: false,
+        description: `Optional schema version to use for tool execution`,
+      },
+      {
+        name: 'strikethrough',
+        type: 'boolean',
+        required: false,
+        description: `Set text to struck through (true) or not (false)`,
+      },
+      {
+        name: 'tool_version',
+        type: 'string',
+        required: false,
+        description: `Optional tool version to use for execution`,
+      },
+      {
+        name: 'underline',
+        type: 'boolean',
+        required: false,
+        description: `Set text to underlined (true) or not (false)`,
+      },
+    ],
+  },
+  {
+    name: 'googledocs_copy_document',
+    description: `Duplicate a Google Doc. Optionally rename the copy or place it in a specific Drive folder. Uses the Drive API and returns the new document's metadata.`,
+    params: [
+      {
+        name: 'document_id',
+        type: 'string',
+        required: true,
+        description: `The ID of the Google Doc to copy`,
+      },
+      {
+        name: 'name',
+        type: 'string',
+        required: false,
+        description: `Name for the copied document. If omitted, the copy is named 'Copy of <original name>'.`,
+      },
+      {
+        name: 'parent_folder_id',
+        type: 'string',
+        required: false,
+        description: `ID of the destination folder for the copy. If omitted, the copy is placed in the same folder as the original.`,
+      },
+      {
+        name: 'schema_version',
+        type: 'string',
+        required: false,
+        description: `Optional schema version to use for tool execution`,
+      },
+      {
+        name: 'tool_version',
+        type: 'string',
+        required: false,
+        description: `Optional tool version to use for execution`,
+      },
+    ],
+  },
+  {
+    name: 'googledocs_create_comment',
+    description: `Add a comment to a Google Doc. Comments are managed through the Drive API. Optionally anchor the comment to a quoted section of the document.`,
+    params: [
+      {
+        name: 'content',
+        type: 'string',
+        required: true,
+        description: `The plain-text content of the comment`,
+      },
+      {
+        name: 'document_id',
+        type: 'string',
+        required: true,
+        description: `The ID of the Google Doc to comment on`,
+      },
+      {
+        name: 'schema_version',
+        type: 'string',
+        required: false,
+        description: `Optional schema version to use for tool execution`,
+      },
+      {
+        name: 'tool_version',
+        type: 'string',
+        required: false,
+        description: `Optional tool version to use for execution`,
+      },
+    ],
+  },
+  {
     name: 'googledocs_create_document',
     description: `Create a new blank Google Doc with an optional title. Returns the new document's ID and metadata.`,
     params: [
@@ -12,6 +139,442 @@ export const tools: Tool[] = [
         description: `Optional schema version to use for tool execution`,
       },
       { name: 'title', type: 'string', required: false, description: `Title of the new document` },
+      {
+        name: 'tool_version',
+        type: 'string',
+        required: false,
+        description: `Optional tool version to use for execution`,
+      },
+    ],
+  },
+  {
+    name: 'googledocs_create_named_range',
+    description: `Create a named range over a span of content in a Google Doc. Named ranges let you reference and update a region of the document later by name.`,
+    params: [
+      {
+        name: 'document_id',
+        type: 'string',
+        required: true,
+        description: `The ID of the Google Doc to edit`,
+      },
+      {
+        name: 'end_index',
+        type: 'integer',
+        required: true,
+        description: `End index of the range (exclusive)`,
+      },
+      {
+        name: 'name',
+        type: 'string',
+        required: true,
+        description: `Name for the range. Multiple ranges can share the same name.`,
+      },
+      {
+        name: 'start_index',
+        type: 'integer',
+        required: true,
+        description: `Zero-based start index of the range (inclusive)`,
+      },
+      {
+        name: 'schema_version',
+        type: 'string',
+        required: false,
+        description: `Optional schema version to use for tool execution`,
+      },
+      {
+        name: 'tool_version',
+        type: 'string',
+        required: false,
+        description: `Optional tool version to use for execution`,
+      },
+    ],
+  },
+  {
+    name: 'googledocs_create_paragraph_bullets',
+    description: `Turn the paragraphs in a range into a bulleted or numbered list using a preset glyph pattern.`,
+    params: [
+      {
+        name: 'document_id',
+        type: 'string',
+        required: true,
+        description: `The ID of the Google Doc to edit`,
+      },
+      {
+        name: 'end_index',
+        type: 'integer',
+        required: true,
+        description: `End index of the paragraph range (exclusive)`,
+      },
+      {
+        name: 'start_index',
+        type: 'integer',
+        required: true,
+        description: `Zero-based start index of the paragraph range (inclusive)`,
+      },
+      {
+        name: 'bullet_preset',
+        type: 'string',
+        required: false,
+        description: `The bullet glyph preset. Use a BULLET_* preset for unordered lists or a NUMBERED_* preset for ordered lists.`,
+      },
+      {
+        name: 'schema_version',
+        type: 'string',
+        required: false,
+        description: `Optional schema version to use for tool execution`,
+      },
+      {
+        name: 'tool_version',
+        type: 'string',
+        required: false,
+        description: `Optional tool version to use for execution`,
+      },
+    ],
+  },
+  {
+    name: 'googledocs_delete_comment',
+    description: `Permanently delete a comment from a Google Doc. Comments are managed through the Drive API. This cannot be undone.`,
+    params: [
+      {
+        name: 'comment_id',
+        type: 'string',
+        required: true,
+        description: `The ID of the comment to delete`,
+      },
+      {
+        name: 'document_id',
+        type: 'string',
+        required: true,
+        description: `The ID of the Google Doc that holds the comment`,
+      },
+      {
+        name: 'schema_version',
+        type: 'string',
+        required: false,
+        description: `Optional schema version to use for tool execution`,
+      },
+      {
+        name: 'tool_version',
+        type: 'string',
+        required: false,
+        description: `Optional tool version to use for execution`,
+      },
+    ],
+  },
+  {
+    name: 'googledocs_delete_content_range',
+    description: `Delete content between two character indexes in a Google Doc. The start index is inclusive and the end index is exclusive.`,
+    params: [
+      {
+        name: 'document_id',
+        type: 'string',
+        required: true,
+        description: `The ID of the Google Doc to edit`,
+      },
+      {
+        name: 'end_index',
+        type: 'integer',
+        required: true,
+        description: `End index of the range to delete (exclusive)`,
+      },
+      {
+        name: 'start_index',
+        type: 'integer',
+        required: true,
+        description: `Zero-based start index of the range to delete (inclusive)`,
+      },
+      {
+        name: 'schema_version',
+        type: 'string',
+        required: false,
+        description: `Optional schema version to use for tool execution`,
+      },
+      {
+        name: 'tool_version',
+        type: 'string',
+        required: false,
+        description: `Optional tool version to use for execution`,
+      },
+    ],
+  },
+  {
+    name: 'googledocs_delete_named_range',
+    description: `Delete named ranges from a Google Doc. Provide a named range ID to remove one specific range, or a name to remove all ranges sharing that name. The underlying document content is not deleted.`,
+    params: [
+      {
+        name: 'document_id',
+        type: 'string',
+        required: true,
+        description: `The ID of the Google Doc to edit`,
+      },
+      {
+        name: 'name',
+        type: 'string',
+        required: false,
+        description: `The name of the range(s) to delete. All named ranges with this name are removed.`,
+      },
+      {
+        name: 'named_range_id',
+        type: 'string',
+        required: false,
+        description: `The ID of a specific named range to delete. Takes precedence over name when both are provided.`,
+      },
+      {
+        name: 'schema_version',
+        type: 'string',
+        required: false,
+        description: `Optional schema version to use for tool execution`,
+      },
+      {
+        name: 'tool_version',
+        type: 'string',
+        required: false,
+        description: `Optional tool version to use for execution`,
+      },
+    ],
+  },
+  {
+    name: 'googledocs_delete_paragraph_bullets',
+    description: `Remove list bullets or numbering from the paragraphs in a range, converting them back to normal paragraphs.`,
+    params: [
+      {
+        name: 'document_id',
+        type: 'string',
+        required: true,
+        description: `The ID of the Google Doc to edit`,
+      },
+      {
+        name: 'end_index',
+        type: 'integer',
+        required: true,
+        description: `End index of the paragraph range (exclusive)`,
+      },
+      {
+        name: 'start_index',
+        type: 'integer',
+        required: true,
+        description: `Zero-based start index of the paragraph range (inclusive)`,
+      },
+      {
+        name: 'schema_version',
+        type: 'string',
+        required: false,
+        description: `Optional schema version to use for tool execution`,
+      },
+      {
+        name: 'tool_version',
+        type: 'string',
+        required: false,
+        description: `Optional tool version to use for execution`,
+      },
+    ],
+  },
+  {
+    name: 'googledocs_export_document',
+    description: `Export a Google Doc to another format such as PDF, plain text, HTML, Word (.docx), RTF, or EPUB. Uses the Drive API export endpoint. Exported files are limited to 10 MB.`,
+    params: [
+      {
+        name: 'document_id',
+        type: 'string',
+        required: true,
+        description: `The ID of the Google Doc to export`,
+      },
+      {
+        name: 'mime_type',
+        type: 'string',
+        required: true,
+        description: `The MIME type of the target export format`,
+      },
+      {
+        name: 'schema_version',
+        type: 'string',
+        required: false,
+        description: `Optional schema version to use for tool execution`,
+      },
+      {
+        name: 'tool_version',
+        type: 'string',
+        required: false,
+        description: `Optional tool version to use for execution`,
+      },
+    ],
+  },
+  {
+    name: 'googledocs_insert_inline_image',
+    description: `Insert an inline image from a publicly accessible URL into a Google Doc. Optionally set the image width and height in points. Provide an index to insert at that position, or omit it to append at the end of the document body.`,
+    params: [
+      {
+        name: 'document_id',
+        type: 'string',
+        required: true,
+        description: `The ID of the Google Doc to edit`,
+      },
+      {
+        name: 'image_uri',
+        type: 'string',
+        required: true,
+        description: `Publicly accessible URL of the image to insert (PNG, JPEG, or GIF, max 50 MB / 25 megapixels)`,
+      },
+      { name: 'height_pt', type: 'number', required: false, description: `Image height in points` },
+      {
+        name: 'index',
+        type: 'integer',
+        required: false,
+        description: `Zero-based character index at which to insert the image. Omit to append at the end of the document body.`,
+      },
+      {
+        name: 'schema_version',
+        type: 'string',
+        required: false,
+        description: `Optional schema version to use for tool execution`,
+      },
+      {
+        name: 'tool_version',
+        type: 'string',
+        required: false,
+        description: `Optional tool version to use for execution`,
+      },
+      { name: 'width_pt', type: 'number', required: false, description: `Image width in points` },
+    ],
+  },
+  {
+    name: 'googledocs_insert_page_break',
+    description: `Insert a page break into a Google Doc. Provide an index to insert at that position, or omit it to append at the end of the document body.`,
+    params: [
+      {
+        name: 'document_id',
+        type: 'string',
+        required: true,
+        description: `The ID of the Google Doc to edit`,
+      },
+      {
+        name: 'index',
+        type: 'integer',
+        required: false,
+        description: `Zero-based character index at which to insert the page break. Omit to append at the end of the document body.`,
+      },
+      {
+        name: 'schema_version',
+        type: 'string',
+        required: false,
+        description: `Optional schema version to use for tool execution`,
+      },
+      {
+        name: 'tool_version',
+        type: 'string',
+        required: false,
+        description: `Optional tool version to use for execution`,
+      },
+    ],
+  },
+  {
+    name: 'googledocs_insert_table',
+    description: `Insert an empty table with the given number of rows and columns into a Google Doc. Provide an index to insert at that position, or omit it to append at the end of the document body.`,
+    params: [
+      {
+        name: 'columns',
+        type: 'integer',
+        required: true,
+        description: `Number of columns in the table`,
+      },
+      {
+        name: 'document_id',
+        type: 'string',
+        required: true,
+        description: `The ID of the Google Doc to edit`,
+      },
+      { name: 'rows', type: 'integer', required: true, description: `Number of rows in the table` },
+      {
+        name: 'index',
+        type: 'integer',
+        required: false,
+        description: `Zero-based character index at which to insert the table. Omit to append at the end of the document body.`,
+      },
+      {
+        name: 'schema_version',
+        type: 'string',
+        required: false,
+        description: `Optional schema version to use for tool execution`,
+      },
+      {
+        name: 'tool_version',
+        type: 'string',
+        required: false,
+        description: `Optional tool version to use for execution`,
+      },
+    ],
+  },
+  {
+    name: 'googledocs_insert_text',
+    description: `Insert text into a Google Doc at a specific location. Provide an index to insert at that position, or omit it to append at the end of the document body.`,
+    params: [
+      {
+        name: 'document_id',
+        type: 'string',
+        required: true,
+        description: `The ID of the Google Doc to edit`,
+      },
+      { name: 'text', type: 'string', required: true, description: `The text to insert` },
+      {
+        name: 'index',
+        type: 'integer',
+        required: false,
+        description: `Zero-based character index at which to insert the text. Omit to append at the end of the document body.`,
+      },
+      {
+        name: 'schema_version',
+        type: 'string',
+        required: false,
+        description: `Optional schema version to use for tool execution`,
+      },
+      {
+        name: 'tool_version',
+        type: 'string',
+        required: false,
+        description: `Optional tool version to use for execution`,
+      },
+    ],
+  },
+  {
+    name: 'googledocs_list_comments',
+    description: `List the comments on a Google Doc, including their replies and resolved status. Comments are managed through the Drive API. Supports pagination.`,
+    params: [
+      {
+        name: 'document_id',
+        type: 'string',
+        required: true,
+        description: `The ID of the Google Doc whose comments to list`,
+      },
+      {
+        name: 'include_deleted',
+        type: 'boolean',
+        required: false,
+        description: `Whether to include deleted comments. Deleted comments have their content and author stripped. Defaults to false.`,
+      },
+      {
+        name: 'page_size',
+        type: 'integer',
+        required: false,
+        description: `Maximum number of comments to return per page (1-100, default 20)`,
+      },
+      {
+        name: 'page_token',
+        type: 'string',
+        required: false,
+        description: `Token for retrieving the next page of results. Use the nextPageToken from a previous response.`,
+      },
+      {
+        name: 'schema_version',
+        type: 'string',
+        required: false,
+        description: `Optional schema version to use for tool execution`,
+      },
+      {
+        name: 'start_modified_time',
+        type: 'string',
+        required: false,
+        description: `Only return comments modified after this RFC 3339 timestamp`,
+      },
       {
         name: 'tool_version',
         type: 'string',
@@ -81,6 +644,120 @@ export const tools: Tool[] = [
     ],
   },
   {
+    name: 'googledocs_replace_all_text',
+    description: `Find every occurrence of a text string in a Google Doc and replace it with new text. Useful for templating and bulk edits.`,
+    params: [
+      {
+        name: 'document_id',
+        type: 'string',
+        required: true,
+        description: `The ID of the Google Doc to edit`,
+      },
+      {
+        name: 'find_text',
+        type: 'string',
+        required: true,
+        description: `The exact text to search for`,
+      },
+      {
+        name: 'replace_text',
+        type: 'string',
+        required: true,
+        description: `The text to substitute for each match`,
+      },
+      {
+        name: 'match_case',
+        type: 'boolean',
+        required: false,
+        description: `Whether the search is case-sensitive. Defaults to false.`,
+      },
+      {
+        name: 'schema_version',
+        type: 'string',
+        required: false,
+        description: `Optional schema version to use for tool execution`,
+      },
+      {
+        name: 'tool_version',
+        type: 'string',
+        required: false,
+        description: `Optional tool version to use for execution`,
+      },
+    ],
+  },
+  {
+    name: 'googledocs_reply_to_comment',
+    description: `Post a reply to an existing comment on a Google Doc. Comments and replies are managed through the Drive API.`,
+    params: [
+      {
+        name: 'comment_id',
+        type: 'string',
+        required: true,
+        description: `The ID of the comment to reply to`,
+      },
+      {
+        name: 'content',
+        type: 'string',
+        required: true,
+        description: `The plain-text content of the reply`,
+      },
+      {
+        name: 'document_id',
+        type: 'string',
+        required: true,
+        description: `The ID of the Google Doc that holds the comment`,
+      },
+      {
+        name: 'schema_version',
+        type: 'string',
+        required: false,
+        description: `Optional schema version to use for tool execution`,
+      },
+      {
+        name: 'tool_version',
+        type: 'string',
+        required: false,
+        description: `Optional tool version to use for execution`,
+      },
+    ],
+  },
+  {
+    name: 'googledocs_resolve_comment',
+    description: `Resolve an open comment on a Google Doc by posting a resolving reply. Comments are managed through the Drive API. Optionally include reply text alongside the resolution.`,
+    params: [
+      {
+        name: 'comment_id',
+        type: 'string',
+        required: true,
+        description: `The ID of the comment to resolve`,
+      },
+      {
+        name: 'document_id',
+        type: 'string',
+        required: true,
+        description: `The ID of the Google Doc that holds the comment`,
+      },
+      {
+        name: 'content',
+        type: 'string',
+        required: false,
+        description: `Optional reply text to post along with the resolution`,
+      },
+      {
+        name: 'schema_version',
+        type: 'string',
+        required: false,
+        description: `Optional schema version to use for tool execution`,
+      },
+      {
+        name: 'tool_version',
+        type: 'string',
+        required: false,
+        description: `Optional tool version to use for execution`,
+      },
+    ],
+  },
+  {
     name: 'googledocs_update_document',
     description: `Update the content of an existing Google Doc using batch update requests. Supports inserting and deleting text, formatting, tables, and other document elements.`,
     params: [
@@ -113,6 +790,49 @@ export const tools: Tool[] = [
         type: 'object',
         required: false,
         description: `Optional write control for revision management`,
+      },
+    ],
+  },
+  {
+    name: 'googledocs_update_paragraph_style',
+    description: `Apply paragraph-level formatting to a range: set a named style such as a heading or title, and/or set text alignment. Use this to turn text into a heading.`,
+    params: [
+      {
+        name: 'document_id',
+        type: 'string',
+        required: true,
+        description: `The ID of the Google Doc to edit`,
+      },
+      {
+        name: 'end_index',
+        type: 'integer',
+        required: true,
+        description: `End index of the paragraph range (exclusive)`,
+      },
+      {
+        name: 'start_index',
+        type: 'integer',
+        required: true,
+        description: `Zero-based start index of the paragraph range (inclusive)`,
+      },
+      { name: 'alignment', type: 'string', required: false, description: `Paragraph alignment` },
+      {
+        name: 'named_style_type',
+        type: 'string',
+        required: false,
+        description: `Named paragraph style to apply (e.g. a heading level, title, or normal text)`,
+      },
+      {
+        name: 'schema_version',
+        type: 'string',
+        required: false,
+        description: `Optional schema version to use for tool execution`,
+      },
+      {
+        name: 'tool_version',
+        type: 'string',
+        required: false,
+        description: `Optional tool version to use for execution`,
       },
     ],
   },

--- a/src/data/agent-connectors/tools-index.json
+++ b/src/data/agent-connectors/tools-index.json
@@ -316,6 +316,26 @@
   },
   {
     "slug": "advancedmd",
+    "name": "advancedmd_care_plan_read",
+    "description": "Retrieve a single FHIR CarePlan resource by its logical ID. Care plans describe planned activities to manage a patient's health issues."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_care_plan_search",
+    "description": "Search for FHIR CarePlan resources describing planned patient care activities using parameters like patient, category, status, and date."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_care_team_read",
+    "description": "Retrieve a single FHIR CareTeam resource by its logical ID. Care teams represent the group of practitioners involved in a patient's care."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_care_team_search",
+    "description": "Search for FHIR CareTeam resources representing groups of practitioners involved in patient care, filtered by patient and status."
+  },
+  {
+    "slug": "advancedmd",
     "name": "advancedmd_condition_create",
     "description": "Create a new FHIR Condition resource representing a diagnosis or health problem for a patient."
   },
@@ -338,6 +358,26 @@
     "slug": "advancedmd",
     "name": "advancedmd_condition_update",
     "description": "Update an existing FHIR Condition resource by its ID. Replaces the resource with the provided data."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_coverage_read",
+    "description": "Retrieve a single FHIR Coverage resource by its logical ID. Coverage resources describe a patient's insurance or payment details."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_coverage_search",
+    "description": "Search for FHIR Coverage resources describing a patient's insurance or payment details, filtered by patient."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_device_read",
+    "description": "Retrieve a single FHIR Device resource by its logical ID. Devices represent implantable medical devices associated with a patient."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_device_search",
+    "description": "Search for FHIR Device resources representing implantable medical devices using parameters like patient and device type."
   },
   {
     "slug": "advancedmd",
@@ -366,6 +406,16 @@
   },
   {
     "slug": "advancedmd",
+    "name": "advancedmd_document_reference_read",
+    "description": "Retrieve a single FHIR DocumentReference resource by its logical ID. Document references index clinical documents such as summaries and notes."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_document_reference_search",
+    "description": "Search for FHIR DocumentReference resources indexing clinical documents using parameters like patient, status, category, type, date, and period."
+  },
+  {
+    "slug": "advancedmd",
     "name": "advancedmd_encounter_create",
     "description": "Create a new FHIR Encounter resource representing a patient visit or admission."
   },
@@ -391,6 +441,26 @@
   },
   {
     "slug": "advancedmd",
+    "name": "advancedmd_endpoint_read",
+    "description": "Retrieve a single FHIR Endpoint resource by its logical ID. Endpoints describe technical details of a service endpoint used for exchanging data."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_endpoint_search",
+    "description": "Search for FHIR Endpoint resources describing service endpoints for data exchange, filtered by category, status, patient, and date."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_goal_read",
+    "description": "Retrieve a single FHIR Goal resource by its logical ID. Goals describe desired health outcomes for a patient."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_goal_search",
+    "description": "Search for FHIR Goal resources describing desired patient health outcomes using parameters like patient, lifecycle status, and target date."
+  },
+  {
+    "slug": "advancedmd",
     "name": "advancedmd_immunization_create",
     "description": "Create a new FHIR Immunization resource recording a vaccination event for a patient."
   },
@@ -413,6 +483,26 @@
     "slug": "advancedmd",
     "name": "advancedmd_immunization_update",
     "description": "Update an existing FHIR Immunization resource by its ID."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_location_read",
+    "description": "Retrieve a single FHIR Location resource by its logical ID. Locations represent physical places where care is delivered, such as clinics or rooms."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_location_search",
+    "description": "Search for FHIR Location resources representing care facilities using parameters like name and address."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_medication_dispense_read",
+    "description": "Retrieve a single FHIR MedicationDispense resource by its logical ID. Medication dispenses record medications that have been provided to a patient."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_medication_dispense_search",
+    "description": "Search for FHIR MedicationDispense resources recording medications provided to a patient using parameters like status, type, patient, and medication."
   },
   {
     "slug": "advancedmd",
@@ -568,6 +658,41 @@
     "slug": "advancedmd",
     "name": "advancedmd_procedure_update",
     "description": "Update an existing FHIR Procedure resource by its ID."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_provenance_read",
+    "description": "Retrieve a single FHIR Provenance resource by its logical ID. Provenance records who created or changed a resource and when."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_related_person_read",
+    "description": "Retrieve a single FHIR RelatedPerson resource by its logical ID. Related persons represent individuals connected to a patient, such as family members or caregivers."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_related_person_search",
+    "description": "Search for FHIR RelatedPerson resources representing individuals connected to a patient, such as family members or caregivers, filtered by patient and name."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_service_request_read",
+    "description": "Retrieve a single FHIR ServiceRequest resource by its logical ID. Service requests represent orders for services such as lab tests or referrals."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_service_request_search",
+    "description": "Search for FHIR ServiceRequest resources representing orders for services such as lab tests or referrals, filtered by patient."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_specimen_read",
+    "description": "Retrieve a single FHIR Specimen resource by its logical ID. Specimens represent samples collected from a patient for laboratory analysis."
+  },
+  {
+    "slug": "advancedmd",
+    "name": "advancedmd_specimen_search",
+    "description": "Search for FHIR Specimen resources representing laboratory samples collected from a patient, filtered by patient."
   },
   {
     "slug": "adzvisermcp",
@@ -12524,6 +12649,11 @@
     "description": "Recall data previously saved to Cognee memory. Runs a semantic search over the knowledge graph (and, optionally, session memory) and returns an answer or matching context. Use searchType to control the retrieval strategy."
   },
   {
+    "slug": "cognee",
+    "name": "cognee_remember",
+    "description": "Save data to Cognee memory. Ingests the provided content into a dataset and builds a knowledge graph from it in a single operation, so it can be recalled later with semantic search. Creates the dataset if it does not already exist. NOTE: Coming soon — Cognee's ingest endpoint (P…"
+  },
+  {
     "slug": "coinmarketcapmcp",
     "name": "coinmarketcapmcp_get_crypto_info",
     "description": "Get static metadata for one or more cryptocurrencies, including logo, description, website, social links, and technical documentation URLs."
@@ -23963,8 +24093,83 @@
   },
   {
     "slug": "googledocs",
+    "name": "googledocs_apply_text_style",
+    "description": "Apply character formatting (bold, italic, underline, strikethrough, font size) to a range of text in a Google Doc. Only the attributes you set are changed."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_copy_document",
+    "description": "Duplicate a Google Doc. Optionally rename the copy or place it in a specific Drive folder. Uses the Drive API and returns the new document's metadata."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_create_comment",
+    "description": "Add a comment to a Google Doc. Comments are managed through the Drive API. Optionally anchor the comment to a quoted section of the document."
+  },
+  {
+    "slug": "googledocs",
     "name": "googledocs_create_document",
     "description": "Create a new blank Google Doc with an optional title. Returns the new document's ID and metadata."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_create_named_range",
+    "description": "Create a named range over a span of content in a Google Doc. Named ranges let you reference and update a region of the document later by name."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_create_paragraph_bullets",
+    "description": "Turn the paragraphs in a range into a bulleted or numbered list using a preset glyph pattern."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_delete_comment",
+    "description": "Permanently delete a comment from a Google Doc. Comments are managed through the Drive API. This cannot be undone."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_delete_content_range",
+    "description": "Delete content between two character indexes in a Google Doc. The start index is inclusive and the end index is exclusive."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_delete_named_range",
+    "description": "Delete named ranges from a Google Doc. Provide a named range ID to remove one specific range, or a name to remove all ranges sharing that name. The underlying document content is not deleted."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_delete_paragraph_bullets",
+    "description": "Remove list bullets or numbering from the paragraphs in a range, converting them back to normal paragraphs."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_export_document",
+    "description": "Export a Google Doc to another format such as PDF, plain text, HTML, Word (.docx), RTF, or EPUB. Uses the Drive API export endpoint. Exported files are limited to 10 MB."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_insert_inline_image",
+    "description": "Insert an inline image from a publicly accessible URL into a Google Doc. Optionally set the image width and height in points. Provide an index to insert at that position, or omit it to append at the end of the document body."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_insert_page_break",
+    "description": "Insert a page break into a Google Doc. Provide an index to insert at that position, or omit it to append at the end of the document body."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_insert_table",
+    "description": "Insert an empty table with the given number of rows and columns into a Google Doc. Provide an index to insert at that position, or omit it to append at the end of the document body."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_insert_text",
+    "description": "Insert text into a Google Doc at a specific location. Provide an index to insert at that position, or omit it to append at the end of the document body."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_list_comments",
+    "description": "List the comments on a Google Doc, including their replies and resolved status. Comments are managed through the Drive API. Supports pagination."
   },
   {
     "slug": "googledocs",
@@ -23978,8 +24183,28 @@
   },
   {
     "slug": "googledocs",
+    "name": "googledocs_replace_all_text",
+    "description": "Find every occurrence of a text string in a Google Doc and replace it with new text. Useful for templating and bulk edits."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_reply_to_comment",
+    "description": "Post a reply to an existing comment on a Google Doc. Comments and replies are managed through the Drive API."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_resolve_comment",
+    "description": "Resolve an open comment on a Google Doc by posting a resolving reply. Comments are managed through the Drive API. Optionally include reply text alongside the resolution."
+  },
+  {
+    "slug": "googledocs",
     "name": "googledocs_update_document",
     "description": "Update the content of an existing Google Doc using batch update requests. Supports inserting and deleting text, formatting, tables, and other document elements."
+  },
+  {
+    "slug": "googledocs",
+    "name": "googledocs_update_paragraph_style",
+    "description": "Apply paragraph-level formatting to a range: set a named style such as a heading or title, and/or set text alignment. Use this to turn text into a heading."
   },
   {
     "slug": "googledrive",


### PR DESCRIPTION
## Summary
Reconciled docs against Scalekit prod (324 providers, unchanged count — no new connectors, just new tools on existing ones).

- **AdvancedMD**: 61 → 86 tools
- **Cognee**: 7 → 8 tools
- **Google Docs**: 4 → 23 tools

Generated via `scripts/sync-agent-connectors-local.js` against the prod provider/tool definitions.

## Test plan
- [x] `pnpm format:check` passes
- [x] `pnpm build` completes successfully
- Preview: `https://deploy-preview-{PR_NUMBER}--scalekit-starlight.netlify.app/agentkit/connectors/googledocs/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AdvancedMD support for reading and searching additional healthcare resources.
  * Expanded Google Docs capabilities with formatting, content insertion, document export, templating, and comment management.
  * Added Cognee memory-saving functionality.
* **Documentation**
  * Updated Cognee and Google Docs connector documentation to reflect available capabilities.
* **Changes**
  * Replaced the Cognee recall tool with the new remember tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->