### PR TITLE
Fix docs nav lag and line spacing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ venv/
 examples/*
 project-docs/BUILD_AUDIT.md
 project-docs/BUILD_COMPARISON.md
+.lighthouse/

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -37,12 +37,10 @@ export default defineConfig({
   // Memory-intensive builds: see vite.build settings below.
   output: 'server',
   site: 'https://docs.scalekit.com',
-  // Starlight enables this by default; keep it explicit. Hover-prefetch warms
-  // the next docs page so full navigations feel faster without SPA routing
-  // (which breaks Scalar API reference and some Starlight widgets).
+  // Viewport + manual secondary-nav prefetch so ClientRouter swaps feel instant.
   prefetch: {
     prefetchAll: true,
-    defaultStrategy: 'hover',
+    defaultStrategy: 'viewport',
   },
   server: {
     // Match Netlify dev's readiness probe, which connects to `localhost`.

--- a/src/components/SecondaryNav.astro
+++ b/src/components/SecondaryNav.astro
@@ -54,7 +54,12 @@ const navItems = secondaryNavConfig[activeProduct]
                   </div>
                 </button>
               ) : (
-                <a href={item.href} class={itemClass} aria-current={isCurrent ? 'page' : undefined}>
+                <a
+                  href={item.href}
+                  class={itemClass}
+                  aria-current={isCurrent ? 'page' : undefined}
+                  data-astro-prefetch="viewport"
+                >
                   <div class="nav-item-content">
                     {IconComponent && <IconComponent class="nav-icon" />}
                     {item.label && <span class="nav-label">{item.label}</span>}
@@ -120,6 +125,7 @@ const navItems = secondaryNavConfig[activeProduct]
                             }
                             data-nav-label={child.label}
                             data-dropdown-label={child.dropdownLabel || child.label}
+                            data-astro-prefetch="viewport"
                           >
                             <div class="dropdown-item-icon-wrapper">
                               {(function () {
@@ -174,6 +180,7 @@ const navItems = secondaryNavConfig[activeProduct]
                             }
                             data-nav-label={child.label}
                             data-dropdown-label={child.dropdownLabel || child.label}
+                            data-astro-prefetch="viewport"
                           >
                             <div class="dropdown-item-icon-wrapper">
                               {(function () {
@@ -212,6 +219,7 @@ const navItems = secondaryNavConfig[activeProduct]
                             ? 'page'
                             : undefined
                         }
+                        data-astro-prefetch="viewport"
                       >
                         <div class="dropdown-item-icon-wrapper">
                           {(function () {

--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -25,7 +25,9 @@ import { ClientRouter } from 'astro:transitions'
       try {
         const url = new URL(href, location.origin)
         if (url.origin !== location.origin) return
-        const key = url.pathname.replace(/\/+$/, '') || '/'
+        // Include search so /path?mode=a and /path?mode=b stay distinct
+        const pathname = url.pathname.replace(/\/+$/, '') || '/'
+        const key = pathname + url.search
         if (prefetched.has(key)) return
         prefetched.add(key)
         // Prefer native document prefetch for ClientRouter HTML payloads

--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -51,11 +51,6 @@ import { ClientRouter } from 'astro:transitions'
       prefetchDocument('/authenticate/fsa/quickstart/')
     }
 
-    const setNavigating = (on) => {
-      if (on) document.documentElement.setAttribute('data-sk-navigating', '')
-      else document.documentElement.removeAttribute('data-sk-navigating')
-    }
-
     // Optimistic current-state so secondary nav feels instant before HTML arrives
     document.addEventListener(
       'click',
@@ -77,7 +72,6 @@ import { ClientRouter } from 'astro:transitions'
           return
         }
 
-        setNavigating(true)
         prefetchDocument(anchor.href)
 
         if (anchor.classList.contains('nav-item')) {
@@ -116,10 +110,7 @@ import { ClientRouter } from 'astro:transitions'
       true,
     )
 
-    document.addEventListener('astro:before-preparation', () => setNavigating(true))
-    document.addEventListener('astro:after-swap', () => setNavigating(false))
     document.addEventListener('astro:page-load', () => {
-      setNavigating(false)
       prefetchChromeDestinations()
     })
 

--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -9,14 +9,127 @@ import { ClientRouter } from 'astro:transitions'
 
 <!--
   Smooth docs navigation (Starlight + Astro utilities):
-  - ClientRouter: soft navigations keep chrome stable (secondary nav does not
-    hard-flash). Pair with transition:persist on the header top row.
-  - Starlight hover prefetch (astro.config) warms the next page.
-  - Scalar API pages MUST use <ScalarComponent renderMode="client" /> so the
-    reference remounts on astro:page-load (see @scalar/astro docs — static
-    mode only runs on hard refresh under ClientRouter).
+  - ClientRouter: soft navigations keep chrome stable.
+  - Prefetch: viewport (astro.config) + eager secondary-nav/product destinations.
+  - Scalar: renderMode="client" so API reference remounts after soft nav.
+  - Optimistic chrome updates run in capture phase so UI reacts before fetch.
 -->
 <ClientRouter />
+
+<!-- Prefetch + navigation UX: cut ~1s secondary-nav/product-switch lag -->
+<script is:inline>
+  ;(() => {
+    const prefetched = new Set()
+
+    const prefetchDocument = (href) => {
+      try {
+        const url = new URL(href, location.origin)
+        if (url.origin !== location.origin) return
+        const key = url.pathname.replace(/\/+$/, '') || '/'
+        if (prefetched.has(key)) return
+        prefetched.add(key)
+        // Prefer native document prefetch for ClientRouter HTML payloads
+        const link = document.createElement('link')
+        link.rel = 'prefetch'
+        link.as = 'document'
+        link.href = url.pathname + url.search
+        link.dataset.skPrefetch = key
+        document.head.appendChild(link)
+      } catch {
+        // ignore invalid hrefs
+      }
+    }
+
+    const prefetchChromeDestinations = () => {
+      document
+        .querySelectorAll(
+          '.secondary-nav a[href], #dropdown-portal a[href], [data-product-switch][href]',
+        )
+        .forEach((a) => prefetchDocument(a.getAttribute('href')))
+      // Product homes — always warm both
+      prefetchDocument('/agentkit/quickstart/')
+      prefetchDocument('/authenticate/fsa/quickstart/')
+    }
+
+    const setNavigating = (on) => {
+      if (on) document.documentElement.setAttribute('data-sk-navigating', '')
+      else document.documentElement.removeAttribute('data-sk-navigating')
+    }
+
+    // Optimistic current-state so secondary nav feels instant before HTML arrives
+    document.addEventListener(
+      'click',
+      (event) => {
+        if (event.defaultPrevented) return
+        if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey)
+          return
+        const target = event.target
+        if (!(target instanceof Element)) return
+        const anchor = target.closest(
+          'a.nav-item[href], a.dropdown-item[href], a[data-product-switch][href]',
+        )
+        if (!(anchor instanceof HTMLAnchorElement)) return
+        try {
+          const next = new URL(anchor.href, location.origin)
+          if (next.origin !== location.origin) return
+          if (next.pathname === location.pathname && next.search === location.search) return
+        } catch {
+          return
+        }
+
+        setNavigating(true)
+        prefetchDocument(anchor.href)
+
+        if (anchor.classList.contains('nav-item')) {
+          document.querySelectorAll('.secondary-nav .nav-item.current').forEach((el) => {
+            el.classList.remove('current')
+            el.removeAttribute('aria-current')
+          })
+          anchor.classList.add('current')
+          anchor.setAttribute('aria-current', 'page')
+        }
+
+        if (anchor.classList.contains('dropdown-item')) {
+          document.querySelectorAll('.dropdown-item.current').forEach((el) => {
+            el.classList.remove('current')
+            el.removeAttribute('aria-current')
+          })
+          anchor.classList.add('current')
+          anchor.setAttribute('aria-current', 'page')
+          const menu = anchor.closest('[data-dropdown]')
+          const navKey = menu?.getAttribute('data-nav-key')
+          if (navKey) {
+            const parent = document.querySelector(
+              `.nav-item-wrapper.has-dropdown .nav-item[data-nav-key="${navKey}"]`,
+            )
+            if (parent) {
+              document.querySelectorAll('.secondary-nav .nav-item.current').forEach((el) => {
+                el.classList.remove('current')
+                el.removeAttribute('aria-current')
+              })
+              parent.classList.add('current')
+              parent.setAttribute('aria-current', 'page')
+            }
+          }
+        }
+      },
+      true,
+    )
+
+    document.addEventListener('astro:before-preparation', () => setNavigating(true))
+    document.addEventListener('astro:after-swap', () => setNavigating(false))
+    document.addEventListener('astro:page-load', () => {
+      setNavigating(false)
+      prefetchChromeDestinations()
+    })
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', prefetchChromeDestinations, { once: true })
+    } else {
+      prefetchChromeDestinations()
+    }
+  })()
+</script>
 
 <!-- WebMCP: expose site tools to AI agents via the browser -->
 <script src="/js/webmcp.js" defer></script>

--- a/src/components/overrides/Header.astro
+++ b/src/components/overrides/Header.astro
@@ -11,27 +11,28 @@ import AuthCTA from '../auth/AuthCTA.astro'
 const { entry, locale } = Astro.props
 ---
 
-<div class="header" transition:name="sk-site-header">
+{
+  /*
+  No transition:name / transition:persist — named regions morph from left/right/center.
+  Page transitions are a single root fade in custom.css.
+*/
+}
+<div class="header">
   <div class="top-row">
     <div class="header-left">
