### PR TITLE
fix(docs-ui): stop SDKs page CSS leaking after ClientRouter soft nav

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ examples/*
 project-docs/BUILD_AUDIT.md
 project-docs/BUILD_COMPARISON.md
 .lighthouse/
+
+# Hallmark local project memory (tool cache)
+.hallmark/

--- a/src/components/overrides/Header.astro
+++ b/src/components/overrides/Header.astro
@@ -227,8 +227,16 @@ const { entry, locale } = Astro.props
       border-radius: var(--sk-radius-md, 0.375rem);
     }
 
+    /* Visible outline even when Starlight's border-color: inherit collapses */
+    .right-actions :global(.sk-secondary) {
+      border: 1px solid var(--sl-color-gray-5);
+      color: var(--sl-color-text);
+      background-color: transparent;
+    }
+
     .right-actions :global(.sk-secondary:hover) {
       background-color: var(--sl-color-gray-6);
+      border-color: var(--sl-color-gray-4);
     }
 
     .right-actions :global(.sk-primary:focus-visible),

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -157,6 +157,17 @@
       opacity 0.15s ease;
   }
 
+  /*
+   * Explicit secondary outline — Starlight uses border-color: inherit, which
+   * becomes invisible when ClientRouter restacks color inheritance after
+   * visiting pages with aggressive overflow/color chrome (e.g. SDKs splash).
+   */
+  .sk-secondary {
+    border: 1px solid var(--sl-color-gray-5);
+    background-color: transparent;
+    color: var(--sl-color-text);
+  }
+
   .sk-primary:hover {
     background: var(--sl-color-gray-5);
     box-shadow: var(--sk-shadow-button);
@@ -659,6 +670,45 @@ body {
 .sl-markdown-content :is(h1, h2, h3, h4, h5, h6) {
   line-height: var(--sl-line-height-headings);
   font-weight: 600;
+}
+
+/*
+ * Resilient chrome after ClientRouter soft navigations.
+ * Unlayered so these win over page CSS chunks that stick in <head> after
+ * visiting SDKs / fold landings (overflow clipping + lost inherit borders).
+ */
+.header .sl-link-button.sk-secondary,
+.header .sl-link-button.secondary {
+  border: 1px solid var(--sl-color-gray-5);
+  border-color: var(--sl-color-gray-5);
+  color: var(--sl-color-text);
+  background-color: transparent;
+}
+
+/*
+ * Nova code frames: border lives on [data-nova-code-container], not the inner
+ * pre (Nova zeros pre borders on purpose). Reassert the container edge so soft
+ * nav + leftover page CSS cannot wash out the left hairline.
+ */
+.sl-markdown-content [data-nova-code-container] {
+  border: 1px solid var(--sl-color-gray-5);
+  border-radius: 0.5rem;
+  box-sizing: border-box;
+}
+
+/* Standalone shiki blocks (no nova wrapper) keep a full edge + scroll */
+.sl-markdown-content pre.astro-code {
+  border: 1px solid var(--sl-color-gray-5);
+  border-radius: 0.5rem;
+  overflow-x: auto;
+}
+
+/* Nova zeros inner pre borders — keep that (border is on the container) */
+.sl-markdown-content [data-nova-code-container] pre.astro-code,
+.sl-markdown-content [data-nova-code-container] pre.astro-code code {
+  border-width: 0;
+  border-color: transparent;
+  border-radius: 0;
 }
 
 /* =============================================================================

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -3,8 +3,11 @@
 * https://github.com/withastro/starlight/blob/main/packages/starlight/style/props.css
 */
 
-/* Layer declarations */
-@layer nova, starlight, scalekit.tokens, scalekit.layout, scalekit.components, scalekit.overrides;
+/*
+ * Layer order is pinned in theme-priority.css (always-loaded entry).
+ * Nested starlight.* order must stay: base < reset < core < content < components < utils
+ * so content spacing beats reset's * { margin: 0 } after ClientRouter soft-nav.
+ */
 
 /* =============================================================================
    TOKENS LAYER - Design system tokens and theme variables
@@ -674,9 +677,29 @@ body {
 
 /*
  * Resilient chrome after ClientRouter soft navigations.
- * Unlayered so these win over page CSS chunks that stick in <head> after
- * visiting SDKs / fold landings (overflow clipping + lost inherit borders).
+ * Unlayered so these win even if nested starlight.* layer order is corrupted
+ * (see layer pin at top of this file) or page CSS chunks stick in <head>.
+ * Unlayered overrides layered starlight/nova per Nova cascade docs:
+ * https://starlight-theme-nova.pages.dev/guide/css-and-styling/
  */
+
+/* Restore vertical rhythm when starlight.content loses to starlight.reset */
+.sl-markdown-content :not(h1, h2, h3, h4, h5, h6, .sl-heading-wrapper) + .sl-heading-wrapper {
+  margin-top: 1.5em;
+}
+
+.sl-markdown-content
+  :not(a, strong, em, del, span, input, code, br)
+  + :not(a, strong, em, del, span, input, code, br, :where(.not-content *)) {
+  margin-top: var(--sl-content-gap-y, 1rem);
+}
+
+.sl-markdown-content
+  :not(h1, h2, h3, h4, h5, h6)
+  + :is(h1, h2, h3, h4, h5, h6):not(:where(.not-content *)) {
+  margin-top: 1.5em;
+}
+
 .header .sl-link-button.sk-secondary,
 .header .sl-link-button.secondary {
   border: 1px solid var(--sl-color-gray-5);

--- a/src/styles/folds.css
+++ b/src/styles/folds.css
@@ -14,7 +14,8 @@
   margin: 0;
 }
 
-body > div > div > div > div > main {
+/* Homepage / fold landing only — do not zero main padding site-wide after soft nav */
+body:has(.fold-section) main {
   padding-bottom: 0;
 }
 

--- a/src/styles/pages/sdks.css
+++ b/src/styles/pages/sdks.css
@@ -1,10 +1,18 @@
-/* SDKs Page Styles */
+/* SDKs Page Styles
+ *
+ * ClientRouter keeps stylesheets from visited pages in the document head.
+ * Never target bare `main` / `body` / `.hero` here — those leak site-wide and
+ * clip borders (code frames, header CTAs) and collapse spacing after you leave.
+ * Scope page-only chrome hacks under body:has(.sdk-section-layout).
+ */
 
-right-sidebar-panel {
+/* Page-only: hide right sidebar + hero on SDK splash pages */
+body:has(.sdk-section-layout) .right-sidebar-panel,
+body:has(.sdk-section-layout) right-sidebar-panel {
   display: none !important;
 }
 
-.hero {
+body:has(.sdk-section-layout) .hero {
   display: none !important;
 }
 
@@ -76,11 +84,12 @@ body:has(.sdk-section-layout) .content-panel {
   z-index: 1;
 }
 
-main {
+/* Clip full-bleed fold sections on this page only — not site-wide */
+body:has(.sdk-section-layout) {
   overflow-x: hidden;
 }
 
-body {
+body:has(.sdk-section-layout) main {
   overflow-x: hidden;
 }
 
@@ -397,9 +406,8 @@ body {
   }
 }
 
-/* Hide mobile menu button on this page */
-
-button[aria-label='Menu'].sl-flex.md\:sl-hidden {
+/* Hide mobile menu button on this page only */
+body:has(.sdk-section-layout) button[aria-label='Menu'].sl-flex.md\:sl-hidden {
   display: none !important;
 }
 

--- a/src/styles/pages/sdks.css
+++ b/src/styles/pages/sdks.css
@@ -294,72 +294,16 @@ body:has(.sdk-section-layout) main {
   gap: 0.5rem;
 }
 
-/* Scope to SDK page only — prevents this from leaking to other pages via Astro's shared CSS chunks */
-.sl-markdown-content:has(.sdk-section-layout)
-  :not(
-    a,
-    strong,
-    em,
-    del,
-    span,
-    code,
-    kbd,
-    samp,
-    var,
-    pre,
-    abbr,
-    acronym,
-    b,
-    bdi,
-    bdo,
-    big,
-    cite,
-    dfn,
-    i,
-    mark,
-    q,
-    rp,
-    rt,
-    ruby,
-    s,
-    small,
-    sub,
-    sup,
-    time,
-    tt,
-    u,
-    wbr,
-    img,
-    video,
-    audio,
-    canvas,
-    svg,
-    iframe,
-    embed,
-    object,
-    picture,
-    source,
-    track,
-    map,
-    area,
-    input,
-    button,
-    select,
-    textarea,
-    label,
-    output,
-    progress,
-    meter,
-    details,
-    summary,
-    dialog,
-    script,
-    noscript,
-    template,
-    slot,
-    content *
-  ) {
-  margin-top: 0 !important;
+/*
+ * Do NOT use unlayered `margin-top: 0 !important` on .sl-markdown-content
+ * descendants. That rule is a ClientRouter footgun: even when scoped with
+ * :has(.sdk-section-layout), loading it mid-session contributes to cascade
+ * thrash, and any broader match zeros Starlight content spacing site-wide.
+ * Zero margins only on the SDK layout root itself.
+ */
+body:has(.sdk-section-layout) .sdk-section-layout,
+body:has(.sdk-section-layout) .sdk-section-layout > * {
+  margin-top: 0;
 }
 
 /* Full Stack Auth Layout */

--- a/src/styles/theme-priority.css
+++ b/src/styles/theme-priority.css
@@ -3,8 +3,20 @@
  * and centralizes Tailwind/Starlight base imports to avoid duplication.
  */
 
-/* Use Nova's defaults; ensure Tailwind utilities are available but don't override Nova layout */
-@layer base, nova, starlight, theme, components, utilities, scalekit.tokens, scalekit.layout, scalekit.components, scalekit.overrides;
+/*
+ * Pin cascade layer order in the always-loaded entry stylesheet.
+ * ClientRouter can drop Starlight's layers.css mid-session (splash routes like
+ * SDKs); without this pin, nested starlight.* order can invert so
+ * starlight.reset (* { margin: 0 }) beats starlight.content and the docs look
+ * crammed after soft-nav away from SDKs.
+ * Mirrors: @astrojs/starlight/style/layers.css + starlight-theme-nova/lib/layer.css
+ * Docs: https://starlight-theme-nova.pages.dev/guide/css-and-styling/
+ */
+@layer base, starlight, nova, theme, components, utilities, scalekit.tokens, scalekit.layout,
+  scalekit.components, scalekit.overrides;
+@layer starlight.base, starlight.reset, starlight.core, starlight.content, starlight.components,
+  starlight.utils;
+
 @import '@astrojs/starlight-tailwind';
 @import 'starlight-theme-nova/tailwind.css';
 @import 'tailwindcss/theme.css' layer(theme);


### PR DESCRIPTION
## Summary
- ClientRouter keeps stylesheets from visited pages in the document head. The SDKs splash (`src/styles/pages/sdks.css`) targeted bare `main`/`body`/`.hero`, so after visiting SDKs those rules kept applying site-wide: cramped layout, clipped code-frame left borders, and missing **Talk to an Engineer** outlines.
- Scoped page-only chrome under `body:has(.sdk-section-layout)` (and fold main padding under `body:has(.fold-section)`).
- Hardened secondary header CTAs and Nova `[data-nova-code-container]` borders with explicit unlayered CSS (matches [Starlight Nova cascade guidance](https://starlight-theme-nova.pages.dev/guide/css-and-styling/): unlayered CSS overrides `starlight`/`nova` layers).
- Ignore local `.hallmark/` tool cache so pre-push hooks stay clean.

## Test plan
- [ ] `pnpm start` → open a normal guide; note code borders + Talk to an Engineer outline
- [ ] Secondary nav → **SDKs** → Node SDK reference → navigate to another AgentKit page
- [ ] Confirm layout is not cramped, code-frame left borders stay visible, header secondary CTA keeps its border (no hard refresh)
- [ ] Full reload on a non-SDK page still looks correct

## Preview
https://deploy-preview-886--scalekit-starlight.netlify.app/agentkit/sdks/node/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved visibility, borders, and hover behavior for secondary header toolbar buttons.
  - Restored consistent styling for code “chrome” (borders/radius and scrolling) after soft navigation.
  - Prevented SDK page styling from impacting other site pages.
  - Applied homepage fold-section spacing only when fold content is present.
- **Style**
  - Pinned the CSS cascade layer order for Starlight theme rendering to ensure consistent overrides.
- **Chores**
  - Updated ignore rules to exclude the local `.hallmark/` directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->