-      {/* Logo stable across soft navigations */}
-      <div transition:persist="sk-site-title">
-        <SiteTitle {locale} />
-      </div>
-      {/* Must re-render — active product label is page-dependent */}
+      <SiteTitle {locale} />
       <HeaderProductToggle entry={entry} />
     </div>
 
     <div class="header-center">
-      {/* Persist DocSearch instance so it does not remount/break after soft nav */}
-      <div class="search-wrapper" transition:persist="sk-search">
+      <div class="search-wrapper">
         <Search {locale} />
         <MobileMenuToggle />
       </div>
     </div>
 
     <div class="header-right">
-      <div class="right-actions sl-hidden md:sl-flex" transition:persist="sk-header-actions">
+      <div class="right-actions sl-hidden md:sl-flex">
         <LinkButton
           href="https://schedule.scalekit.com/meet/ravi-madabhushi/demo-8b100203"
           target="_blank"
@@ -57,13 +58,6 @@ const { entry, locale } = Astro.props
     </div>
   </div>
 
-  {
-    /*
-    Soft-swap (not persist): keeps the same chrome layout while current highlight
-    and product-specific items update. Full MPA reload was what made secondary
-    nav vanish and reappear on API reference.
-  */
-  }
   <SecondaryNav entry={entry} />
 </div>
 

--- a/src/components/overrides/HeaderProductToggle.astro
+++ b/src/components/overrides/HeaderProductToggle.astro
@@ -89,6 +89,7 @@ const productLinks = [
               data-storage-value={link.storageValue}
               data-label={link.label}
               data-product-switch
+              data-astro-prefetch="viewport"
             >
               <div class="item-icon-wrapper">
                 {IconComponent && <IconComponent class="item-icon" />}

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -22,27 +22,68 @@ head:
         margin-top: 0 !important;
       }
 
-      /* Keep custom footer near the fold on average laptop screens */
+      /* Sticky footer: fill viewport under fixed nav so residual space
+         grows the gateway (not a white band below the footer). */
+      body:has(.gateway) .page {
+        min-height: 100dvh;
+      }
+      body:has(.gateway) .main-frame {
+        flex: 1 1 auto;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+        box-sizing: border-box;
+      }
+      body:has(.gateway) .main-frame > .lg\:sl-flex,
+      body:has(.gateway) .main-pane,
+      body:has(.gateway) main {
+        flex: 1 1 auto;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+      }
+      /* Drop Starlight bottom padding that left a white strip under the footer */
+      body:has(.gateway) main {
+        padding-bottom: 0 !important;
+      }
+      body:has(.gateway) .content-panel:has(.gateway-shell) {
+        flex: 1 1 auto;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+        padding-top: 0 !important;
+        padding-bottom: 0 !important;
+        border-top: 0 !important;
+      }
+      body:has(.gateway) .content-panel:has(.gateway-shell) > .sl-container {
+        flex: 1 1 auto;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+        max-width: none !important;
+        width: 100%;
+      }
+      /* VideosMarkdownContent nests a second .sl-markdown-content — both must flex */
+      body:has(.gateway) .content-panel:has(.gateway-shell) .sl-markdown-content {
+        flex: 1 1 auto;
+        display: flex !important;
+        flex-direction: column;
+        min-height: 0;
+        margin-top: 0 !important;
+      }
+
       body:has(.gateway) .footer {
-        margin-top: 0.75rem !important;
-        margin-bottom: 0.75rem !important;
+        margin-top: 0.5rem !important;
+        margin-bottom: 0.5rem !important;
+        flex-shrink: 0;
       }
       body:has(.gateway) .footer-fold-separator {
-        margin-top: 0 !important;
+        margin-top: auto !important;
+        flex-shrink: 0;
       }
 
       body:has(.gateway) button[aria-label="Menu"].sl-flex.md\:sl-hidden {
         display: none !important;
-      }
-      body:has(.gateway) .content-panel:has(.gateway-shell) {
-        padding-top: 0 !important;
-        border-top: 0 !important;
-      }
-      body:has(.gateway) .content-panel:has(.gateway-shell) > .sl-container {
-        max-width: none !important;
-      }
-      body:has(.gateway) .content-panel:has(.gateway-shell) > .sl-container > .sl-markdown-content {
-        margin-top: 0 !important;
       }
       body:has(.gateway) starlight-image-zoom-zoomable {
         display: contents !important;
@@ -72,7 +113,8 @@ head:
         z-index: 1;
         display: flex;
         flex-direction: column;
-        /* Content-sized: do not force full viewport (that buried the footer) */
+        /* Grow into residual viewport height; footer stays at bottom */
+        flex: 1 1 auto;
         min-height: 0;
       }
 
@@ -93,8 +135,8 @@ head:
       .gateway {
         display: flex;
         flex-direction: row;
-        flex: 0 0 auto;
-        /* Compact half-panels for average laptop heights (~900–1000px) */
+        /* Absorb leftover height so the footer sits at the viewport bottom */
+        flex: 1 1 auto;
         min-height: 0;
         margin-top: 0;
         padding-top: 0;

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -21,6 +21,16 @@ head:
         display: none !important;
         margin-top: 0 !important;
       }
+
+      /* Keep custom footer near the fold on average laptop screens */
+      body:has(.gateway) .footer {
+        margin-top: 0.75rem !important;
+        margin-bottom: 0.75rem !important;
+      }
+      body:has(.gateway) .footer-fold-separator {
+        margin-top: 0 !important;
+      }
+
       body:has(.gateway) button[aria-label="Menu"].sl-flex.md\:sl-hidden {
         display: none !important;
       }
@@ -62,7 +72,8 @@ head:
         z-index: 1;
         display: flex;
         flex-direction: column;
-        min-height: calc(100dvh - var(--sl-nav-height, 6.3rem));
+        /* Content-sized: do not force full viewport (that buried the footer) */
+        min-height: 0;
       }
 
       .gateway-section-label {
@@ -72,7 +83,7 @@ head:
         text-transform: uppercase;
         color: var(--sl-color-text-muted);
         text-align: center;
-        margin: 0 0 1rem;
+        margin: 0 0 0.65rem;
         padding: 0;
       }
 
@@ -82,7 +93,8 @@ head:
       .gateway {
         display: flex;
         flex-direction: row;
-        flex: 1;
+        flex: 0 0 auto;
+        /* Compact half-panels for average laptop heights (~900–1000px) */
         min-height: 0;
         margin-top: 0;
         padding-top: 0;
@@ -96,8 +108,8 @@ head:
         flex-direction: column;
         align-items: center;
         justify-content: center;
-        gap: 1rem;
-        padding: 2rem 2.5rem;
+        gap: 0.65rem;
+        padding: 1.35rem 2rem;
         text-align: center;
         text-decoration: none;
         color: inherit;
@@ -240,30 +252,29 @@ head:
       }
 
       .panel-label {
-        font-size: clamp(1.625rem, 1.2rem + 1vw, 2.2rem);
+        font-size: clamp(1.35rem, 1.05rem + 0.85vw, 1.85rem);
         font-weight: 500;
         color: var(--sl-color-text-heading);
-        line-height: 1.15;
+        line-height: 1.2;
         letter-spacing: -0.03em;
-        max-width: 30rem;
+        max-width: 28rem;
         margin: 0;
       }
 
       /* SaaS headline: keep to two lines — wider measure + slightly smaller type than agents */
       .panel-saas .panel-label {
-        max-width: 34rem;
-        font-size: clamp(1.45rem, 1.05rem + 1vw, 2.05rem);
+        max-width: 32rem;
+        font-size: clamp(1.25rem, 0.95rem + 0.8vw, 1.7rem);
         text-wrap: pretty;
       }
 
       .panel-desc {
-        font-size: 1rem;
+        font-size: 0.9375rem;
         color: var(--sl-color-text-muted);
-        line-height: 1.6;
+        line-height: 1.5;
         max-width: 24rem;
         margin: 0;
       }
-
 
       .panel-visual {
         width: min(100%, 36rem);
@@ -417,9 +428,9 @@ head:
       }
 
       .panel-cta {
-        font-size: 0.95rem;
+        font-size: 0.9rem;
         font-weight: 600;
-        margin-top: 0.25rem;
+        margin-top: 0.1rem;
         color: var(--sl-color-accent);
       }
 
@@ -458,7 +469,7 @@ head:
         }
         .panel {
           flex: 1;
-          padding: 2rem 1.5rem;
+          padding: 1.25rem 1.25rem;
         }
         .panel-label {
           max-width: 100%;
@@ -474,7 +485,7 @@ head:
         }
       }
 
-      /* Desktop: hide illustrations so panels + CLI strip fill the viewport */
+      /* Desktop: hide illustrations so panels stay compact and footer stays in view */
       @media (min-width: 1024px) {
         .panel-visual {
           display: none;
@@ -483,7 +494,7 @@ head:
 
       .gateway-cli {
         text-align: center;
-        padding: 1.5rem 1.5rem 1.75rem;
+        padding: 1rem 1.25rem 1.15rem;
         margin: 0;
         background: var(--sl-color-bg);
         border-top: 1px solid var(--sl-color-hairline);
@@ -510,7 +521,7 @@ head:
         display: flex;
         flex-direction: column;
         align-items: center;
-        gap: 0.5rem;
+        gap: 0.4rem;
         flex: 1 1 12rem;
         min-width: 11rem;
         max-width: 18rem;
@@ -518,7 +529,7 @@ head:
         background: var(--sl-color-bg-card);
         border: 1px solid var(--sl-color-hairline);
         border-radius: var(--sk-radius-xl, 0.75rem);
-        padding: 1rem 1.1rem;
+        padding: 0.75rem 0.9rem;
         overflow: hidden;
         box-shadow: var(--sk-shadow-menu, 0 1px 2px rgba(10, 10, 10, 0.04));
       }

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -662,48 +662,35 @@ body {
 }
 
 /* =============================================================================
-   VIEW TRANSITIONS (with Astro <ClientRouter />)
+   VIEW TRANSITIONS — simple full-page fade only
    -----------------------------------------------------------------------------
-   Keep transitions near-zero so lag is only network/prefetch, not animation.
-   Prefetch (viewport + secondary-nav eager) should make swaps feel instant.
+   No named regions (those morph from left/right/center). One short opacity
+   cross-fade on the root snapshot. Prefetch still removes the wait.
    ============================================================================= */
 
-/* No root fade — avoids a perceived “pause” between pages */
-::view-transition-old(root),
+@keyframes sk-page-fade-out {
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes sk-page-fade-in {
+  from {
+    opacity: 0;
+  }
+}
+
+/* Do not morph individual elements — only fade the whole page */
+::view-transition-group(*) {
+  animation: none;
+}
+
+::view-transition-old(root) {
+  animation: sk-page-fade-out 0.12s ease-out both;
+}
+
 ::view-transition-new(root) {
-  animation: none;
-  mix-blend-mode: normal;
-}
-
-header.header {
-  view-transition-name: sk-site-header;
-}
-
-::view-transition-old(sk-site-header),
-::view-transition-new(sk-site-header) {
-  animation: none;
-  mix-blend-mode: normal;
-}
-
-.secondary-nav {
-  view-transition-name: sk-secondary-nav;
-}
-
-::view-transition-old(sk-secondary-nav),
-::view-transition-new(sk-secondary-nav) {
-  animation: none;
-  mix-blend-mode: normal;
-}
-
-main {
-  view-transition-name: sk-main-content;
-}
-
-/* Barely-there content swap (50ms) — lag should not come from animation */
-::view-transition-old(sk-main-content),
-::view-transition-new(sk-main-content) {
-  animation: none;
-  mix-blend-mode: normal;
+  animation: sk-page-fade-in 0.12s ease-out both;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -712,10 +699,4 @@ main {
   ::view-transition-new(*) {
     animation: none !important;
   }
-}
-
-/* While ClientRouter is fetching, keep chrome fully interactive/visible */
-html[data-sk-navigating] main {
-  opacity: 0.92;
-  transition: opacity 0.08s linear;
 }

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -566,21 +566,21 @@
   }
 
   .sl-markdown-content :is(h1, h2, h3, h4, h5, h6):not(:where(.not-content *)) {
-    font-weight: 500;
+    font-weight: 600;
   }
 
-  /* Base body is ~500 (Nova/Tailwind); match real bold semantics vs. normal text */
+  /* Body is regular 400; strong must read clearly above it */
   .sl-markdown-content strong,
   .sl-markdown-content b {
     font-weight: 600;
   }
 
   .sl-markdown-content summary:not(:where(.not-content *)) {
-    font-weight: 500;
+    font-weight: 600;
   }
 
   .card-title {
-    font-weight: 500;
+    font-weight: 600;
   }
 
   /* Inline code — minimal treatment
@@ -628,35 +628,53 @@ main:not(:has(.posts, .post-footer)) .content-panel:nth-of-type(2) {
 :root,
 ::backdrop {
   --sl-content-width: 50rem;
+  /*
+   * Typography must be unlayered: Nova/Starlight set unlayered :root tokens that
+   * otherwise beat @layer scalekit.tokens and leave body leading/weight looking off
+   * on production/preview builds even when local looked fine.
+   */
+  --sl-line-height: 1.65;
+  --sl-line-height-headings: 1.25;
+  --sl-text-base: 1rem; /* 16px — was 1.1rem (~17.6px), inflated spacing with 1.75 lh */
+  --sl-text-body: var(--sl-text-base);
+  --sl-text-sm: 0.875rem;
+}
+
+/* Force body/prose leading + weight so utilities cannot leave sparse 1.75 × heavy text */
+body {
+  line-height: var(--sl-line-height);
+  font-weight: 400;
+}
+
+.sl-markdown-content {
+  line-height: var(--sl-line-height);
+  font-weight: 400;
+}
+
+.sl-markdown-content :is(p, li, td, th, dd, blockquote) {
+  line-height: var(--sl-line-height);
+  font-weight: 400;
+}
+
+.sl-markdown-content :is(h1, h2, h3, h4, h5, h6) {
+  line-height: var(--sl-line-height-headings);
+  font-weight: 600;
 }
 
 /* =============================================================================
    VIEW TRANSITIONS (with Astro <ClientRouter />)
    -----------------------------------------------------------------------------
-   Root/chrome stay put; only main content cross-fades quickly so secondary nav
-   and header do not “blink out”. Scalar uses renderMode="client".
+   Keep transitions near-zero so lag is only network/prefetch, not animation.
+   Prefetch (viewport + secondary-nav eager) should make swaps feel instant.
    ============================================================================= */
 
-@keyframes sk-content-out {
-  to {
-    opacity: 0;
-  }
-}
-
-@keyframes sk-content-in {
-  from {
-    opacity: 0;
-  }
-}
-
-/* Default: no full-page flash */
+/* No root fade — avoids a perceived “pause” between pages */
 ::view-transition-old(root),
 ::view-transition-new(root) {
   animation: none;
   mix-blend-mode: normal;
 }
 
-/* Sticky header + product chrome morph in place */
 header.header {
   view-transition-name: sk-site-header;
 }
@@ -667,29 +685,25 @@ header.header {
   mix-blend-mode: normal;
 }
 
-/* Secondary nav swaps in-place with a tight cross-fade (product switch) */
 .secondary-nav {
   view-transition-name: sk-secondary-nav;
 }
 
 ::view-transition-old(sk-secondary-nav),
 ::view-transition-new(sk-secondary-nav) {
-  animation-duration: 0.08s;
-  animation-timing-function: ease-out;
+  animation: none;
   mix-blend-mode: normal;
 }
 
-/* Article / API body is the only surface that should feel like “loading” */
 main {
   view-transition-name: sk-main-content;
 }
 
-::view-transition-old(sk-main-content) {
-  animation: sk-content-out 0.07s ease-out both;
-}
-
+/* Barely-there content swap (50ms) — lag should not come from animation */
+::view-transition-old(sk-main-content),
 ::view-transition-new(sk-main-content) {
-  animation: sk-content-in 0.09s ease-out both;
+  animation: none;
+  mix-blend-mode: normal;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -698,4 +712,10 @@ main {
   ::view-transition-new(*) {
     animation: none !important;
   }
+}
+
+/* While ClientRouter is fetching, keep chrome fully interactive/visible */
+html[data-sk-navigating] main {
+  opacity: 0.92;
+  transition: opacity 0.08s linear;
 }

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -39,9 +39,9 @@
   --translate-reverse-box-shadow-x: 2px;
   --translate-reverse-box-shadow-y: -4px;
 
-  /* Font weights */
-  --font-weight-base: 500;
-  --font-weight-heading: 700;
+  /* Font weights — body must stay regular; 500 made docs look dense/off-leading */
+  --font-weight-base: 400;
+  --font-weight-heading: 600;
 }
 
 /*


### PR DESCRIPTION
## Summary

Follow-up to #882 for production UX issues:

1. **~1s lag** on secondary-nav / product-switch hops
2. **Line spacing** looking off on deploy preview vs local
3. **Homepage white void** below the footer on short viewports

### Nav lag
- Prefetch strategy: `viewport` (was hover-only)
- Eager `<link rel="prefetch" as="document">` for all secondary-nav, dropdown, and product-switch destinations on load
- Optimistic `current` highlight in capture phase so chrome reacts before HTML arrives
- Drop view-transition animations that added perceived pause

### Line spacing
- Unlayered `--sl-line-height: 1.65` and body weight `400` (Nova/Starlight unlayered tokens were beating `@layer scalekit.tokens`)
- Base size back to `1rem` (was `1.1rem` × default 1.75 lh → airy/off spacing)
- Explicit prose `line-height` / `font-weight` on `.sl-markdown-content`

### Sticky homepage footer
- Grow the gateway flex column through Starlight’s page chrome so residual viewport height expands the homepage content
- Pin the custom footer to the bottom of short viewports instead of leaving a large white band below it
- Drop Starlight bottom padding that contributed to the white strip under the footer

## Test plan
- [ ] Hover secondary nav items then click — swap should feel near-instant after first warm
- [ ] Cold click product switch AgentKit ↔ Auth for SaaS — label updates immediately
- [ ] Body text on a doc page: denser/normal leading vs preview-882
- [ ] AgentKit SDKs → API reference still loads Scalar
- [ ] Homepage on a short laptop viewport (~900px): footer sits at the bottom with no large white void below
- [ ] Homepage on a tall viewport: gateway grows; footer still at bottom without overlapping content

## Preview
https://deploy-preview-884--scalekit-starlight.netlify.app/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Navigation and product links now prefetch as they enter the viewport to speed up page loads.
* **Improvements**
  * Selected navigation state updates instantly, including correct ARIA and dropdown parent “current” handling.
  * Page transitions now use a simpler full-page fade with improved reduced-motion behavior.
  * Refined the documentation landing “gateway” layout, spacing, typography, and smaller-screen responsiveness.
  * Updated font weights for a clearer, more consistent text hierarchy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->