### PR TITLE
docs(webhooks): add organization domain verification events (SK-958)

### DIFF
--- a/openapi/scalekit.yaml
+++ b/openapi/scalekit.yaml
@@ -10719,6 +10719,10 @@ components:
             - organization.created
             - organization.updated
             - organization.deleted
+            - organization.domain_created
+            - organization.domain_deleted
+            - organization.domain_dns_verification_success
+            - organization.domain_dns_verification_failed
             - organization.sso_created
             - organization.sso_deleted
             - organization.sso_enabled
@@ -11048,6 +11052,134 @@ webhooks:
                     - enabled: false
                       name: dir_sync
               display_name: Organization Deleted
+      responses:
+        '200':
+          description: Webhook received successfully
+  organization.domain_created:
+    post:
+      summary: Organization Domain Created
+      description: Triggered when a domain is added to an organization (organization domain or allowed email domain).
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScalekitEvent'
+            example:
+              spec_version: '1'
+              id: evt_4567890123
+              type: organization.domain_created
+              object: Organization
+              occurred_at: 2024-01-15T11:00:00.123456789Z
+              environment_id: env_1234567890
+              organization_id: org_1234567890
+              data:
+                id: dom_1234567890
+                domain: acmecorp.com
+                domain_type: ORGANIZATION_DOMAIN
+                organization_id: org_1234567890
+                environment_id: env_1234567890
+                txt_record_key: scalekit-domain-verification
+                txt_record_secret: sk_dom_verify_abc123
+                verification_status: PENDING
+                verification_method: DNS
+                updated_at: 2024-01-15T11:00:00.123456789Z
+              display_name: Organization Domain Created
+      responses:
+        '200':
+          description: Webhook received successfully
+  organization.domain_deleted:
+    post:
+      summary: Organization Domain Deleted
+      description: Triggered when a domain is removed from an organization.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScalekitEvent'
+            example:
+              spec_version: '1'
+              id: evt_4567890456
+              type: organization.domain_deleted
+              object: Organization
+              occurred_at: 2024-01-16T09:30:00.123456789Z
+              environment_id: env_1234567890
+              organization_id: org_1234567890
+              data:
+                id: dom_1234567890
+                domain: acmecorp.com
+                domain_type: ORGANIZATION_DOMAIN
+                organization_id: org_1234567890
+                environment_id: env_1234567890
+                txt_record_key: scalekit-domain-verification
+                txt_record_secret: sk_dom_verify_abc123
+                verification_status: VERIFIED
+                verification_method: DNS
+                updated_at: 2024-01-16T09:30:00.123456789Z
+              display_name: Organization Domain Deleted
+      responses:
+        '200':
+          description: Webhook received successfully
+  organization.domain_dns_verification_success:
+    post:
+      summary: Organization Domain DNS Verification Success
+      description: Triggered when DNS TXT record validation confirms ownership of an organization domain.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScalekitEvent'
+            example:
+              spec_version: '1'
+              id: evt_4567890789
+              type: organization.domain_dns_verification_success
+              object: Organization
+              occurred_at: 2024-01-15T12:15:00.123456789Z
+              environment_id: env_1234567890
+              organization_id: org_1234567890
+              data:
+                id: dom_1234567890
+                domain: acmecorp.com
+                domain_type: ORGANIZATION_DOMAIN
+                organization_id: org_1234567890
+                environment_id: env_1234567890
+                txt_record_key: scalekit-domain-verification
+                txt_record_secret: sk_dom_verify_abc123
+                verification_status: VERIFIED
+                verification_method: DNS
+                updated_at: 2024-01-15T12:15:00.123456789Z
+              display_name: Organization Domain DNS Verification Success
+      responses:
+        '200':
+          description: Webhook received successfully
+  organization.domain_dns_verification_failed:
+    post:
+      summary: Organization Domain DNS Verification Failed
+      description: Triggered when the DNS verification window expires without a successful TXT record match.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScalekitEvent'
+            example:
+              spec_version: '1'
+              id: evt_4567891012
+              type: organization.domain_dns_verification_failed
+              object: Organization
+              occurred_at: 2024-01-16T11:00:00.123456789Z
+              environment_id: env_1234567890
+              organization_id: org_1234567890
+              data:
+                id: dom_1234567890
+                domain: acmecorp.com
+                domain_type: ORGANIZATION_DOMAIN
+                organization_id: org_1234567890
+                environment_id: env_1234567890
+                txt_record_key: scalekit-domain-verification
+                txt_record_secret: sk_dom_verify_abc123
+                verification_status: FAILED
+                verification_method: DNS
+                updated_at: 2024-01-16T11:00:00.123456789Z
+              display_name: Organization Domain DNS Verification Failed
       responses:
         '200':
           description: Webhook received successfully

--- a/public/api/agentkit.scalar.json
+++ b/public/api/agentkit.scalar.json
@@ -57,7 +57,9 @@
     "/api/v1/connected_accounts": {
       "get": {
         "description": "Retrieves a paginated list of connected accounts for third-party integrations. Filter by organization, user, connector type, provider, or identifier. Returns OAuth tokens, API keys, and connection status for each account. Use pagination tokens to navigate through large result sets.",
-        "tags": ["Connected Accounts"],
+        "tags": [
+          "Connected Accounts"
+        ],
         "summary": "List connected accounts",
         "operationId": "ConnectedAccountService_ListConnectedAccounts",
         "parameters": [
@@ -172,18 +174,30 @@
           {
             "label": "Node.js SDK",
             "lang": "javascript",
-            "source": "// Coming soon — accurate SDK snippets for List connected accounts will be added via scalekit-code-doctor (SK-399)"
+            "source": "const response = await scalekit.connectedAccounts.listConnectedAccounts({\n  organizationId: 'org_123',\n  pageSize: 20,\n})\nconst connectedAccounts = response.connectedAccounts"
           },
           {
             "label": "Python SDK",
             "lang": "python",
-            "source": "# Coming soon — accurate SDK snippets for List connected accounts will be added via scalekit-code-doctor (SK-399)"
+            "source": "response = scalekit_client.connected_accounts.list_connected_accounts(\n    organization_id=\"org_123\",\n    page_size=20,\n)\n# with_call returns (response, call)\nconnected_accounts = response[0].connected_accounts"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "// Connected Accounts are not available in the Go SDK public API yet.\n// Use the REST API (GET /api/v1/connected_accounts) or the Node.js/Python SDKs."
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "// Connected Accounts are not part of the Java SDK public API yet.\n// Use the REST API (GET /api/v1/connected_accounts) or the Node.js/Python SDKs."
           }
         ]
       },
       "put": {
         "description": "Updates authentication credentials and configuration for an existing connected account. Modify OAuth tokens, refresh tokens, access scopes, or API configuration settings. Specify the account by ID, or by combination of organization/user, connector, and identifier. Returns the updated account with new token expiry and status information.",
-        "tags": ["Connected Accounts"],
+        "tags": [
+          "Connected Accounts"
+        ],
         "summary": "Update connected account credentials",
         "operationId": "ConnectedAccountService_UpdateConnectedAccount",
         "responses": {
@@ -235,7 +249,9 @@
       },
       "post": {
         "description": "Creates a new connected account with OAuth tokens or API credentials for third-party service integration. Supply authorization details including access tokens, refresh tokens, scopes, and optional API configuration. The account can be scoped to an organization or user. Returns the created account with its unique identifier and authentication status.",
-        "tags": ["Connected Accounts"],
+        "tags": [
+          "Connected Accounts"
+        ],
         "summary": "Create a connected account",
         "operationId": "ConnectedAccountService_CreateConnectedAccount",
         "responses": {
@@ -289,7 +305,9 @@
     "/api/v1/connected_accounts/auth": {
       "get": {
         "description": "Retrieves complete authentication details for a connected account including OAuth tokens, refresh tokens, scopes, and API configuration. Query by account ID or by combination of organization/user, connector, and identifier. Returns sensitive credential information - use appropriate access controls.",
-        "tags": ["Connected Accounts"],
+        "tags": [
+          "Connected Accounts"
+        ],
         "summary": "Get connected account auth credentials",
         "operationId": "ConnectedAccountService_GetConnectedAccountAuth",
         "parameters": [
@@ -375,7 +393,9 @@
     "/api/v1/connected_accounts/details": {
       "get": {
         "description": "Returns metadata for a connected account including status, connector type, provider, and configuration without exposing stored authorization credentials. Look up by account ID, or by a combination of organization (or user), connector, and external identifier.",
-        "tags": ["Connected Accounts"],
+        "tags": [
+          "Connected Accounts"
+        ],
         "summary": "Get connected account metadata",
         "operationId": "ConnectedAccountService_GetConnectedAccountDetails",
         "parameters": [
@@ -461,7 +481,9 @@
     "/api/v1/connected_accounts/magic_link": {
       "post": {
         "description": "Creates a time-limited magic link for connecting or re-authorizing a third-party account. The link directs users to the OAuth authorization flow for the specified connector. Returns the generated link URL and expiration timestamp. Links typically expire after a short duration for security.",
-        "tags": ["Connected Accounts"],
+        "tags": [
+          "Connected Accounts"
+        ],
         "summary": "Generate authentication magic link",
         "operationId": "ConnectedAccountService_GetMagicLinkForConnectedAccount",
         "responses": {
@@ -507,7 +529,9 @@
     "/api/v1/connected_accounts/user/verify": {
       "post": {
         "description": "Confirms the user assertion and activates the connected account after the user completes third-party OAuth. Called by the B2B app server with auth_request_id and identifier. Validates that the asserted identifier matches the one stored on the auth request and promotes pending tokens to live.",
-        "tags": ["Connected Accounts"],
+        "tags": [
+          "Connected Accounts"
+        ],
         "summary": "Verify connected account user",
         "operationId": "ConnectedAccountService_VerifyConnectedAccountUser",
         "responses": {
@@ -569,7 +593,9 @@
     "/api/v1/connected_accounts:delete": {
       "post": {
         "description": "Permanently removes a connected account and revokes all associated authentication credentials. Identify the account by ID, or by combination of organization/user, connector, and identifier. This action cannot be undone. All OAuth tokens and API keys for this account will be invalidated.",
-        "tags": ["Connected Accounts"],
+        "tags": [
+          "Connected Accounts"
+        ],
         "summary": "Delete a connected account",
         "operationId": "ConnectedAccountService_DeleteConnectedAccount",
         "responses": {
@@ -621,7 +647,9 @@
     "/api/v1/connected_accounts:search": {
       "get": {
         "description": "Search for connected accounts in your environment using a text query that matches against identifiers, providers, or connectors. The search performs case-insensitive matching across account details. Returns paginated results with account status and authentication type information.",
-        "tags": ["Connected Accounts"],
+        "tags": [
+          "Connected Accounts"
+        ],
         "summary": "Search connected accounts",
         "operationId": "ConnectedAccountService_SearchConnectedAccounts",
         "parameters": [
@@ -692,7 +720,9 @@
     "/api/v1/custom-providers": {
       "post": {
         "description": "Creates an environment-scoped custom provider (connector) with authentication patterns and optional proxy configuration. The returned identifier must be used for all subsequent update and delete operations on this provider.",
-        "tags": ["Connectors"],
+        "tags": [
+          "Connectors"
+        ],
         "summary": "Create a custom provider",
         "operationId": "ProviderService_CreateCustomProvider",
         "responses": {
@@ -731,7 +761,9 @@
     "/api/v1/custom-providers/{identifier}": {
       "put": {
         "description": "Updates an existing environment-scoped custom provider (connector) by its identifier. Only the fields provided in the request are modified.",
-        "tags": ["Connectors"],
+        "tags": [
+          "Connectors"
+        ],
         "summary": "Update a custom provider",
         "operationId": "ProviderService_UpdateCustomProvider",
         "parameters": [
@@ -787,7 +819,9 @@
       },
       "delete": {
         "description": "Deletes an environment-scoped custom provider (connector) by its identifier. This operation is permanent and removes the provider definition from the environment.",
-        "tags": ["Connectors"],
+        "tags": [
+          "Connectors"
+        ],
         "summary": "Delete a custom provider",
         "operationId": "ProviderService_DeleteCustomProvider",
         "parameters": [
@@ -825,7 +859,9 @@
     "/api/v1/execute_tool": {
       "post": {
         "description": "Executes a tool action using authentication credentials from a connected account. Specify the tool by name and provide required parameters as JSON. The connected account can be identified by ID, or by combination of organization/user, connector, and identifier. Returns the execution result data and a unique execution ID for tracking. Use this endpoint to perform actions like sending emails, creating calendar events, or managing resources in external services.",
-        "tags": ["Tool Calling"],
+        "tags": [
+          "Tool Calling"
+        ],
         "summary": "Execute a tool using a connected account",
         "operationId": "ToolService_ExecuteTool",
         "responses": {
@@ -886,12 +922,22 @@
           {
             "label": "Node.js SDK",
             "lang": "javascript",
-            "source": "// Coming soon — accurate SDK snippets for Execute tool (Tool Calling) will be added via scalekit-code-doctor (SK-399)"
+            "source": "const response = await scalekit.tools.executeTool({\n  toolName: 'gmail_send_email',\n  identifier: 'user@example.com',\n  params: {\n    to: 'team@example.com',\n    subject: 'Hello from Scalekit',\n    body: 'Tool execution succeeded.',\n  },\n})"
           },
           {
             "label": "Python SDK",
             "lang": "python",
-            "source": "# Coming soon — accurate SDK snippets for Execute tool (Tool Calling) will be added via scalekit-code-doctor (SK-399)"
+            "source": "response = scalekit_client.tools.execute_tool(\n    tool_name=\"gmail_send_email\",\n    identifier=\"user@example.com\",\n    params={\n        \"to\": \"team@example.com\",\n        \"subject\": \"Hello from Scalekit\",\n        \"body\": \"Tool execution succeeded.\",\n    },\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "// Tool calling (execute_tool) is not available in the Go SDK public API yet.\n// Use the REST API (POST /api/v1/execute_tool) or the Node.js/Python SDKs."
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "// Tool calling (execute_tool) is not part of the Java SDK public API yet.\n// Use the REST API (POST /api/v1/execute_tool) or the Node.js/Python SDKs."
           }
         ]
       }
@@ -899,7 +945,9 @@
     "/api/v1/mcp/configs": {
       "get": {
         "description": "Lists MCP configurations for the current environment with optional filters for id, name prefix, and provider.",
-        "tags": ["MCP Configurations"],
+        "tags": [
+          "MCP Configurations"
+        ],
         "summary": "List MCP configurations",
         "operationId": "McpService_ListMcpConfigs",
         "parameters": [
@@ -992,7 +1040,9 @@
       },
       "post": {
         "description": "Creates a new MCP configuration with a set of connections and tools.",
-        "tags": ["MCP Configurations"],
+        "tags": [
+          "MCP Configurations"
+        ],
         "summary": "Create a new MCP configuration",
         "operationId": "McpService_CreateMcpConfig",
         "responses": {
@@ -1039,7 +1089,9 @@
     "/api/v1/mcp/configs/{config_id}": {
       "get": {
         "description": "Returns a single MCP configuration for the current environment by ID.",
-        "tags": ["MCP Configurations"],
+        "tags": [
+          "MCP Configurations"
+        ],
         "summary": "Fetch an MCP configuration",
         "operationId": "McpService_GetMcpConfig",
         "parameters": [
@@ -1092,7 +1144,9 @@
       },
       "put": {
         "description": "Updates the description and connection-to-tool mappings for an existing MCP configuration. The configuration name cannot be changed after creation.",
-        "tags": ["MCP Configurations"],
+        "tags": [
+          "MCP Configurations"
+        ],
         "summary": "Update an existing MCP configuration",
         "operationId": "McpService_UpdateMcpConfig",
         "parameters": [
@@ -1155,7 +1209,9 @@
       },
       "delete": {
         "description": "Deletes the MCP configuration and any associated mappings and instances in the current environment.",
-        "tags": ["MCP Configurations"],
+        "tags": [
+          "MCP Configurations"
+        ],
         "summary": "Delete an MCP configuration",
         "operationId": "McpService_DeleteMcpConfig",
         "parameters": [
@@ -1208,7 +1264,9 @@
     "/api/v1/mcp/configs/{config_id}/connected_accounts": {
       "post": {
         "description": "Returns the connected account state for each connection in the MCP configuration for the given user identifier. When include_auth_link is true, creates connected accounts on the fly if they do not exist and returns a fresh authentication link per connection. When include_auth_link is false or omitted, returns the current status of existing connected accounts only — no accounts are created and authentication_link is always empty. Authentication links are only present when the connection has an associated key; if the connection has no key, authentication_link is empty regardless of include_auth_link.",
-        "tags": ["MCP Configurations"],
+        "tags": [
+          "MCP Configurations"
+        ],
         "summary": "List connected accounts for an MCP configuration",
         "operationId": "McpService_ListMcpConnectedAccounts",
         "parameters": [
@@ -1265,7 +1323,9 @@
     "/api/v1/mcp/configs/{mcp_config_id}/tokens": {
       "post": {
         "description": "Mints a short-lived JWT that represents a user identifier across the connected accounts associated with an MCP configuration. The supplied identifier becomes the token's `sub` claim; the token's `aud` claim is the MCP server URL bound to the configuration. Claims also carry the MCP configuration ID (`mcp_cfg`) and the list of resolved connected-account IDs (`ca_ids`). Use this operation to issue a single credential an MCP server can present on the user's behalf when calling provider tools. The mint fails if any connection mapped to the configuration has no active connected account for the identifier.",
-        "tags": ["MCP Configurations"],
+        "tags": [
+          "MCP Configurations"
+        ],
         "summary": "Create an MCP session token",
         "operationId": "McpService_CreateMcpSessionToken",
         "parameters": [
@@ -1661,30 +1721,40 @@
     "schemas": {
       "McpServiceCreateMcpSessionTokenBody": {
         "type": "object",
-        "required": ["identifier"],
+        "required": [
+          "identifier"
+        ],
         "properties": {
           "expiry": {
             "description": "Optional token lifetime. Must be between 60s and 24h. Defaults to 1h when omitted.",
             "type": "string",
-            "examples": ["3600s"]
+            "examples": [
+              "3600s"
+            ]
           },
           "identifier": {
             "description": "Upstream-provider identifier (typically the user's email or provider user-id) shared by the connected accounts the token represents. A single identifier can map to one connected account per connection in the MCP configuration.",
             "type": "string",
             "maxLength": 255,
             "minLength": 1,
-            "examples": ["alice@acme.com"]
+            "examples": [
+              "alice@acme.com"
+            ]
           }
         }
       },
       "McpServiceListMcpConnectedAccountsBody": {
         "type": "object",
-        "required": ["identifier"],
+        "required": [
+          "identifier"
+        ],
         "properties": {
           "identifier": {
             "description": "Identifier for the end user whose connected accounts to retrieve",
             "type": "string",
-            "examples": ["john.doe@example.com"]
+            "examples": [
+              "john.doe@example.com"
+            ]
           },
           "include_auth_link": {
             "description": "When true, generates a fresh authentication link for each connection and creates connected accounts if they do not exist. When false or omitted, returns existing connected account status without creating accounts or generating links.",
@@ -1706,7 +1776,9 @@
           "description": {
             "description": "Updated description for the MCP configuration",
             "type": "string",
-            "examples": ["Updated daily summarizer config"]
+            "examples": [
+              "Updated daily summarizer config"
+            ]
           }
         }
       },
@@ -1757,33 +1829,45 @@
           "connection_id": {
             "description": "Reference to the parent connection configuration. Links this account to a specific connector setup in your environment.",
             "type": "string",
-            "examples": ["conn_24834495392086178"]
+            "examples": [
+              "conn_24834495392086178"
+            ]
           },
           "connector": {
             "description": "Connector identifier (e.g., 'notion', 'slack', 'salesforce'). Indicates which third-party application this account connects to.",
             "type": "string",
-            "examples": ["notion"]
+            "examples": [
+              "notion"
+            ]
           },
           "id": {
             "description": "Unique Scalekit-generated identifier for this connected account. Always prefixed with 'ca_'.",
             "type": "string",
-            "examples": ["ca_24834495392086178"]
+            "examples": [
+              "ca_24834495392086178"
+            ]
           },
           "identifier": {
             "description": "The unique identifier for this account in the third-party service. Typically an email address, user ID, or workspace identifier.",
             "type": "string",
-            "examples": ["user@example.com"]
+            "examples": [
+              "user@example.com"
+            ]
           },
           "last_used_at": {
             "description": "Timestamp when this connected account was last used to make an API call. Useful for tracking active connections.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-03-20T14:30:00Z"]
+            "examples": [
+              "2024-03-20T14:30:00Z"
+            ]
           },
           "provider": {
             "description": "OAuth provider name (e.g., 'google', 'microsoft', 'github'). Identifies which authentication service manages this connection.",
             "type": "string",
-            "examples": ["google"]
+            "examples": [
+              "google"
+            ]
           },
           "status": {
             "description": "Current status of the connected account. Indicates if the account is active, expired, pending authorization, or pending user identity verification.",
@@ -1793,13 +1877,17 @@
             "description": "Expiration timestamp for the access token. After this time, the token must be refreshed or re-authorized.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-12-31T23:59:59Z"]
+            "examples": [
+              "2024-12-31T23:59:59Z"
+            ]
           },
           "updated_at": {
             "description": "Timestamp when this connected account was last modified. Updated whenever credentials or configuration changes.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-03-20T15:04:05Z"]
+            "examples": [
+              "2024-03-20T15:04:05Z"
+            ]
           }
         }
       },
@@ -1814,33 +1902,45 @@
           "connection_id": {
             "description": "Parent connection configuration reference.",
             "type": "string",
-            "examples": ["conn_24834495392086178"]
+            "examples": [
+              "conn_24834495392086178"
+            ]
           },
           "connector": {
             "description": "Connector identifier.",
             "type": "string",
-            "examples": ["notion"]
+            "examples": [
+              "notion"
+            ]
           },
           "id": {
             "description": "Unique connected account identifier.",
             "type": "string",
-            "examples": ["ca_24834495392086178"]
+            "examples": [
+              "ca_24834495392086178"
+            ]
           },
           "identifier": {
             "description": "The unique identifier for this account in the third-party service.",
             "type": "string",
-            "examples": ["user@example.com"]
+            "examples": [
+              "user@example.com"
+            ]
           },
           "last_used_at": {
             "description": "Last usage timestamp.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-03-20T14:30:00Z"]
+            "examples": [
+              "2024-03-20T14:30:00Z"
+            ]
           },
           "provider": {
             "description": "OAuth provider name (e.g., 'google', 'microsoft').",
             "type": "string",
-            "examples": ["google"]
+            "examples": [
+              "google"
+            ]
           },
           "status": {
             "description": "Current connection status.",
@@ -1850,13 +1950,17 @@
             "description": "Token expiration timestamp.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-12-31T23:59:59Z"]
+            "examples": [
+              "2024-12-31T23:59:59Z"
+            ]
           },
           "updated_at": {
             "description": "Last modification timestamp.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-03-20T15:04:05Z"]
+            "examples": [
+              "2024-03-20T15:04:05Z"
+            ]
           }
         }
       },
@@ -1864,7 +1968,13 @@
         "description": "- ACTIVE: Account is connected and credentials are valid\n - EXPIRED: Access token has expired and needs refresh\n - PENDING_AUTH: Account awaiting user authorization (re-auth initiated)\n - PENDING_VERIFICATION: OAuth complete; awaiting user identity verification\nbefore activation\n - DISCONNECTED: Account has been manually disconnected",
         "type": "string",
         "title": "Status of a connected account indicating its current state",
-        "enum": ["ACTIVE", "EXPIRED", "PENDING_AUTH", "PENDING_VERIFICATION", "DISCONNECTED"]
+        "enum": [
+          "ACTIVE",
+          "EXPIRED",
+          "PENDING_AUTH",
+          "PENDING_VERIFICATION",
+          "DISCONNECTED"
+        ]
       },
       "connected_accountsConnectorType": {
         "description": "- OAUTH: OAuth 2.0 authorization with access and refresh tokens\n - API_KEY: Static API key authentication\n - BASIC_AUTH: HTTP Basic Authentication (username/password)\n - BEARER_TOKEN: Bearer token authentication\n - CUSTOM: Custom authentication mechanism\n - BASIC: Basic authentication (alias)\n - OAUTH_M2M: OAuth 2.0 client credentials (machine-to-machine)\n - TRELLO_OAUTH1: Trello token-based OAuth1-style browser authorization\n - GOOGLE_DWD: Google Domain-Wide Delegation\n - TRUSTED_IDP: Trusted Identity Provider federation (e.g. AWS STS AssumeRoleWithWebIdentity)\n - SMART_FHIR: SMART on FHIR (SMART App Launch) — OAuth 2.0 authorization\nfor FHIR servers",
@@ -1896,7 +2006,10 @@
                   "oauth_token": {
                     "access_token": "...",
                     "refresh_token": "...",
-                    "scopes": ["read", "write"]
+                    "scopes": [
+                      "read",
+                      "write"
+                    ]
                   }
                 },
                 "authorization_type": "OAUTH2"
@@ -1906,22 +2019,30 @@
           "connector": {
             "description": "Connector identifier (e.g., 'notion', 'slack', 'google'). Alphanumeric characters, spaces, hyphens, underscores, and colons are allowed.",
             "type": "string",
-            "examples": ["notion"]
+            "examples": [
+              "notion"
+            ]
           },
           "identifier": {
             "description": "The unique identifier for the connected account within the third-party service (e.g., email address, user ID, workspace identifier).",
             "type": "string",
-            "examples": ["user@example.com"]
+            "examples": [
+              "user@example.com"
+            ]
           },
           "organization_id": {
             "description": "Organization ID for the connector",
             "type": "string",
-            "examples": ["org_121312434123312"]
+            "examples": [
+              "org_121312434123312"
+            ]
           },
           "user_id": {
             "description": "User ID for the connector",
             "type": "string",
-            "examples": ["user_121312434123312"]
+            "examples": [
+              "user_121312434123312"
+            ]
           }
         }
       },
@@ -1940,27 +2061,37 @@
           "connector": {
             "description": "Connector identifier (e.g., 'notion', 'slack', 'google'). Alphanumeric characters, spaces, hyphens, underscores, and colons are allowed.",
             "type": "string",
-            "examples": ["notion"]
+            "examples": [
+              "notion"
+            ]
           },
           "id": {
             "description": "Unique identifier for the connected account to delete",
             "type": "string",
-            "examples": ["ca_123"]
+            "examples": [
+              "ca_123"
+            ]
           },
           "identifier": {
             "description": "The unique identifier for the connected account within the third-party service (e.g., email address, user ID, workspace identifier).",
             "type": "string",
-            "examples": ["user@example.com"]
+            "examples": [
+              "user@example.com"
+            ]
           },
           "organization_id": {
             "description": "Organization ID for the connector",
             "type": "string",
-            "examples": ["org_121312434123312"]
+            "examples": [
+              "org_121312434123312"
+            ]
           },
           "user_id": {
             "description": "User ID for the connector",
             "type": "string",
-            "examples": ["user_121312434123312"]
+            "examples": [
+              "user_121312434123312"
+            ]
           }
         }
       },
@@ -1979,37 +2110,51 @@
           "connector": {
             "description": "Connector identifier (e.g., 'notion', 'slack', 'google'). Alphanumeric characters, spaces, hyphens, underscores, and colons are allowed.",
             "type": "string",
-            "examples": ["notion"]
+            "examples": [
+              "notion"
+            ]
           },
           "id": {
             "description": "Unique identifier for the connected account",
             "type": "string",
-            "examples": ["ca_123"]
+            "examples": [
+              "ca_123"
+            ]
           },
           "identifier": {
             "description": "The unique identifier for the connected account within the third-party service (e.g., email address, user ID, workspace identifier).",
             "type": "string",
-            "examples": ["user@example.com"]
+            "examples": [
+              "user@example.com"
+            ]
           },
           "organization_id": {
             "description": "Organization ID for the connector",
             "type": "string",
-            "examples": ["org_121312434123312"]
+            "examples": [
+              "org_121312434123312"
+            ]
           },
           "state": {
             "description": "Optional opaque state value. State added to the user verify redirect URL query params to validate the user verification",
             "type": "string",
-            "examples": ["QVNDSUFyY2hhYml0dGVyXzE2ODQ5NzIwNzI0NTY="]
+            "examples": [
+              "QVNDSUFyY2hhYml0dGVyXzE2ODQ5NzIwNzI0NTY="
+            ]
           },
           "user_id": {
             "description": "User ID for the connector",
             "type": "string",
-            "examples": ["user_121312434123312"]
+            "examples": [
+              "user_121312434123312"
+            ]
           },
           "user_verify_url": {
             "description": "B2B app's user verify redirect URL",
             "type": "string",
-            "examples": ["https://app.yourapp.com/user/verify/callback"]
+            "examples": [
+              "https://app.yourapp.com/user/verify/callback"
+            ]
           }
         }
       },
@@ -2020,12 +2165,16 @@
             "description": "Expiry timestamp for the authentication link",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-03-20T15:04:05Z"]
+            "examples": [
+              "2024-03-20T15:04:05Z"
+            ]
           },
           "link": {
             "description": "Authentication link for the connector",
             "type": "string",
-            "examples": ["https://notion.com/oauth/authorize?client_id=..."]
+            "examples": [
+              "https://notion.com/oauth/authorize?client_id=..."
+            ]
           }
         }
       },
@@ -2037,7 +2186,9 @@
             "description": "OAuth access token acquired via the jwt-bearer grant. Present in responses only.",
             "type": "string",
             "readOnly": true,
-            "examples": ["ya29.a0AfH6SMBx..."]
+            "examples": [
+              "ya29.a0AfH6SMBx..."
+            ]
           },
           "scopes": {
             "description": "OAuth scopes granted to this token. Present in responses only.",
@@ -2046,12 +2197,19 @@
               "type": "string"
             },
             "readOnly": true,
-            "examples": [["openid", "https://www.googleapis.com/auth/userinfo.email"]]
+            "examples": [
+              [
+                "openid",
+                "https://www.googleapis.com/auth/userinfo.email"
+              ]
+            ]
           },
           "subject": {
             "description": "Email address of the Google Workspace user to impersonate via Domain-Wide Delegation.",
             "type": "string",
-            "examples": ["user@example.com"]
+            "examples": [
+              "user@example.com"
+            ]
           },
           "token_expires_at": {
             "description": "When the access token expires. Present in responses only.",
@@ -2075,18 +2233,24 @@
           "next_page_token": {
             "description": "Pagination token for retrieving the next page. Empty if this is the last page. Pass this value to page_token in the next request.",
             "type": "string",
-            "examples": ["eyJvZmZzZXQiOjIwfQ=="]
+            "examples": [
+              "eyJvZmZzZXQiOjIwfQ=="
+            ]
           },
           "prev_page_token": {
             "description": "Pagination token for retrieving the previous page. Empty if this is the first page. Pass this value to page_token to go back.",
             "type": "string",
-            "examples": ["eyJvZmZzZXQiOjB9"]
+            "examples": [
+              "eyJvZmZzZXQiOjB9"
+            ]
           },
           "total_size": {
             "description": "Total count of connected accounts matching the filter criteria across all pages. Use for calculating pagination.",
             "type": "integer",
             "format": "int64",
-            "examples": [100]
+            "examples": [
+              100
+            ]
           }
         }
       },
@@ -2097,17 +2261,23 @@
           "access_token": {
             "description": "OAuth access token for API requests. Typically short-lived and must be refreshed after expiration.",
             "type": "string",
-            "examples": ["ya29.a0AfH6SMBx..."]
+            "examples": [
+              "ya29.a0AfH6SMBx..."
+            ]
           },
           "domain": {
             "description": "Associated domain for workspace or organization-scoped OAuth connections (e.g., Google Workspace domain).",
             "type": "string",
-            "examples": ["example.com"]
+            "examples": [
+              "example.com"
+            ]
           },
           "refresh_token": {
             "description": "OAuth refresh token for obtaining new access tokens. Long-lived and used to maintain persistent authorization.",
             "type": "string",
-            "examples": ["1//0gHJxZ-Lb2..."]
+            "examples": [
+              "1//0gHJxZ-Lb2..."
+            ]
           },
           "scopes": {
             "description": "List of granted OAuth scopes defining the permissions and access levels for this connection.",
@@ -2138,18 +2308,24 @@
           "next_page_token": {
             "description": "Pagination token for the next page. Empty if this is the last page.",
             "type": "string",
-            "examples": ["eyJvZmZzZXQiOjMwfQ=="]
+            "examples": [
+              "eyJvZmZzZXQiOjMwfQ=="
+            ]
           },
           "prev_page_token": {
             "description": "Pagination token for the previous page. Empty if this is the first page.",
             "type": "string",
-            "examples": ["eyJvZmZzZXQiOjB9"]
+            "examples": [
+              "eyJvZmZzZXQiOjB9"
+            ]
           },
           "total_size": {
             "description": "Total count of accounts matching the search query across all pages.",
             "type": "integer",
             "format": "int64",
-            "examples": [100]
+            "examples": [
+              100
+            ]
           }
         }
       },
@@ -2177,12 +2353,16 @@
             "description": "Federated access key ID issued by the trusted identity provider. Present in responses only.",
             "type": "string",
             "readOnly": true,
-            "examples": ["ASIA..."]
+            "examples": [
+              "ASIA..."
+            ]
           },
           "db_user": {
             "description": "Target database user for the federated session (required for provisioned Redshift clusters; ignored for serverless workgroups).",
             "type": "string",
-            "examples": ["analytics_reader"]
+            "examples": [
+              "analytics_reader"
+            ]
           },
           "expiry": {
             "description": "When the federated credentials expire. Present in responses only.",
@@ -2214,7 +2394,10 @@
                   "oauth_token": {
                     "access_token": "...",
                     "refresh_token": "...",
-                    "scopes": ["read", "write"]
+                    "scopes": [
+                      "read",
+                      "write"
+                    ]
                   }
                 },
                 "authorization_type": "OAUTH2"
@@ -2224,27 +2407,37 @@
           "connector": {
             "description": "Connector identifier (e.g., 'notion', 'slack', 'google'). Alphanumeric characters, spaces, hyphens, underscores, and colons are allowed.",
             "type": "string",
-            "examples": ["notion"]
+            "examples": [
+              "notion"
+            ]
           },
           "id": {
             "description": "Unique identifier for the connected account to update",
             "type": "string",
-            "examples": ["ca_123"]
+            "examples": [
+              "ca_123"
+            ]
           },
           "identifier": {
             "description": "The unique identifier for the connected account within the third-party service (e.g., email address, user ID, workspace identifier).",
             "type": "string",
-            "examples": ["user@example.com"]
+            "examples": [
+              "user@example.com"
+            ]
           },
           "organization_id": {
             "description": "Organization ID for the connector",
             "type": "string",
-            "examples": ["org_121312434123312"]
+            "examples": [
+              "org_121312434123312"
+            ]
           },
           "user_id": {
             "description": "User ID for the connector",
             "type": "string",
-            "examples": ["user_121312434123312"]
+            "examples": [
+              "user_121312434123312"
+            ]
           }
         }
       },
@@ -2259,17 +2452,24 @@
       },
       "connected_accountsVerifyConnectedAccountUserRequest": {
         "type": "object",
-        "required": ["auth_request_id", "identifier"],
+        "required": [
+          "auth_request_id",
+          "identifier"
+        ],
         "properties": {
           "auth_request_id": {
             "description": "Auth request ID as base64url-encoded opaque token from the user verify redirect URL query params",
             "type": "string",
-            "examples": ["QVNDSUFyY2hhYml0dGVyXzE2ODQ5NzIwNzI0NTY="]
+            "examples": [
+              "QVNDSUFyY2hhYml0dGVyXzE2ODQ5NzIwNzI0NTY="
+            ]
           },
           "identifier": {
             "description": "Current logged in user's connected account identifier",
             "type": "string",
-            "examples": ["user@example.com"]
+            "examples": [
+              "user@example.com"
+            ]
           }
         }
       },
@@ -2279,7 +2479,9 @@
           "post_user_verify_redirect_url": {
             "description": "URL to redirect the user to after successful verification",
             "type": "string",
-            "examples": ["https://env1.example.com/connect/success"]
+            "examples": [
+              "https://env1.example.com/connect/success"
+            ]
           }
         }
       },
@@ -2373,13 +2575,17 @@
           "description": {
             "description": "Description of the MCP configuration",
             "type": "string",
-            "examples": ["Summarizes daily emails and posts to Slack"]
+            "examples": [
+              "Summarizes daily emails and posts to Slack"
+            ]
           },
           "id": {
             "description": "Unique ID of the MCP config",
             "type": "string",
             "readOnly": true,
-            "examples": ["cfg_85630864460904897"]
+            "examples": [
+              "cfg_85630864460904897"
+            ]
           },
           "mcp_server_url": {
             "description": "URL of the MCP server for this configuration. Empty when the MCP config server URL feature is not enabled for this environment.",
@@ -2394,7 +2600,9 @@
             "type": "string",
             "maxLength": 100,
             "minLength": 1,
-            "examples": ["daily-summarizer"]
+            "examples": [
+              "daily-summarizer"
+            ]
           }
         }
       },
@@ -2524,12 +2732,16 @@
           "is_custom": {
             "description": "Indicates whether the provider is environment-scoped (custom provider)",
             "type": "boolean",
-            "examples": [false]
+            "examples": [
+              false
+            ]
           },
           "is_custom_mcp": {
             "description": "Indicates whether this is an environment-scoped MCP-based custom provider",
             "type": "boolean",
-            "examples": [false]
+            "examples": [
+              false
+            ]
           },
           "metadata": {
             "description": "Custom key-value metadata stored for this provider. Returned for all providers; defaults to {} when no metadata has been set.",
@@ -2566,27 +2778,37 @@
           "agent_run_id": {
             "description": "Optional. Customer-supplied identifier grouping multiple tool calls into a single agent run. Useful for correlating logs across an agentic workflow.",
             "type": "string",
-            "examples": ["run_abc123"]
+            "examples": [
+              "run_abc123"
+            ]
           },
           "connected_account_id": {
             "description": "Optional. The unique ID of the connected account. Use this to directly identify the connected account instead of using identifier + connector combination.",
             "type": "string",
-            "examples": ["ca_123"]
+            "examples": [
+              "ca_123"
+            ]
           },
           "connector": {
             "description": "Optional. The name of the connector/provider (e.g., 'Google Workspace', 'Slack', 'Notion'). Alphanumeric characters, spaces, hyphens, underscores, and colons are allowed. Use this in combination with identifier to identify the connected account.",
             "type": "string",
-            "examples": ["Google Workspace"]
+            "examples": [
+              "Google Workspace"
+            ]
           },
           "identifier": {
             "description": "Optional. The unique identifier for the connected account within the third-party service (e.g., email address, user ID, workspace identifier). Use this in combination with connector to identify the connected account.",
             "type": "string",
-            "examples": ["user@example.com"]
+            "examples": [
+              "user@example.com"
+            ]
           },
           "organization_id": {
             "description": "Optional. The organization ID to scope the connected account lookup. Use this to narrow down the search when the same identifier exists across multiple organizations.",
             "type": "string",
-            "examples": ["org_123"]
+            "examples": [
+              "org_123"
+            ]
           },
           "params": {
             "description": "JSON object containing the parameters required for tool execution. The structure depends on the specific tool being executed.",
@@ -2602,12 +2824,16 @@
           "tool_name": {
             "description": "Name of the tool to execute",
             "type": "string",
-            "examples": ["send_email"]
+            "examples": [
+              "send_email"
+            ]
           },
           "user_id": {
             "description": "Optional. The user ID to scope the connected account lookup. Use this to narrow down the search when the same identifier exists across multiple users.",
             "type": "string",
-            "examples": ["user_123"]
+            "examples": [
+              "user_123"
+            ]
           }
         }
       },
@@ -2628,7 +2854,9 @@
           "execution_id": {
             "description": "Unique identifier for the tool execution",
             "type": "string",
-            "examples": ["123456789"]
+            "examples": [
+              "123456789"
+            ]
           }
         }
       },
@@ -2655,7 +2883,10 @@
                 "oauth_token": {
                   "access_token": "ya29.a0...",
                   "refresh_token": "1//0g...",
-                  "scopes": ["email", "profile"]
+                  "scopes": [
+                    "email",
+                    "profile"
+                  ]
                 }
               }
             ]
@@ -2684,7 +2915,11 @@
                 "oauth_token": {
                   "access_token": "ya29.new_token...",
                   "refresh_token": "1//0g...",
-                  "scopes": ["email", "profile", "calendar"]
+                  "scopes": [
+                    "email",
+                    "profile",
+                    "calendar"
+                  ]
                 }
               }
             ]
@@ -2704,17 +2939,23 @@
           "description": {
             "description": "Description of the connected app provider",
             "type": "string",
-            "examples": ["Connect to Google Workspace for email and calendar integration"]
+            "examples": [
+              "Connect to Google Workspace for email and calendar integration"
+            ]
           },
           "display_name": {
             "description": "Display name for the connected app provider",
             "type": "string",
-            "examples": ["Google Workspace"]
+            "examples": [
+              "Google Workspace"
+            ]
           },
           "icon_src": {
             "description": "URL for the provider icon. Should be an SVG image sized 800x800 pixels for best rendering experience.",
             "type": "string",
-            "examples": ["https://example.com/images/my-connector.svg"]
+            "examples": [
+              "https://example.com/images/my-connector.svg"
+            ]
           },
           "metadata": {
             "description": "Custom key-value metadata for this provider. Keys must be 3-25 characters, values must be 1-256 characters, with a maximum of 20 key-value pairs.",
@@ -2732,12 +2973,16 @@
           "proxy_enabled": {
             "description": "This flag indicates whether proxying is turned on for the connected app provider. When enabled, requests are routed through the provider proxy instead of being sent directly.",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "proxy_url": {
             "description": "Proxy URL for the connected app provider. Must start with https://",
             "type": "string",
-            "examples": ["https://mcp.example.com/mcp"]
+            "examples": [
+              "https://mcp.example.com/mcp"
+            ]
           }
         }
       },
@@ -2754,17 +2999,23 @@
           "description": {
             "description": "Description of the connected app provider",
             "type": "string",
-            "examples": ["Connect to Google Workspace for email and calendar integration"]
+            "examples": [
+              "Connect to Google Workspace for email and calendar integration"
+            ]
           },
           "display_name": {
             "description": "Display name for the connected app provider",
             "type": "string",
-            "examples": ["Google Workspace"]
+            "examples": [
+              "Google Workspace"
+            ]
           },
           "icon_src": {
             "description": "URL for the provider icon. Should be an SVG image sized 800x800 pixels for best rendering experience.",
             "type": "string",
-            "examples": ["https://example.com/images/my-connector.svg"]
+            "examples": [
+              "https://example.com/images/my-connector.svg"
+            ]
           },
           "metadata": {
             "description": "Custom key-value metadata for this provider. Keys must be 3-25 characters, values must be 1-256 characters, with a maximum of 20 key-value pairs.",
@@ -2782,18 +3033,29 @@
           "proxy_enabled": {
             "description": "This flag indicates whether proxying is turned on for the connected app provider. When enabled, requests are routed through the provider proxy instead of being sent directly.",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "proxy_url": {
             "description": "Proxy URL for the connected app provider. Must start with https://",
             "type": "string",
-            "examples": ["https://mcp.example.com/mcp"]
+            "examples": [
+              "https://mcp.example.com/mcp"
+            ]
           }
         }
       },
       "ScalekitEvent": {
         "type": "object",
-        "required": ["spec_version", "id", "type", "occurred_at", "environment_id", "object"],
+        "required": [
+          "spec_version",
+          "id",
+          "type",
+          "occurred_at",
+          "environment_id",
+          "object"
+        ],
         "properties": {
           "spec_version": {
             "type": "string",
@@ -2817,6 +3079,10 @@
               "organization.created",
               "organization.updated",
               "organization.deleted",
+              "organization.domain_created",
+              "organization.domain_deleted",
+              "organization.domain_dns_verification_success",
+              "organization.domain_dns_verification_failed",
               "organization.sso_created",
               "organization.sso_deleted",
               "organization.sso_enabled",
@@ -2931,7 +3197,9 @@
           "type": {
             "type": "string",
             "description": "The event type",
-            "enum": ["connected_account.status_updated"],
+            "enum": [
+              "connected_account.status_updated"
+            ],
             "example": "connected_account.status_updated"
           },
           "occurred_at": {
@@ -2951,7 +3219,9 @@
           "object": {
             "type": "string",
             "description": "The type of object that triggered the webhook",
-            "enum": ["ConnectedAccount"],
+            "enum": [
+              "ConnectedAccount"
+            ],
             "example": "ConnectedAccount"
           },
           "data": {
@@ -3000,17 +3270,43 @@
             "description": "The provider of the connected account"
           },
           "authorization_type": {
-            "$ref": "#/components/schemas/connected_accountsConnectorType",
+            "type": "string",
+            "enum": [
+              "OAUTH",
+              "API_KEY",
+              "BASIC_AUTH",
+              "BEARER_TOKEN",
+              "BASIC",
+              "OAUTH_M2M",
+              "TRELLO_OAUTH1",
+              "GOOGLE_DWD",
+              "TRUSTED_IDP",
+              "SMART_FHIR"
+            ],
             "example": "OAUTH",
             "description": "The authorization type of the connected account"
           },
           "status": {
-            "$ref": "#/components/schemas/connected_accountsConnectorStatus",
+            "type": "string",
+            "enum": [
+              "ACTIVE",
+              "EXPIRED",
+              "PENDING_AUTH",
+              "PENDING_VERIFICATION",
+              "DISCONNECTED"
+            ],
             "example": "EXPIRED",
             "description": "The new status of the connected account"
           },
           "old_status": {
-            "$ref": "#/components/schemas/connected_accountsConnectorStatus",
+            "type": "string",
+            "enum": [
+              "ACTIVE",
+              "EXPIRED",
+              "PENDING_AUTH",
+              "PENDING_VERIFICATION",
+              "DISCONNECTED"
+            ],
             "example": "ACTIVE",
             "description": "The previous status of the connected account"
           }

--- a/public/api/agentkit.scalar.yaml
+++ b/public/api/agentkit.scalar.yaml
@@ -185,10 +185,31 @@ paths:
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
-          source: // Coming soon — accurate SDK snippets for List connected accounts will be added via scalekit-code-doctor (SK-399)
+          source: |-
+            const response = await scalekit.connectedAccounts.listConnectedAccounts({
+              organizationId: 'org_123',
+              pageSize: 20,
+            })
+            const connectedAccounts = response.connectedAccounts
         - label: Python SDK
           lang: python
-          source: '# Coming soon — accurate SDK snippets for List connected accounts will be added via scalekit-code-doctor (SK-399)'
+          source: |-
+            response = scalekit_client.connected_accounts.list_connected_accounts(
+                organization_id="org_123",
+                page_size=20,
+            )
+            # with_call returns (response, call)
+            connected_accounts = response[0].connected_accounts
+        - label: Go SDK
+          lang: go
+          source: |-
+            // Connected Accounts are not available in the Go SDK public API yet.
+            // Use the REST API (GET /api/v1/connected_accounts) or the Node.js/Python SDKs.
+        - label: Java SDK
+          lang: java
+          source: |-
+            // Connected Accounts are not part of the Java SDK public API yet.
+            // Use the REST API (GET /api/v1/connected_accounts) or the Node.js/Python SDKs.
     put:
       description: Updates authentication credentials and configuration for an existing connected account. Modify OAuth tokens, refresh tokens, access scopes, or API configuration settings. Specify the account by ID, or by combination of organization/user, connector, and identifier. Returns the updated account with new token expiry and status information.
       tags:
@@ -648,10 +669,38 @@ paths:
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
-          source: // Coming soon — accurate SDK snippets for Execute tool (Tool Calling) will be added via scalekit-code-doctor (SK-399)
+          source: |-
+            const response = await scalekit.tools.executeTool({
+              toolName: 'gmail_send_email',
+              identifier: 'user@example.com',
+              params: {
+                to: 'team@example.com',
+                subject: 'Hello from Scalekit',
+                body: 'Tool execution succeeded.',
+              },
+            })
         - label: Python SDK
           lang: python
-          source: '# Coming soon — accurate SDK snippets for Execute tool (Tool Calling) will be added via scalekit-code-doctor (SK-399)'
+          source: |-
+            response = scalekit_client.tools.execute_tool(
+                tool_name="gmail_send_email",
+                identifier="user@example.com",
+                params={
+                    "to": "team@example.com",
+                    "subject": "Hello from Scalekit",
+                    "body": "Tool execution succeeded.",
+                },
+            )
+        - label: Go SDK
+          lang: go
+          source: |-
+            // Tool calling (execute_tool) is not available in the Go SDK public API yet.
+            // Use the REST API (POST /api/v1/execute_tool) or the Node.js/Python SDKs.
+        - label: Java SDK
+          lang: java
+          source: |-
+            // Tool calling (execute_tool) is not part of the Java SDK public API yet.
+            // Use the REST API (POST /api/v1/execute_tool) or the Node.js/Python SDKs.
   /api/v1/mcp/configs:
     get:
       description: Lists MCP configurations for the current environment with optional filters for id, name prefix, and provider.
@@ -2158,6 +2207,10 @@ components:
             - organization.created
             - organization.updated
             - organization.deleted
+            - organization.domain_created
+            - organization.domain_deleted
+            - organization.domain_dns_verification_success
+            - organization.domain_dns_verification_failed
             - organization.sso_created
             - organization.sso_deleted
             - organization.sso_enabled
@@ -2315,15 +2368,38 @@ components:
           example: GMAIL
           description: The provider of the connected account
         authorization_type:
-          $ref: '#/components/schemas/connected_accountsConnectorType'
+          type: string
+          enum:
+            - OAUTH
+            - API_KEY
+            - BASIC_AUTH
+            - BEARER_TOKEN
+            - BASIC
+            - OAUTH_M2M
+            - TRELLO_OAUTH1
+            - GOOGLE_DWD
+            - TRUSTED_IDP
+            - SMART_FHIR
           example: OAUTH
           description: The authorization type of the connected account
         status:
-          $ref: '#/components/schemas/connected_accountsConnectorStatus'
+          type: string
+          enum:
+            - ACTIVE
+            - EXPIRED
+            - PENDING_AUTH
+            - PENDING_VERIFICATION
+            - DISCONNECTED
           example: EXPIRED
           description: The new status of the connected account
         old_status:
-          $ref: '#/components/schemas/connected_accountsConnectorStatus'
+          type: string
+          enum:
+            - ACTIVE
+            - EXPIRED
+            - PENDING_AUTH
+            - PENDING_VERIFICATION
+            - DISCONNECTED
           example: ACTIVE
           description: The previous status of the connected account
   securitySchemes:

--- a/public/api/saaskit.scalar.json
+++ b/public/api/saaskit.scalar.json
@@ -88,7 +88,9 @@
     "/api/v1/connections": {
       "get": {
         "description": "Retrieves a list of connections in the environment",
-        "tags": ["Connections"],
+        "tags": [
+          "Connections"
+        ],
         "summary": "List connections",
         "operationId": "ConnectionService_ListConnections",
         "parameters": [
@@ -156,7 +158,9 @@
     "/api/v1/invites/organizations/{organization_id}/users/{id}/resend": {
       "patch": {
         "description": "Resends an invitation email to a user who has a pending or expired invitation in the specified organization. If the invitation has expired, a new invitation will be automatically created and sent. If the invitation is still valid, a reminder email will be sent instead. Use this endpoint when a user hasn't responded to their initial invitation and you need to send them a reminder or when the original invitation has expired. The invitation email includes a secure magic link that allows the user to complete their account setup and join the organization. Each resend operation increments the resent counter.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Resend user invitation email",
         "operationId": "UserService_ResendInvite",
         "parameters": [
@@ -236,7 +240,9 @@
     "/api/v1/memberships/organizations/{organization_id}/users/{id}": {
       "post": {
         "description": "Adds an existing user to an organization and assigns them specific roles and permissions. Use this endpoint when you want to grant an existing user access to a particular organization. You can specify roles, metadata, and other membership details during the invitation process.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Add existing user to organization",
         "operationId": "UserService_CreateMembership",
         "parameters": [
@@ -284,7 +290,9 @@
             "application/json": {
               "schema": {
                 "description": "Membership details to create. Required fields must be provided.",
-                "required": ["membership"],
+                "required": [
+                  "membership"
+                ],
                 "$ref": "#/components/schemas/v1usersCreateMembership"
               }
             }
@@ -295,7 +303,7 @@
           {
             "label": "Node.js SDK",
             "lang": "javascript",
-            "source": "import { ScalekitClient } from '@scalekit-sdk/node'\nconst scalekit = new ScalekitClient(\n  process.env.SCALEKIT_ENV_URL,\n  process.env.SCALEKIT_CLIENT_ID,\n  process.env.SCALEKIT_CLIENT_SECRET,\n)\nawait scalekit.user.createMembership('org_123', 'usr_123', {\n  roles: ['admin'],\n  metadata: {\n    department: 'engineering',\n    location: 'nyc-office',\n  },\n})"
+            "source": "await scalekit.user.createMembership('org_123', 'usr_123', {\n  roles: ['admin'],\n  metadata: {\n    department: 'engineering',\n    location: 'nyc-office',\n  },\n})"
           },
           {
             "label": "Python SDK",
@@ -305,18 +313,20 @@
           {
             "label": "Go SDK",
             "lang": "go",
-            "source": "func main() {\n    scalekitClient := scalekit.NewScalekitClient(\n        os.Getenv(\"SCALEKIT_ENV_URL\"),\n        os.Getenv(\"SCALEKIT_CLIENT_ID\"),\n        os.Getenv(\"SCALEKIT_CLIENT_SECRET\"),\n    )\n    membership := &usersv1.CreateMembership{\n        Roles: []*usersv1.Role{{Name: \"admin\"}},\n        Metadata: map[string]string{\n            \"department\": \"engineering\",\n            \"location\":   \"nyc-office\",\n        },\n    }\n    resp, \n      err := scalekitClient.User().CreateMembership(\n        context.Background(), \"org_123\", \n          \"usr_123\", membership, false)\n    if err != nil {\n        panic(err)\n    }\n}"
+            "source": "membership := &usersv1.CreateMembership{\n  Roles: []*usersv1.Role{{Name: \"admin\"}},\n  Metadata: map[string]string{\n    \"department\": \"engineering\",\n    \"location\":   \"nyc-office\",\n  },\n}\nresp, err := scalekitClient.User().CreateMembership(\n  ctx,\n  \"org_123\",\n  \"usr_123\",\n  membership,\n  false,\n)\nif err != nil {\n  // handle error\n  return\n}\n_ = resp"
           },
           {
             "label": "Java SDK",
             "lang": "java",
-            "source": "import com.scalekit.ScalekitClient;\nimport com.scalekit.api.UserClient;\nimport com.scalekit.grpc.scalekit.v1.users.*;\nScalekitClient scalekitClient = new ScalekitClient(\n    System.getenv(\"SCALEKIT_ENV_URL\"),\n    System.getenv(\"SCALEKIT_CLIENT_ID\"),\n    System.getenv(\"SCALEKIT_CLIENT_SECRET\")\n);\nUserClient users = scalekitClient.users();\nCreateMembershipRequest membershipReq = CreateMemb\n  ershipRequest.newBuilder()\n        .setMembership(\n          CreateMembership.newBuilder()\n                .addRoles(Role.newBuilder(\n                  ).setName(\"admin\").build())\n                .putMetadata(\"department\", \"engineering\")\n                .putMetadata(\"location\", \"nyc-office\")\n                .build())\n        .build();\nCreateMembershipResponse res = users.\n  createMembership(\"org_123\", \"usr_123\", \n    membershipReq);"
+            "source": "CreateMembershipRequest membershipReq = CreateMembershipRequest.newBuilder()\n    .setMembership(\n        CreateMembership.newBuilder()\n            .addRoles(Role.newBuilder().setName(\"admin\").build())\n            .putMetadata(\"department\", \"engineering\")\n            .putMetadata(\"location\", \"nyc-office\")\n            .build())\n    .build();\nCreateMembershipResponse res = scalekitClient.users().createMembership(\n    \"org_123\",\n    \"usr_123\",\n    membershipReq\n);"
           }
         ]
       },
       "delete": {
         "description": "Removes a user from an organization by user ID. This action is irreversible and may also remove related group memberships.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Delete organization membership for user",
         "operationId": "UserService_DeleteMembership",
         "parameters": [
@@ -351,15 +361,32 @@
         },
         "x-codeSamples": [
           {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await scalekit.user.deleteMembership('org_123', 'usr_123')"
+          },
+          {
             "label": "Python SDK",
             "lang": "python",
-            "source": "response = scalekit_client.users.delete_membership(\n  organization_id=org_id,user_id=user_id\n)"
+            "source": "scalekit_client.users.delete_membership(\n    organization_id=\"org_123\",\n    user_id=\"usr_123\",\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "err := scalekitClient.User().DeleteMembership(\n  ctx,\n  \"org_123\",\n  \"usr_123\",\n  false, // cascade: also remove from nested groups when true\n)\nif err != nil {\n  // handle error\n  return\n}"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "scalekitClient.users().deleteMembership(\"org_123\", \"usr_123\");"
           }
         ]
       },
       "patch": {
         "description": "Updates a user's membership details within an organization by user ID. You can update roles and membership metadata.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Update organization membership for user",
         "operationId": "UserService_UpdateMembership",
         "parameters": [
@@ -415,7 +442,9 @@
     "/api/v1/memberships/organizations/{organization_id}/users:external/{external_id}": {
       "post": {
         "description": "Adds an existing user to an organization using your application's external identifier for the user. Use this endpoint when you store users in Scalekit using your own system's identifiers and need to manage their organization memberships without storing Scalekit's internal user ID.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Add existing user to organization by external ID",
         "operationId": "UserService_CreateMembership2",
         "parameters": [
@@ -463,7 +492,9 @@
             "application/json": {
               "schema": {
                 "description": "Membership details to create. Required fields must be provided.",
-                "required": ["membership"],
+                "required": [
+                  "membership"
+                ],
                 "$ref": "#/components/schemas/v1usersCreateMembership"
               }
             }
@@ -473,7 +504,9 @@
       },
       "delete": {
         "description": "Removes a user from an organization using your application's external identifier for the user. Use this endpoint to revoke organization access without needing to store Scalekit's internal user ID.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Delete organization membership by external ID",
         "operationId": "UserService_DeleteMembership2",
         "parameters": [
@@ -509,7 +542,9 @@
       },
       "patch": {
         "description": "Updates a user's membership details within an organization using your application's external identifier for the user. Use this endpoint to update roles and membership metadata without needing to store Scalekit's internal user ID.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Update organization membership by external ID",
         "operationId": "UserService_UpdateMembership2",
         "parameters": [
@@ -565,7 +600,9 @@
     "/api/v1/organizations": {
       "get": {
         "description": "Retrieve a paginated list of organizations within your environment. The response includes a `page_token` that can be used to access subsequent pages of results.",
-        "tags": ["Organizations"],
+        "tags": [
+          "Organizations"
+        ],
         "summary": "List organizations",
         "operationId": "OrganizationService_ListOrganization",
         "parameters": [
@@ -629,7 +666,7 @@
           {
             "label": "Go SDK",
             "lang": "go",
-            "source": "organizations, err := scalekitClient.Organization.ListOrganizations(\n  ctx,\n  &scalekit.ListOrganizationOptions{\n    PageSize: 10,\n  }\n)"
+            "source": "organizations, err := scalekitClient.Organization().ListOrganization(\n  ctx,\n  &scalekit.ListOrganizationOptions{\n    PageSize: 10,\n  },\n)"
           },
           {
             "label": "Java SDK",
@@ -640,7 +677,9 @@
       },
       "post": {
         "description": "Creates a new organization in your environment. Use this endpoint to add a new tenant that can be configured with various settings and metadata",
-        "tags": ["Organizations"],
+        "tags": [
+          "Organizations"
+        ],
         "summary": "Create an organization",
         "operationId": "OrganizationService_CreateOrganization",
         "responses": {
@@ -686,7 +725,7 @@
           {
             "label": "Go SDK",
             "lang": "go",
-            "source": "organization, err := ScalekitClient.Organization.CreateOrganization(\n  ctx,\n  name,\n  scalekit.CreateOrganizationOptions{\n    ExternalID: \"externalId\",\n  },\n)"
+            "source": "organization, err := scalekitClient.Organization().CreateOrganization(\n  ctx,\n  name,\n  scalekit.CreateOrganizationOptions{\n    ExternalId: \"externalId\",\n  },\n)"
           },
           {
             "label": "Java SDK",
@@ -699,7 +738,9 @@
     "/api/v1/organizations/{id}": {
       "get": {
         "description": "Retrieves organization details by Scalekit ID, including name, region, metadata, and settings",
-        "tags": ["Organizations"],
+        "tags": [
+          "Organizations"
+        ],
         "summary": "Get organization details",
         "operationId": "OrganizationService_GetOrganization",
         "parameters": [
@@ -729,17 +770,17 @@
           {
             "label": "Node.js SDK",
             "lang": "javascript",
-            "source": "import { ScalekitClient } from '@scalekit-sdk/node'\nconst scalekit = new ScalekitClient(\n  process.env.SCALEKIT_ENV_URL,\n  process.env.SCALEKIT_CLIENT_ID,\n  process.env.SCALEKIT_CLIENT_SECRET,\n)\nconst organization = await scalekit.organization.getOrganization(organization_id)"
+            "source": "const organization = await scalekit.organization.getOrganization(organizationId)"
           },
           {
             "label": "Python SDK",
             "lang": "python",
-            "source": "scalekit_client = ScalekitClient(\n  <SCALEKIT_ENVIRONMENT_URL>,\n  <SCALEKIT_CLIENT_ID>,\n  <SCALEKIT_CLIENT_SECRET>\n)\n\norganization = scalekit_client.organization.get_organization(\n  organization_id\n)"
+            "source": "organization = scalekit_client.organization.get_organization(organization_id)"
           },
           {
             "label": "Go SDK",
             "lang": "go",
-            "source": "scalekitClient := scalekit.NewScalekitClient(\n  <SCALEKIT_ENVIRONMENT_URL>,\n  <SCALEKIT_CLIENT_ID>,\n  <SCALEKIT_CLIENT_SECRET>\n)\n\norganization, err := scalekitClient.Organization.GetOrganization(\n  ctx,\n  organizationId\n)"
+            "source": "organization, err := scalekitClient.Organization().GetOrganization(\n  ctx,\n  organizationId,\n)"
           },
           {
             "label": "Java SDK",
@@ -750,7 +791,9 @@
       },
       "delete": {
         "description": "Remove an existing organization from the environment using its unique identifier",
-        "tags": ["Organizations"],
+        "tags": [
+          "Organizations"
+        ],
         "summary": "Delete an organization",
         "operationId": "OrganizationService_DeleteOrganization",
         "parameters": [
@@ -788,7 +831,7 @@
           {
             "label": "Go SDK",
             "lang": "go",
-            "source": "err := scalekitClient.Organization.DeleteOrganization(\n  ctx,\n  organizationId\n)"
+            "source": "err := scalekitClient.Organization().DeleteOrganization(\n  ctx,\n  organizationId,\n)"
           },
           {
             "label": "Java SDK",
@@ -799,7 +842,9 @@
       },
       "patch": {
         "description": "Updates an organization's display name, external ID, or metadata. Requires a valid organization identifier. Region code cannot be modified through this endpoint.",
-        "tags": ["Organizations"],
+        "tags": [
+          "Organizations"
+        ],
         "summary": "Update organization details",
         "operationId": "OrganizationService_UpdateOrganization",
         "parameters": [
@@ -850,7 +895,7 @@
           {
             "label": "Go SDK",
             "lang": "go",
-            "source": "organization, err := scalekitClient.Organization.UpdateOrganization(\n  ctx,\n  organizationId,\n  &scalekit.UpdateOrganization{\n    DisplayName: \"displayName\",\n    ExternalId: \"externalId\",\n  },\n)"
+            "source": "organization, err := scalekitClient.Organization().UpdateOrganization(\n  ctx,\n  organizationId,\n  &scalekit.UpdateOrganization{\n    DisplayName: \"displayName\",\n    ExternalId:  \"externalId\",\n  },\n)"
           },
           {
             "label": "Java SDK",
@@ -863,7 +908,9 @@
     "/api/v1/organizations/{id}/portal_links": {
       "put": {
         "description": "Creates a single use Admin Portal URL valid for 1 minute. Once the generated admin portal URL is accessed or rendered, a temporary session of 6 hours is created to allow the admin to update SSO/SCIM configuration.",
-        "tags": ["Organizations"],
+        "tags": [
+          "Organizations"
+        ],
         "summary": "Generate admin portal link",
         "operationId": "OrganizationService_GeneratePortalLink",
         "parameters": [
@@ -880,7 +927,10 @@
             "schema": {
               "type": "array",
               "items": {
-                "enum": ["dir_sync", "sso"],
+                "enum": [
+                  "dir_sync",
+                  "sso"
+                ],
                 "type": "string"
               }
             },
@@ -917,7 +967,7 @@
           {
             "label": "Go SDK",
             "lang": "go",
-            "source": "link, err := scalekitClient.Organization.GeneratePortalLink(\n  ctx,\n  organizationId\n)"
+            "source": "link, err := scalekitClient.Organization().GeneratePortalLink(\n  ctx,\n  organizationId,\n)"
           },
           {
             "label": "Java SDK",
@@ -930,7 +980,9 @@
     "/api/v1/organizations/{id}/settings": {
       "patch": {
         "description": "Updates configuration settings for an organization. Supports modifying SSO configuration, directory synchronization settings, and session parameters. Requires organization ID and the specific settings to update.",
-        "tags": ["Organizations"],
+        "tags": [
+          "Organizations"
+        ],
         "summary": "Toggle organization settings",
         "operationId": "OrganizationService_UpdateOrganizationSettings",
         "parameters": [
@@ -1024,7 +1076,9 @@
     "/api/v1/organizations/{org_id}/roles": {
       "get": {
         "description": "Retrieves all environment roles and organization specific roles. Use this endpoint to view all role definitions, including custom roles and their configurations. You can optionally include permission details for each role to understand their capabilities. This is useful for role management, auditing organization access controls, or understanding the available access levels within the organization.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "List organization roles",
         "operationId": "RolesService_ListOrganizationRoles",
         "parameters": [
@@ -1083,7 +1137,9 @@
       },
       "post": {
         "description": "Creates a new role within the specified organization with basic configuration including name, display name, description, and permissions. Use this endpoint to define custom roles that can be assigned to users within the organization. You can create hierarchical roles by extending existing roles and assign specific permissions to control access levels. The role will be scoped to the organization and can be used for organization-specific access control.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "Create organization role",
         "operationId": "RolesService_CreateOrganizationRole",
         "parameters": [
@@ -1147,7 +1203,9 @@
     "/api/v1/organizations/{org_id}/roles/{role_name}": {
       "get": {
         "description": "Retrieves complete information for a specific organization role including metadata, inheritance details, and optionally permissions. Use this endpoint to audit role configuration and understand the role's place in the organization's role hierarchy. You can include permission details to see what capabilities the role provides. This operation is useful for role management, user assignment decisions, or understanding organization access controls.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "Get organization role details",
         "operationId": "RolesService_GetOrganizationRole",
         "parameters": [
@@ -1215,7 +1273,9 @@
       },
       "put": {
         "description": "Modifies an existing organization role's properties including display name, description, permissions, and inheritance settings. Use this endpoint to update role metadata, change permission assignments, or modify role hierarchy within the organization. Only the fields you specify will be updated, leaving other properties unchanged. When updating permissions, the new list replaces all existing permissions for the role.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "Update organization role",
         "operationId": "RolesService_UpdateOrganizationRole",
         "parameters": [
@@ -1286,7 +1346,9 @@
       },
       "delete": {
         "description": "Permanently removes a role from the organization and optionally reassigns users who had that role to a different role. Use this endpoint when you need to clean up unused roles or restructure your organization's access control system. If users are assigned to the role being deleted, you can provide a reassign_role_name to move those users to a different role before deletion. This action cannot be undone, so ensure no critical users depend on the role before deletion.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "Delete organization role",
         "operationId": "RolesService_DeleteOrganizationRole",
         "parameters": [
@@ -1354,7 +1416,9 @@
     "/api/v1/organizations/{org_id}/roles:set_defaults": {
       "patch": {
         "description": "Updates the default member role for the specified organization. Use this endpoint to configure which role is automatically assigned to new users when they join the organization. The system will validate that the specified role exists and update the organization settings accordingly. This configuration affects all new user invitations and memberships within the organization.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "Set default organization roles",
         "operationId": "RolesService_UpdateDefaultOrganizationRoles",
         "parameters": [
@@ -1417,7 +1481,9 @@
     "/api/v1/organizations/{organization_id}/clients": {
       "get": {
         "description": "Retrieves a paginated list of API clients for a specific organization. Returns client details including metadata, scopes, and secret information (without exposing actual secret values).",
-        "tags": ["API Auth"],
+        "tags": [
+          "API Auth"
+        ],
         "summary": "List organization API clients",
         "operationId": "ClientService_ListOrganizationClients",
         "parameters": [
@@ -1462,15 +1528,32 @@
         },
         "x-codeSamples": [
           {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const response = await scalekit.m2m.listOrganizationClients('org_123', {\n  pageSize: 30,\n})\nconst clients = response.clients"
+          },
+          {
             "label": "Python SDK",
             "lang": "python",
-            "source": "# List clients for a specific organization\norg_id = 'SCALEKIT_ORGANIZATION_ID'\n\n# Retrieve all clients with default pagination\nresponse = scalekit_client.m2m_client.list_organization_clients(\n    organization_id=org_id,\n    page_size=30\n)\n\n# Access the clients list\nclients = response.clients\nfor client in clients:\n    print(f\"Client ID: {scalekit_client.id}, Name: {scalekit_client.name}\")"
+            "source": "# List clients for a specific organization\norg_id = \"org_123\"\n\nresponse = scalekit_client.m2m_client.list_organization_clients(\n    organization_id=org_id,\n    page_size=30,\n)\n\nclients = response.clients\nfor client in clients:\n    print(f\"Client ID: {client.id}, Name: {client.name}\")"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "response, err := scalekitClient.M2M().ListOrganizationClients(\n  ctx,\n  \"org_123\",\n  scalekit.ListOrganizationClientsOptions{\n    PageSize: 30,\n  },\n)\nif err != nil {\n  // handle error\n  return\n}\n_ = response"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "ListOrganizationClientsResponse response = scalekitClient.m2m()\n    .listOrganizationClients(\"org_123\", 30, \"\");"
           }
         ]
       },
       "post": {
         "description": "Creates a new API client for an organization. Returns the client details and a plain secret (available only once).",
-        "tags": ["API Auth"],
+        "tags": [
+          "API Auth"
+        ],
         "summary": "Create organization API client",
         "operationId": "ClientService_CreateOrganizationClient",
         "parameters": [
@@ -1509,9 +1592,24 @@
         },
         "x-codeSamples": [
           {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const response = await scalekit.m2m.createOrganizationClient('org_123', {\n  name: 'GitHub Actions Deployment Service',\n  description: 'Service account for GitHub Actions to deploy applications to production',\n  scopes: ['deploy:applications', 'read:deployments'],\n  audience: ['deployment-api.acmecorp.com'],\n})"
+          },
+          {
             "label": "Python SDK",
             "lang": "python",
-            "source": "from scalekit.v1.clients.clients_pb2 import OrganizationClient\n\nm2m_client = OrganizationClient(\n    name=\"GitHub Actions Deployment Service\",\n    description=\"Service account for GitHub Actions to deploy applications\nto production\",\n    custom_claims=[\n        {\"key\": \"github_repository\", \"value\": \"acmecorp/inventory-service\"},\n        {\"key\": \"environment\", \"value\": \"production_us\"}\n    ],\n    scopes=[\"deploy:applications\", \"read:deployments\"],\n    audience=[\"deployment-api.acmecorp.com\"],\n    expiry=3600\n)\n\nresponse = scalekit_client.m2m_client.create_organization_client(\n    organization_id=\"SCALEKIT_ORGANIZATION_ID\",\n    m2m_client=m2m_client\n)"
+            "source": "from scalekit.v1.clients.clients_pb2 import OrganizationClient\n\nm2m_client = OrganizationClient(\n    name=\"GitHub Actions Deployment Service\",\n    description=\"Service account for GitHub Actions to deploy applications to production\",\n    custom_claims=[\n        {\"key\": \"github_repository\", \"value\": \"acmecorp/inventory-service\"},\n        {\"key\": \"environment\", \"value\": \"production_us\"},\n    ],\n    scopes=[\"deploy:applications\", \"read:deployments\"],\n    audience=[\"deployment-api.acmecorp.com\"],\n    expiry=3600,\n)\n\nresponse = scalekit_client.m2m_client.create_organization_client(\n    organization_id=\"org_123\",\n    m2m_client=m2m_client,\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "response, err := scalekitClient.M2M().CreateOrganizationClient(\n  ctx,\n  \"org_123\",\n  scalekit.CreateOrganizationClientOptions{\n    Name:        \"GitHub Actions Deployment Service\",\n    Description: \"Service account for GitHub Actions to deploy applications to production\",\n    Scopes:      []string{\"deploy:applications\", \"read:deployments\"},\n    Audience:    []string{\"deployment-api.acmecorp.com\"},\n  },\n)\nif err != nil {\n  // handle error\n  return\n}\n_ = response"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "import com.scalekit.grpc.scalekit.v1.clients.OrganizationClient;\n\nOrganizationClient orgClient = OrganizationClient.newBuilder()\n    .setName(\"GitHub Actions Deployment Service\")\n    .setDescription(\"Service account for GitHub Actions to deploy applications to production\")\n    .addScopes(\"deploy:applications\")\n    .addScopes(\"read:deployments\")\n    .addAudience(\"deployment-api.acmecorp.com\")\n    .build();\n\nCreateOrganizationClientResponse response = scalekitClient.m2m()\n    .createOrganizationClient(\"org_123\", orgClient);"
           }
         ]
       }
@@ -1519,7 +1617,9 @@
     "/api/v1/organizations/{organization_id}/clients/{client_id}": {
       "get": {
         "description": "Retrieves details of a specific API client in an organization.",
-        "tags": ["API Auth"],
+        "tags": [
+          "API Auth"
+        ],
         "summary": "Get organization API client",
         "operationId": "ClientService_GetOrganizationClient",
         "parameters": [
@@ -1556,15 +1656,32 @@
         },
         "x-codeSamples": [
           {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const response = await scalekit.m2m.getOrganizationClient('org_123', 'skc_xxxxx')"
+          },
+          {
             "label": "Python SDK",
             "lang": "python",
-            "source": "# Get client ID from environment variables\norg_id = 'SCALEKIT_ORGANIZATION_ID'\nclient_id = os.environ['M2M_CLIENT_ID']\n\n# Fetch client details for the specified organization\nresponse = scalekit_client.m2m_client.get_organization_client(\n    organization_id=org_id,\n    client_id=client_id\n)"
+            "source": "import os\n\norg_id = \"org_123\"\nclient_id = os.environ[\"M2M_CLIENT_ID\"]\n\nresponse = scalekit_client.m2m_client.get_organization_client(\n    organization_id=org_id,\n    client_id=client_id,\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "response, err := scalekitClient.M2M().GetOrganizationClient(\n  ctx,\n  \"org_123\",\n  \"skc_xxxxx\",\n)\nif err != nil {\n  // handle error\n  return\n}\n_ = response"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "GetOrganizationClientResponse response = scalekitClient.m2m()\n    .getOrganizationClient(\"org_123\", \"skc_xxxxx\");"
           }
         ]
       },
       "delete": {
         "description": "Permanently deletes an API client from an organization. This operation cannot be undone and will revoke all access for the client. All associated secrets will also be invalidated. Use this endpoint to remove unused or compromised clients.",
-        "tags": ["API Auth"],
+        "tags": [
+          "API Auth"
+        ],
         "summary": "Delete organization API client",
         "operationId": "ClientService_DeleteOrganizationClient",
         "parameters": [
@@ -1599,15 +1716,32 @@
         },
         "x-codeSamples": [
           {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await scalekit.m2m.deleteOrganizationClient('org_123', 'skc_xxxxx')"
+          },
+          {
             "label": "Python SDK",
             "lang": "python",
-            "source": "# Get client ID from environment variables\norg_id = '<SCALEKIT_ORGANIZATION_ID>'\nclient_id = os.environ['M2M_CLIENT_ID']\n\n# Delete the specified client from the organization\nresponse = scalekit_client.m2m_client.delete_organization_client(\n    organization_id=org_id,\n    client_id=client_id\n)"
+            "source": "import os\n\norg_id = \"org_123\"\nclient_id = os.environ[\"M2M_CLIENT_ID\"]\n\nscalekit_client.m2m_client.delete_organization_client(\n    organization_id=org_id,\n    client_id=client_id,\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "err := scalekitClient.M2M().DeleteOrganizationClient(\n  ctx,\n  \"org_123\",\n  \"skc_xxxxx\",\n)\nif err != nil {\n  // handle error\n  return\n}"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "scalekitClient.m2m().deleteOrganizationClient(\"org_123\", \"skc_xxxxx\");"
           }
         ]
       },
       "patch": {
         "description": "Updates an existing organization API client. Only specified fields are modified.",
-        "tags": ["API Auth"],
+        "tags": [
+          "API Auth"
+        ],
         "summary": "Update organization API client",
         "operationId": "ClientService_UpdateOrganizationClient",
         "parameters": [
@@ -1655,9 +1789,24 @@
         },
         "x-codeSamples": [
           {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const response = await scalekit.m2m.updateOrganizationClient('org_123', 'skc_xxxxx', {\n  description: 'Service account for GitHub Actions to deploy applications to production_eu',\n})"
+          },
+          {
             "label": "Python SDK",
             "lang": "python",
-            "source": "from scalekit.v1.clients.clients_pb2 import OrganizationClient\n\norg_id = '<SCALEKIT_ORGANIZATION_ID>'\nclient_id = os.environ['M2M_CLIENT_ID']\n\nupdate_m2m_client = OrganizationClient(\n    description=\"Service account for GitHub Actions to deploy applications\nto production_eu\",\n    custom_claims=[\n        {\"key\": \"github_repository\", \"value\": \"acmecorp/inventory\"},\n        {\"key\": \"environment\", \"value\": \"production_eu\"}\n    ]\n)\n\nresponse = scalekit_client.m2m_client.update_organization_client(\n    organization_id=org_id,\n    client_id=client_id,\n    m2m_client=update_m2m_client\n)"
+            "source": "import os\nfrom scalekit.v1.clients.clients_pb2 import OrganizationClient\n\norg_id = \"org_123\"\nclient_id = os.environ[\"M2M_CLIENT_ID\"]\n\nupdate_m2m_client = OrganizationClient(\n    description=\"Service account for GitHub Actions to deploy applications to production_eu\",\n    custom_claims=[\n        {\"key\": \"github_repository\", \"value\": \"acmecorp/inventory\"},\n        {\"key\": \"environment\", \"value\": \"production_eu\"},\n    ],\n)\n\nresponse = scalekit_client.m2m_client.update_organization_client(\n    organization_id=org_id,\n    client_id=client_id,\n    m2m_client=update_m2m_client,\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "response, err := scalekitClient.M2M().UpdateOrganizationClient(\n  ctx,\n  \"org_123\",\n  \"skc_xxxxx\",\n  scalekit.UpdateOrganizationClientOptions{\n    Description: \"Service account for GitHub Actions to deploy applications to production_eu\",\n  },\n)\nif err != nil {\n  // handle error\n  return\n}\n_ = response"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "import com.scalekit.grpc.scalekit.v1.clients.OrganizationClient;\n\nOrganizationClient updates = OrganizationClient.newBuilder()\n    .setDescription(\"Service account for GitHub Actions to deploy applications to production_eu\")\n    .build();\n\nUpdateOrganizationClientResponse response = scalekitClient.m2m()\n    .updateOrganizationClient(\"org_123\", \"skc_xxxxx\", updates);"
           }
         ]
       }
@@ -1665,7 +1814,9 @@
     "/api/v1/organizations/{organization_id}/clients/{client_id}/secrets": {
       "post": {
         "description": "Creates a new secret for an organization API client. Returns the plain secret (available only once).",
-        "tags": ["API Auth"],
+        "tags": [
+          "API Auth"
+        ],
         "summary": "Create organization API client secret",
         "operationId": "ClientService_CreateOrganizationClientSecret",
         "parameters": [
@@ -1702,9 +1853,24 @@
         },
         "x-codeSamples": [
           {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const response = await scalekit.m2m.addOrganizationClientSecret('org_123', 'skc_xxxxx')\nconst secretId = response.secret?.id"
+          },
+          {
             "label": "Python SDK",
             "lang": "python",
-            "source": "# Get client ID from environment variables\norg_id = 'SCALEKIT_ORGANIZATION_ID'\nclient_id = os.environ['M2M_CLIENT_ID']\n\n# Add a new secret to the specified client\nresponse = scalekit_client.m2m_client.add_organization_client_secret(\n    organization_id=org_id,\n    client_id=client_id\n)\n\n# Extract the secret ID from the response\nsecret_id = response[0].secret.id"
+            "source": "import os\n\norg_id = \"org_123\"\nclient_id = os.environ[\"M2M_CLIENT_ID\"]\n\nresponse = scalekit_client.m2m_client.add_organization_client_secret(\n    organization_id=org_id,\n    client_id=client_id,\n)\n\n# with_call returns (response, call)\nsecret_id = response[0].secret.id"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "response, err := scalekitClient.M2M().CreateOrganizationClientSecret(\n  ctx,\n  \"org_123\",\n  \"skc_xxxxx\",\n)\nif err != nil {\n  // handle error\n  return\n}\n_ = response"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "CreateOrganizationClientSecretResponse response = scalekitClient.m2m()\n    .createOrganizationClientSecret(\"org_123\", \"skc_xxxxx\");"
           }
         ]
       }
@@ -1712,7 +1878,9 @@
     "/api/v1/organizations/{organization_id}/clients/{client_id}/secrets/{secret_id}": {
       "delete": {
         "description": "Permanently deletes a secret from an organization API client. This operation cannot be undone.",
-        "tags": ["API Auth"],
+        "tags": [
+          "API Auth"
+        ],
         "summary": "Delete organization API client secret",
         "operationId": "ClientService_DeleteOrganizationClientSecret",
         "parameters": [
@@ -1756,9 +1924,24 @@
         },
         "x-codeSamples": [
           {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await scalekit.m2m.removeOrganizationClientSecret('org_123', 'skc_xxxxx', 'sks_xxxxx')"
+          },
+          {
             "label": "Python SDK",
             "lang": "python",
-            "source": "# Get client and secret IDs from environment variables\norg_id = '<SCALEKIT_ORGANIZATION_ID>'\nclient_id = os.environ['M2M_CLIENT_ID']\nsecret_id = os.environ['M2M_SECRET_ID']\n\n# Remove the specified secret from the client\nresponse = scalekit_client.m2m_client.remove_organization_client_secret(\n    organization_id=org_id,\n    client_id=client_id,\n    secret_id=secret_id\n)"
+            "source": "import os\n\norg_id = \"org_123\"\nclient_id = os.environ[\"M2M_CLIENT_ID\"]\nsecret_id = os.environ[\"M2M_SECRET_ID\"]\n\nscalekit_client.m2m_client.remove_organization_client_secret(\n    organization_id=org_id,\n    client_id=client_id,\n    secret_id=secret_id,\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "err := scalekitClient.M2M().DeleteOrganizationClientSecret(\n  ctx,\n  \"org_123\",\n  \"skc_xxxxx\",\n  \"sks_xxxxx\",\n)\nif err != nil {\n  // handle error\n  return\n}"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "scalekitClient.m2m().deleteOrganizationClientSecret(\n    \"org_123\",\n    \"skc_xxxxx\",\n    \"sks_xxxxx\"\n);"
           }
         ]
       }
@@ -1766,7 +1949,9 @@
     "/api/v1/organizations/{organization_id}/connections/{id}": {
       "get": {
         "description": "Retrieves the complete configuration and status details for a specific connection by its ID within an organization. Returns all connection properties including provider settings, protocols, and current status.",
-        "tags": ["Connections"],
+        "tags": [
+          "Connections"
+        ],
         "summary": "Get connection details",
         "operationId": "ConnectionService_GetConnection",
         "parameters": [
@@ -1815,7 +2000,7 @@
           {
             "label": "Go SDK",
             "lang": "go",
-            "source": "connection, err := scalekitClient.Connection.GetConnection(\n  ctx,\n  organizationId,\n  connectionId,\n)"
+            "source": "connection, err := scalekitClient.Connection().GetConnection(\n  ctx,\n  organizationId,\n  connectionId,\n)"
           },
           {
             "label": "Java SDK",
@@ -1826,7 +2011,9 @@
       },
       "delete": {
         "description": "Deletes an SSO connection from the specified organization by connection ID. Use this endpoint when an identity provider integration is no longer needed for the organization. Returns an empty response after the SSO connection is deleted successfully.",
-        "tags": ["Connections"],
+        "tags": [
+          "Connections"
+        ],
         "summary": "Delete SSO connection",
         "operationId": "ConnectionService_DeleteConnection",
         "parameters": [
@@ -1873,7 +2060,7 @@
           {
             "label": "Go SDK",
             "lang": "go",
-            "source": "err := scalekitClient.Connection.DeleteConnection(\n  ctx,\n  organizationId,\n  connectionId,\n)"
+            "source": "err := scalekitClient.Connection().DeleteConnection(\n  ctx,\n  organizationId,\n  connectionId,\n)"
           },
           {
             "label": "Java SDK",
@@ -1886,7 +2073,9 @@
     "/api/v1/organizations/{organization_id}/connections/{id}:disable": {
       "patch": {
         "description": "Deactivate an existing connection for the specified organization. When disabled, users cannot authenticate using this connection. This endpoint changes the connection state from enabled to disabled without modifying other configuration settings",
-        "tags": ["Connections"],
+        "tags": [
+          "Connections"
+        ],
         "summary": "Disable SSO connection",
         "operationId": "ConnectionService_DisableConnection",
         "parameters": [
@@ -1935,7 +2124,7 @@
           {
             "label": "Go SDK",
             "lang": "go",
-            "source": "err := scalekitClient.Connection.DisableConnection(\n  ctx,\n  organizationId,\n  connectionId,\n)"
+            "source": "err := scalekitClient.Connection().DisableConnection(\n  ctx,\n  organizationId,\n  connectionId,\n)"
           },
           {
             "label": "Java SDK",
@@ -1948,7 +2137,9 @@
     "/api/v1/organizations/{organization_id}/connections/{id}:enable": {
       "patch": {
         "description": "Activate an existing connection for the specified organization. When enabled, users can authenticate using this connection. This endpoint changes the connection state from disabled to enabled without modifying other configuration settings",
-        "tags": ["Connections"],
+        "tags": [
+          "Connections"
+        ],
         "summary": "Enable SSO connection",
         "operationId": "ConnectionService_EnableConnection",
         "parameters": [
@@ -1997,7 +2188,7 @@
           {
             "label": "Go SDK",
             "lang": "go",
-            "source": "err := scalekitClient.Connection.EnableConnection(\n  ctx,\n  organizationId,\n  connectionId,\n)"
+            "source": "err := scalekitClient.Connection().EnableConnection(\n  ctx,\n  organizationId,\n  connectionId,\n)"
           },
           {
             "label": "Java SDK",
@@ -2009,7 +2200,9 @@
     },
     "/api/v1/organizations/{organization_id}/directories": {
       "get": {
-        "tags": ["Directory"],
+        "tags": [
+          "Directory"
+        ],
         "summary": "List organization directories",
         "operationId": "DirectoryService_ListDirectories",
         "parameters": [
@@ -2062,7 +2255,9 @@
     "/api/v1/organizations/{organization_id}/directories/{directory_id}/groups": {
       "get": {
         "description": "Retrieves all groups from a specified directory. Use this endpoint to view group structures from your connected identity provider.",
-        "tags": ["Directory"],
+        "tags": [
+          "Directory"
+        ],
         "summary": "List directory groups",
         "operationId": "DirectoryService_ListDirectoryGroups",
         "parameters": [
@@ -2166,7 +2361,9 @@
     "/api/v1/organizations/{organization_id}/directories/{directory_id}/users": {
       "get": {
         "description": "Retrieves a list of all users within a specified directory for an organization. This endpoint allows you to view user accounts associated with your connected Directory Providers.",
-        "tags": ["Directory"],
+        "tags": [
+          "Directory"
+        ],
         "summary": "List directory users",
         "operationId": "DirectoryService_ListDirectoryUsers",
         "parameters": [
@@ -2270,7 +2467,9 @@
     "/api/v1/organizations/{organization_id}/directories/{id}": {
       "get": {
         "description": "Retrieves detailed information about a specific directory within an organization",
-        "tags": ["Directory"],
+        "tags": [
+          "Directory"
+        ],
         "summary": "Get directory details",
         "operationId": "DirectoryService_GetDirectory",
         "parameters": [
@@ -2332,7 +2531,9 @@
     "/api/v1/organizations/{organization_id}/directories/{id}:disable": {
       "patch": {
         "description": "Stops synchronization of users and groups from a specified directory within an organization. This operation prevents further updates from the connected Directory provider",
-        "tags": ["Directory"],
+        "tags": [
+          "Directory"
+        ],
         "summary": "Disable a directory",
         "operationId": "DirectoryService_DisableDirectory",
         "parameters": [
@@ -2394,7 +2595,9 @@
     "/api/v1/organizations/{organization_id}/directories/{id}:enable": {
       "patch": {
         "description": "Activates a directory within an organization, allowing it to synchronize users and groups with the connected Directory provider",
-        "tags": ["Directory"],
+        "tags": [
+          "Directory"
+        ],
         "summary": "Enable a directory",
         "operationId": "DirectoryService_EnableDirectory",
         "parameters": [
@@ -2456,7 +2659,9 @@
     "/api/v1/organizations/{organization_id}/domains": {
       "get": {
         "description": "Retrieves a paginated list of all domains configured for the specified organization.\n\nDomain types:\n- ALLOWED_EMAIL_DOMAIN: Trusted domains used to suggest the organization in the organization switcher during sign-in/sign-up (auth-method agnostic).\n- ORGANIZATION_DOMAIN: SSO discovery domains used to route users to the correct SSO provider and enforce SSO.\n\n",
-        "tags": ["Domains"],
+        "tags": [
+          "Domains"
+        ],
         "summary": "List Domains",
         "operationId": "DomainService_ListDomains",
         "parameters": [
@@ -2498,7 +2703,10 @@
           {
             "schema": {
               "type": "string",
-              "enum": ["ALLOWED_EMAIL_DOMAIN", "ORGANIZATION_DOMAIN"]
+              "enum": [
+                "ALLOWED_EMAIL_DOMAIN",
+                "ORGANIZATION_DOMAIN"
+              ]
             },
             "description": "The domain type.\n- ALLOWED_EMAIL_DOMAIN: trusted domain used to suggest the organization in the organization switcher during sign-in/sign-up.\n- ORGANIZATION_DOMAIN: SSO discovery domain used to route users to the correct SSO provider and enforce SSO.\n",
             "name": "domain_type",
@@ -2542,7 +2750,9 @@
       },
       "post": {
         "description": "Creates and associates a domain with an organization.\n\nUse one of the following domain types:\n- ALLOWED_EMAIL_DOMAIN: Adds a trusted email domain for organization suggestions in the organization switcher during sign-in/sign-up (auth-method agnostic).\n- ORGANIZATION_DOMAIN: Enables SSO domain discovery. If a user signs in with a matching email domain, Scalekit redirects them to the organization’s SSO provider and enforces SSO.\n\nThe domain must be a valid business domain that you control. Public/disposable domains (e.g., gmail.com) are blocked for security.\n\n",
-        "tags": ["Domains"],
+        "tags": [
+          "Domains"
+        ],
         "summary": "Create Domain",
         "operationId": "DomainService_CreateDomain",
         "parameters": [
@@ -2616,7 +2826,9 @@
     "/api/v1/organizations/{organization_id}/domains/{id}": {
       "get": {
         "description": "Retrieves complete details for a domain including domain type, timestamps, and configuration information.\n\n",
-        "tags": ["Domains"],
+        "tags": [
+          "Domains"
+        ],
         "summary": "Get Domain",
         "operationId": "DomainService_GetDomain",
         "parameters": [
@@ -2676,7 +2888,9 @@
       },
       "delete": {
         "description": "Permanently removes a domain record from an organization.\n\n- Deleting an ORGANIZATION_DOMAIN disables SSO routing/enforcement for that domain.\n- Deleting an ALLOWED_EMAIL_DOMAIN stops organization suggestions for users with that email domain.\n\n",
-        "tags": ["Domains"],
+        "tags": [
+          "Domains"
+        ],
         "summary": "Delete Domain",
         "operationId": "DomainService_DeleteDomain",
         "parameters": [
@@ -2736,7 +2950,9 @@
     "/api/v1/organizations/{organization_id}/session-policy": {
       "get": {
         "description": "Retrieves the session policy for an organization. Returns session_policy='APPLICATION' if the organization inherits the application-level defaults, or session_policy='CUSTOM' with the configured values if a custom policy is active.",
-        "tags": ["Organizations"],
+        "tags": [
+          "Organizations"
+        ],
         "summary": "Get organization session policy",
         "operationId": "OrganizationService_GetOrganizationSessionPolicy",
         "parameters": [
@@ -2773,7 +2989,9 @@
       },
       "patch": {
         "description": "Sets a custom session policy for an organization or reverts to application-level settings. Send session_policy='APPLICATION' to revert to application defaults. Send session_policy='CUSTOM' with timeout values to activate a custom policy.",
-        "tags": ["Organizations"],
+        "tags": [
+          "Organizations"
+        ],
         "summary": "Update organization session policy",
         "operationId": "OrganizationService_UpdateOrganizationSessionPolicy",
         "parameters": [
@@ -2822,7 +3040,9 @@
     "/api/v1/organizations/{organization_id}/settings/usermanagement": {
       "patch": {
         "description": "Upsert user management settings for an organization",
-        "tags": ["Organizations"],
+        "tags": [
+          "Organizations"
+        ],
         "summary": "Upsert organization user setting",
         "operationId": "OrganizationService_UpsertUserManagementSettings",
         "parameters": [
@@ -2863,7 +3083,9 @@
     "/api/v1/organizations/{organization_id}/users": {
       "get": {
         "description": "Retrieves a paginated list of all users who are members of the specified organization. Use this endpoint to view all users with access to a particular organization, including their roles, metadata, and membership details. Supports pagination for large user lists.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "List organization users",
         "operationId": "UserService_ListOrganizationUsers",
         "parameters": [
@@ -2915,7 +3137,7 @@
           {
             "label": "Python SDK",
             "lang": "python",
-            "source": "resp, _ = scalekit_client.users.list_users(organization_id=\"org_123\", page_size=50)"
+            "source": "response = scalekit_client.users.list_organization_users(\n    organization_id=\"org_123\",\n    page_size=50,\n)"
           },
           {
             "label": "Go SDK",
@@ -2931,7 +3153,9 @@
       },
       "post": {
         "description": "Creates a new user account and immediately adds them to the specified organization. Use this endpoint when you want to create a user and grant them access to an organization in a single operation. You can provide user profile information, assign roles, and configure membership metadata. The user receives an activation email unless this feature is disabled in the organization settings.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Create new user in organization",
         "operationId": "UserService_CreateUserAndMembership",
         "parameters": [
@@ -3001,7 +3225,9 @@
     "/api/v1/organizations/{organization_id}/users/{user_id}/permissions": {
       "get": {
         "description": "Retrieves all permissions a user has access to within a specific organization. This includes permissions from direct role assignments and inherited permissions from role hierarchy.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "List user permissions",
         "operationId": "UserService_ListUserPermissions",
         "parameters": [
@@ -3063,7 +3289,9 @@
     "/api/v1/organizations/{organization_id}/users/{user_id}/roles": {
       "get": {
         "description": "Retrieves all roles assigned to a user within a specific organization. This includes both direct role assignments and inherited roles from role hierarchy.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "List user roles",
         "operationId": "UserService_ListUserRoles",
         "parameters": [
@@ -3125,7 +3353,9 @@
     "/api/v1/organizations/{organization_id}/users:search": {
       "get": {
         "description": "Searches for users within a specific organization by email address, user ID, or external ID. The query must be at least 3 characters and is case-insensitive. Scopes results strictly to the given organization. Returns a paginated list of matching users with up to 30 results per page. Use the next_page_token from the response to retrieve subsequent pages.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Search organization users",
         "operationId": "UserService_SearchOrganizationUsers",
         "parameters": [
@@ -3202,7 +3432,9 @@
     "/api/v1/organizations:external/{external_id}": {
       "get": {
         "description": "Retrieves organization details by external ID, including name, region, metadata, and settings. Only provide external_id in the path. If the id query parameter is also supplied, it silently takes precedence over external_id due to protobuf oneof semantics, which causes the request to fail with a 400 Bad Request ('ExternalId is required').",
-        "tags": ["Organizations"],
+        "tags": [
+          "Organizations"
+        ],
         "summary": "Get organization details by external Id",
         "operationId": "OrganizationService_GetOrganizationByExternalId",
         "parameters": [
@@ -3257,7 +3489,9 @@
     "/api/v1/passwordless/email/resend": {
       "post": {
         "description": "Resend a verification email if the user didn't receive it or if the previous code/link has expired",
-        "tags": ["Magic link & OTP"],
+        "tags": [
+          "Magic link & OTP"
+        ],
         "summary": "Resend passwordless email",
         "operationId": "PasswordlessService_ResendPasswordlessEmail",
         "responses": {
@@ -3301,7 +3535,7 @@
           {
             "label": "Java SDK",
             "lang": "java",
-            "source": "SendPasswordlessResponse resendResponse = passwordlessClient.resendPasswordlessEmail(authRequestId);"
+            "source": "SendPasswordlessResponse resendResponse = scalekitClient.passwordless()\n    .resendPasswordlessEmail(authRequestId);"
           }
         ]
       }
@@ -3309,7 +3543,9 @@
     "/api/v1/passwordless/email/send": {
       "post": {
         "description": "Send a verification email containing either a verification code (OTP), magic link, or both to a user's email address",
-        "tags": ["Magic link & OTP"],
+        "tags": [
+          "Magic link & OTP"
+        ],
         "summary": "Send passwordless email",
         "operationId": "PasswordlessService_SendPasswordlessEmail",
         "responses": {
@@ -3338,22 +3574,22 @@
           {
             "label": "Node.js SDK",
             "lang": "javascript",
-            "source": "const response = await scalekit.passwordless.sendPasswordlessEmail('john.doe@example.com', {\n  template: 'SIGNIN',\n  expiresIn: 100,\n  magiclinkAuthUri: 'https://www.google.com',\n  templateVariables: {\n    employeeID: 'EMP523',\n    teamName: 'Alpha Team',\n    supportEmail: 'support@yourcompany.com',\n  },\n})"
+            "source": "const response = await scalekit.passwordless.sendPasswordlessEmail('john.doe@example.com', {\n  template: 'SIGNIN',\n  expiresIn: 100,\n  magiclinkAuthUri: 'https://yourapp.com/auth/passwordless/callback',\n  templateVariables: {\n    employeeID: 'EMP523',\n    teamName: 'Alpha Team',\n    supportEmail: 'support@yourcompany.com',\n  },\n})"
           },
           {
             "label": "Python SDK",
             "lang": "python",
-            "source": "response = scalekit_client.passwordless.send_passwordless_email(\n    email=\"john.doe@example.com\",\n    template=\"SIGNIN\",  # or \"SIGNUP\", \"UNSPECIFIED\"\n    expires_in=100,\n    magiclink_auth_uri=\"https://www.google.com\",\n    template_variables={\n        \"employeeID\": \"EMP523\",\n        \"teamName\": \"Alpha Team\",\n        \"supportEmail\": \"support@yourcompany.com\",\n    },\n)\n\n# Extract auth request ID from response\nauth_request_id = response[0].auth_request_id"
+            "source": "response = scalekit_client.passwordless.send_passwordless_email(\n    email=\"john.doe@example.com\",\n    template=\"SIGNIN\",  # or \"SIGNUP\", \"UNSPECIFIED\"\n    expires_in=100,\n    magiclink_auth_uri=\"https://yourapp.com/auth/passwordless/callback\",\n    template_variables={\n        \"employeeID\": \"EMP523\",\n        \"teamName\": \"Alpha Team\",\n        \"supportEmail\": \"support@yourcompany.com\",\n    },\n)\n\n# with_call returns (response, call)\nauth_request_id = response[0].auth_request_id"
           },
           {
             "label": "Go SDK",
             "lang": "go",
-            "source": "templateType := scalekit.TemplateTypeSignin\nresponse, err := scalekitClient.Passwordless().SendPasswordlessEmail(\n    ctx,\n    \"john.doe@example.com\",\n    &scalekit.SendPasswordlessOptions{\n        Template:         &templateType,\n        ExpiresIn:        100,\n        MagiclinkAuthUri: \"https://www.google.com\",\n        TemplateVariables: map[string]string{\n            \"employeeID\":    \"EMP523\",\n            \"teamName\":      \"Alpha Team\",\n            \"supportEmail\":  \"support@yourcompany.com\",\n        },\n    },\n)\n\nif err != nil {\n    // Handle error\n    return\n}\n\nauthRequestId := response.AuthRequestId"
+            "source": "templateType := scalekit.TemplateTypeSignin\nresponse, err := scalekitClient.Passwordless().SendPasswordlessEmail(\n  ctx,\n  \"john.doe@example.com\",\n  &scalekit.SendPasswordlessOptions{\n    Template:         &templateType,\n    ExpiresIn:        100,\n    MagiclinkAuthUri: \"https://yourapp.com/auth/passwordless/callback\",\n    TemplateVariables: map[string]string{\n      \"employeeID\":   \"EMP523\",\n      \"teamName\":     \"Alpha Team\",\n      \"supportEmail\": \"support@yourcompany.com\",\n    },\n  },\n)\nif err != nil {\n  // handle error\n  return\n}\nauthRequestId := response.AuthRequestId"
           },
           {
             "label": "Java SDK",
             "lang": "java",
-            "source": "TemplateType templateType = TemplateType.SIGNIN;\nMap<String, String> templateVariables = new HashMap<>();\ntemplateVariables.put(\"employeeID\", \"EMP523\");\ntemplateVariables.put(\"teamName\", \"Alpha Team\");\ntemplateVariables.put(\"supportEmail\", \"support@yourcompany.com\");\n\nSendPasswordlessOptions options = new SendPasswordlessOptions();\noptions.setTemplate(templateType);\noptions.setExpiresIn(100);\noptions.setMagiclinkAuthUri(\"https://www.example.com\");\noptions.setTemplateVariables(templateVariables);\n\nSendPasswordlessResponse response = passwordlessClient.sendPasswordlessEmail(\n    \"john.doe@example.com\",\n    options\n);\n\nString authRequestId = response.getAuthRequestId();"
+            "source": "TemplateType templateType = TemplateType.SIGNIN;\nMap<String, String> templateVariables = new HashMap<>();\ntemplateVariables.put(\"employeeID\", \"EMP523\");\ntemplateVariables.put(\"teamName\", \"Alpha Team\");\ntemplateVariables.put(\"supportEmail\", \"support@yourcompany.com\");\n\nSendPasswordlessOptions options = new SendPasswordlessOptions();\noptions.setTemplate(templateType);\noptions.setExpiresIn(100);\noptions.setMagiclinkAuthUri(\"https://yourapp.com/auth/passwordless/callback\");\noptions.setTemplateVariables(templateVariables);\n\nSendPasswordlessResponse response = scalekitClient.passwordless().sendPasswordlessEmail(\n    \"john.doe@example.com\",\n    options\n);\n\nString authRequestId = response.getAuthRequestId();"
           }
         ]
       }
@@ -3361,7 +3597,9 @@
     "/api/v1/passwordless/email/verify": {
       "post": {
         "description": "Verify a user's identity using either a verification code or magic link token",
-        "tags": ["Magic link & OTP"],
+        "tags": [
+          "Magic link & OTP"
+        ],
         "summary": "Verify passwordless email",
         "operationId": "PasswordlessService_VerifyPasswordlessEmail",
         "responses": {
@@ -3390,7 +3628,7 @@
           {
             "label": "Node.js SDK",
             "lang": "javascript",
-            "source": "const { authRequestId } = sendResponse\nconst verifyResponse = await scalekit.passwordless.verifyPasswordlessEmail(\n  // Verification Code (OTP)\n\n  { code: '123456' },\n\n  // Magic Link Token\n\n  { linkToken: link_token },\n\n  authRequestId,\n)"
+            "source": "const { authRequestId } = sendResponse\n\n// Verify with OTP code\nconst verifyResponse = await scalekit.passwordless.verifyPasswordlessEmail(\n  { code: '123456' },\n  authRequestId,\n)\n\n// Or verify with magic link token\nconst linkVerifyResponse = await scalekit.passwordless.verifyPasswordlessEmail({\n  linkToken: linkToken,\n})"
           },
           {
             "label": "Python SDK",
@@ -3405,7 +3643,7 @@
           {
             "label": "Java SDK",
             "lang": "java",
-            "source": "// Verify with OTP code\nVerifyPasswordlessOptions verifyOptions = new VerifyPasswordlessOptions();\nverifyOptions.setCode(\"123456\"); // OTP code\nverifyOptions.setAuthRequestId(authRequestId);\n\nVerifyPasswordLessResponse verifyResponse = passwordlessClient.verifyPasswordlessEmail(verifyOptions);\n\n// User verified successfully\nString userEmail = verifyResponse.getEmail();\n\n// Verify with magic link token\nVerifyPasswordlessOptions verifyOptions = new VerifyPasswordlessOptions();\nverifyOptions.setLinkToken(linkToken); // Magic link token\n\nVerifyPasswordLessResponse verifyResponse = passwordlessClient.verifyPasswordlessEmail(verifyOptions);\n\n// User verified successfully\nString userEmail = verifyResponse.getEmail();"
+            "source": "// Verify with OTP code\nVerifyPasswordlessOptions verifyOptions = new VerifyPasswordlessOptions();\nverifyOptions.setCode(\"123456\"); // OTP code\nverifyOptions.setAuthRequestId(authRequestId);\n\nVerifyPasswordLessResponse verifyResponse = scalekitClient.passwordless()\n    .verifyPasswordlessEmail(verifyOptions);\n\n// User verified successfully\nString userEmail = verifyResponse.getEmail();\n\n// Verify with magic link token\nVerifyPasswordlessOptions linkVerifyOptions = new VerifyPasswordlessOptions();\nlinkVerifyOptions.setLinkToken(linkToken); // Magic link token\n\nVerifyPasswordLessResponse linkVerifyResponse = scalekitClient.passwordless()\n    .verifyPasswordlessEmail(linkVerifyOptions);\n\nString verifiedEmail = linkVerifyResponse.getEmail();"
           }
         ]
       }
@@ -3413,7 +3651,9 @@
     "/api/v1/permissions": {
       "get": {
         "description": "Retrieves a comprehensive, paginated list of all permissions available within the environment. Use this endpoint to view all permission definitions for auditing, role management, or understanding the complete set of available access controls. The response includes pagination tokens to navigate through large sets of permissions efficiently. Each permission object contains the permission name, description, creation time, and last update time. This operation is useful for building permission selection interfaces, auditing permission usage, or understanding the scope of available access controls in your RBAC system.",
-        "tags": ["Permissions"],
+        "tags": [
+          "Permissions"
+        ],
         "summary": "List all permissions",
         "operationId": "RolesService_ListPermissions",
         "parameters": [
@@ -3437,7 +3677,10 @@
           {
             "schema": {
               "type": "string",
-              "enum": ["SCALEKIT", "ENVIRONMENT"]
+              "enum": [
+                "SCALEKIT",
+                "ENVIRONMENT"
+              ]
             },
             "description": "Filter permissions by type: ALL, SCALEKIT, or ENVIRONMENT, where SCALEKIT are predefined Scalekit permissions and ENVIRONMENT are custom permissions created in the environment, default is ALL",
             "name": "type",
@@ -3481,7 +3724,9 @@
       },
       "post": {
         "description": "Creates a new permission that represents a specific action users can perform within the environment. Use this endpoint to define granular access controls for your RBAC system. You can provide a unique permission name following the format 'action:resource' (for example, 'read:documents', 'write:users') and an optional description explaining the permission's purpose. The permission name must be unique across the environment and follows alphanumeric naming conventions with colons and underscores. Returns the created permission object including system-generated ID and timestamps.",
-        "tags": ["Permissions"],
+        "tags": [
+          "Permissions"
+        ],
         "summary": "Create new permission",
         "operationId": "RolesService_CreatePermission",
         "responses": {
@@ -3533,7 +3778,9 @@
     "/api/v1/permissions/{permission_name}": {
       "get": {
         "description": "Retrieves complete information for a specific permission by its unique name identifier. Use this endpoint to view permission details including description, creation time, and last update time. Provide the permission name in the path parameter following the format 'action:resource' (for example, 'read:documents'). This operation is useful for auditing permission definitions, understanding permission purposes, or verifying permission existence before assignment. Returns the complete permission object with all metadata and system-generated timestamps.",
-        "tags": ["Permissions"],
+        "tags": [
+          "Permissions"
+        ],
         "summary": "Retrieve permission details",
         "operationId": "RolesService_GetPermission",
         "parameters": [
@@ -3584,7 +3831,9 @@
       },
       "put": {
         "description": "Modifies an existing permission's attributes including description and metadata. Use this endpoint to update permission descriptions or clarify permission purposes after creation. The permission is identified by its unique name in the path parameter, and only the fields you specify in the request body will be updated. Note that the permission name itself cannot be changed as it serves as the immutable identifier. This operation is useful for maintaining clear documentation of permission purposes or updating descriptions to reflect changes in system functionality. Returns the updated permission object with modified timestamps.",
-        "tags": ["Permissions"],
+        "tags": [
+          "Permissions"
+        ],
         "summary": "Update permission details",
         "operationId": "RolesService_UpdatePermission",
         "parameters": [
@@ -3645,7 +3894,9 @@
       },
       "delete": {
         "description": "Permanently removes a permission from the environment using its unique name identifier. Use this endpoint when you need to clean up unused permissions or remove access controls that are no longer relevant. The permission is identified by its name in the path parameter following the format 'action:resource'. This operation cannot be undone, so ensure no active roles depend on the permission before deletion. If the permission is currently assigned to any roles, you may need to remove those assignments first or update the roles to use alternative permissions. Returns no content on successful deletion.",
-        "tags": ["Permissions"],
+        "tags": [
+          "Permissions"
+        ],
         "summary": "Delete permission",
         "operationId": "RolesService_DeletePermission",
         "parameters": [
@@ -3696,7 +3947,9 @@
     "/api/v1/roles": {
       "get": {
         "description": "Retrieves a comprehensive list of all roles available within the specified environment including organization roles. Use this endpoint to view all role definitions, including custom roles and their configurations. You can optionally include permission details for each role to understand their capabilities. This is useful for role management, auditing organization access controls, or understanding the available access levels within the organization.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "List all roles in environment",
         "operationId": "RolesService_ListRoles",
         "parameters": [
@@ -3746,7 +3999,9 @@
       },
       "post": {
         "description": "Creates a new role within the environment with specified permissions and metadata. Use this endpoint to define custom roles that can be assigned to users or groups. You can create hierarchical roles by extending existing roles, assign specific permissions, and configure display information. Roles are the foundation of your access control system and determine what actions users can perform.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "Create new role in environment",
         "operationId": "RolesService_CreateRole",
         "responses": {
@@ -3772,7 +4027,10 @@
                     "description": "Can edit content",
                     "display_name": "Content Editor",
                     "name": "content_editor",
-                    "permissions": ["read:content", "write:content"]
+                    "permissions": [
+                      "read:content",
+                      "write:content"
+                    ]
                   }
                 ]
               }
@@ -3807,7 +4065,9 @@
     "/api/v1/roles/default": {
       "patch": {
         "description": "Updates the default creator and member roles for the current environment. Use this endpoint to configure which roles are automatically assigned to new users when they join the environment. You can specify role names for both creator and member default roles. The system will validate that the specified roles exist and update the environment settings accordingly. Returns the updated default role objects including their complete role information and permissions.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "Set default creator and member roles",
         "operationId": "RolesService_UpdateDefaultRoles2",
         "responses": {
@@ -3837,7 +4097,9 @@
     "/api/v1/roles/{role_name}": {
       "get": {
         "description": "Retrieves complete information for a specific role including metadata and inheritance details (base role and dependent role count). Use this endpoint to audit role configuration and understand the role's place in the hierarchy. To view the role's permissions, use the ListRolePermissions endpoint.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "Get role details",
         "operationId": "RolesService_GetRole",
         "parameters": [
@@ -3896,7 +4158,9 @@
       },
       "put": {
         "description": "Modifies an existing role's properties including display name, description, permissions, and inheritance. Use this endpoint to update role metadata, change permission assignments, or modify role hierarchy. Only the fields you specify will be updated, leaving other properties unchanged. When updating permissions, the new list replaces all existing permissions for the role.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "Update role information",
         "operationId": "RolesService_UpdateRole",
         "parameters": [
@@ -3964,7 +4228,9 @@
       },
       "delete": {
         "description": "Permanently removes a role from the environment and reassigns users who had that role to a different role. Use this endpoint when you need to clean up unused roles or restructure your access control system. The role cannot be deleted if it has dependent roles (roles that extend it) unless you specify a replacement role. If users are assigned to the role being deleted, you must provide a reassign_role_name to move those users to a different role before deletion can proceed. This action cannot be undone, so ensure no critical users depend on the role before deletion.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "Delete role and reassign users",
         "operationId": "RolesService_DeleteRole",
         "parameters": [
@@ -4031,7 +4297,9 @@
     "/api/v1/roles/{role_name}/dependents": {
       "get": {
         "description": "Retrieves all roles that directly extend the specified base role through inheritance. Use this endpoint to understand the role hierarchy and identify which roles inherit permissions from a particular base role. Provide the base role name as a path parameter, and the response will include all dependent roles with their metadata and permission information. This operation is useful for auditing role inheritance relationships, understanding the impact of changes to base roles, or managing role hierarchies effectively. Returns a list of dependent role objects including their names, display names, descriptions, and permission details.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "List dependent roles",
         "operationId": "RolesService_ListDependentRoles",
         "parameters": [
@@ -4084,7 +4352,9 @@
     "/api/v1/roles/{role_name}/permissions": {
       "get": {
         "description": "Retrieves all permissions directly assigned to the specified role, excluding permissions inherited from base roles. Use this endpoint to view the explicit permission assignments for a role, which is useful for understanding direct role capabilities, auditing permission assignments, or managing role-permission relationships. Provide the role name as a path parameter, and the response will include only the permissions that are directly assigned to that role. This operation does not include inherited permissions from role hierarchies - use ListEffectiveRolePermissions to see the complete set of permissions including inheritance. Returns a list of permission objects with their names, descriptions, and assignment metadata.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "List permissions for role",
         "operationId": "RolesService_ListRolePermissions",
         "parameters": [
@@ -4135,7 +4405,9 @@
       },
       "post": {
         "description": "Adds one or more permissions to the specified role while preserving existing permission assignments. Use this endpoint to grant additional capabilities to a role without affecting its current permission set. Provide the role name as a path parameter and a list of permission names in the request body. The system will validate that all specified permissions exist in the environment and add them to the role. Existing permission assignments remain unchanged, making this operation safe for incremental permission management. This is useful for gradually expanding role capabilities or adding new permissions as your system evolves. Returns the updated list of all permissions now assigned to the role.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "Add permissions to role",
         "operationId": "RolesService_AddPermissionsToRole",
         "parameters": [
@@ -4198,7 +4470,9 @@
     "/api/v1/roles/{role_name}/permissions/{permission_name}": {
       "delete": {
         "description": "Removes a specific permission from the specified role, revoking that capability from all users assigned to the role. Use this endpoint to restrict role capabilities or remove unnecessary permissions. Provide both the role name and permission name as path parameters. This operation only affects the direct permission assignment and does not impact permissions inherited from base roles. If the permission is inherited through role hierarchy, you may need to modify the base role instead. This is useful for fine-tuning role permissions, implementing least-privilege access controls, or removing deprecated permissions. Returns no content on successful removal.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "Remove permission from role",
         "operationId": "RolesService_RemovePermissionFromRole",
         "parameters": [
@@ -4258,7 +4532,9 @@
     "/api/v1/roles/{role_name}/permissions:all": {
       "get": {
         "description": "Retrieves the complete set of effective permissions for a role, including both directly assigned permissions and permissions inherited from base roles through the role hierarchy. Use this endpoint to understand the full scope of capabilities available to users assigned to a specific role. Provide the role name as a path parameter, and the response will include all permissions that apply to the role, accounting for inheritance relationships. This operation is essential for auditing role capabilities, understanding permission inheritance, or verifying the complete access scope before role assignment. Returns a comprehensive list of permission names representing the full set of effective permissions for the specified role.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "List effective permissions for role",
         "operationId": "RolesService_ListEffectiveRolePermissions",
         "parameters": [
@@ -4289,7 +4565,9 @@
     "/api/v1/roles/{role_name}/users:count": {
       "get": {
         "description": "Retrieves the total number of users currently assigned to the specified role within the environment. Use this endpoint to monitor role usage, enforce user limits, or understand the scope of role assignments. Provide the role's unique name as a path parameter, and the response will include the current user count for that role. This operation is read-only and does not modify any data or user assignments. The count reflects all users who have the role either directly assigned or inherited through organization membership. This information is useful for capacity planning, security auditing, or understanding the impact of role changes across your user base.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "Retrieve user count for role",
         "operationId": "RolesService_GetRoleUsersCount",
         "parameters": [
@@ -4342,7 +4620,9 @@
     "/api/v1/roles:set_defaults": {
       "patch": {
         "description": "Updates the default creator and member roles for the current environment. Use this endpoint to configure which roles are automatically assigned to new users when they join the environment. You can specify role names for both creator and member default roles. The system will validate that the specified roles exist and update the environment settings accordingly. Returns the updated default role objects including their complete role information and permissions.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "Set default creator and member roles",
         "operationId": "RolesService_UpdateDefaultRoles",
         "responses": {
@@ -4394,7 +4674,9 @@
     "/api/v1/sessions/{session_id}": {
       "get": {
         "description": "Retrieves comprehensive details for a specific user session including authentication status, device information, and expiration timelines. Use this endpoint to fetch current session metadata for security audits, session validation, or to display session information in user account management interfaces. Returns all session properties including the user ID, authenticated organizations, device details with browser/OS information, IP address and geolocation, and all relevant timestamps (creation, last activity, idle expiration, absolute expiration, and actual expiration if applicable).",
-        "tags": ["Sessions"],
+        "tags": [
+          "Sessions"
+        ],
         "summary": "Get session details",
         "operationId": "SessionService_GetSession",
         "parameters": [
@@ -4447,7 +4729,9 @@
     "/api/v1/sessions/{session_id}/revoke": {
       "post": {
         "description": "Immediately invalidates a specific user session by session ID, setting its status to 'revoked'. Once revoked, the session cannot be used for any future API requests or application access. Use this endpoint to implement session-level logout, force a user to reauthenticate on a specific device, or terminate suspicious sessions. The revocation is instantaneous and irreversible. Returns the revoked session details including the session ID, user ID, and the revocation timestamp.",
-        "tags": ["Sessions"],
+        "tags": [
+          "Sessions"
+        ],
         "summary": "Revoke user session",
         "operationId": "SessionService_RevokeSession",
         "parameters": [
@@ -4500,7 +4784,9 @@
     "/api/v1/users": {
       "get": {
         "description": "Retrieves a paginated list of all users across your entire environment. Use this endpoint to view all users regardless of their organization memberships. This is useful for administrative purposes, user audits, or when you need to see all users in your Scalekit environment. Supports pagination for large user bases.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "List all users in environment",
         "operationId": "UserService_ListUsers",
         "parameters": [
@@ -4543,7 +4829,7 @@
           {
             "label": "Python SDK",
             "lang": "python",
-            "source": "# pass empty org to fetch all users in environment\nresp,_ = scalekit_client.users.list_users(organization_id=\"\", page_size=100)"
+            "source": "# List all users in the environment\nresponse = scalekit_client.users.list_users(page_size=100)"
           },
           {
             "label": "Go SDK",
@@ -4553,7 +4839,7 @@
           {
             "label": "Java SDK",
             "lang": "java",
-            "source": "ListUsersRequest lur = ListUsersRequest.\n  newBuilder().setPageSize(100).build();\nListUsersResponse allUsers = users.listUsers(lur);"
+            "source": "ListUsersRequest lur = ListUsersRequest.newBuilder()\n    .setPageSize(100)\n    .build();\nListUsersResponse allUsers = scalekitClient.users().listUsers(lur);"
           }
         ]
       }
@@ -4561,7 +4847,9 @@
     "/api/v1/users/{id}": {
       "get": {
         "description": "Retrieves all details for a user by system-generated user ID. The response includes organization memberships and user metadata.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Get user",
         "operationId": "UserService_GetUser",
         "parameters": [
@@ -4612,7 +4900,9 @@
       },
       "delete": {
         "description": "Permanently removes a user from your environment and deletes all associated data. Use this endpoint when you need to completely remove a user account. This action deletes the user's profile, memberships, and all related data across all organizations. This operation cannot be undone, so use with caution.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Delete user permanently",
         "operationId": "UserService_DeleteUser",
         "parameters": [
@@ -4645,7 +4935,7 @@
           {
             "label": "Python SDK",
             "lang": "python",
-            "source": "scalekit_client.users.delete_user(organization_id=\"org_123\", \n  user_id=\"usr_123\")"
+            "source": "scalekit_client.users.delete_user(\"usr_123\")"
           },
           {
             "label": "Go SDK",
@@ -4655,13 +4945,15 @@
           {
             "label": "Java SDK",
             "lang": "java",
-            "source": "users.deleteUser(\"usr_123\");"
+            "source": "scalekitClient.users().deleteUser(\"usr_123\");"
           }
         ]
       },
       "patch": {
         "description": "Modifies user account information including profile details, metadata, and external ID. Use this endpoint to update a user's personal information, contact details, or custom metadata. You can update the user's profile, phone number, and metadata fields. Note that fields like user ID, email address, environment ID, and creation time cannot be modified.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Update user information",
         "operationId": "UserService_UpdateUser",
         "parameters": [
@@ -4713,7 +5005,7 @@
           {
             "label": "Python SDK",
             "lang": "python",
-            "source": "import os\nfrom scalekit import ScalekitClient\nfrom scalekit.v1.users.users_pb2 import UpdateUser\nfrom scalekit.v1.commons.commons_pb2 import UserProfile\nscalekit_client = ScalekitClient(\n    env_url=os.getenv(\"SCALEKIT_ENV_URL\"),\n    client_id=os.getenv(\"SCALEKIT_CLIENT_ID\"),\n    client_secret=os.getenv(\"SCALEKIT_CLIENT_SECRET\"),\n)\nupdate_user = UpdateUser(\n    user_profile=UserProfile(\n        first_name=\"John\",\n        last_name=\"Smith\"\n    ),\n    metadata={\"department\": \"sales\"}\n)\nscalekit_client.users.update_user(organization_id=\"org_123\", \n  user=update_user)"
+            "source": "from scalekit.v1.users.users_pb2 import UpdateUser\nfrom scalekit.v1.commons.commons_pb2 import UserProfile\n\nupdate_user = UpdateUser(\n    user_profile=UserProfile(\n        first_name=\"John\",\n        last_name=\"Smith\",\n    ),\n    metadata={\"department\": \"sales\"},\n)\nresponse = scalekit_client.users.update_user(\"usr_123\", update_user)"
           },
           {
             "label": "Go SDK",
@@ -4723,7 +5015,7 @@
           {
             "label": "Java SDK",
             "lang": "java",
-            "source": "UpdateUser upd = UpdateUser.newBuilder()\n        .setUserProfile(\n          UpdateUserProfile.newBuilder()\n                .setFirstName(\"John\")\n                .setLastName(\"Smith\")\n                .build())\n        .putMetadata(\"department\", \"sales\")\n        .build();\nUpdateUserRequest updReq = UpdateUserRequest.\n  newBuilder().setUser(upd).build();\nusers.updateUser(\"usr_123\", updReq);"
+            "source": "UpdateUser upd = UpdateUser.newBuilder()\n    .setUserProfile(\n        UpdateUserProfile.newBuilder()\n            .setFirstName(\"John\")\n            .setLastName(\"Smith\")\n            .build())\n    .putMetadata(\"department\", \"sales\")\n    .build();\nUpdateUserRequest updReq = UpdateUserRequest.newBuilder()\n    .setUser(upd)\n    .build();\nscalekitClient.users().updateUser(\"usr_123\", updReq);"
           }
         ]
       }
@@ -4731,7 +5023,9 @@
     "/api/v1/users/{user_id}/sessions": {
       "get": {
         "description": "Retrieves a paginated list of all sessions associated with a specific user across all devices and browsers. Use this endpoint to audit user activity, display all active sessions in account management interfaces, or verify user authentication status across devices. Supports filtering by session status (active, expired, revoked, logout) and time range (creation date). Returns session details for each session including device information, IP address, geolocation, and current status. The response includes pagination metadata (page tokens and total count) to handle large session lists efficiently.",
-        "tags": ["Sessions"],
+        "tags": [
+          "Sessions"
+        ],
         "summary": "List user sessions",
         "operationId": "SessionService_GetUserSessions",
         "parameters": [
@@ -4832,7 +5126,9 @@
     "/api/v1/users/{user_id}/sessions/revoke": {
       "post": {
         "description": "Immediately invalidates all active sessions for a specific user across all devices and browsers, setting their status to 'revoked'. Use this endpoint to implement global logout functionality, force re-authentication after security incidents, or terminate all sessions following a password reset or credential compromise. Only active sessions are revoked; already expired, logout, or previously revoked sessions remain unchanged. The revocation is atomic and instantaneous. Returns a list of all revoked sessions with their details and a total count of sessions revoked.",
-        "tags": ["Sessions"],
+        "tags": [
+          "Sessions"
+        ],
         "summary": "Revoke all user sessions",
         "operationId": "SessionService_RevokeAllUserSessions",
         "parameters": [
@@ -4885,7 +5181,9 @@
     "/api/v1/users:external/{external_id}": {
       "get": {
         "description": "Retrieves all details for a user by your application's external identifier. Use this endpoint when you store users in Scalekit using your own system's identifiers and need to retrieve the Scalekit user record. The response includes organization memberships and user metadata.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Get user by external ID",
         "operationId": "UserService_GetUser2",
         "parameters": [
@@ -4914,7 +5212,9 @@
       },
       "delete": {
         "description": "Permanently removes a user identified by your application's external identifier. This action deletes the user's profile, memberships, and all related data across all organizations. This operation cannot be undone.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Delete user by external ID",
         "operationId": "UserService_DeleteUser2",
         "parameters": [
@@ -4941,7 +5241,9 @@
       },
       "patch": {
         "description": "Modifies user account information for a user identified by your application's external identifier. Use this endpoint to keep user profile data in sync from your system without needing to store Scalekit's internal user ID. You can update the user's profile, phone number, and metadata fields.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Update user by external ID",
         "operationId": "UserService_UpdateUser2",
         "parameters": [
@@ -4989,7 +5291,9 @@
     "/api/v1/users:search": {
       "get": {
         "description": "Searches for users across the entire environment by email address, user ID, or external ID. The query must be at least 3 characters and is case-insensitive. Returns a paginated list of matching users with up to 30 results per page. Use the next_page_token from the response to retrieve subsequent pages.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Search users",
         "operationId": "UserService_SearchUsers",
         "parameters": [
@@ -5049,7 +5353,9 @@
     "/api/v1/webauthn/credentials": {
       "get": {
         "description": "Retrieves all registered passkeys for the current user, including device information, creation timestamps, and display names. Use this to show users their registered authenticators.",
-        "tags": ["Passkeys"],
+        "tags": [
+          "Passkeys"
+        ],
         "summary": "List user's passkeys",
         "operationId": "WebAuthnService_ListCredentials",
         "parameters": [
@@ -5093,7 +5399,7 @@
           {
             "label": "Java SDK",
             "lang": "java",
-            "source": "ListCredentialsResponse res = scalekitClient.webauthn().listCredentials(\"user_123\");"
+            "source": "ListCredentialsResponse res = scalekitClient.webAuthn().listCredentials(\"user_123\");"
           }
         ]
       }
@@ -5101,7 +5407,9 @@
     "/api/v1/webauthn/credentials/{credential_id}": {
       "delete": {
         "description": "Deletes a specific passkey credential for the current user. After removal, the authenticator can no longer be used for authentication.",
-        "tags": ["Passkeys"],
+        "tags": [
+          "Passkeys"
+        ],
         "summary": "Remove a passkey",
         "operationId": "WebAuthnService_DeleteCredential",
         "parameters": [
@@ -5146,13 +5454,15 @@
           {
             "label": "Java SDK",
             "lang": "java",
-            "source": "DeleteCredentialResponse res = scalekitClient.webauthn().deleteCredential(\"wac_123\");"
+            "source": "DeleteCredentialResponse res = scalekitClient.webAuthn().deleteCredential(\"wac_123\");"
           }
         ]
       },
       "patch": {
         "description": "Updates the display name of a passkey credential to help users identify their authenticators. Only the display name can be modified.",
-        "tags": ["Passkeys"],
+        "tags": [
+          "Passkeys"
+        ],
         "summary": "Rename a passkey",
         "operationId": "WebAuthnService_UpdateCredential",
         "parameters": [
@@ -5207,7 +5517,7 @@
           {
             "label": "Java SDK",
             "lang": "java",
-            "source": "UpdateCredentialResponse res = scalekitClient.webauthn()\n    .updateCredential(\"wac_123\", \"Work Laptop Passkey\");"
+            "source": "UpdateCredentialResponse res = scalekitClient.webAuthn()\n    .updateCredential(\"wac_123\", \"Work Laptop Passkey\");"
           }
         ]
       }
@@ -5368,6 +5678,174 @@
         }
       }
     },
+    "organization.domain_created": {
+      "post": {
+        "summary": "Organization Domain Created",
+        "description": "Triggered when a domain is added to an organization (organization domain or allowed email domain).",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScalekitEvent"
+              },
+              "example": {
+                "spec_version": "1",
+                "id": "evt_4567890123",
+                "type": "organization.domain_created",
+                "object": "Organization",
+                "occurred_at": "2024-01-15T11:00:00.123456789Z",
+                "environment_id": "env_1234567890",
+                "organization_id": "org_1234567890",
+                "data": {
+                  "id": "dom_1234567890",
+                  "domain": "acmecorp.com",
+                  "domain_type": "ORGANIZATION_DOMAIN",
+                  "organization_id": "org_1234567890",
+                  "environment_id": "env_1234567890",
+                  "txt_record_key": "scalekit-domain-verification",
+                  "txt_record_secret": "sk_dom_verify_abc123",
+                  "verification_status": "PENDING",
+                  "verification_method": "DNS",
+                  "updated_at": "2024-01-15T11:00:00.123456789Z"
+                },
+                "display_name": "Organization Domain Created"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Webhook received successfully"
+          }
+        }
+      }
+    },
+    "organization.domain_deleted": {
+      "post": {
+        "summary": "Organization Domain Deleted",
+        "description": "Triggered when a domain is removed from an organization.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScalekitEvent"
+              },
+              "example": {
+                "spec_version": "1",
+                "id": "evt_4567890456",
+                "type": "organization.domain_deleted",
+                "object": "Organization",
+                "occurred_at": "2024-01-16T09:30:00.123456789Z",
+                "environment_id": "env_1234567890",
+                "organization_id": "org_1234567890",
+                "data": {
+                  "id": "dom_1234567890",
+                  "domain": "acmecorp.com",
+                  "domain_type": "ORGANIZATION_DOMAIN",
+                  "organization_id": "org_1234567890",
+                  "environment_id": "env_1234567890",
+                  "txt_record_key": "scalekit-domain-verification",
+                  "txt_record_secret": "sk_dom_verify_abc123",
+                  "verification_status": "VERIFIED",
+                  "verification_method": "DNS",
+                  "updated_at": "2024-01-16T09:30:00.123456789Z"
+                },
+                "display_name": "Organization Domain Deleted"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Webhook received successfully"
+          }
+        }
+      }
+    },
+    "organization.domain_dns_verification_success": {
+      "post": {
+        "summary": "Organization Domain DNS Verification Success",
+        "description": "Triggered when DNS TXT record validation confirms ownership of an organization domain.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScalekitEvent"
+              },
+              "example": {
+                "spec_version": "1",
+                "id": "evt_4567890789",
+                "type": "organization.domain_dns_verification_success",
+                "object": "Organization",
+                "occurred_at": "2024-01-15T12:15:00.123456789Z",
+                "environment_id": "env_1234567890",
+                "organization_id": "org_1234567890",
+                "data": {
+                  "id": "dom_1234567890",
+                  "domain": "acmecorp.com",
+                  "domain_type": "ORGANIZATION_DOMAIN",
+                  "organization_id": "org_1234567890",
+                  "environment_id": "env_1234567890",
+                  "txt_record_key": "scalekit-domain-verification",
+                  "txt_record_secret": "sk_dom_verify_abc123",
+                  "verification_status": "VERIFIED",
+                  "verification_method": "DNS",
+                  "updated_at": "2024-01-15T12:15:00.123456789Z"
+                },
+                "display_name": "Organization Domain DNS Verification Success"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Webhook received successfully"
+          }
+        }
+      }
+    },
+    "organization.domain_dns_verification_failed": {
+      "post": {
+        "summary": "Organization Domain DNS Verification Failed",
+        "description": "Triggered when the DNS verification window expires without a successful TXT record match.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScalekitEvent"
+              },
+              "example": {
+                "spec_version": "1",
+                "id": "evt_4567891012",
+                "type": "organization.domain_dns_verification_failed",
+                "object": "Organization",
+                "occurred_at": "2024-01-16T11:00:00.123456789Z",
+                "environment_id": "env_1234567890",
+                "organization_id": "org_1234567890",
+                "data": {
+                  "id": "dom_1234567890",
+                  "domain": "acmecorp.com",
+                  "domain_type": "ORGANIZATION_DOMAIN",
+                  "organization_id": "org_1234567890",
+                  "environment_id": "env_1234567890",
+                  "txt_record_key": "scalekit-domain-verification",
+                  "txt_record_secret": "sk_dom_verify_abc123",
+                  "verification_status": "FAILED",
+                  "verification_method": "DNS",
+                  "updated_at": "2024-01-16T11:00:00.123456789Z"
+                },
+                "display_name": "Organization Domain DNS Verification Failed"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Webhook received successfully"
+          }
+        }
+      }
+    },
     "user.signup": {
       "post": {
         "summary": "User Signup",
@@ -5504,7 +5982,9 @@
                   },
                   "user_session": {
                     "absolute_expires_at": "2026-01-08T12:04:41.737394Z",
-                    "authenticated_organizations": ["org_102701193188409609"],
+                    "authenticated_organizations": [
+                      "org_102701193188409609"
+                    ],
                     "created_at": "2025-12-09T12:04:41.48Z",
                     "expired_at": null,
                     "idle_expires_at": "2025-12-16T12:04:41.737395Z",
@@ -5603,7 +6083,9 @@
                   },
                   "user_session": {
                     "absolute_expires_at": "2026-01-08T12:04:41.737394Z",
-                    "authenticated_organizations": ["org_102701193188409609"],
+                    "authenticated_organizations": [
+                      "org_102701193188409609"
+                    ],
                     "created_at": "2025-12-09T12:04:41.48Z",
                     "expired_at": null,
                     "idle_expires_at": "2025-12-16T12:04:41.737395Z",
@@ -6742,33 +7224,45 @@
             "description": "The absolute session timeout value. The unit is specified by absolute_session_timeout_unit. Omit when policy_source is APPLICATION.",
             "type": "integer",
             "format": "int32",
-            "examples": [360]
+            "examples": [
+              360
+            ]
           },
           "absolute_session_timeout_unit": {
             "description": "Unit for absolute_session_timeout. Accepted values: 'MINUTES', 'HOURS', 'DAYS'. Defaults to MINUTES.",
             "$ref": "#/components/schemas/commonsTimeUnit",
-            "examples": ["MINUTES"]
+            "examples": [
+              "MINUTES"
+            ]
           },
           "idle_session_timeout": {
             "description": "The idle session timeout value. The unit is specified by idle_session_timeout_unit. Omit when idle_session_timeout_enabled is false.",
             "type": "integer",
             "format": "int32",
-            "examples": [84]
+            "examples": [
+              84
+            ]
           },
           "idle_session_timeout_enabled": {
             "description": "Whether idle session timeout is enabled. Omit when policy_source is APPLICATION.",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "idle_session_timeout_unit": {
             "description": "Unit for idle_session_timeout. Accepted values: 'MINUTES', 'HOURS', 'DAYS'. Defaults to MINUTES.",
             "$ref": "#/components/schemas/commonsTimeUnit",
-            "examples": ["MINUTES"]
+            "examples": [
+              "MINUTES"
+            ]
           },
           "policy_source": {
             "description": "Policy source. Send 'APPLICATION' to revert to application defaults. Send 'CUSTOM' with timeout values to activate a custom policy.",
             "$ref": "#/components/schemas/organizationsSessionPolicyType",
-            "examples": ["CUSTOM"]
+            "examples": [
+              "CUSTOM"
+            ]
           }
         }
       },
@@ -6799,7 +7293,9 @@
           "default_member_role": {
             "description": "Unique name of the default member role",
             "type": "string",
-            "examples": ["member"]
+            "examples": [
+              "member"
+            ]
           }
         }
       },
@@ -6947,7 +7443,9 @@
           "attachment": {
             "description": "Attachment type: \"platform\" (built-in) or \"cross-platform\"",
             "type": "string",
-            "examples": ["platform"]
+            "examples": [
+              "platform"
+            ]
           },
           "icon_dark": {
             "description": "Icon URL for dark theme display",
@@ -6960,7 +7458,9 @@
           "name": {
             "description": "Human-readable name of the authenticator model",
             "type": "string",
-            "examples": ["Apple Touch ID"]
+            "examples": [
+              "Apple Touch ID"
+            ]
           }
         }
       },
@@ -6991,22 +7491,30 @@
           "city": {
             "description": "City name",
             "type": "string",
-            "examples": ["San Francisco"]
+            "examples": [
+              "San Francisco"
+            ]
           },
           "ip": {
             "description": "IP address from which credential was registered",
             "type": "string",
-            "examples": ["192.0.2.1"]
+            "examples": [
+              "192.0.2.1"
+            ]
           },
           "region": {
             "description": "Geographic region (e.g., \"US\")",
             "type": "string",
-            "examples": ["US"]
+            "examples": [
+              "US"
+            ]
           },
           "region_subdivision": {
             "description": "Regional subdivision (e.g., \"CA\")",
             "type": "string",
-            "examples": ["CA"]
+            "examples": [
+              "CA"
+            ]
           }
         }
       },
@@ -7016,32 +7524,44 @@
           "browser": {
             "description": "Browser name (e.g., \"Chrome\", \"Safari\")",
             "type": "string",
-            "examples": ["Chrome"]
+            "examples": [
+              "Chrome"
+            ]
           },
           "browser_version": {
             "description": "Browser version number",
             "type": "string",
-            "examples": ["120.0.6099.129"]
+            "examples": [
+              "120.0.6099.129"
+            ]
           },
           "device_model": {
             "description": "Device model if available",
             "type": "string",
-            "examples": ["iPhone15,2"]
+            "examples": [
+              "iPhone15,2"
+            ]
           },
           "device_type": {
             "description": "Device type: \"desktop\", \"mobile\", or \"tablet\"",
             "type": "string",
-            "examples": ["mobile"]
+            "examples": [
+              "mobile"
+            ]
           },
           "os": {
             "description": "Operating system name (e.g., \"Windows\", \"iOS\")",
             "type": "string",
-            "examples": ["macOS"]
+            "examples": [
+              "macOS"
+            ]
           },
           "os_version": {
             "description": "Operating system version",
             "type": "string",
-            "examples": ["14.2"]
+            "examples": [
+              "14.2"
+            ]
           },
           "raw": {
             "description": "Raw user agent string from the browser",
@@ -7059,13 +7579,19 @@
           "display_name": {
             "description": "Human-friendly name for this credential (1-120 characters)",
             "type": "string",
-            "examples": ["My iPhone 15 Pro"]
+            "examples": [
+              "My iPhone 15 Pro"
+            ]
           }
         }
       },
       "authpasswordlessPasswordlessType": {
         "type": "string",
-        "enum": ["OTP", "LINK", "LINK_OTP"]
+        "enum": [
+          "OTP",
+          "LINK",
+          "LINK_OTP"
+        ]
       },
       "clientsClientSecret": {
         "description": "A secure credential used for authenticating an API client. Each client can have multiple secrets for key rotation purposes.",
@@ -7076,57 +7602,77 @@
             "description": "The timestamp when this secret was created. This field is automatically set by the server and cannot be modified.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-01-05T14:48:00Z"]
+            "examples": [
+              "2024-01-05T14:48:00Z"
+            ]
           },
           "created_by": {
             "description": "The identifier of the user or system that created this secret. This field helps track who created the secret for audit and compliance purposes.",
             "type": "string",
-            "examples": ["user_12345"]
+            "examples": [
+              "user_12345"
+            ]
           },
           "expire_time": {
             "description": "The timestamp when this secret will expire. After this time, the secret cannot be used for authentication regardless of its status. If not set, the secret does not expire.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-05T14:48:00Z"]
+            "examples": [
+              "2025-01-05T14:48:00Z"
+            ]
           },
           "id": {
             "description": "The unique identifier for this client secret. This ID is used to reference the secret in API requests for management operations like updating or deleting the secret.",
             "type": "string",
-            "examples": ["sec_1234abcd5678efgh"]
+            "examples": [
+              "sec_1234abcd5678efgh"
+            ]
           },
           "last_used_time": {
             "description": "The timestamp when this secret was last used for authentication. This field helps track secret usage for security monitoring and identifying unused secrets that may be candidates for rotation.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-02-15T10:30:00Z"]
+            "examples": [
+              "2024-02-15T10:30:00Z"
+            ]
           },
           "plain_secret": {
             "description": "The full plaintext secret value. This field is only populated when the secret is first created and is never stored by the server. It must be securely stored by the client application as it cannot be retrieved again.",
             "type": "string",
-            "examples": ["sec_1234567890abcdefghijklmnopqrstuvwxyz"]
+            "examples": [
+              "sec_1234567890abcdefghijklmnopqrstuvwxyz"
+            ]
           },
           "secret_suffix": {
             "description": "A suffix that helps identify this secret. This is the last few characters of the full secret value but is not sufficient for authentication. Helps identify which secret is being used in logs and debugging.",
             "type": "string",
-            "examples": ["xyzw"]
+            "examples": [
+              "xyzw"
+            ]
           },
           "status": {
             "description": "The current status of this secret. A secret must be ACTIVE to be used for authentication. INACTIVE secrets cannot be used for authentication but are retained for audit purposes.",
             "$ref": "#/components/schemas/clientsClientSecretStatus",
-            "examples": ["INACTIVE"]
+            "examples": [
+              "INACTIVE"
+            ]
           },
           "update_time": {
             "description": "The timestamp when this secret was last updated. This field is automatically updated by the server when the secret's status changes or other properties are modified.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-01-10T09:12:00Z"]
+            "examples": [
+              "2024-01-10T09:12:00Z"
+            ]
           }
         }
       },
       "clientsClientSecretStatus": {
         "description": "ClientSecretStatus indicates whether a client secret can be used for authentication.\nACTIVE secrets can be used for authentication while INACTIVE secrets cannot.\n\n - INACTIVE: The secret is inactive and cannot be used for authentication",
         "type": "string",
-        "enum": ["INACTIVE"]
+        "enum": [
+          "INACTIVE"
+        ]
       },
       "clientsCreateOrganizationClientResponse": {
         "type": "object",
@@ -7138,7 +7684,9 @@
           "plain_secret": {
             "description": "Client secret value (only returned once at creation)",
             "type": "string",
-            "examples": ["CdExsdErfccxDDssddfffgfeFHH1"]
+            "examples": [
+              "CdExsdErfccxDDssddfffgfeFHH1"
+            ]
           }
         }
       },
@@ -7148,7 +7696,9 @@
           "plain_secret": {
             "description": "Client secret value (only returned once at creation)",
             "type": "string",
-            "examples": ["m2morg_client_secret_xyz123"]
+            "examples": [
+              "m2morg_client_secret_xyz123"
+            ]
           },
           "secret": {
             "description": "Details of the created client secret",
@@ -7162,12 +7712,16 @@
           "key": {
             "description": "The name of the custom claim. Must be between 1 and 128 characters. Use descriptive names that clearly indicate the claim's purpose.",
             "type": "string",
-            "examples": ["environment"]
+            "examples": [
+              "environment"
+            ]
           },
           "value": {
             "description": "The value of the custom claim. This value will be included in access tokens issued to the client.",
             "type": "string",
-            "examples": ["production"]
+            "examples": [
+              "production"
+            ]
           }
         }
       },
@@ -7198,20 +7752,26 @@
             "description": "Pagination token for the next page of results. Use this token to fetch the next page.",
             "type": "string",
             "title": "Pagination token for the next page of results",
-            "examples": ["<next_page_token>"]
+            "examples": [
+              "<next_page_token>"
+            ]
           },
           "prev_page_token": {
             "description": "Pagination token for the previous page of results. Use this token to fetch the previous page.",
             "type": "string",
             "title": "Pagination token for the previous page of results",
-            "examples": ["<prev_page_token>"]
+            "examples": [
+              "<prev_page_token>"
+            ]
           },
           "total_size": {
             "description": "Total number of API clients in the organization.",
             "type": "integer",
             "format": "int64",
             "title": "Total number of clients in the organization",
-            "examples": [30]
+            "examples": [
+              30
+            ]
           }
         }
       },
@@ -7224,18 +7784,26 @@
             "items": {
               "type": "string"
             },
-            "examples": [["https://api.example.com"]]
+            "examples": [
+              [
+                "https://api.example.com"
+              ]
+            ]
           },
           "client_id": {
             "description": "The unique identifier for this API client. This ID is used to identify the client in API requests and logs. It is automatically generated when the client is created and cannot be modified.",
             "type": "string",
-            "examples": ["m2morg_1231234233424344"]
+            "examples": [
+              "m2morg_1231234233424344"
+            ]
           },
           "create_time": {
             "description": "The timestamp when this API client was created. This field is automatically set by the server and cannot be modified.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-01-05T14:48:00Z"]
+            "examples": [
+              "2024-01-05T14:48:00Z"
+            ]
           },
           "custom_claims": {
             "description": "Additional claims included in access tokens issued to this client. These claims provide context about the client and can be used for authorization decisions.",
@@ -7248,38 +7816,52 @@
           "description": {
             "description": "A detailed description of the client's purpose and usage. This helps administrators understand what the client is used for.",
             "type": "string",
-            "examples": ["Service account for automated deployment processes"]
+            "examples": [
+              "Service account for automated deployment processes"
+            ]
           },
           "expiry": {
             "description": "Expiry time in seconds for the token generated by the client",
             "type": "string",
             "format": "int64",
-            "examples": [3600]
+            "examples": [
+              3600
+            ]
           },
           "is_cimd": {
             "description": "Indicates if the client was created via Client ID Metadata Document (CIMD). CIMD clients can update their own configuration according to the CIMD specification.",
             "type": "boolean",
-            "examples": [false]
+            "examples": [
+              false
+            ]
           },
           "is_dcr": {
             "description": "Indicates if the client was created via Dynamic Client Registration (DCR). Clients created through DCR may have different management and lifecycle policies compared to those created manually.",
             "type": "boolean",
-            "examples": [false]
+            "examples": [
+              false
+            ]
           },
           "metadata_uri": {
             "description": "The URI to the client's metadata, which is utilized to obtain the client's configuration details",
             "type": "string",
-            "examples": ["https://example.com/client-metadata.json"]
+            "examples": [
+              "https://example.com/client-metadata.json"
+            ]
           },
           "name": {
             "description": "The display name of the API client. This name helps identify the client in the dashboard and logs.",
             "type": "string",
-            "examples": ["GitHub Actions Deployment Service"]
+            "examples": [
+              "GitHub Actions Deployment Service"
+            ]
           },
           "organization_id": {
             "description": "The ID of the organization that owns this API client. This ID is used to associate the client with the correct organization and enforce organization-specific access controls.",
             "type": "string",
-            "examples": ["org_1231234233424344"]
+            "examples": [
+              "org_1231234233424344"
+            ]
           },
           "redirect_uris": {
             "description": "The redirect URI for this API client. This URI is used in the OAuth 2.0 authorization flow to redirect users after authentication.",
@@ -7287,12 +7869,18 @@
             "items": {
               "type": "string"
             },
-            "examples": [["https://example.com/callback"]]
+            "examples": [
+              [
+                "https://example.com/callback"
+              ]
+            ]
           },
           "resource_id": {
             "description": "The ID of the resource associated with this M2M client. This field is used to link the client to a specific resource in the system.",
             "type": "string",
-            "examples": ["app_1231234233424344"]
+            "examples": [
+              "app_1231234233424344"
+            ]
           },
           "scopes": {
             "description": "The OAuth 2.0 scopes granted to this client. These scopes determine what resources and actions the client can access.",
@@ -7300,7 +7888,12 @@
             "items": {
               "type": "string"
             },
-            "examples": [["deploy:resources", "read:deployments"]]
+            "examples": [
+              [
+                "deploy:resources",
+                "read:deployments"
+              ]
+            ]
           },
           "secrets": {
             "description": "List of client secrets associated with this client. Each secret can be used for authentication, but only the most recently created secret is typically active. Secrets are stored securely and their values are never returned after creation.",
@@ -7314,7 +7907,9 @@
             "description": "The timestamp when this API client was last updated. This field is automatically updated by the server whenever the client's configuration changes.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-01-05T14:48:00Z"]
+            "examples": [
+              "2024-01-05T14:48:00Z"
+            ]
           }
         }
       },
@@ -7328,7 +7923,10 @@
               "type": "string"
             },
             "examples": [
-              ["https://api.example.com/api/analytics", "https://deployment-api.acmecorp.com"]
+              [
+                "https://api.example.com/api/analytics",
+                "https://deployment-api.acmecorp.com"
+              ]
             ]
           },
           "custom_claims": {
@@ -7354,18 +7952,24 @@
           "description": {
             "description": "A detailed explanation of the client's purpose and usage. This helps administrators understand what the client is used for and who manages it.",
             "type": "string",
-            "examples": ["Service account for GitHub Actions to deploy resources to production"]
+            "examples": [
+              "Service account for GitHub Actions to deploy resources to production"
+            ]
           },
           "expiry": {
             "description": "Expiry time in seconds for the token generated by the client",
             "type": "string",
             "format": "int64",
-            "examples": [3600]
+            "examples": [
+              3600
+            ]
           },
           "name": {
             "description": "A descriptive name for the API client that helps identify its purpose. This name is displayed in the dashboard and logs. Must be between 1 and 128 characters.",
             "type": "string",
-            "examples": ["GitHub Actions Deployment Service"]
+            "examples": [
+              "GitHub Actions Deployment Service"
+            ]
           },
           "scopes": {
             "description": "OAuth 2.0 scopes that define the permissions granted to this client. Each scope represents a specific permission or set of permissions. The client can only access resources that match its granted scopes.",
@@ -7373,7 +7977,12 @@
             "items": {
               "type": "string"
             },
-            "examples": [["deploy:resources", "read:deployments"]]
+            "examples": [
+              [
+                "deploy:resources",
+                "read:deployments"
+              ]
+            ]
           }
         }
       },
@@ -7393,25 +8002,33 @@
             "description": "Unique identifier for the external identity connection. Immutable and read-only.",
             "type": "string",
             "readOnly": true,
-            "examples": ["conn_1234abcd5678efgh"]
+            "examples": [
+              "conn_1234abcd5678efgh"
+            ]
           },
           "connection_provider": {
             "description": "Type of the identity provider.",
             "$ref": "#/components/schemas/commonsIdentityProviderType",
             "readOnly": true,
-            "examples": ["GOOGLE"]
+            "examples": [
+              "GOOGLE"
+            ]
           },
           "connection_type": {
             "description": "Name of the external identity connection.",
             "type": "string",
             "readOnly": true,
-            "examples": ["OAUTH"]
+            "examples": [
+              "OAUTH"
+            ]
           },
           "connection_user_id": {
             "description": "Unique identifier for the user in the external identity provider system. Immutable and read-only.",
             "type": "string",
             "readOnly": true,
-            "examples": ["ext_user_12345"]
+            "examples": [
+              "ext_user_12345"
+            ]
           },
           "created_time": {
             "description": "Timestamp when this external identity connection was first created. Immutable and read-only.",
@@ -7423,7 +8040,9 @@
             "description": "Indicates if the identity provider is a social provider (true) or enterprise/custom provider (false). Read-only.",
             "type": "boolean",
             "readOnly": true,
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "last_login_time": {
             "description": "Timestamp of the user's last successful login via this external identity provider. Automatically updated by the system.",
@@ -7462,7 +8081,12 @@
       },
       "commonsMembershipStatus": {
         "type": "string",
-        "enum": ["ACTIVE", "INACTIVE", "PENDING_INVITE", "INVITE_EXPIRED"]
+        "enum": [
+          "ACTIVE",
+          "INACTIVE",
+          "PENDING_INVITE",
+          "INVITE_EXPIRED"
+        ]
       },
       "commonsOrganizationMembership": {
         "type": "object",
@@ -7480,7 +8104,9 @@
           "display_name": {
             "description": "Organization display name. This field stores a user-friendly name for the organization that may be different from the formal name, often used for UI display purposes.",
             "type": "string",
-            "examples": ["Acme Corporation"]
+            "examples": [
+              "Acme Corporation"
+            ]
           },
           "expires_at": {
             "description": "Timestamp when the invitation expired.",
@@ -7515,12 +8141,16 @@
           "name": {
             "description": "Organization name. This field stores the formal organization name used for identification and display purposes.",
             "type": "string",
-            "examples": ["AcmeCorp"]
+            "examples": [
+              "AcmeCorp"
+            ]
           },
           "organization_id": {
             "description": "Unique identifier for the organization. Immutable and read-only.",
             "type": "string",
-            "examples": ["org_1234abcd5678efgh"]
+            "examples": [
+              "org_1234abcd5678efgh"
+            ]
           },
           "permissions": {
             "description": "Effective permissions granted to the user within the organization (including inherited permissions from assigned roles). Lists the specific actions and access rights the user can perform.",
@@ -7528,7 +8158,13 @@
             "items": {
               "type": "string"
             },
-            "examples": [["read_projects", "write_tasks", "manage_users"]]
+            "examples": [
+              [
+                "read_projects",
+                "write_tasks",
+                "manage_users"
+              ]
+            ]
           },
           "provisioning_method": {
             "description": "How the user was provisioned. \nPossible values: \n- `jit_using_sso` (Just-in-time provisioning during SSO login)\n- `allowed_email_domain` (User joined via allowed email domain matching)\n- `org_creator` (User created the organization)\n- `direct_provision` (User was directly provisioned via API or SCIM)\n- `invitation` (User was invited and accepted an invitation)",
@@ -7545,7 +8181,10 @@
       },
       "commonsRegionCode": {
         "type": "string",
-        "enum": ["US", "EU"]
+        "enum": [
+          "US",
+          "EU"
+        ]
       },
       "commonsRole": {
         "type": "object",
@@ -7553,24 +8192,34 @@
           "display_name": {
             "description": "Human-readable name for the role",
             "type": "string",
-            "examples": ["Dev Team"]
+            "examples": [
+              "Dev Team"
+            ]
           },
           "id": {
             "description": "Role ID",
             "type": "string",
             "readOnly": true,
-            "examples": ["role_79643236410327240"]
+            "examples": [
+              "role_79643236410327240"
+            ]
           },
           "name": {
             "description": "Attribute name/identifier for the role used in system operations and API calls. This should be a machine-readable identifier that follows naming conventions.",
             "type": "string",
-            "examples": ["team_dev"]
+            "examples": [
+              "team_dev"
+            ]
           }
         }
       },
       "commonsTimeUnit": {
         "type": "string",
-        "enum": ["MINUTES", "HOURS", "DAYS"]
+        "enum": [
+          "MINUTES",
+          "HOURS",
+          "DAYS"
+        ]
       },
       "commonsUserProfile": {
         "type": "object",
@@ -7592,7 +8241,9 @@
             "description": "Indicates if the user's email address has been verified. Automatically updated by the system.",
             "type": "boolean",
             "readOnly": true,
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "external_identities": {
             "description": "List of external identity connections associated with the user profile.",
@@ -7606,17 +8257,23 @@
           "family_name": {
             "description": "The user's family name (last name or surname). This field stores the user's last name and is combined with the given name to create the full display name. The family name is used in formal communications, user listings, and organizational directories throughout the system. Maximum 255 characters allowed.",
             "type": "string",
-            "examples": ["Doe"]
+            "examples": [
+              "Doe"
+            ]
           },
           "gender": {
             "description": "The user's gender identity information. This field stores the user's gender identity for personalization, compliance reporting, or organizational analytics purposes. This field supports any string value to accommodate diverse gender identities and should be handled with appropriate privacy considerations according to your organization's policies and applicable regulations.",
             "type": "string",
-            "examples": ["male"]
+            "examples": [
+              "male"
+            ]
           },
           "given_name": {
             "description": "The user's given name (first name). This field stores the user's first name and is used for personalization, display purposes, and when generating the full display name. The given name appears in user interfaces, formal communications, and user listings throughout the system. Maximum 255 characters allowed.",
             "type": "string",
-            "examples": ["John"]
+            "examples": [
+              "John"
+            ]
           },
           "groups": {
             "description": "The list of group names the user belongs to within the organization. This field stores the user's group memberships for role-based access control, team assignments, and organizational structure. Groups are typically used for permission management, collaborative access, and organizational hierarchy. Each group name represents a distinct organizational unit or team that the user is associated with.",
@@ -7624,18 +8281,27 @@
             "items": {
               "type": "string"
             },
-            "examples": [["admin", "developer"]]
+            "examples": [
+              [
+                "admin",
+                "developer"
+              ]
+            ]
           },
           "id": {
             "description": "Unique system-generated identifier for the user profile. Immutable and read-only.",
             "type": "string",
             "readOnly": true,
-            "examples": ["usr_profile_1234abcd5678efgh"]
+            "examples": [
+              "usr_profile_1234abcd5678efgh"
+            ]
           },
           "locale": {
             "description": "The user's preferred language and region settings using BCP-47 format codes. This field customizes the user's experience with localized content, date formats, number formatting, and UI language throughout the system. When not specified, the user inherits the organization's default locale settings. Common values include `en-US`, `en-GB`, `fr-FR`, `de-DE`, and `es-ES`.",
             "type": "string",
-            "examples": ["en-US"]
+            "examples": [
+              "en-US"
+            ]
           },
           "metadata": {
             "description": "Raw attributes received from identity providers during authentication. This field stores the original user profile data as received from external IdP systems (SAML, OIDC, etc.) including provider-specific claims and attributes. These fields preserve the complete set of attributes received from the identity source and are used for mapping, synchronization, and audit purposes. Keys must be 3-25 characters, values must be 1-256 characters, with a maximum of 20 key-value pairs.",
@@ -7654,38 +8320,54 @@
           "name": {
             "description": "The user's complete display name in formatted form. This field stores the full name as a single string and is typically used when you want to set the complete name rather than using separate given and family names. This name appears in user interfaces, reports, directory listings, and anywhere a formatted display name is needed. This field serves as a formatted display name that complements the individual given_name and family_name fields.",
             "type": "string",
-            "examples": ["John Michael Doe"]
+            "examples": [
+              "John Michael Doe"
+            ]
           },
           "phone_number": {
             "description": "The user's phone number in E.164 international format. This field stores the phone number for user contact and identification purposes. The phone number must include the country code and be formatted according to E.164 standards (e.g., `+1` for US numbers). This field is optional.",
             "type": "string",
-            "examples": ["+14155552671"]
+            "examples": [
+              "+14155552671"
+            ]
           },
           "phone_number_verified": {
             "description": "Indicates if the user's phone number has been verified. Automatically updated by the system.",
             "type": "boolean",
             "readOnly": true,
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "picture": {
             "description": "The URL to the user's profile picture or avatar image. This field stores the location of the user's profile photo that appears in user interfaces, directory listings, and collaborative features throughout the system. The URL should point to a publicly accessible image file. Supported formats typically include JPEG, PNG, and GIF. This image is used for visual identification and personalization across the platform.",
             "type": "string",
-            "examples": ["https://example.com/avatar.jpg"]
+            "examples": [
+              "https://example.com/avatar.jpg"
+            ]
           },
           "preferred_username": {
             "description": "The user's preferred username for display and identification purposes. This field stores a custom username that the user prefers to be known by, which may differ from their email or formal name. This username appears in user interfaces, mentions, informal communications, and collaborative features throughout the system. Maximum 512 characters allowed.",
             "type": "string",
-            "examples": ["johndoe"]
+            "examples": [
+              "johndoe"
+            ]
           }
         }
       },
       "connectionsCodeChallengeType": {
         "type": "string",
-        "enum": ["NUMERIC", "ALPHANUMERIC"]
+        "enum": [
+          "NUMERIC",
+          "ALPHANUMERIC"
+        ]
       },
       "connectionsConfigurationType": {
         "type": "string",
-        "enum": ["DISCOVERY", "MANUAL"]
+        "enum": [
+          "DISCOVERY",
+          "MANUAL"
+        ]
       },
       "connectionsConnection": {
         "type": "object",
@@ -7700,12 +8382,16 @@
           "configuration_type": {
             "description": "How the connection was configured: DISCOVERY (automatic configuration) or MANUAL (administrator configured)",
             "$ref": "#/components/schemas/connectionsConfigurationType",
-            "examples": ["MANUAL"]
+            "examples": [
+              "MANUAL"
+            ]
           },
           "debug_enabled": {
             "description": "Enables testing mode that allows non-HTTPS endpoints. Should only be enabled in development environments, never in production.",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "domains": {
             "description": "Domain associated with this connection, used for domain-based authentication flows.",
@@ -7725,7 +8411,9 @@
           "enabled": {
             "description": "Controls whether users can sign in using this connection. When false, the connection exists but cannot be used for authentication.",
             "type": "boolean",
-            "examples": [false]
+            "examples": [
+              false
+            ]
           },
           "google_dwd_config": {
             "description": "Configuration details for Google Domain-Wide Delegation. Present only when type is GOOGLE_DWD.",
@@ -7734,7 +8422,9 @@
           "id": {
             "description": "Unique identifier for this connection. Used in API calls to reference this specific connection.",
             "type": "string",
-            "examples": ["conn_2123312131125533"]
+            "examples": [
+              "conn_2123312131125533"
+            ]
           },
           "key_id": {
             "description": "Alternative identifier for this connection, typically used in frontend applications or URLs.",
@@ -7744,7 +8434,9 @@
             "description": "URL of the MCP server for this connection. Agents can point directly at this URL to access only the tools for this connection, without needing to call list_connections or execute_tool with a connection_name. Empty when the MCP virtual servers feature is not enabled for this environment.",
             "type": "string",
             "readOnly": true,
-            "examples": ["https://acmecorp.scalekit.dev/mcp/v3/connections/gmail_work"]
+            "examples": [
+              "https://acmecorp.scalekit.dev/mcp/v3/connections/gmail_work"
+            ]
           },
           "oauth_config": {
             "description": "Configuration details for OAuth connections. Present only when type is OAUTH.",
@@ -7757,7 +8449,9 @@
           "organization_id": {
             "description": "Identifier of the organization that owns this connection. Connections are typically scoped to a single organization.",
             "type": "string",
-            "examples": ["org_2123312131125533"]
+            "examples": [
+              "org_2123312131125533"
+            ]
           },
           "passwordless_config": {
             "description": "Configuration details for Magic Link authentication. Present only when type is MAGIC_LINK.",
@@ -7766,12 +8460,16 @@
           "provider": {
             "description": "Identity provider service that handles authentication (such as OKTA, Google, Azure AD, or a custom provider)",
             "$ref": "#/components/schemas/connectionsConnectionProvider",
-            "examples": ["OKTA"]
+            "examples": [
+              "OKTA"
+            ]
           },
           "provider_key": {
             "description": "Key ID of the identity provider service that handles authentication",
             "type": "string",
-            "examples": ["google"]
+            "examples": [
+              "google"
+            ]
           },
           "saml_config": {
             "description": "Configuration details for SAML connections. Present only when type is SAML.",
@@ -7785,17 +8483,23 @@
             "description": "Current configuration status of the connection. Possible values include IN_PROGRESS, CONFIGURED, and ERROR.",
             "$ref": "#/components/schemas/connectionsConnectionStatus",
             "readOnly": true,
-            "examples": ["IN_PROGRESS"]
+            "examples": [
+              "IN_PROGRESS"
+            ]
           },
           "test_connection_uri": {
             "description": "URI that can be used to test this connection. Visit this URL to verify the connection works correctly.",
             "type": "string",
-            "examples": ["https://auth.example.com/test-connection/conn_2123312131125533"]
+            "examples": [
+              "https://auth.example.com/test-connection/conn_2123312131125533"
+            ]
           },
           "type": {
             "description": "Authentication protocol used by this connection. Can be OIDC (OpenID Connect), SAML, OAUTH, or MAGIC_LINK.",
             "$ref": "#/components/schemas/connectionsConnectionType",
-            "examples": ["OIDC"]
+            "examples": [
+              "OIDC"
+            ]
           },
           "webauthn_config": {
             "description": "Configuration details for WebAuthn (passkeys). Present only when type is WEBAUTHN.",
@@ -7826,7 +8530,11 @@
       },
       "connectionsConnectionStatus": {
         "type": "string",
-        "enum": ["DRAFT", "IN_PROGRESS", "COMPLETED"]
+        "enum": [
+          "DRAFT",
+          "IN_PROGRESS",
+          "COMPLETED"
+        ]
       },
       "connectionsConnectionType": {
         "type": "string",
@@ -7887,23 +8595,31 @@
             "description": "Certificate Creation Time",
             "type": "string",
             "format": "date-time",
-            "examples": ["2021-09-01T00:00:00Z"]
+            "examples": [
+              "2021-09-01T00:00:00Z"
+            ]
           },
           "expiry_time": {
             "description": "Certificate Expiry Time",
             "type": "string",
             "format": "date-time",
-            "examples": ["2021-09-01T00:00:00Z"]
+            "examples": [
+              "2021-09-01T00:00:00Z"
+            ]
           },
           "id": {
             "description": "Certificate ID",
             "type": "string",
-            "examples": ["cert_123123123123"]
+            "examples": [
+              "cert_123123123123"
+            ]
           },
           "issuer": {
             "description": "Certificate Issuer",
             "type": "string",
-            "examples": ["https://youridp.com/service/saml"]
+            "examples": [
+              "https://youridp.com/service/saml"
+            ]
           }
         }
       },
@@ -7916,59 +8632,84 @@
             "items": {
               "type": "string"
             },
-            "examples": [["yourapp.com", "yourworkspace.com"]]
+            "examples": [
+              [
+                "yourapp.com",
+                "yourworkspace.com"
+              ]
+            ]
           },
           "enabled": {
             "description": "Whether the connection is currently active for organization users",
             "type": "boolean",
-            "examples": [false]
+            "examples": [
+              false
+            ]
           },
           "id": {
             "description": "Unique identifier of the connection",
             "type": "string",
-            "examples": ["conn_2123312131125533"]
+            "examples": [
+              "conn_2123312131125533"
+            ]
           },
           "key_id": {
             "description": "Alternative identifier for this connection, typically used in frontend applications or URLs",
             "type": "string",
-            "examples": ["conn_2123312131125533"]
+            "examples": [
+              "conn_2123312131125533"
+            ]
           },
           "mcp_server_url": {
             "description": "MCP virtual server URL for this connection. Agents can point directly at this URL to access only the tools for this connection, without needing to call list_connections or execute_tool with a connection_name. Empty when the MCP virtual servers feature is not enabled for this environment.",
             "type": "string",
             "readOnly": true,
-            "examples": ["https://acmecorp.scalekit.dev/mcp/v3/connections/gmail_work"]
+            "examples": [
+              "https://acmecorp.scalekit.dev/mcp/v3/connections/gmail_work"
+            ]
           },
           "organization_id": {
             "description": "Unique identifier of the organization that owns this connection",
             "type": "string",
-            "examples": ["org_2123312131125533"]
+            "examples": [
+              "org_2123312131125533"
+            ]
           },
           "organization_name": {
             "description": "Name of the organization of the connection",
             "type": "string",
-            "examples": ["Your Organization"]
+            "examples": [
+              "Your Organization"
+            ]
           },
           "provider": {
             "description": "Identity provider type (e.g., OKTA, Google, Azure AD)",
             "$ref": "#/components/schemas/connectionsConnectionProvider",
-            "examples": ["CUSTOM"]
+            "examples": [
+              "CUSTOM"
+            ]
           },
           "provider_key": {
             "description": "Key ID of the identity provider service that handles authentication",
             "type": "string",
-            "examples": ["google"]
+            "examples": [
+              "google"
+            ]
           },
           "status": {
             "description": "Current configuration status of the connection",
             "$ref": "#/components/schemas/connectionsConnectionStatus",
             "readOnly": true,
-            "examples": ["IN_PROGRESS"]
+            "examples": [
+              "IN_PROGRESS"
+            ]
           },
           "type": {
             "description": "Authentication protocol used by the connection",
             "$ref": "#/components/schemas/connectionsConnectionType",
-            "examples": ["OIDC"]
+            "examples": [
+              "OIDC"
+            ]
           }
         }
       },
@@ -7987,7 +8728,12 @@
       },
       "connectionsNameIdFormat": {
         "type": "string",
-        "enum": ["UNSPECIFIED", "EMAIL", "TRANSIENT", "PERSISTENT"]
+        "enum": [
+          "UNSPECIFIED",
+          "EMAIL",
+          "TRANSIENT",
+          "PERSISTENT"
+        ]
       },
       "connectionsOAuthConnectionConfig": {
         "type": "object",
@@ -7995,32 +8741,44 @@
           "access_type": {
             "description": "Access Type",
             "type": "string",
-            "examples": ["offline"]
+            "examples": [
+              "offline"
+            ]
           },
           "app_name": {
             "description": "Application name used by providers that require it as an authorize query parameter (e.g., Trello's app_name).",
             "type": "string",
-            "examples": ["My Trello App"]
+            "examples": [
+              "My Trello App"
+            ]
           },
           "authorize_uri": {
             "description": "Authorize URI",
             "type": "string",
-            "examples": ["https://youridp.com/service/oauth/authorize"]
+            "examples": [
+              "https://youridp.com/service/oauth/authorize"
+            ]
           },
           "client_id": {
             "description": "Client ID",
             "type": "string",
-            "examples": ["oauth_client_id"]
+            "examples": [
+              "oauth_client_id"
+            ]
           },
           "client_secret": {
             "description": "Client Secret",
             "type": "string",
-            "examples": ["oauth_client_secret"]
+            "examples": [
+              "oauth_client_secret"
+            ]
           },
           "custom_scope_name": {
             "description": "Custom Scope Name",
             "type": "string",
-            "examples": ["user_scope"]
+            "examples": [
+              "user_scope"
+            ]
           },
           "extensions": {
             "description": "OAuth extension profiles for this connection, such as SMART on FHIR. Carries typed extension configuration plus a generic escape hatch for provider-specific authorize query parameters.",
@@ -8030,7 +8788,9 @@
             "description": "Indicates whether this connection was registered using Client ID Metadata Document (CIMD) instead of Dynamic Client Registration.",
             "type": "boolean",
             "readOnly": true,
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "optional_scopes": {
             "description": "Optional scopes configuration for identity providers that support or require additional scopes to be sent in a custom field during authentication requests.",
@@ -8039,17 +8799,23 @@
           "pkce_enabled": {
             "description": "PKCE Enabled",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "prompt": {
             "description": "Prompt for the user",
             "type": "string",
-            "examples": ["none"]
+            "examples": [
+              "none"
+            ]
           },
           "redirect_uri": {
             "description": "Redirect URI",
             "type": "string",
-            "examples": ["https://yourapp.com/service/oauth/redirect"]
+            "examples": [
+              "https://yourapp.com/service/oauth/redirect"
+            ]
           },
           "scopes": {
             "description": "OIDC Scopes",
@@ -8057,37 +8823,54 @@
             "items": {
               "type": "string"
             },
-            "examples": [["openid", "profile"]]
+            "examples": [
+              [
+                "openid",
+                "profile"
+              ]
+            ]
           },
           "sync_user_profile_on_login": {
             "description": "Indicates whether user profiles should be synchronized with the identity provider upon each log-in.",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "tenant_id": {
             "description": "Microsoft Entra tenant ID. Required when using a single-tenant or multi-tenant app registered in Microsoft Entra. Leave empty to use the common endpoint.",
             "type": "string",
-            "examples": ["xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"]
+            "examples": [
+              "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+            ]
           },
           "token_access_type": {
             "description": "Token Access Type",
             "type": "string",
-            "examples": ["offline"]
+            "examples": [
+              "offline"
+            ]
           },
           "token_uri": {
             "description": "Token URI",
             "type": "string",
-            "examples": ["https://youridp.com/service/oauth/token"]
+            "examples": [
+              "https://youridp.com/service/oauth/token"
+            ]
           },
           "use_platform_creds": {
             "description": "Use Scalekit credentials",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "user_info_uri": {
             "description": "User Info URI",
             "type": "string",
-            "examples": ["https://youridp.com/service/oauth/userinfo"]
+            "examples": [
+              "https://youridp.com/service/oauth/userinfo"
+            ]
           }
         }
       },
@@ -8097,64 +8880,88 @@
           "authorize_uri": {
             "description": "Authorize URI",
             "type": "string",
-            "examples": ["https://youridp.com/service/oauth/authorize"]
+            "examples": [
+              "https://youridp.com/service/oauth/authorize"
+            ]
           },
           "backchannel_logout_redirect_uri": {
             "description": "backchannel logout redirect uri where idp sends logout_token",
             "type": "string",
             "readOnly": true,
-            "examples": ["https://yourapp.com/sso/v1/oidc/conn_1234/backchannel-logout"]
+            "examples": [
+              "https://yourapp.com/sso/v1/oidc/conn_1234/backchannel-logout"
+            ]
           },
           "client_id": {
             "description": "Client ID",
             "type": "string",
-            "examples": ["oauth_client_id"]
+            "examples": [
+              "oauth_client_id"
+            ]
           },
           "client_secret": {
             "description": "Client Secret",
             "type": "string",
-            "examples": ["oauth_client_secret"]
+            "examples": [
+              "oauth_client_secret"
+            ]
           },
           "discovery_endpoint": {
             "description": "Discovery Endpoint",
             "type": "string",
-            "examples": ["https://youridp.com/service/oauth/.well-known/openid-configuration"]
+            "examples": [
+              "https://youridp.com/service/oauth/.well-known/openid-configuration"
+            ]
           },
           "idp_logout_required": {
             "description": "Enable IDP logout",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "issuer": {
             "description": "Issuer URL",
             "type": "string",
-            "examples": ["https://youridp.com/service/oauth"]
+            "examples": [
+              "https://youridp.com/service/oauth"
+            ]
           },
           "jit_provisioning_with_sso_enabled": {
             "description": "Indicates if Just In Time user provisioning is enabled for the connection",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "jwks_uri": {
             "description": "JWKS URI",
             "type": "string",
-            "examples": ["https://youridp.com/service/oauth/jwks"]
+            "examples": [
+              "https://youridp.com/service/oauth/jwks"
+            ]
           },
           "pkce_enabled": {
             "description": "PKCE Enabled",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "post_logout_redirect_uri": {
             "description": "post logout redirect uri",
             "type": "string",
             "readOnly": true,
-            "examples": ["https://yourapp.com/sso/v1/oidc/conn_1234/logout/callback"]
+            "examples": [
+              "https://yourapp.com/sso/v1/oidc/conn_1234/logout/callback"
+            ]
           },
           "redirect_uri": {
             "description": "Redirect URI",
             "type": "string",
-            "examples": ["https://yourapp.com/sso/v1/oidc/conn_1234/callback"]
+            "examples": [
+              "https://yourapp.com/sso/v1/oidc/conn_1234/callback"
+            ]
           },
           "scopes": {
             "description": "OIDC Scopes",
@@ -8162,33 +8969,52 @@
             "items": {
               "$ref": "#/components/schemas/connectionsOIDCScope"
             },
-            "examples": [["openid", "profile"]]
+            "examples": [
+              [
+                "openid",
+                "profile"
+              ]
+            ]
           },
           "sync_user_profile_on_login": {
             "description": "Indicates whether user profiles should be synchronized with the identity provider upon each log-in.",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "token_auth_type": {
             "description": "Token Auth Type",
             "$ref": "#/components/schemas/connectionsTokenAuthType",
-            "examples": ["URL_PARAMS"]
+            "examples": [
+              "URL_PARAMS"
+            ]
           },
           "token_uri": {
             "description": "Token URI",
             "type": "string",
-            "examples": ["https://youridp.com/service/oauth/token"]
+            "examples": [
+              "https://youridp.com/service/oauth/token"
+            ]
           },
           "user_info_uri": {
             "description": "User Info URI",
             "type": "string",
-            "examples": ["https://youridp.com/service/oauth/userinfo"]
+            "examples": [
+              "https://youridp.com/service/oauth/userinfo"
+            ]
           }
         }
       },
       "connectionsOIDCScope": {
         "type": "string",
-        "enum": ["openid", "profile", "email", "address", "phone"]
+        "enum": [
+          "openid",
+          "profile",
+          "email",
+          "address",
+          "phone"
+        ]
       },
       "connectionsOauthExtensions": {
         "description": "OauthExtensions groups OAuth extension-profile configuration for a connection.\nSignificant profiles (e.g. SMART on FHIR) get a typed sub-message; the long tail\nof one-off authorize parameters uses extra_authorize_params.",
@@ -8218,7 +9044,9 @@
           "field_name": {
             "description": "Name of the field in which scope should be sent in the authentication request. This is required by some identity providers that expect scopes to be sent in a custom field instead of the standard 'scope' parameter.",
             "type": "string",
-            "examples": ["optional_scope or bot_scope"]
+            "examples": [
+              "optional_scope or bot_scope"
+            ]
           },
           "scopes": {
             "description": "List of optional scopes that can be requested during authentication",
@@ -8226,7 +9054,12 @@
             "items": {
               "type": "string"
             },
-            "examples": [["scope1", "scope2"]]
+            "examples": [
+              [
+                "scope1",
+                "scope2"
+              ]
+            ]
           }
         }
       },
@@ -8237,49 +9070,70 @@
             "description": "Code Challenge Length",
             "type": "integer",
             "format": "int64",
-            "examples": [6]
+            "examples": [
+              6
+            ]
           },
           "code_challenge_type": {
             "description": "Code Challenge Type",
             "$ref": "#/components/schemas/connectionsCodeChallengeType",
-            "examples": ["NUMERIC"]
+            "examples": [
+              "NUMERIC"
+            ]
           },
           "enforce_same_browser_origin": {
             "description": "Enforce Same Browser Origin",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "frequency": {
             "description": "Link Frequency",
             "type": "integer",
             "format": "int64",
-            "examples": [1]
+            "examples": [
+              1
+            ]
           },
           "regenerate_passwordless_credentials_on_resend": {
             "description": "Regenerate the ",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "type": {
             "description": "Passwordless Type",
             "$ref": "#/components/schemas/connectionsPasswordlessType",
-            "examples": ["LINK"]
+            "examples": [
+              "LINK"
+            ]
           },
           "validity": {
             "description": "Link Validity in Seconds",
             "type": "integer",
             "format": "int64",
-            "examples": [600]
+            "examples": [
+              600
+            ]
           }
         }
       },
       "connectionsPasswordlessType": {
         "type": "string",
-        "enum": ["LINK", "OTP", "LINK_OTP"]
+        "enum": [
+          "LINK",
+          "OTP",
+          "LINK_OTP"
+        ]
       },
       "connectionsRequestBinding": {
         "type": "string",
-        "enum": ["HTTP_POST", "HTTP_REDIRECT"]
+        "enum": [
+          "HTTP_POST",
+          "HTTP_REDIRECT"
+        ]
       },
       "connectionsSAMLConnectionConfigResponse": {
         "type": "object",
@@ -8287,27 +9141,37 @@
           "allow_idp_initiated_login": {
             "description": "Allow IDP Initiated Login",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "assertion_encrypted": {
             "description": "Assertion Encrypted",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "certificate_id": {
             "description": "Certificate ID",
             "type": "string",
-            "examples": ["cer_35585423166144613"]
+            "examples": [
+              "cer_35585423166144613"
+            ]
           },
           "default_redirect_uri": {
             "description": "Default Redirect URI",
             "type": "string",
-            "examples": ["https://yourapp.com/service/saml/redirect"]
+            "examples": [
+              "https://yourapp.com/service/saml/redirect"
+            ]
           },
           "force_authn": {
             "description": "Force Authn",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "idp_certificates": {
             "description": "IDP Certificates",
@@ -8320,88 +9184,122 @@
           "idp_entity_id": {
             "description": "IDP Entity ID",
             "type": "string",
-            "examples": ["https://youridp.com/service/saml"]
+            "examples": [
+              "https://youridp.com/service/saml"
+            ]
           },
           "idp_metadata_url": {
             "description": "IDP Metadata URL",
             "type": "string",
-            "examples": ["https://youridp.com/service/saml/metadata"]
+            "examples": [
+              "https://youridp.com/service/saml/metadata"
+            ]
           },
           "idp_name_id_format": {
             "description": "IDP Name ID Format",
             "$ref": "#/components/schemas/connectionsNameIdFormat",
-            "examples": ["EMAIL"]
+            "examples": [
+              "EMAIL"
+            ]
           },
           "idp_slo_request_binding": {
             "description": "IDP SLO Request Binding",
             "$ref": "#/components/schemas/connectionsRequestBinding",
-            "examples": ["HTTP_POST"]
+            "examples": [
+              "HTTP_POST"
+            ]
           },
           "idp_slo_required": {
             "description": "Enable IDP logout",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "idp_slo_url": {
             "description": "IDP SLO URL",
             "type": "string",
-            "examples": ["https://youridp.com/service/saml/slo"]
+            "examples": [
+              "https://youridp.com/service/saml/slo"
+            ]
           },
           "idp_sso_request_binding": {
             "description": "IDP SSO Request Binding",
             "$ref": "#/components/schemas/connectionsRequestBinding",
-            "examples": ["HTTP_POST"]
+            "examples": [
+              "HTTP_POST"
+            ]
           },
           "idp_sso_url": {
             "description": "IDP SSO URL",
             "type": "string",
-            "examples": ["https://youridp.com/service/saml/sso"]
+            "examples": [
+              "https://youridp.com/service/saml/sso"
+            ]
           },
           "jit_provisioning_with_sso_enabled": {
             "description": "Indicates if Just In Time user provisioning is enabled for the connection",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "saml_signing_option": {
             "description": "SAML Signing Option",
             "$ref": "#/components/schemas/connectionsSAMLSigningOptions",
-            "examples": ["SAML_ONLY_RESPONSE_SIGNING"]
+            "examples": [
+              "SAML_ONLY_RESPONSE_SIGNING"
+            ]
           },
           "sp_assertion_url": {
             "description": "SP Assertion URL",
             "type": "string",
-            "examples": ["https://youridp.com/service/saml/assertion"]
+            "examples": [
+              "https://youridp.com/service/saml/assertion"
+            ]
           },
           "sp_entity_id": {
             "description": "SP Entity ID",
             "type": "string",
-            "examples": ["https://yourapp.com/service/saml"]
+            "examples": [
+              "https://yourapp.com/service/saml"
+            ]
           },
           "sp_metadata_url": {
             "description": "SP Metadata URL",
             "type": "string",
-            "examples": ["https://youridp.com/service/saml/metadata"]
+            "examples": [
+              "https://youridp.com/service/saml/metadata"
+            ]
           },
           "sp_slo_url": {
             "description": "Service Provider SLO url",
             "type": "string",
             "readOnly": true,
-            "examples": ["https://yourapp.com/sso/v1/saml/conn_1234/slo/callback"]
+            "examples": [
+              "https://yourapp.com/sso/v1/saml/conn_1234/slo/callback"
+            ]
           },
           "sync_user_profile_on_login": {
             "description": "Indicates whether user profiles should be synchronized with the identity provider upon each log-in.",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "ui_button_title": {
             "description": "UI Button Title",
             "type": "string",
-            "examples": ["Login with SSO"]
+            "examples": [
+              "Login with SSO"
+            ]
           },
           "want_request_signed": {
             "description": "Want Request Signed",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           }
         }
       },
@@ -8423,12 +9321,16 @@
           "aud": {
             "description": "FHIR resource server base URL, sent as the required 'aud' authorization parameter per the SMART App Launch specification. Binds the issued token to the intended FHIR server.",
             "type": "string",
-            "examples": ["https://fhir.example.com/r4"]
+            "examples": [
+              "https://fhir.example.com/r4"
+            ]
           },
           "domain": {
             "description": "FHIR server domain for the SMART on FHIR connection. Stored alongside the audience and editable through the connection update API.",
             "type": "string",
-            "examples": ["fhir.example.com"]
+            "examples": [
+              "fhir.example.com"
+            ]
           }
         }
       },
@@ -8446,18 +9348,25 @@
           "enabled": {
             "description": "Current state of the connection after the operation. True means the connection is now enabled and can be used for authentication.",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "error_message": {
             "description": "Error message if the operation fails",
             "type": "string",
-            "examples": ["placeholder"]
+            "examples": [
+              "placeholder"
+            ]
           }
         }
       },
       "connectionsTokenAuthType": {
         "type": "string",
-        "enum": ["URL_PARAMS", "BASIC_AUTH"]
+        "enum": [
+          "URL_PARAMS",
+          "BASIC_AUTH"
+        ]
       },
       "connectionsWebAuthConfiguration": {
         "type": "object",
@@ -8525,53 +9434,73 @@
           "directory_endpoint": {
             "description": "The endpoint URL generated by Scalekit for synchronizing users and groups from the Directory Provider",
             "type": "string",
-            "examples": ["https://yourapp.scalekit.com/api/v1/directoies/dir_123212312/scim/v2"]
+            "examples": [
+              "https://yourapp.scalekit.com/api/v1/directoies/dir_123212312/scim/v2"
+            ]
           },
           "directory_provider": {
             "description": "Identity provider connected to this directory",
             "$ref": "#/components/schemas/directoriesDirectoryProvider",
-            "examples": ["OKTA"]
+            "examples": [
+              "OKTA"
+            ]
           },
           "directory_type": {
             "description": "Type of the directory, indicating the protocol or standard used for synchronization",
             "$ref": "#/components/schemas/directoriesDirectoryType",
-            "examples": ["SCIM"]
+            "examples": [
+              "SCIM"
+            ]
           },
           "email": {
             "description": "Email Id associated with Directory whose access will be used for polling",
             "type": "string",
-            "examples": ["john.doe@scalekit.cloud"]
+            "examples": [
+              "john.doe@scalekit.cloud"
+            ]
           },
           "enabled": {
             "description": "Indicates whether the directory is currently enabled and actively synchronizing users and groups",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "groups_tracked": {
             "description": "It indicates if all groups are tracked or select groups are tracked",
             "type": "string",
-            "examples": ["ALL"]
+            "examples": [
+              "ALL"
+            ]
           },
           "id": {
             "description": "Unique identifier of the directory",
             "type": "string",
-            "examples": ["dir_121312434123312"]
+            "examples": [
+              "dir_121312434123312"
+            ]
           },
           "last_synced_at": {
             "description": "Timestamp of the last successful synchronization of users and groups from the Directory Provider",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-10-01T00:00:00Z"]
+            "examples": [
+              "2024-10-01T00:00:00Z"
+            ]
           },
           "name": {
             "description": "Name of the directory, typically representing the connected Directory provider",
             "type": "string",
-            "examples": ["Azure AD"]
+            "examples": [
+              "Azure AD"
+            ]
           },
           "organization_id": {
             "description": "Unique identifier of the organization to which the directory belongs",
             "type": "string",
-            "examples": ["org_121312434123312"]
+            "examples": [
+              "org_121312434123312"
+            ]
           },
           "role_assignments": {
             "description": "Role assignments associated with the directory, defining group based role assignments",
@@ -8592,19 +9521,25 @@
           "status": {
             "description": "Directory Status",
             "type": "string",
-            "examples": ["IN_PROGRESS"]
+            "examples": [
+              "IN_PROGRESS"
+            ]
           },
           "total_groups": {
             "description": "Total number of groups in the directory",
             "type": "integer",
             "format": "int32",
-            "examples": [10]
+            "examples": [
+              10
+            ]
           },
           "total_users": {
             "description": "Total number of users in the directory",
             "type": "integer",
             "format": "int32",
-            "examples": [10]
+            "examples": [
+              10
+            ]
           }
         }
       },
@@ -8614,7 +9549,9 @@
           "display_name": {
             "description": "Display Name",
             "type": "string",
-            "examples": ["Admins"]
+            "examples": [
+              "Admins"
+            ]
           },
           "group_detail": {
             "description": "Complete Group Details Payload",
@@ -8623,19 +9560,25 @@
           "id": {
             "description": "Group ID",
             "type": "string",
-            "examples": ["dirgroup_121312434123312"]
+            "examples": [
+              "dirgroup_121312434123312"
+            ]
           },
           "total_users": {
             "description": "Total Users in the Group",
             "type": "integer",
             "format": "int32",
-            "examples": [10]
+            "examples": [
+              10
+            ]
           },
           "updated_at": {
             "description": "Updated At",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-10-01T00:00:00Z"]
+            "examples": [
+              "2024-10-01T00:00:00Z"
+            ]
           }
         }
       },
@@ -8653,7 +9596,11 @@
       },
       "directoriesDirectoryType": {
         "type": "string",
-        "enum": ["SCIM", "LDAP", "POLL"]
+        "enum": [
+          "SCIM",
+          "LDAP",
+          "POLL"
+        ]
       },
       "directoriesDirectoryUser": {
         "type": "object",
@@ -8661,7 +9608,9 @@
           "email": {
             "description": "Email",
             "type": "string",
-            "examples": ["johndoe"]
+            "examples": [
+              "johndoe"
+            ]
           },
           "emails": {
             "description": "Emails",
@@ -8673,12 +9622,16 @@
           "family_name": {
             "description": "Last Name",
             "type": "string",
-            "examples": ["Doe"]
+            "examples": [
+              "Doe"
+            ]
           },
           "given_name": {
             "description": "First Name",
             "type": "string",
-            "examples": ["John"]
+            "examples": [
+              "John"
+            ]
           },
           "groups": {
             "description": "Groups",
@@ -8691,18 +9644,24 @@
           "id": {
             "description": "User ID",
             "type": "string",
-            "examples": ["diruser_121312434123312"]
+            "examples": [
+              "diruser_121312434123312"
+            ]
           },
           "preferred_username": {
             "description": "Preferred Username",
             "type": "string",
-            "examples": ["johndoe"]
+            "examples": [
+              "johndoe"
+            ]
           },
           "updated_at": {
             "description": "Updated At",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-10-01T00:00:00Z"]
+            "examples": [
+              "2024-10-01T00:00:00Z"
+            ]
           },
           "user_detail": {
             "description": "Complete User Details Payload",
@@ -8790,7 +9749,9 @@
           "group_id": {
             "description": "group ID for the role mapping",
             "type": "string",
-            "examples": ["dirgroup_121312434123"]
+            "examples": [
+              "dirgroup_121312434123"
+            ]
           },
           "role_name": {
             "type": "string"
@@ -8816,18 +9777,24 @@
             "description": "Creation Time",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-10-01T00:00:00Z"]
+            "examples": [
+              "2024-10-01T00:00:00Z"
+            ]
           },
           "directory_id": {
             "description": "Directory ID",
             "type": "string",
-            "examples": ["dir_12362474900684814"]
+            "examples": [
+              "dir_12362474900684814"
+            ]
           },
           "expire_time": {
             "description": "Expiry Time",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-10-01T00:00:00Z"]
+            "examples": [
+              "2025-10-01T00:00:00Z"
+            ]
           },
           "id": {
             "type": "string"
@@ -8836,23 +9803,31 @@
             "description": "Last Used Time",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-10-01T00:00:00Z"]
+            "examples": [
+              "2024-10-01T00:00:00Z"
+            ]
           },
           "secret_suffix": {
             "description": "Secret Suffix",
             "type": "string",
-            "examples": ["Nzg5"]
+            "examples": [
+              "Nzg5"
+            ]
           },
           "status": {
             "description": "Secret Status",
             "$ref": "#/components/schemas/directoriesSecretStatus",
-            "examples": ["INACTIVE"]
+            "examples": [
+              "INACTIVE"
+            ]
           }
         }
       },
       "directoriesSecretStatus": {
         "type": "string",
-        "enum": ["INACTIVE"]
+        "enum": [
+          "INACTIVE"
+        ]
       },
       "directoriesStats": {
         "type": "object",
@@ -8861,25 +9836,33 @@
             "description": "Max time of Group Updated At for Directory",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-10-01T00:00:00Z"]
+            "examples": [
+              "2024-10-01T00:00:00Z"
+            ]
           },
           "total_groups": {
             "description": "Total Groups in the Directory",
             "type": "integer",
             "format": "int32",
-            "examples": [10]
+            "examples": [
+              10
+            ]
           },
           "total_users": {
             "description": "Total Users in the Directory",
             "type": "integer",
             "format": "int32",
-            "examples": [10]
+            "examples": [
+              10
+            ]
           },
           "user_updated_at": {
             "description": "Max time of User Updated At for Directory",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-10-01T00:00:00Z"]
+            "examples": [
+              "2024-10-01T00:00:00Z"
+            ]
           }
         }
       },
@@ -8889,12 +9872,16 @@
           "enabled": {
             "description": "Specifies the directory's state after the toggle operation. A value of `true` indicates that the directory is enabled and actively synchronizing users and groups. A value of `false` means the directory is disabled, halting synchronization",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "error_message": {
             "description": "Contains a human-readable error message if the toggle operation encountered an issue. If the operation was successful, this field will be empty",
             "type": "string",
-            "examples": ["The directory is already enabled"]
+            "examples": [
+              "The directory is already enabled"
+            ]
           }
         }
       },
@@ -8914,12 +9901,16 @@
             "description": "Timestamp when the domain was first created.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-09-01T12:14:43.100000Z"]
+            "examples": [
+              "2025-09-01T12:14:43.100000Z"
+            ]
           },
           "domain": {
             "description": "The business domain name that was configured for allowed email domain functionality (e.g., company.com, subdomain.company.com).",
             "type": "string",
-            "examples": ["customerdomain.com"]
+            "examples": [
+              "customerdomain.com"
+            ]
           },
           "domain_type": {
             "example": "ORGANIZATION_DOMAIN"
@@ -8927,40 +9918,58 @@
           "environment_id": {
             "description": "The environment ID where this domain is configured.",
             "type": "string",
-            "examples": ["env_58345499215790610"]
+            "examples": [
+              "env_58345499215790610"
+            ]
           },
           "id": {
             "description": "Scalekit-generated unique identifier for this domain record.",
             "type": "string",
-            "examples": ["dom_88351643129225005"]
+            "examples": [
+              "dom_88351643129225005"
+            ]
           },
           "organization_id": {
             "description": "The organization to which the domain belongs.",
             "type": "string",
-            "examples": ["org_81667076086825451"]
+            "examples": [
+              "org_81667076086825451"
+            ]
           },
           "update_time": {
             "description": "Timestamp when the domain was last updated.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-09-01T12:14:43.110455Z"]
+            "examples": [
+              "2025-09-01T12:14:43.110455Z"
+            ]
           },
           "verification_method": {
             "description": "Method that determines how domain ownership is verified.\n- ADMIN: domain is marked verified without DNS validation, typically by an admin.\n- DNS: domain must be verified by adding a TXT record to your DNS configuration.\n- NOT_APPLICABLE: verification does not apply to this domain type.",
             "$ref": "#/components/schemas/domainsVerificationMethod",
-            "examples": ["ADMIN"]
+            "examples": [
+              "ADMIN"
+            ]
           },
           "verification_status": {
             "description": "Verification status of the domain.\n- PENDING: DNS TXT record has not been validated yet.\n- VERIFIED: domain confirmed via DNS TXT record validation or admin approval.\n- AUTO_VERIFIED: domain verified automatically without DNS changes.\n- FAILED: DNS TXT record was not validated within the verification window.",
             "$ref": "#/components/schemas/domainsVerificationStatus",
-            "examples": ["AUTO_VERIFIED"]
+            "examples": [
+              "AUTO_VERIFIED"
+            ]
           }
         }
       },
       "domainsDomainType": {
         "type": "string",
-        "enum": ["ALLOWED_EMAIL_DOMAIN", "ORGANIZATION_DOMAIN"],
-        "x-enum-varnames": ["ORGANIZATION_DOMAIN", "ALLOWED_EMAIL_DOMAIN"]
+        "enum": [
+          "ALLOWED_EMAIL_DOMAIN",
+          "ORGANIZATION_DOMAIN"
+        ],
+        "x-enum-varnames": [
+          "ORGANIZATION_DOMAIN",
+          "ALLOWED_EMAIL_DOMAIN"
+        ]
       },
       "domainsGetDomainResponse": {
         "type": "object",
@@ -8986,23 +9995,36 @@
             "description": "Current page number in the pagination sequence.",
             "type": "integer",
             "format": "int32",
-            "examples": [1]
+            "examples": [
+              1
+            ]
           },
           "page_size": {
             "description": "Number of domains returned in this page.",
             "type": "integer",
             "format": "int32",
-            "examples": [1]
+            "examples": [
+              1
+            ]
           }
         }
       },
       "domainsVerificationMethod": {
         "type": "string",
-        "enum": ["ADMIN", "DNS", "NOT_APPLICABLE"]
+        "enum": [
+          "ADMIN",
+          "DNS",
+          "NOT_APPLICABLE"
+        ]
       },
       "domainsVerificationStatus": {
         "type": "string",
-        "enum": ["PENDING", "VERIFIED", "FAILED", "AUTO_VERIFIED"]
+        "enum": [
+          "PENDING",
+          "VERIFIED",
+          "FAILED",
+          "AUTO_VERIFIED"
+        ]
       },
       "errdetailsDebugInfo": {
         "description": "Describes additional debugging info.",
@@ -9186,17 +10208,23 @@
             "description": "Expiry time of the link. The link is valid for 1 minute.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-02-06T14:48:00Z"]
+            "examples": [
+              "2024-02-06T14:48:00Z"
+            ]
           },
           "id": {
             "description": "Unique Identifier for the link",
             "type": "string",
-            "examples": ["lnk_123123123123123"]
+            "examples": [
+              "lnk_123123123123123"
+            ]
           },
           "location": {
             "description": "Location of the link. This is the URL that can be used to access the Admin portal. The link is valid for 1 minute",
             "type": "string",
-            "examples": ["https://scalekit.com/portal/lnk_123123123123123"]
+            "examples": [
+              "https://scalekit.com/portal/lnk_123123123123123"
+            ]
           }
         }
       },
@@ -9206,7 +10234,9 @@
           "next_page_token": {
             "description": "Pagination token for the next page of results. Use this token to fetch the next page.",
             "type": "string",
-            "examples": ["<next_page_token>"]
+            "examples": [
+              "<next_page_token>"
+            ]
           },
           "organizations": {
             "description": "List of organization objects",
@@ -9219,44 +10249,58 @@
           "prev_page_token": {
             "description": "Pagination token for the previous page of results. Use this token to fetch the previous page.",
             "type": "string",
-            "examples": ["<prev_page_token>"]
+            "examples": [
+              "<prev_page_token>"
+            ]
           },
           "total_size": {
             "description": "Total number of organizations in the environment.",
             "type": "integer",
             "format": "int64",
-            "examples": [30]
+            "examples": [
+              30
+            ]
           }
         }
       },
       "organizationsOrganization": {
         "type": "object",
-        "required": ["create_time"],
+        "required": [
+          "create_time"
+        ],
         "properties": {
           "create_time": {
             "description": "Timestamp when the organization was created",
             "type": "string",
             "format": "date-time",
             "title": "Created Time",
-            "examples": ["2025-02-15T06:23:44.560000Z"]
+            "examples": [
+              "2025-02-15T06:23:44.560000Z"
+            ]
           },
           "display_name": {
             "description": "Name of the organization. Must be between 1 and 200 characters",
             "type": "string",
             "title": "Name of the org to be used in display",
-            "examples": ["Megasoft"]
+            "examples": [
+              "Megasoft"
+            ]
           },
           "external_id": {
             "description": "Your application's unique identifier for this organization, used to link Scalekit with your system.",
             "type": "string",
             "title": "External Id is useful to store a unique identifier for a given Org that. The unique Identifier can be the id of your tenant / org in your SaaSApp",
-            "examples": ["my_unique_id"]
+            "examples": [
+              "my_unique_id"
+            ]
           },
           "id": {
             "description": "Unique scalekit-generated identifier that uniquely references an organization",
             "type": "string",
             "title": "Id",
-            "examples": ["org_59615193906282635"]
+            "examples": [
+              "org_59615193906282635"
+            ]
           },
           "logo_url": {
             "description": "HTTPS URL of the organization's logo image. Maximum 1024 characters. Must use the https scheme.",
@@ -9264,7 +10308,9 @@
             "format": "uri",
             "maxLength": 1024,
             "pattern": "^https://",
-            "examples": ["https://cdn.example.com/acme-logo.png"]
+            "examples": [
+              "https://cdn.example.com/acme-logo.png"
+            ]
           },
           "metadata": {
             "description": "Key value pairs extension attributes.",
@@ -9277,7 +10323,9 @@
             "description": "Geographic region code for the organization. Currently limited to US.",
             "title": "Optional regioncode",
             "$ref": "#/components/schemas/commonsRegionCode",
-            "examples": ["US"]
+            "examples": [
+              "US"
+            ]
           },
           "settings": {
             "title": "Organization Settings",
@@ -9289,14 +10337,18 @@
             "maxLength": 253,
             "minLength": 1,
             "pattern": "^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$",
-            "examples": ["acme"]
+            "examples": [
+              "acme"
+            ]
           },
           "update_time": {
             "description": "Timestamp when the organization was last updated",
             "type": "string",
             "format": "date-time",
             "title": "Updated time",
-            "examples": ["2025-02-15T06:23:44.560000Z"]
+            "examples": [
+              "2025-02-15T06:23:44.560000Z"
+            ]
           }
         }
       },
@@ -9307,33 +10359,45 @@
             "description": "The absolute session timeout value. The unit is specified by absolute_session_timeout_unit. Omitted when policy_source is 'environment'.",
             "type": "integer",
             "format": "int32",
-            "examples": [360]
+            "examples": [
+              360
+            ]
           },
           "absolute_session_timeout_unit": {
             "description": "Unit for absolute_session_timeout. Accepted values: 'minutes', 'hours', 'days'. Responses always return 'minutes'.",
             "$ref": "#/components/schemas/commonsTimeUnit",
-            "examples": ["minutes"]
+            "examples": [
+              "minutes"
+            ]
           },
           "idle_session_timeout": {
             "description": "The idle session timeout value. The unit is specified by idle_session_timeout_unit. Omitted when idle_session_timeout_enabled is false or policy_source is 'environment'.",
             "type": "integer",
             "format": "int32",
-            "examples": [84]
+            "examples": [
+              84
+            ]
           },
           "idle_session_timeout_enabled": {
             "description": "Whether idle session timeout is enabled for this organization. Omitted when policy_source is 'environment'.",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "idle_session_timeout_unit": {
             "description": "Unit for idle_session_timeout. Accepted values: 'minutes', 'hours', 'days'. Responses always return 'minutes'.",
             "$ref": "#/components/schemas/commonsTimeUnit",
-            "examples": ["minutes"]
+            "examples": [
+              "minutes"
+            ]
           },
           "policy_source": {
             "description": "Policy source. 'APPLICATION' means the organization inherits the application-level session policy. 'CUSTOM' means organization-specific timeout values are active.",
             "$ref": "#/components/schemas/organizationsSessionPolicyType",
-            "examples": ["CUSTOM"]
+            "examples": [
+              "CUSTOM"
+            ]
           }
         }
       },
@@ -9382,17 +10446,24 @@
         "description": "Controls the activation state of a specific organization feature",
         "type": "object",
         "title": "Organization Feature Toggle",
-        "required": ["name", "enabled"],
+        "required": [
+          "name",
+          "enabled"
+        ],
         "properties": {
           "enabled": {
             "description": "Whether the feature is enabled (true) or disabled (false) for this organization",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "name": {
             "description": "Feature identifier. Supported values include: \"sso\" (Single Sign-On), \"directory_sync\" (Directory Synchronization), \"domain_verification\" (Domain Verification), \"session_policy\" (Organization-level session policy override)",
             "type": "string",
-            "examples": ["sso"]
+            "examples": [
+              "sso"
+            ]
           }
         }
       },
@@ -9403,13 +10474,18 @@
             "description": "Maximum number of users allowed in the organization. When nil (not set), there feature is not enabled. When explicitly set to zero, it also means no limit. When set to a positive integer, it enforces the maximum user limit.",
             "type": "integer",
             "format": "int32",
-            "examples": [100]
+            "examples": [
+              100
+            ]
           }
         }
       },
       "organizationsSessionPolicyType": {
         "type": "string",
-        "enum": ["APPLICATION", "CUSTOM"]
+        "enum": [
+          "APPLICATION",
+          "CUSTOM"
+        ]
       },
       "organizationsUpdateOrganizationResponse": {
         "type": "object",
@@ -9444,7 +10520,9 @@
           "auth_request_id": {
             "description": "The authentication request identifier from the original send passwordless email request. Use this to resend the Verification Code (OTP) or Magic Link to the same email address.",
             "type": "string",
-            "examples": ["h5Y8kT5RVwaea5WEgW4n-6C-aO_-fuTUW7Vb9-Rh3AcY9qxZqQ"]
+            "examples": [
+              "h5Y8kT5RVwaea5WEgW4n-6C-aO_-fuTUW7Vb9-Rh3AcY9qxZqQ"
+            ]
           }
         }
       },
@@ -9454,28 +10532,38 @@
           "email": {
             "description": "Email address where the passwordless authentication credentials will be sent. Must be a valid email format.",
             "type": "string",
-            "examples": ["john.doe@example.com"]
+            "examples": [
+              "john.doe@example.com"
+            ]
           },
           "expires_in": {
             "description": "Time in seconds until the passwordless authentication expires. If not specified, defaults to 300 seconds (5 minutes)",
             "type": "integer",
             "format": "int64",
-            "examples": [300]
+            "examples": [
+              300
+            ]
           },
           "magiclink_auth_uri": {
             "description": "Your application's callback URL where users will be redirected after clicking the magic link in their email. The link token will be appended as a query parameter as link_token",
             "type": "string",
-            "examples": ["https://yourapp.com/auth/passwordless/callback"]
+            "examples": [
+              "https://yourapp.com/auth/passwordless/callback"
+            ]
           },
           "state": {
             "description": "Custom state parameter that will be returned unchanged in the verification response. Use this to maintain application state between the authentication request and callback, such as the intended destination after login",
             "type": "string",
-            "examples": ["d62ivasry29lso"]
+            "examples": [
+              "d62ivasry29lso"
+            ]
           },
           "template": {
             "description": "Specifies the authentication intent for the passwordless request. Use SIGNIN for existing users or SIGNUP for new user registration. This affects the email template and user experience flow.",
             "$ref": "#/components/schemas/passwordlessTemplateType",
-            "examples": ["SIGNIN"]
+            "examples": [
+              "SIGNIN"
+            ]
           },
           "template_variables": {
             "description": "A set of key-value pairs to personalize the email template.\n\n* You may include up to 30 key-value pairs.\n* The following variable names are reserved by the system and cannot be supplied: `otp`, `expiry_time_relative`, `link`, `expire_time`, `expiry_time`.\n* Every variable referenced in your email template must be included as a key-value pair.\n\nUse these variables to insert custom information, such as a team name, URL or the user's employee ID. All variables are interpolated before the email is sent, regardless of the email provider.",
@@ -9498,32 +10586,43 @@
             "description": "Unique identifier for this passwordless authentication request. Use this ID to resend emails.",
             "type": "string",
             "readOnly": true,
-            "examples": ["h5Y8kT5RVwaea5WEgW4n-6C-aO_-fuTUW7Vb9-Rh3AcY9qxZqQ"]
+            "examples": [
+              "h5Y8kT5RVwaea5WEgW4n-6C-aO_-fuTUW7Vb9-Rh3AcY9qxZqQ"
+            ]
           },
           "expires_at": {
             "description": "Unix timestamp (seconds since epoch) when the passwordless authentication will expire. After this time, the OTP or magic link will no longer be valid.",
             "type": "string",
             "format": "int64",
             "readOnly": true,
-            "examples": [1748696575]
+            "examples": [
+              1748696575
+            ]
           },
           "expires_in": {
             "description": "Number of seconds from now until the passwordless authentication expires. This is a convenience field calculated from the expires_at timestamp.",
             "type": "integer",
             "format": "int64",
             "readOnly": true,
-            "examples": [300]
+            "examples": [
+              300
+            ]
           },
           "passwordless_type": {
             "description": "Type of passwordless authentication that was sent via email. OTP sends a numeric code, LINK sends a clickable magic link, and LINK_OTP provides both options for user convenience.",
             "$ref": "#/components/schemas/authpasswordlessPasswordlessType",
-            "examples": ["OTP"]
+            "examples": [
+              "OTP"
+            ]
           }
         }
       },
       "passwordlessTemplateType": {
         "type": "string",
-        "enum": ["SIGNIN", "SIGNUP"]
+        "enum": [
+          "SIGNIN",
+          "SIGNUP"
+        ]
       },
       "passwordlessVerifyPasswordLessRequest": {
         "type": "object",
@@ -9531,17 +10630,23 @@
           "auth_request_id": {
             "description": "The authentication request identifier returned from the send passwordless email endpoint. Required when verifying OTP codes to link the verification with the original request.",
             "type": "string",
-            "examples": ["h5Y8kT5RVwaea5WEgW4n-6C-aO_-fuTUW7Vb9-Rh3AcY9qxZqQ"]
+            "examples": [
+              "h5Y8kT5RVwaea5WEgW4n-6C-aO_-fuTUW7Vb9-Rh3AcY9qxZqQ"
+            ]
           },
           "code": {
             "description": "The Verification Code (OTP) received via email. This is typically a 6-digit numeric code that users enter manually to verify their identity.",
             "type": "string",
-            "examples": ["123456"]
+            "examples": [
+              "123456"
+            ]
           },
           "link_token": {
             "description": "The unique token from the magic link URL received via email. Extract this token when users click the magic link and are redirected to your application to later verify the user.",
             "type": "string",
-            "examples": ["afe9d61c-d80d-4020-a8ee-61765ab71cb3"]
+            "examples": [
+              "afe9d61c-d80d-4020-a8ee-61765ab71cb3"
+            ]
           }
         }
       },
@@ -9552,23 +10657,31 @@
             "description": "Email address of the successfully authenticated user. This confirms which email account was verified through the passwordless flow.",
             "type": "string",
             "readOnly": true,
-            "examples": ["john.doe@example.com"]
+            "examples": [
+              "john.doe@example.com"
+            ]
           },
           "passwordless_type": {
             "description": "The type of passwordless authentication that was successfully verified, confirming which method the user completed.",
             "$ref": "#/components/schemas/authpasswordlessPasswordlessType",
-            "examples": ["OTP"]
+            "examples": [
+              "OTP"
+            ]
           },
           "state": {
             "description": "The custom state parameter that was provided in the original authentication request, returned unchanged. Use this to restore your application's context after authentication.",
             "type": "string",
             "readOnly": true,
-            "examples": ["kdt7yiag28t341fr1"]
+            "examples": [
+              "kdt7yiag28t341fr1"
+            ]
           },
           "template": {
             "description": "Specifies which email template to choose. For User Signin choose SIGNIN and for User Signup use SIGNUP",
             "$ref": "#/components/schemas/passwordlessTemplateType",
-            "examples": ["SIGNIN"]
+            "examples": [
+              "SIGNIN"
+            ]
           }
         }
       },
@@ -9663,7 +10776,9 @@
             "description": "Number of users associated with the role",
             "type": "string",
             "format": "int64",
-            "examples": [10]
+            "examples": [
+              10
+            ]
           }
         }
       },
@@ -9712,7 +10827,9 @@
           "next_page_token": {
             "description": "Token to retrieve next page of results",
             "type": "string",
-            "examples": ["token_def456"]
+            "examples": [
+              "token_def456"
+            ]
           },
           "permissions": {
             "type": "array",
@@ -9724,13 +10841,17 @@
           "prev_page_token": {
             "description": "Token to retrieve previous page of results",
             "type": "string",
-            "examples": ["token_def456"]
+            "examples": [
+              "token_def456"
+            ]
           },
           "total_size": {
             "description": "Total number of permissions available",
             "type": "integer",
             "format": "int64",
-            "examples": [150]
+            "examples": [
+              150
+            ]
           }
         }
       },
@@ -9791,7 +10912,9 @@
           "is_scalekit_permission": {
             "description": "Indicates whether this permission is predefined by Scalekit",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "name": {
             "type": "string"
@@ -9822,7 +10945,9 @@
           "role_name": {
             "description": "Name of the role from which this permission was sourced",
             "type": "string",
-            "examples": ["admin_role"]
+            "examples": [
+              "admin_role"
+            ]
           },
           "update_time": {
             "type": "string",
@@ -9856,7 +10981,9 @@
           "name": {
             "description": "Unique name of the role",
             "type": "string",
-            "examples": ["creator"]
+            "examples": [
+              "creator"
+            ]
           }
         }
       },
@@ -9878,7 +11005,9 @@
           "default_creator_role": {
             "description": "Name of the role to set as the default creator role. This role will be automatically assigned to users who create new resources in the environment. Must be a valid role name that exists in the environment.",
             "type": "string",
-            "examples": ["creator"]
+            "examples": [
+              "creator"
+            ]
           },
           "default_member": {
             "description": "Default member role (deprecated - use default_member_role field instead)",
@@ -9895,7 +11024,9 @@
           "default_member_role": {
             "description": "Name of the role to set as the default member role. This role will be automatically assigned to new users when they join the environment. Must be a valid role name that exists in the environment.",
             "type": "string",
-            "examples": ["member"]
+            "examples": [
+              "member"
+            ]
           }
         }
       },
@@ -9968,12 +11099,16 @@
           "client_id": {
             "description": "Unique identifier of the authenticated client application.",
             "type": "string",
-            "examples": ["skc_1234567890"]
+            "examples": [
+              "skc_1234567890"
+            ]
           },
           "organization_id": {
             "description": "Active or last active Organization ID associated with the authenticated client.",
             "type": "string",
-            "examples": ["org_1234567890"]
+            "examples": [
+              "org_1234567890"
+            ]
           }
         }
       },
@@ -9983,22 +11118,30 @@
           "browser": {
             "description": "Browser name and family extracted from the user agent. Examples: Chrome, Safari, Firefox, Edge, Mobile Safari.",
             "type": "string",
-            "examples": ["Chrome"]
+            "examples": [
+              "Chrome"
+            ]
           },
           "browser_version": {
             "description": "Version of the browser application. Represents the specific release version of the browser being used.",
             "type": "string",
-            "examples": ["120.0.0.0"]
+            "examples": [
+              "120.0.0.0"
+            ]
           },
           "device_type": {
             "description": "Categorized device type classification. Possible values: 'desktop' (traditional computers), 'mobile' (smartphones and small tablets), 'tablet' (large tablets), 'other'. Useful for displaying session information by device category.",
             "type": "string",
-            "examples": ["desktop"]
+            "examples": [
+              "desktop"
+            ]
           },
           "ip": {
             "description": "IP address of the device that initiated the session. This is the public-facing IP address used to connect to the application. Useful for security audits and geographic distribution analysis.",
             "type": "string",
-            "examples": ["192.0.2.1"]
+            "examples": [
+              "192.0.2.1"
+            ]
           },
           "location": {
             "description": "Geographic location information derived from IP address geolocation. Includes country, region, city, and coordinates. Note: Based on IP location data and may not represent the user's exact physical location.",
@@ -10007,12 +11150,16 @@
           "os": {
             "description": "Operating system name extracted from the user agent and device headers. Examples: macOS, Windows, Linux, iOS, Android.",
             "type": "string",
-            "examples": ["macOS"]
+            "examples": [
+              "macOS"
+            ]
           },
           "os_version": {
             "description": "Version of the operating system. Represents the specific OS release the device is running.",
             "type": "string",
-            "examples": ["14.2"]
+            "examples": [
+              "14.2"
+            ]
           },
           "user_agent": {
             "description": "Complete HTTP User-Agent header string from the client request. Contains browser type, version, and operating system information. Used for detailed device fingerprinting and user agent analysis.",
@@ -10038,7 +11185,9 @@
             "description": "Total count of active sessions that were revoked. Useful for confirmation and audit logging.",
             "type": "integer",
             "format": "int64",
-            "examples": [5]
+            "examples": [
+              5
+            ]
           }
         }
       },
@@ -10058,58 +11207,78 @@
             "description": "The absolute expiration timestamp that was configured for this session before revocation. Represents the hard deadline regardless of activity.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-22T10:30:00Z"]
+            "examples": [
+              "2025-01-22T10:30:00Z"
+            ]
           },
           "created_at": {
             "description": "Timestamp indicating when the session was originally created before revocation.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-15T10:30:00Z"]
+            "examples": [
+              "2025-01-15T10:30:00Z"
+            ]
           },
           "expired_at": {
             "description": "Timestamp when the session was actually terminated. Set to the revocation time when the session is revoked.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-15T12:00:00Z"]
+            "examples": [
+              "2025-01-15T12:00:00Z"
+            ]
           },
           "idle_expires_at": {
             "description": "The idle expiration timestamp that was configured for this session before revocation. Represents when the session would have expired due to inactivity.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-15T11:30:00Z"]
+            "examples": [
+              "2025-01-15T11:30:00Z"
+            ]
           },
           "last_active_at": {
             "description": "Timestamp of the last recorded user activity in this session before revocation. Helps identify inactive sessions that were revoked.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-15T10:55:30Z"]
+            "examples": [
+              "2025-01-15T10:55:30Z"
+            ]
           },
           "logout_at": {
             "description": "Timestamp when the user explicitly logged out (if applicable). Null if the session was revoked without prior logout.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-15T14:00:00Z"]
+            "examples": [
+              "2025-01-15T14:00:00Z"
+            ]
           },
           "session_id": {
             "description": "Unique identifier for the revoked session. System-generated read-only field.",
             "type": "string",
-            "examples": ["ses_1234567890123456"]
+            "examples": [
+              "ses_1234567890123456"
+            ]
           },
           "status": {
             "description": "Status of the session after revocation. Always 'revoked' since only active sessions can be revoked. Sessions that were already expired or logged out are not included in the revocation response.",
             "type": "string",
-            "examples": ["revoked"]
+            "examples": [
+              "revoked"
+            ]
           },
           "updated_at": {
             "description": "Timestamp indicating when the session was last modified before revocation.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-15T10:45:00Z"]
+            "examples": [
+              "2025-01-15T10:45:00Z"
+            ]
           },
           "user_id": {
             "description": "Unique identifier for the user who owned this session.",
             "type": "string",
-            "examples": ["usr_1234567890123456"]
+            "examples": [
+              "usr_1234567890123456"
+            ]
           }
         }
       },
@@ -10120,7 +11289,9 @@
             "description": "Hard expiration timestamp for the session regardless of user activity. The session will be forcibly terminated at this time. This represents the maximum session lifetime from creation.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-22T10:30:00Z"]
+            "examples": [
+              "2025-01-22T10:30:00Z"
+            ]
           },
           "authenticated_clients": {
             "description": "Details of the authenticated clients for this session: client ID and organization context.",
@@ -10136,13 +11307,20 @@
             "items": {
               "type": "string"
             },
-            "examples": [["org_123", "org_456"]]
+            "examples": [
+              [
+                "org_123",
+                "org_456"
+              ]
+            ]
           },
           "created_at": {
             "description": "Timestamp indicating when the session was created. This is set once at session creation and remains constant throughout the session lifetime.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-15T10:30:00Z"]
+            "examples": [
+              "2025-01-15T10:30:00Z"
+            ]
           },
           "device": {
             "description": "Complete device metadata associated with this session including browser, operating system, device type, and geographic location based on IP address.",
@@ -10152,51 +11330,69 @@
             "description": "Timestamp when the session was terminated. Null if the session is still active. Set when the session expires due to reaching idle_expires_at or absolute_expires_at timeout, or when administratively revoked. Not set for user-initiated logout (see logout_at instead).",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-15T12:00:00Z"]
+            "examples": [
+              "2025-01-15T12:00:00Z"
+            ]
           },
           "idle_expires_at": {
             "description": "Projected expiration timestamp if the session remains idle without user activity. This timestamp is recalculated with each user activity. Session will be automatically terminated at this time if no activity occurs.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-15T11:30:00Z"]
+            "examples": [
+              "2025-01-15T11:30:00Z"
+            ]
           },
           "last_active_at": {
             "description": "Timestamp of the most recent user activity detected in this session. Updated on each API request or user interaction. Used to determine if a session has exceeded the idle timeout threshold.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-15T10:55:30Z"]
+            "examples": [
+              "2025-01-15T10:55:30Z"
+            ]
           },
           "logout_at": {
             "description": "Timestamp when the user explicitly logged out from the session. Null if the user has not logged out. When set, indicates the session ended due to explicit user logout rather than timeout.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-15T14:00:00Z"]
+            "examples": [
+              "2025-01-15T14:00:00Z"
+            ]
           },
           "organization_id": {
             "description": "Organization ID for the user's most recently active organization within this session. This represents the primary organization context for the current session.",
             "type": "string",
-            "examples": ["org_1234567890123456"]
+            "examples": [
+              "org_1234567890123456"
+            ]
           },
           "session_id": {
             "description": "Unique identifier for the session. System-generated read-only field used to reference this session.",
             "type": "string",
-            "examples": ["ses_1234567890123456"]
+            "examples": [
+              "ses_1234567890123456"
+            ]
           },
           "status": {
             "description": "Current operational status of the session. Possible values: 'active' (session is valid and requests are allowed), 'expired' (session terminated due to idle or absolute timeout), 'revoked' (session was administratively revoked), 'logout' (user explicitly logged out). Use this to determine if the session can be used for new requests.",
             "type": "string",
-            "examples": ["active"]
+            "examples": [
+              "active"
+            ]
           },
           "updated_at": {
             "description": "Timestamp indicating when the session was last updated. Updated whenever session state changes such as organization context changes or metadata updates.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-15T10:45:00Z"]
+            "examples": [
+              "2025-01-15T10:45:00Z"
+            ]
           },
           "user_id": {
             "description": "Unique identifier for the user who owns and is authenticated within this session.",
             "type": "string",
-            "examples": ["usr_1234567890123456"]
+            "examples": [
+              "usr_1234567890123456"
+            ]
           }
         }
       },
@@ -10206,12 +11402,16 @@
           "next_page_token": {
             "description": "Pagination token for retrieving the next page of results. Empty string if there are no more pages (you have reached the final page of results).",
             "type": "string",
-            "examples": ["eyJwYWdlIjogMiwgImxhc3RfaWQiOiAic2VzXzEyMzQ1In0="]
+            "examples": [
+              "eyJwYWdlIjogMiwgImxhc3RfaWQiOiAic2VzXzEyMzQ1In0="
+            ]
           },
           "prev_page_token": {
             "description": "Pagination token for retrieving the previous page of results. Empty string for the first page. Use this to navigate backward through result pages.",
             "type": "string",
-            "examples": ["eyJwYWdlIjogMCwgImZpcnN0X2lkIjogInNlc183OTAxIn0="]
+            "examples": [
+              "eyJwYWdlIjogMCwgImZpcnN0X2lkIjogInNlc183OTAxIn0="
+            ]
           },
           "sessions": {
             "description": "Array of session objects for the requested user. May contain fewer entries than the requested page_size when reaching the final page of results.",
@@ -10225,7 +11425,9 @@
             "description": "Total number of sessions matching the applied filter criteria, regardless of pagination. This represents the complete result set size before pagination is applied.",
             "type": "integer",
             "format": "int64",
-            "examples": [42]
+            "examples": [
+              42
+            ]
           }
         }
       },
@@ -10243,12 +11445,16 @@
           "email": {
             "description": "Primary email address for the user. Must be unique across the environment and valid per RFC 5322.",
             "type": "string",
-            "examples": ["user@example.com"]
+            "examples": [
+              "user@example.com"
+            ]
           },
           "external_id": {
             "description": "Your application's unique identifier for this organization, used to link Scalekit with your system.",
             "type": "string",
-            "examples": ["ext_12345a67b89c"]
+            "examples": [
+              "ext_12345a67b89c"
+            ]
           },
           "membership": {
             "description": "List of organization memberships. Automatically populated based on group assignments.",
@@ -10300,17 +11506,23 @@
           "family_name": {
             "description": "User's family name. Maximum 255 characters.",
             "type": "string",
-            "examples": ["Doe"]
+            "examples": [
+              "Doe"
+            ]
           },
           "gender": {
             "description": "User's gender identity.",
             "type": "string",
-            "examples": ["male"]
+            "examples": [
+              "male"
+            ]
           },
           "given_name": {
             "description": "User's given name. Maximum 255 characters.",
             "type": "string",
-            "examples": ["John"]
+            "examples": [
+              "John"
+            ]
           },
           "groups": {
             "description": "List of group names the user belongs to. Each group name must be 1-250 characters",
@@ -10318,12 +11530,19 @@
             "items": {
               "type": "string"
             },
-            "examples": [["engineering", "managers"]]
+            "examples": [
+              [
+                "engineering",
+                "managers"
+              ]
+            ]
           },
           "locale": {
             "description": "User's localization preference in BCP-47 format. Defaults to organization settings.",
             "type": "string",
-            "examples": ["en-US"]
+            "examples": [
+              "en-US"
+            ]
           },
           "metadata": {
             "description": "System-managed key-value pairs for internal tracking. Keys (3-25 chars), values (1-256 chars).",
@@ -10341,22 +11560,30 @@
           "name": {
             "description": "Full name in display format. Typically combines first_name and last_name.",
             "type": "string",
-            "examples": ["John Michael Doe"]
+            "examples": [
+              "John Michael Doe"
+            ]
           },
           "phone_number": {
             "description": "Phone number in E.164 international format. Required for SMS-based authentication.",
             "type": "string",
-            "examples": ["+14155552671"]
+            "examples": [
+              "+14155552671"
+            ]
           },
           "picture": {
             "description": "URL to the user's profile picture or avatar.",
             "type": "string",
-            "examples": ["https://example.com/avatar.jpg"]
+            "examples": [
+              "https://example.com/avatar.jpg"
+            ]
           },
           "preferred_username": {
             "description": "User's preferred username for display purposes.",
             "type": "string",
-            "examples": ["John Michael Doe"]
+            "examples": [
+              "John Michael Doe"
+            ]
           }
         }
       },
@@ -10375,45 +11602,61 @@
             "description": "Timestamp when the invite was originally created.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-07-10T08:00:00Z"]
+            "examples": [
+              "2025-07-10T08:00:00Z"
+            ]
           },
           "expires_at": {
             "description": "The time at which the invite expires.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-12-31T23:59:59Z"]
+            "examples": [
+              "2025-12-31T23:59:59Z"
+            ]
           },
           "inviter_email": {
             "description": "Identifier of the user or system that initiated the invite.",
             "type": "string",
-            "examples": ["admin@example.com"]
+            "examples": [
+              "admin@example.com"
+            ]
           },
           "organization_id": {
             "description": "The organization to which the invite belongs.",
             "type": "string",
-            "examples": ["org_987654321"]
+            "examples": [
+              "org_987654321"
+            ]
           },
           "resent_at": {
             "description": "Timestamp when the invite was last resent, if applicable.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-07-15T09:30:00Z"]
+            "examples": [
+              "2025-07-15T09:30:00Z"
+            ]
           },
           "resent_count": {
             "description": "Number of times the invite has been resent.",
             "type": "integer",
             "format": "int32",
-            "examples": [2]
+            "examples": [
+              2
+            ]
           },
           "status": {
             "description": "Current status of the invite (e.g., pending, accepted, expired, revoked).",
             "type": "string",
-            "examples": ["pending_invite"]
+            "examples": [
+              "pending_invite"
+            ]
           },
           "user_id": {
             "description": "User ID to whom the invite is sent. May be empty if the user has not signed up yet.",
             "type": "string",
-            "examples": ["usr_123456"]
+            "examples": [
+              "usr_123456"
+            ]
           }
         }
       },
@@ -10423,18 +11666,24 @@
           "next_page_token": {
             "description": "Opaque token for retrieving the next page of results. Empty if there are no more pages.",
             "type": "string",
-            "examples": ["eyJwYWdlIjogMiwgImxhc3RfaWQiOiAidXNyXzEyMzQ1In0="]
+            "examples": [
+              "eyJwYWdlIjogMiwgImxhc3RfaWQiOiAidXNyXzEyMzQ1In0="
+            ]
           },
           "prev_page_token": {
             "description": "Opaque token for retrieving the previous page of results. Empty for the first page.",
             "type": "string",
-            "examples": ["eyJwYWdlIjogMCwgImZpcnN0X2lkIjogInVzcl85ODc2NSJ9"]
+            "examples": [
+              "eyJwYWdlIjogMCwgImZpcnN0X2lkIjogInVzcl85ODc2NSJ9"
+            ]
           },
           "total_size": {
             "description": "Total number of users matching the request criteria, regardless of pagination.",
             "type": "integer",
             "format": "int64",
-            "examples": [1042]
+            "examples": [
+              1042
+            ]
           },
           "users": {
             "description": "List of user objects for the current page. May contain fewer entries than requested page_size.",
@@ -10478,18 +11727,24 @@
           "next_page_token": {
             "description": "Token for retrieving the next page of results. Empty if there are no more pages.",
             "type": "string",
-            "examples": ["eyJwYWdlIjogMiwgImxhc3RfaWQiOiAidXNyXzEyMzQ1In0="]
+            "examples": [
+              "eyJwYWdlIjogMiwgImxhc3RfaWQiOiAidXNyXzEyMzQ1In0="
+            ]
           },
           "prev_page_token": {
             "description": "Token for retrieving the previous page of results. Empty if this is the first page.",
             "type": "string",
-            "examples": ["eyJwYWdlIjogMCwgImZpcnN0X2lkIjogInVzcl85ODc2NSJ9"]
+            "examples": [
+              "eyJwYWdlIjogMCwgImZpcnN0X2lkIjogInVzcl85ODc2NSJ9"
+            ]
           },
           "total_size": {
             "description": "Total number of users matching the request criteria, regardless of pagination.",
             "type": "integer",
             "format": "int64",
-            "examples": [1042]
+            "examples": [
+              1042
+            ]
           },
           "users": {
             "description": "List of users.",
@@ -10507,18 +11762,24 @@
           "description": {
             "description": "Description of what the permission allows",
             "type": "string",
-            "examples": ["Allows creating new user accounts"]
+            "examples": [
+              "Allows creating new user accounts"
+            ]
           },
           "id": {
             "description": "Unique identifier for the permission",
             "type": "string",
             "readOnly": true,
-            "examples": ["perm_1234abcd5678efgh"]
+            "examples": [
+              "perm_1234abcd5678efgh"
+            ]
           },
           "name": {
             "description": "Unique name identifier for the permission",
             "type": "string",
-            "examples": ["users:create"]
+            "examples": [
+              "users:create"
+            ]
           }
         }
       },
@@ -10546,18 +11807,24 @@
           "next_page_token": {
             "description": "Token for retrieving the next page of results. Empty if there are no more pages.",
             "type": "string",
-            "examples": ["eyJwYWdlIjogMiwgImxhc3RfaWQiOiAidXNyXzEyMzQ1In0="]
+            "examples": [
+              "eyJwYWdlIjogMiwgImxhc3RfaWQiOiAidXNyXzEyMzQ1In0="
+            ]
           },
           "prev_page_token": {
             "description": "Token for retrieving the previous page of results. Empty if this is the first page.",
             "type": "string",
-            "examples": ["eyJwYWdlIjogMCwgImZpcnN0X2lkIjogInVzcl85ODc2NSJ9"]
+            "examples": [
+              "eyJwYWdlIjogMCwgImZpcnN0X2lkIjogInVzcl85ODc2NSJ9"
+            ]
           },
           "total_size": {
             "description": "Total number of users matching the request criteria, regardless of pagination.",
             "type": "integer",
             "format": "int64",
-            "examples": [1042]
+            "examples": [
+              1042
+            ]
           },
           "users": {
             "description": "List of matching users.",
@@ -10575,18 +11842,24 @@
           "next_page_token": {
             "description": "Token for retrieving the next page of results. Empty if there are no more pages.",
             "type": "string",
-            "examples": ["eyJwYWdlIjogMiwgImxhc3RfaWQiOiAidXNyXzEyMzQ1In0="]
+            "examples": [
+              "eyJwYWdlIjogMiwgImxhc3RfaWQiOiAidXNyXzEyMzQ1In0="
+            ]
           },
           "prev_page_token": {
             "description": "Token for retrieving the previous page of results. Empty if this is the first page.",
             "type": "string",
-            "examples": ["eyJwYWdlIjogMCwgImZpcnN0X2lkIjogInVzcl85ODc2NSJ9"]
+            "examples": [
+              "eyJwYWdlIjogMCwgImZpcnN0X2lkIjogInVzcl85ODc2NSJ9"
+            ]
           },
           "total_size": {
             "description": "Total number of users matching the request criteria, regardless of pagination.",
             "type": "integer",
             "format": "int64",
-            "examples": [1042]
+            "examples": [
+              1042
+            ]
           },
           "users": {
             "description": "List of matching users.",
@@ -10625,22 +11898,30 @@
           "family_name": {
             "description": "Updates the user's family name (last name or surname). Use this field to modify how the user's last name appears throughout the system. Maximum 255 characters allowed.",
             "type": "string",
-            "examples": ["Doe"]
+            "examples": [
+              "Doe"
+            ]
           },
           "first_name": {
             "description": "[DEPRECATED] Use given_name instead. User's given name. Maximum 200 characters.",
             "type": "string",
-            "examples": ["John"]
+            "examples": [
+              "John"
+            ]
           },
           "gender": {
             "description": "Updates the user's gender identity information. Use this field to store the user's gender identity for personalization, compliance, or reporting purposes. This field supports any string value to accommodate diverse gender identities and should be handled with appropriate privacy considerations according to your organization's policies.",
             "type": "string",
-            "examples": ["male"]
+            "examples": [
+              "male"
+            ]
           },
           "given_name": {
             "description": "Updates the user's given name (first name). Use this field to modify how the user's first name appears in the system and user interfaces. Maximum 255 characters allowed.",
             "type": "string",
-            "examples": ["John"]
+            "examples": [
+              "John"
+            ]
           },
           "groups": {
             "description": "Updates the list of group names the user belongs to within the organization. Use this field to manage the user's group memberships for role-based access control, team assignments, or organizational structure. Groups are typically used for permission management and collaborative access. Each group name must be unique within the list, 1-250 characters long, with a maximum of 50 groups per user.",
@@ -10648,17 +11929,26 @@
             "items": {
               "type": "string"
             },
-            "examples": [["engineering", "managers"]]
+            "examples": [
+              [
+                "engineering",
+                "managers"
+              ]
+            ]
           },
           "last_name": {
             "description": "[DEPRECATED] Use family_name instead. User's family name. Maximum 200 characters.",
             "type": "string",
-            "examples": ["Doe"]
+            "examples": [
+              "Doe"
+            ]
           },
           "locale": {
             "description": "Updates the user's preferred language and region settings using BCP-47 format codes. Use this field to customize the user's experience with localized content, date formats, number formatting, and UI language. When not specified, the user inherits the organization's default locale settings. Common values include `en-US`, `en-GB`, `fr-FR`, `de-DE`, and `es-ES`.",
             "type": "string",
-            "examples": ["en-US"]
+            "examples": [
+              "en-US"
+            ]
           },
           "metadata": {
             "description": "Updates system-managed key-value pairs for internal tracking and operational data. Use this field to store system-generated metadata like account status, signup source, last activity tracking, or integration-specific identifiers. These fields are typically managed by automated processes rather than direct user input. Keys must be 3-25 characters, values must be 1-256 characters, with a maximum of 20 key-value pairs.",
@@ -10676,22 +11966,30 @@
           "name": {
             "description": "Updates the user's complete display name. Use this field when you want to set the full name as a single string rather than using separate given and family names. This name appears in user interfaces, reports, and anywhere a formatted display name is needed.",
             "type": "string",
-            "examples": ["John Doe"]
+            "examples": [
+              "John Doe"
+            ]
           },
           "phone_number": {
             "description": "Updates the user's phone number in E.164 international format. Use this field to enable SMS-based authentication methods, two-factor authentication, or phone-based account recovery. The phone number must include the country code and be formatted according to E.164 standards (e.g., `+1` for US numbers). This field is required when enabling SMS authentication features.",
             "type": "string",
-            "examples": ["+14155552671"]
+            "examples": [
+              "+14155552671"
+            ]
           },
           "picture": {
             "description": "Updates the URL to the user's profile picture or avatar image. Use this field to set or change the user's profile photo that appears in user interfaces, directory listings, and collaborative features. The URL should point to a publicly accessible image file. Supported formats typically include JPEG, PNG, and GIF. Maximum URL length is 2048 characters.",
             "type": "string",
-            "examples": ["https://example.com/avatar.jpg"]
+            "examples": [
+              "https://example.com/avatar.jpg"
+            ]
           },
           "preferred_username": {
             "description": "Updates the user's preferred username for display and identification purposes. Use this field to set a custom username that the user prefers to be known by, which may differ from their email or formal name. This username appears in user interfaces, mentions, and informal communications. Maximum 512 characters allowed.",
             "type": "string",
-            "examples": ["John Michael Doe"]
+            "examples": [
+              "John Michael Doe"
+            ]
           }
         }
       },
@@ -10715,17 +12013,23 @@
           "email": {
             "description": "Primary email address for the user. Must be unique across the environment and valid per RFC 5322.",
             "type": "string",
-            "examples": ["user@example.com"]
+            "examples": [
+              "user@example.com"
+            ]
           },
           "external_id": {
             "description": "Your application's unique identifier for this organization, used to link Scalekit with your system.",
             "type": "string",
-            "examples": ["ext_12345a67b89c"]
+            "examples": [
+              "ext_12345a67b89c"
+            ]
           },
           "id": {
             "description": "Unique system-generated identifier for the user. Immutable once created.",
             "type": "string",
-            "examples": ["usr_1234abcd5678efgh"]
+            "examples": [
+              "usr_1234abcd5678efgh"
+            ]
           },
           "last_login_time": {
             "description": "Timestamp of the user's most recent successful authentication. Updated automatically.",
@@ -10772,28 +12076,38 @@
           "domain": {
             "description": "The domain name to be configured. Must be a valid business domain you control. Public and disposable domains (gmail.com, outlook.com, etc.) are automatically blocked for security.",
             "type": "string",
-            "examples": ["customerdomain.com"]
+            "examples": [
+              "customerdomain.com"
+            ]
           },
           "domain_type": {
             "description": "The domain type.\n- ALLOWED_EMAIL_DOMAIN: trusted domain used to suggest the organization in the organization switcher during sign-in/sign-up.\n- ORGANIZATION_DOMAIN: SSO discovery domain used to route users to the correct SSO provider and enforce SSO.\n",
             "$ref": "#/components/schemas/domainsDomainType",
-            "examples": ["ORGANIZATION_DOMAIN"]
+            "examples": [
+              "ORGANIZATION_DOMAIN"
+            ]
           }
         }
       },
       "v1organizationsCreateOrganization": {
         "type": "object",
-        "required": ["display_name"],
+        "required": [
+          "display_name"
+        ],
         "properties": {
           "display_name": {
             "description": "Name of the organization. Must be between 1 and 200 characters.",
             "type": "string",
-            "examples": ["Megasoft Inc"]
+            "examples": [
+              "Megasoft Inc"
+            ]
           },
           "external_id": {
             "description": "Your application's unique identifier for this organization, used to link Scalekit with your system.",
             "type": "string",
-            "examples": ["my_unique_id"]
+            "examples": [
+              "my_unique_id"
+            ]
           },
           "logo_url": {
             "description": "HTTPS URL of the organization's logo image. Maximum 1024 characters. Must use the https scheme.",
@@ -10801,7 +12115,9 @@
             "format": "uri",
             "maxLength": 1024,
             "pattern": "^https://",
-            "examples": ["https://cdn.example.com/acme-logo.png"]
+            "examples": [
+              "https://cdn.example.com/acme-logo.png"
+            ]
           },
           "metadata": {
             "type": "object",
@@ -10815,7 +12131,9 @@
             "maxLength": 253,
             "minLength": 1,
             "pattern": "^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$",
-            "examples": ["acme"]
+            "examples": [
+              "acme"
+            ]
           }
         }
       },
@@ -10826,12 +12144,16 @@
           "display_name": {
             "description": "Name of the organization to display in the UI. Must be between 1 and 200 characters",
             "type": "string",
-            "examples": ["Acme Corporation"]
+            "examples": [
+              "Acme Corporation"
+            ]
           },
           "external_id": {
             "description": "Your application's unique identifier for this organization, used to link Scalekit with your system",
             "type": "string",
-            "examples": ["tenant_12345"]
+            "examples": [
+              "tenant_12345"
+            ]
           },
           "logo_url": {
             "description": "HTTPS URL of the organization's logo image. Maximum 1024 characters. Must use the https scheme.",
@@ -10839,7 +12161,9 @@
             "format": "uri",
             "maxLength": 1024,
             "pattern": "^https://",
-            "examples": ["https://cdn.example.com/acme-logo.png"]
+            "examples": [
+              "https://cdn.example.com/acme-logo.png"
+            ]
           },
           "metadata": {
             "description": "Custom key-value pairs to store with the organization. Keys must be 3-25 characters, values must be 1-256 characters. Maximum 10 pairs allowed.",
@@ -10858,7 +12182,9 @@
             "type": "string",
             "maxLength": 253,
             "pattern": "^$|^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$",
-            "examples": ["acme"]
+            "examples": [
+              "acme"
+            ]
           }
         }
       },
@@ -10868,22 +12194,30 @@
           "description": {
             "description": "Description of the organization's role",
             "type": "string",
-            "examples": ["Organization Viewer Role will be used only for viewing the objects"]
+            "examples": [
+              "Organization Viewer Role will be used only for viewing the objects"
+            ]
           },
           "display_name": {
             "description": "Display name of the organization's role",
             "type": "string",
-            "examples": ["Organization Viewer Role"]
+            "examples": [
+              "Organization Viewer Role"
+            ]
           },
           "extends": {
             "description": "Base role name for hierarchical roles",
             "type": "string",
-            "examples": ["admin_role"]
+            "examples": [
+              "admin_role"
+            ]
           },
           "name": {
             "description": "Unique name of the organization's role",
             "type": "string",
-            "examples": ["org_viewer_role"]
+            "examples": [
+              "org_viewer_role"
+            ]
           },
           "permissions": {
             "description": "List of permission names to assign to this role. Permissions must exist in the current environment.",
@@ -10891,7 +12225,12 @@
             "items": {
               "type": "string"
             },
-            "examples": [["read:users", "write:documents"]]
+            "examples": [
+              [
+                "read:users",
+                "write:documents"
+              ]
+            ]
           }
         }
       },
@@ -10901,12 +12240,16 @@
           "description": {
             "description": "Description of the permission",
             "type": "string",
-            "examples": ["Allows user to read documents from the system"]
+            "examples": [
+              "Allows user to read documents from the system"
+            ]
           },
           "name": {
             "description": "Unique name/ID of the permission. Must be 1–64 characters using only letters, numbers, underscores (_), and colons (:).",
             "type": "string",
-            "examples": ["read:documents"]
+            "examples": [
+              "read:documents"
+            ]
           }
         }
       },
@@ -10923,17 +12266,23 @@
           "display_name": {
             "description": "Human-readable display name for the role. Used in user interfaces, reports, and user-facing communications.",
             "type": "string",
-            "examples": ["Content Editor"]
+            "examples": [
+              "Content Editor"
+            ]
           },
           "extends": {
             "description": "Name of the base role that this role extends. Enables hierarchical role inheritance where this role inherits all permissions from the base role.",
             "type": "string",
-            "examples": ["viewer"]
+            "examples": [
+              "viewer"
+            ]
           },
           "name": {
             "description": "Unique name identifier for the role. Must be alphanumeric with underscores, 1-64 characters. This name is used in API calls and cannot be changed after creation.",
             "type": "string",
-            "examples": ["content_editor"]
+            "examples": [
+              "content_editor"
+            ]
           },
           "permissions": {
             "description": "List of permission names to assign to this role. Permissions must exist in the current environment. Maximum 100 permissions per role.",
@@ -10941,7 +12290,13 @@
             "items": {
               "type": "string"
             },
-            "examples": [["read:content", "write:content", "publish:content"]]
+            "examples": [
+              [
+                "read:content",
+                "write:content",
+                "publish:content"
+              ]
+            ]
           }
         }
       },
@@ -10951,49 +12306,67 @@
           "default_creator": {
             "description": "Indicates if this role is the default creator role for new organizations.",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "default_member": {
             "description": "Indicates if this role is the default member role for new users.",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "dependent_roles_count": {
             "description": "Number of roles that extend from this role (dependent roles count). Read-only field.",
             "type": "integer",
             "format": "int32",
-            "examples": [3]
+            "examples": [
+              3
+            ]
           },
           "description": {
             "description": "Detailed description of the role's purpose and capabilities. Maximum 2000 characters.",
             "type": "string",
-            "examples": ["Can create, edit, and publish content but cannot delete or manage users"]
+            "examples": [
+              "Can create, edit, and publish content but cannot delete or manage users"
+            ]
           },
           "display_name": {
             "description": "Human-readable display name for the role. Used in user interfaces and reports.",
             "type": "string",
-            "examples": ["Content Editor"]
+            "examples": [
+              "Content Editor"
+            ]
           },
           "extends": {
             "description": "Name of the base role that this role extends. Enables hierarchical role inheritance.",
             "type": "string",
-            "examples": ["admin_role"]
+            "examples": [
+              "admin_role"
+            ]
           },
           "id": {
             "description": "Unique system-generated identifier for the role. Immutable once created.",
             "type": "string",
             "readOnly": true,
-            "examples": ["role_1234abcd5678efgh"]
+            "examples": [
+              "role_1234abcd5678efgh"
+            ]
           },
           "is_org_role": {
             "description": "Indicates if this role is an organization role.",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "name": {
             "description": "Unique name identifier for the role. Must be alphanumeric with underscores, 1-100 characters.",
             "type": "string",
-            "examples": ["content_editor"]
+            "examples": [
+              "content_editor"
+            ]
           },
           "permissions": {
             "description": "List of permissions with role source information. Only included when 'include' parameter is specified in the request.",
@@ -11032,12 +12405,16 @@
           "display_name": {
             "description": "Human-readable display name for the role. Used in user interfaces, reports, and user-facing communications.",
             "type": "string",
-            "examples": ["Senior Content Editor"]
+            "examples": [
+              "Senior Content Editor"
+            ]
           },
           "extends": {
             "description": "Name of the base role that this role extends. Enables hierarchical role inheritance where this role inherits all permissions from the base role.",
             "type": "string",
-            "examples": ["content_editor"]
+            "examples": [
+              "content_editor"
+            ]
           },
           "permissions": {
             "description": "List of permission names to assign to this role. When provided, this replaces all existing role-permission mappings. Permissions must exist in the current environment. Maximum 100 permissions per role.",
@@ -11045,7 +12422,14 @@
             "items": {
               "type": "string"
             },
-            "examples": [["read:content", "write:content", "publish:content", "approve:content"]]
+            "examples": [
+              [
+                "read:content",
+                "write:content",
+                "publish:content",
+                "approve:content"
+              ]
+            ]
           }
         }
       },
@@ -11055,27 +12439,37 @@
           "city": {
             "description": "City name where the session originated based on IP geolocation. Approximate location derived from IP address.",
             "type": "string",
-            "examples": ["San Francisco"]
+            "examples": [
+              "San Francisco"
+            ]
           },
           "latitude": {
             "description": "Latitude coordinate of the estimated location. Decimal format (e.g., '37.7749'). Note: Represents IP geolocation center and may not be precise.",
             "type": "string",
-            "examples": ["37.7749"]
+            "examples": [
+              "37.7749"
+            ]
           },
           "longitude": {
             "description": "Longitude coordinate of the estimated location. Decimal format (e.g., '-122.4194'). Note: Represents IP geolocation center and may not be precise.",
             "type": "string",
-            "examples": ["-122.4194"]
+            "examples": [
+              "-122.4194"
+            ]
           },
           "region": {
             "description": "Geographic region name derived from IP geolocation. Represents the country-level location (e.g., 'United States', 'France').",
             "type": "string",
-            "examples": ["United States"]
+            "examples": [
+              "United States"
+            ]
           },
           "region_subdivision": {
             "description": "Regional subdivision code or name (e.g., state abbreviation for US, province for Canada). Two-letter ISO format when applicable.",
             "type": "string",
-            "examples": ["CA"]
+            "examples": [
+              "CA"
+            ]
           }
         }
       },
@@ -11085,7 +12479,9 @@
           "inviter_email": {
             "description": "Email address of the user who invited this member. Must be a valid email address.",
             "type": "string",
-            "examples": ["john.doe@example.com"]
+            "examples": [
+              "john.doe@example.com"
+            ]
           },
           "metadata": {
             "description": "Custom key-value pairs for storing additional user context. Keys (3-25 chars), values (1-256 chars).",
@@ -11156,7 +12552,9 @@
           "external_id": {
             "description": "Your application's unique identifier for this organization, used to link Scalekit with your system.",
             "type": "string",
-            "examples": ["ext_12345a67b89c"]
+            "examples": [
+              "ext_12345a67b89c"
+            ]
           },
           "metadata": {
             "description": "Custom key-value pairs for storing additional user context. Keys (3-25 chars), values (1-256 chars).",
@@ -11190,12 +12588,16 @@
           "rp_id": {
             "description": "Relying Party ID for credential operations",
             "type": "string",
-            "examples": ["example.com"]
+            "examples": [
+              "example.com"
+            ]
           },
           "user_id": {
             "description": "User ID for credential verification",
             "type": "string",
-            "examples": ["user_xyz789"]
+            "examples": [
+              "user_xyz789"
+            ]
           }
         }
       },
@@ -11205,7 +12607,9 @@
           "success": {
             "description": "Whether the credential was successfully deleted",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "unknown_credential_options": {
             "description": "Options for handling unknown credentials in client applications",
@@ -11236,12 +12640,16 @@
           "credential_id": {
             "description": "The deleted credential ID",
             "type": "string",
-            "examples": ["cred_abc123"]
+            "examples": [
+              "cred_abc123"
+            ]
           },
           "rp_id": {
             "description": "The RP ID for this credential",
             "type": "string",
-            "examples": ["example.com"]
+            "examples": [
+              "example.com"
+            ]
           }
         }
       },
@@ -11260,7 +12668,9 @@
           "attestation_type": {
             "description": "Type of attestation: \"none\", \"indirect\", or \"direct\"",
             "type": "string",
-            "examples": ["direct"]
+            "examples": [
+              "direct"
+            ]
           },
           "authenticator": {
             "description": "Authenticator information including model and name",
@@ -11278,7 +12688,9 @@
             "description": "Timestamp when the credential was created",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-02-15T06:23:44.560000Z"]
+            "examples": [
+              "2025-02-15T06:23:44.560000Z"
+            ]
           },
           "credential_id": {
             "description": "The actual credential ID bytes from the authenticator",
@@ -11288,12 +12700,16 @@
           "display_name": {
             "description": "Optional user-friendly name for this passkey",
             "type": "string",
-            "examples": ["My Yubikey"]
+            "examples": [
+              "My Yubikey"
+            ]
           },
           "id": {
             "description": "Credential unique identifier",
             "type": "string",
-            "examples": ["cred_abc123"]
+            "examples": [
+              "cred_abc123"
+            ]
           },
           "transports": {
             "description": "Supported transports for this credential",
@@ -11306,7 +12722,9 @@
             "description": "Timestamp of last update",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-02-15T06:23:44.560000Z"]
+            "examples": [
+              "2025-02-15T06:23:44.560000Z"
+            ]
           },
           "user_agent": {
             "description": "Browser and device information from registration",
@@ -11315,13 +12733,22 @@
           "user_id": {
             "description": "User ID this credential belongs to",
             "type": "string",
-            "examples": ["user_xyz789"]
+            "examples": [
+              "user_xyz789"
+            ]
           }
         }
       },
       "ScalekitEvent": {
         "type": "object",
-        "required": ["spec_version", "id", "type", "occurred_at", "environment_id", "object"],
+        "required": [
+          "spec_version",
+          "id",
+          "type",
+          "occurred_at",
+          "environment_id",
+          "object"
+        ],
         "properties": {
           "spec_version": {
             "type": "string",
@@ -11345,6 +12772,10 @@
               "organization.created",
               "organization.updated",
               "organization.deleted",
+              "organization.domain_created",
+              "organization.domain_deleted",
+              "organization.domain_dns_verification_success",
+              "organization.domain_dns_verification_failed",
               "organization.sso_created",
               "organization.sso_deleted",
               "organization.sso_enabled",

--- a/public/api/saaskit.scalar.yaml
+++ b/public/api/saaskit.scalar.yaml
@@ -250,12 +250,6 @@ paths:
         - label: Node.js SDK
           lang: javascript
           source: |-
-            import { ScalekitClient } from '@scalekit-sdk/node'
-            const scalekit = new ScalekitClient(
-              process.env.SCALEKIT_ENV_URL,
-              process.env.SCALEKIT_CLIENT_ID,
-              process.env.SCALEKIT_CLIENT_SECRET,
-            )
             await scalekit.user.createMembership('org_123', 'usr_123', {
               roles: ['admin'],
               metadata: {
@@ -281,52 +275,41 @@ paths:
         - label: Go SDK
           lang: go
           source: |-
-            func main() {
-                scalekitClient := scalekit.NewScalekitClient(
-                    os.Getenv("SCALEKIT_ENV_URL"),
-                    os.Getenv("SCALEKIT_CLIENT_ID"),
-                    os.Getenv("SCALEKIT_CLIENT_SECRET"),
-                )
-                membership := &usersv1.CreateMembership{
-                    Roles: []*usersv1.Role{{Name: "admin"}},
-                    Metadata: map[string]string{
-                        "department": "engineering",
-                        "location":   "nyc-office",
-                    },
-                }
-                resp, 
-                  err := scalekitClient.User().CreateMembership(
-                    context.Background(), "org_123", 
-                      "usr_123", membership, false)
-                if err != nil {
-                    panic(err)
-                }
+            membership := &usersv1.CreateMembership{
+              Roles: []*usersv1.Role{{Name: "admin"}},
+              Metadata: map[string]string{
+                "department": "engineering",
+                "location":   "nyc-office",
+              },
             }
+            resp, err := scalekitClient.User().CreateMembership(
+              ctx,
+              "org_123",
+              "usr_123",
+              membership,
+              false,
+            )
+            if err != nil {
+              // handle error
+              return
+            }
+            _ = resp
         - label: Java SDK
           lang: java
           source: |-
-            import com.scalekit.ScalekitClient;
-            import com.scalekit.api.UserClient;
-            import com.scalekit.grpc.scalekit.v1.users.*;
-            ScalekitClient scalekitClient = new ScalekitClient(
-                System.getenv("SCALEKIT_ENV_URL"),
-                System.getenv("SCALEKIT_CLIENT_ID"),
-                System.getenv("SCALEKIT_CLIENT_SECRET")
+            CreateMembershipRequest membershipReq = CreateMembershipRequest.newBuilder()
+                .setMembership(
+                    CreateMembership.newBuilder()
+                        .addRoles(Role.newBuilder().setName("admin").build())
+                        .putMetadata("department", "engineering")
+                        .putMetadata("location", "nyc-office")
+                        .build())
+                .build();
+            CreateMembershipResponse res = scalekitClient.users().createMembership(
+                "org_123",
+                "usr_123",
+                membershipReq
             );
-            UserClient users = scalekitClient.users();
-            CreateMembershipRequest membershipReq = CreateMemb
-              ershipRequest.newBuilder()
-                    .setMembership(
-                      CreateMembership.newBuilder()
-                            .addRoles(Role.newBuilder(
-                              ).setName("admin").build())
-                            .putMetadata("department", "engineering")
-                            .putMetadata("location", "nyc-office")
-                            .build())
-                    .build();
-            CreateMembershipResponse res = users.
-              createMembership("org_123", "usr_123", 
-                membershipReq);
     delete:
       description: Removes a user from an organization by user ID. This action is irreversible and may also remove related group memberships.
       tags:
@@ -353,12 +336,32 @@ paths:
             application/json:
               schema: {}
       x-codeSamples:
+        - label: Node.js SDK
+          lang: javascript
+          source: await scalekit.user.deleteMembership('org_123', 'usr_123')
         - label: Python SDK
           lang: python
           source: |-
-            response = scalekit_client.users.delete_membership(
-              organization_id=org_id,user_id=user_id
+            scalekit_client.users.delete_membership(
+                organization_id="org_123",
+                user_id="usr_123",
             )
+        - label: Go SDK
+          lang: go
+          source: |-
+            err := scalekitClient.User().DeleteMembership(
+              ctx,
+              "org_123",
+              "usr_123",
+              false, // cascade: also remove from nested groups when true
+            )
+            if err != nil {
+              // handle error
+              return
+            }
+        - label: Java SDK
+          lang: java
+          source: scalekitClient.users().deleteMembership("org_123", "usr_123");
     patch:
       description: Updates a user's membership details within an organization by user ID. You can update roles and membership metadata.
       tags:
@@ -550,11 +553,11 @@ paths:
         - label: Go SDK
           lang: go
           source: |-
-            organizations, err := scalekitClient.Organization.ListOrganizations(
+            organizations, err := scalekitClient.Organization().ListOrganization(
               ctx,
               &scalekit.ListOrganizationOptions{
                 PageSize: 10,
-              }
+              },
             )
         - label: Java SDK
           lang: java
@@ -601,11 +604,11 @@ paths:
         - label: Go SDK
           lang: go
           source: |-
-            organization, err := ScalekitClient.Organization.CreateOrganization(
+            organization, err := scalekitClient.Organization().CreateOrganization(
               ctx,
               name,
               scalekit.CreateOrganizationOptions{
-                ExternalID: "externalId",
+                ExternalId: "externalId",
               },
             )
         - label: Java SDK
@@ -640,38 +643,16 @@ paths:
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
-          source: |-
-            import { ScalekitClient } from '@scalekit-sdk/node'
-            const scalekit = new ScalekitClient(
-              process.env.SCALEKIT_ENV_URL,
-              process.env.SCALEKIT_CLIENT_ID,
-              process.env.SCALEKIT_CLIENT_SECRET,
-            )
-            const organization = await scalekit.organization.getOrganization(organization_id)
+          source: const organization = await scalekit.organization.getOrganization(organizationId)
         - label: Python SDK
           lang: python
-          source: |-
-            scalekit_client = ScalekitClient(
-              <SCALEKIT_ENVIRONMENT_URL>,
-              <SCALEKIT_CLIENT_ID>,
-              <SCALEKIT_CLIENT_SECRET>
-            )
-
-            organization = scalekit_client.organization.get_organization(
-              organization_id
-            )
+          source: organization = scalekit_client.organization.get_organization(organization_id)
         - label: Go SDK
           lang: go
           source: |-
-            scalekitClient := scalekit.NewScalekitClient(
-              <SCALEKIT_ENVIRONMENT_URL>,
-              <SCALEKIT_CLIENT_ID>,
-              <SCALEKIT_CLIENT_SECRET>
-            )
-
-            organization, err := scalekitClient.Organization.GetOrganization(
+            organization, err := scalekitClient.Organization().GetOrganization(
               ctx,
-              organizationId
+              organizationId,
             )
         - label: Java SDK
           lang: java
@@ -712,9 +693,9 @@ paths:
         - label: Go SDK
           lang: go
           source: |-
-            err := scalekitClient.Organization.DeleteOrganization(
+            err := scalekitClient.Organization().DeleteOrganization(
               ctx,
-              organizationId
+              organizationId,
             )
         - label: Java SDK
           lang: java
@@ -771,12 +752,12 @@ paths:
         - label: Go SDK
           lang: go
           source: |-
-            organization, err := scalekitClient.Organization.UpdateOrganization(
+            organization, err := scalekitClient.Organization().UpdateOrganization(
               ctx,
               organizationId,
               &scalekit.UpdateOrganization{
                 DisplayName: "displayName",
-                ExternalId: "externalId",
+                ExternalId:  "externalId",
               },
             )
         - label: Java SDK
@@ -843,9 +824,9 @@ paths:
         - label: Go SDK
           lang: go
           source: |-
-            link, err := scalekitClient.Organization.GeneratePortalLink(
+            link, err := scalekitClient.Organization().GeneratePortalLink(
               ctx,
-              organizationId
+              organizationId,
             )
         - label: Java SDK
           lang: java
@@ -967,7 +948,7 @@ paths:
           required: true
         - schema:
             type: string
-          description: "Include additional data in the response. Valid values: 'permissions' (direct permissions only), 'permissions:all' (includes inherited permissions)"
+          description: 'Include additional data in the response. Valid values: ''permissions'' (direct permissions only), ''permissions:all'' (includes inherited permissions)'
           name: include
           in: query
       responses:
@@ -1092,7 +1073,7 @@ paths:
           required: true
         - schema:
             type: string
-          description: "Include additional data in the response. Valid values: 'permissions' (direct permissions only), 'permissions:all' (includes inherited permissions)"
+          description: 'Include additional data in the response. Valid values: ''permissions'' (direct permissions only), ''permissions:all'' (includes inherited permissions)'
           name: include
           in: query
       responses:
@@ -1370,22 +1351,47 @@ paths:
               schema:
                 $ref: '#/components/schemas/clientsListOrganizationClientsResponse'
       x-codeSamples:
+        - label: Node.js SDK
+          lang: javascript
+          source: |-
+            const response = await scalekit.m2m.listOrganizationClients('org_123', {
+              pageSize: 30,
+            })
+            const clients = response.clients
         - label: Python SDK
           lang: python
           source: |-
             # List clients for a specific organization
-            org_id = 'SCALEKIT_ORGANIZATION_ID'
+            org_id = "org_123"
 
-            # Retrieve all clients with default pagination
             response = scalekit_client.m2m_client.list_organization_clients(
                 organization_id=org_id,
-                page_size=30
+                page_size=30,
             )
 
-            # Access the clients list
             clients = response.clients
             for client in clients:
-                print(f"Client ID: {scalekit_client.id}, Name: {scalekit_client.name}")
+                print(f"Client ID: {client.id}, Name: {client.name}")
+        - label: Go SDK
+          lang: go
+          source: |-
+            response, err := scalekitClient.M2M().ListOrganizationClients(
+              ctx,
+              "org_123",
+              scalekit.ListOrganizationClientsOptions{
+                PageSize: 30,
+              },
+            )
+            if err != nil {
+              // handle error
+              return
+            }
+            _ = response
+        - label: Java SDK
+          lang: java
+          source: |-
+            ListOrganizationClientsResponse response = scalekitClient.m2m()
+                .listOrganizationClients("org_123", 30, "");
     post:
       description: Creates a new API client for an organization. Returns the client details and a plain secret (available only once).
       tags:
@@ -1414,6 +1420,15 @@ paths:
               $ref: '#/components/schemas/clientsOrganizationClient'
         required: true
       x-codeSamples:
+        - label: Node.js SDK
+          lang: javascript
+          source: |-
+            const response = await scalekit.m2m.createOrganizationClient('org_123', {
+              name: 'GitHub Actions Deployment Service',
+              description: 'Service account for GitHub Actions to deploy applications to production',
+              scopes: ['deploy:applications', 'read:deployments'],
+              audience: ['deployment-api.acmecorp.com'],
+            })
         - label: Python SDK
           lang: python
           source: |-
@@ -1421,21 +1436,53 @@ paths:
 
             m2m_client = OrganizationClient(
                 name="GitHub Actions Deployment Service",
-                description="Service account for GitHub Actions to deploy applications
-            to production",
+                description="Service account for GitHub Actions to deploy applications to production",
                 custom_claims=[
                     {"key": "github_repository", "value": "acmecorp/inventory-service"},
-                    {"key": "environment", "value": "production_us"}
+                    {"key": "environment", "value": "production_us"},
                 ],
                 scopes=["deploy:applications", "read:deployments"],
                 audience=["deployment-api.acmecorp.com"],
-                expiry=3600
+                expiry=3600,
             )
 
             response = scalekit_client.m2m_client.create_organization_client(
-                organization_id="SCALEKIT_ORGANIZATION_ID",
-                m2m_client=m2m_client
+                organization_id="org_123",
+                m2m_client=m2m_client,
             )
+        - label: Go SDK
+          lang: go
+          source: |-
+            response, err := scalekitClient.M2M().CreateOrganizationClient(
+              ctx,
+              "org_123",
+              scalekit.CreateOrganizationClientOptions{
+                Name:        "GitHub Actions Deployment Service",
+                Description: "Service account for GitHub Actions to deploy applications to production",
+                Scopes:      []string{"deploy:applications", "read:deployments"},
+                Audience:    []string{"deployment-api.acmecorp.com"},
+              },
+            )
+            if err != nil {
+              // handle error
+              return
+            }
+            _ = response
+        - label: Java SDK
+          lang: java
+          source: |-
+            import com.scalekit.grpc.scalekit.v1.clients.OrganizationClient;
+
+            OrganizationClient orgClient = OrganizationClient.newBuilder()
+                .setName("GitHub Actions Deployment Service")
+                .setDescription("Service account for GitHub Actions to deploy applications to production")
+                .addScopes("deploy:applications")
+                .addScopes("read:deployments")
+                .addAudience("deployment-api.acmecorp.com")
+                .build();
+
+            CreateOrganizationClientResponse response = scalekitClient.m2m()
+                .createOrganizationClient("org_123", orgClient);
   /api/v1/organizations/{organization_id}/clients/{client_id}:
     get:
       description: Retrieves details of a specific API client in an organization.
@@ -1464,18 +1511,39 @@ paths:
               schema:
                 $ref: '#/components/schemas/clientsGetOrganizationClientResponse'
       x-codeSamples:
+        - label: Node.js SDK
+          lang: javascript
+          source: const response = await scalekit.m2m.getOrganizationClient('org_123', 'skc_xxxxx')
         - label: Python SDK
           lang: python
           source: |-
-            # Get client ID from environment variables
-            org_id = 'SCALEKIT_ORGANIZATION_ID'
-            client_id = os.environ['M2M_CLIENT_ID']
+            import os
 
-            # Fetch client details for the specified organization
+            org_id = "org_123"
+            client_id = os.environ["M2M_CLIENT_ID"]
+
             response = scalekit_client.m2m_client.get_organization_client(
                 organization_id=org_id,
-                client_id=client_id
+                client_id=client_id,
             )
+        - label: Go SDK
+          lang: go
+          source: |-
+            response, err := scalekitClient.M2M().GetOrganizationClient(
+              ctx,
+              "org_123",
+              "skc_xxxxx",
+            )
+            if err != nil {
+              // handle error
+              return
+            }
+            _ = response
+        - label: Java SDK
+          lang: java
+          source: |-
+            GetOrganizationClientResponse response = scalekitClient.m2m()
+                .getOrganizationClient("org_123", "skc_xxxxx");
     delete:
       description: Permanently deletes an API client from an organization. This operation cannot be undone and will revoke all access for the client. All associated secrets will also be invalidated. Use this endpoint to remove unused or compromised clients.
       tags:
@@ -1502,18 +1570,36 @@ paths:
             application/json:
               schema: {}
       x-codeSamples:
+        - label: Node.js SDK
+          lang: javascript
+          source: await scalekit.m2m.deleteOrganizationClient('org_123', 'skc_xxxxx')
         - label: Python SDK
           lang: python
           source: |-
-            # Get client ID from environment variables
-            org_id = '<SCALEKIT_ORGANIZATION_ID>'
-            client_id = os.environ['M2M_CLIENT_ID']
+            import os
 
-            # Delete the specified client from the organization
-            response = scalekit_client.m2m_client.delete_organization_client(
+            org_id = "org_123"
+            client_id = os.environ["M2M_CLIENT_ID"]
+
+            scalekit_client.m2m_client.delete_organization_client(
                 organization_id=org_id,
-                client_id=client_id
+                client_id=client_id,
             )
+        - label: Go SDK
+          lang: go
+          source: |-
+            err := scalekitClient.M2M().DeleteOrganizationClient(
+              ctx,
+              "org_123",
+              "skc_xxxxx",
+            )
+            if err != nil {
+              // handle error
+              return
+            }
+        - label: Java SDK
+          lang: java
+          source: scalekitClient.m2m().deleteOrganizationClient("org_123", "skc_xxxxx");
     patch:
       description: Updates an existing organization API client. Only specified fields are modified.
       tags:
@@ -1548,28 +1634,61 @@ paths:
               $ref: '#/components/schemas/clientsOrganizationClient'
         required: true
       x-codeSamples:
+        - label: Node.js SDK
+          lang: javascript
+          source: |-
+            const response = await scalekit.m2m.updateOrganizationClient('org_123', 'skc_xxxxx', {
+              description: 'Service account for GitHub Actions to deploy applications to production_eu',
+            })
         - label: Python SDK
           lang: python
           source: |-
+            import os
             from scalekit.v1.clients.clients_pb2 import OrganizationClient
 
-            org_id = '<SCALEKIT_ORGANIZATION_ID>'
-            client_id = os.environ['M2M_CLIENT_ID']
+            org_id = "org_123"
+            client_id = os.environ["M2M_CLIENT_ID"]
 
             update_m2m_client = OrganizationClient(
-                description="Service account for GitHub Actions to deploy applications
-            to production_eu",
+                description="Service account for GitHub Actions to deploy applications to production_eu",
                 custom_claims=[
                     {"key": "github_repository", "value": "acmecorp/inventory"},
-                    {"key": "environment", "value": "production_eu"}
-                ]
+                    {"key": "environment", "value": "production_eu"},
+                ],
             )
 
             response = scalekit_client.m2m_client.update_organization_client(
                 organization_id=org_id,
                 client_id=client_id,
-                m2m_client=update_m2m_client
+                m2m_client=update_m2m_client,
             )
+        - label: Go SDK
+          lang: go
+          source: |-
+            response, err := scalekitClient.M2M().UpdateOrganizationClient(
+              ctx,
+              "org_123",
+              "skc_xxxxx",
+              scalekit.UpdateOrganizationClientOptions{
+                Description: "Service account for GitHub Actions to deploy applications to production_eu",
+              },
+            )
+            if err != nil {
+              // handle error
+              return
+            }
+            _ = response
+        - label: Java SDK
+          lang: java
+          source: |-
+            import com.scalekit.grpc.scalekit.v1.clients.OrganizationClient;
+
+            OrganizationClient updates = OrganizationClient.newBuilder()
+                .setDescription("Service account for GitHub Actions to deploy applications to production_eu")
+                .build();
+
+            UpdateOrganizationClientResponse response = scalekitClient.m2m()
+                .updateOrganizationClient("org_123", "skc_xxxxx", updates);
   /api/v1/organizations/{organization_id}/clients/{client_id}/secrets:
     post:
       description: Creates a new secret for an organization API client. Returns the plain secret (available only once).
@@ -1598,21 +1717,44 @@ paths:
               schema:
                 $ref: '#/components/schemas/clientsCreateOrganizationClientSecretResponse'
       x-codeSamples:
+        - label: Node.js SDK
+          lang: javascript
+          source: |-
+            const response = await scalekit.m2m.addOrganizationClientSecret('org_123', 'skc_xxxxx')
+            const secretId = response.secret?.id
         - label: Python SDK
           lang: python
           source: |-
-            # Get client ID from environment variables
-            org_id = 'SCALEKIT_ORGANIZATION_ID'
-            client_id = os.environ['M2M_CLIENT_ID']
+            import os
 
-            # Add a new secret to the specified client
+            org_id = "org_123"
+            client_id = os.environ["M2M_CLIENT_ID"]
+
             response = scalekit_client.m2m_client.add_organization_client_secret(
                 organization_id=org_id,
-                client_id=client_id
+                client_id=client_id,
             )
 
-            # Extract the secret ID from the response
+            # with_call returns (response, call)
             secret_id = response[0].secret.id
+        - label: Go SDK
+          lang: go
+          source: |-
+            response, err := scalekitClient.M2M().CreateOrganizationClientSecret(
+              ctx,
+              "org_123",
+              "skc_xxxxx",
+            )
+            if err != nil {
+              // handle error
+              return
+            }
+            _ = response
+        - label: Java SDK
+          lang: java
+          source: |-
+            CreateOrganizationClientSecretResponse response = scalekitClient.m2m()
+                .createOrganizationClientSecret("org_123", "skc_xxxxx");
   /api/v1/organizations/{organization_id}/clients/{client_id}/secrets/{secret_id}:
     delete:
       description: Permanently deletes a secret from an organization API client. This operation cannot be undone.
@@ -1646,20 +1788,44 @@ paths:
             application/json:
               schema: {}
       x-codeSamples:
+        - label: Node.js SDK
+          lang: javascript
+          source: await scalekit.m2m.removeOrganizationClientSecret('org_123', 'skc_xxxxx', 'sks_xxxxx')
         - label: Python SDK
           lang: python
           source: |-
-            # Get client and secret IDs from environment variables
-            org_id = '<SCALEKIT_ORGANIZATION_ID>'
-            client_id = os.environ['M2M_CLIENT_ID']
-            secret_id = os.environ['M2M_SECRET_ID']
+            import os
 
-            # Remove the specified secret from the client
-            response = scalekit_client.m2m_client.remove_organization_client_secret(
+            org_id = "org_123"
+            client_id = os.environ["M2M_CLIENT_ID"]
+            secret_id = os.environ["M2M_SECRET_ID"]
+
+            scalekit_client.m2m_client.remove_organization_client_secret(
                 organization_id=org_id,
                 client_id=client_id,
-                secret_id=secret_id
+                secret_id=secret_id,
             )
+        - label: Go SDK
+          lang: go
+          source: |-
+            err := scalekitClient.M2M().DeleteOrganizationClientSecret(
+              ctx,
+              "org_123",
+              "skc_xxxxx",
+              "sks_xxxxx",
+            )
+            if err != nil {
+              // handle error
+              return
+            }
+        - label: Java SDK
+          lang: java
+          source: |-
+            scalekitClient.m2m().deleteOrganizationClientSecret(
+                "org_123",
+                "skc_xxxxx",
+                "sks_xxxxx"
+            );
   /api/v1/organizations/{organization_id}/connections/{id}:
     get:
       description: Retrieves the complete configuration and status details for a specific connection by its ID within an organization. Returns all connection properties including provider settings, protocols, and current status.
@@ -1701,7 +1867,7 @@ paths:
         - label: Go SDK
           lang: go
           source: |-
-            connection, err := scalekitClient.Connection.GetConnection(
+            connection, err := scalekitClient.Connection().GetConnection(
               ctx,
               organizationId,
               connectionId,
@@ -1748,7 +1914,7 @@ paths:
         - label: Go SDK
           lang: go
           source: |-
-            err := scalekitClient.Connection.DeleteConnection(
+            err := scalekitClient.Connection().DeleteConnection(
               ctx,
               organizationId,
               connectionId,
@@ -1797,7 +1963,7 @@ paths:
         - label: Go SDK
           lang: go
           source: |-
-            err := scalekitClient.Connection.DisableConnection(
+            err := scalekitClient.Connection().DisableConnection(
               ctx,
               organizationId,
               connectionId,
@@ -1846,7 +2012,7 @@ paths:
         - label: Go SDK
           lang: go
           source: |-
-            err := scalekitClient.Connection.EnableConnection(
+            err := scalekitClient.Connection().EnableConnection(
               ctx,
               organizationId,
               connectionId,
@@ -2563,7 +2729,11 @@ paths:
             console.log(response.users)
         - label: Python SDK
           lang: python
-          source: resp, _ = scalekit_client.users.list_users(organization_id="org_123", page_size=50)
+          source: |-
+            response = scalekit_client.users.list_organization_users(
+                organization_id="org_123",
+                page_size=50,
+            )
         - label: Go SDK
           lang: go
           source: |-
@@ -2930,7 +3100,9 @@ paths:
             }
         - label: Java SDK
           lang: java
-          source: SendPasswordlessResponse resendResponse = passwordlessClient.resendPasswordlessEmail(authRequestId);
+          source: |-
+            SendPasswordlessResponse resendResponse = scalekitClient.passwordless()
+                .resendPasswordlessEmail(authRequestId);
   /api/v1/passwordless/email/send:
     post:
       description: Send a verification email containing either a verification code (OTP), magic link, or both to a user's email address
@@ -2958,7 +3130,7 @@ paths:
             const response = await scalekit.passwordless.sendPasswordlessEmail('john.doe@example.com', {
               template: 'SIGNIN',
               expiresIn: 100,
-              magiclinkAuthUri: 'https://www.google.com',
+              magiclinkAuthUri: 'https://yourapp.com/auth/passwordless/callback',
               templateVariables: {
                 employeeID: 'EMP523',
                 teamName: 'Alpha Team',
@@ -2972,7 +3144,7 @@ paths:
                 email="john.doe@example.com",
                 template="SIGNIN",  # or "SIGNUP", "UNSPECIFIED"
                 expires_in=100,
-                magiclink_auth_uri="https://www.google.com",
+                magiclink_auth_uri="https://yourapp.com/auth/passwordless/callback",
                 template_variables={
                     "employeeID": "EMP523",
                     "teamName": "Alpha Team",
@@ -2980,32 +3152,30 @@ paths:
                 },
             )
 
-            # Extract auth request ID from response
+            # with_call returns (response, call)
             auth_request_id = response[0].auth_request_id
         - label: Go SDK
           lang: go
           source: |-
             templateType := scalekit.TemplateTypeSignin
             response, err := scalekitClient.Passwordless().SendPasswordlessEmail(
-                ctx,
-                "john.doe@example.com",
-                &scalekit.SendPasswordlessOptions{
-                    Template:         &templateType,
-                    ExpiresIn:        100,
-                    MagiclinkAuthUri: "https://www.google.com",
-                    TemplateVariables: map[string]string{
-                        "employeeID":    "EMP523",
-                        "teamName":      "Alpha Team",
-                        "supportEmail":  "support@yourcompany.com",
-                    },
+              ctx,
+              "john.doe@example.com",
+              &scalekit.SendPasswordlessOptions{
+                Template:         &templateType,
+                ExpiresIn:        100,
+                MagiclinkAuthUri: "https://yourapp.com/auth/passwordless/callback",
+                TemplateVariables: map[string]string{
+                  "employeeID":   "EMP523",
+                  "teamName":     "Alpha Team",
+                  "supportEmail": "support@yourcompany.com",
                 },
+              },
             )
-
             if err != nil {
-                // Handle error
-                return
+              // handle error
+              return
             }
-
             authRequestId := response.AuthRequestId
         - label: Java SDK
           lang: java
@@ -3019,10 +3189,10 @@ paths:
             SendPasswordlessOptions options = new SendPasswordlessOptions();
             options.setTemplate(templateType);
             options.setExpiresIn(100);
-            options.setMagiclinkAuthUri("https://www.example.com");
+            options.setMagiclinkAuthUri("https://yourapp.com/auth/passwordless/callback");
             options.setTemplateVariables(templateVariables);
 
-            SendPasswordlessResponse response = passwordlessClient.sendPasswordlessEmail(
+            SendPasswordlessResponse response = scalekitClient.passwordless().sendPasswordlessEmail(
                 "john.doe@example.com",
                 options
             );
@@ -3053,17 +3223,17 @@ paths:
           lang: javascript
           source: |-
             const { authRequestId } = sendResponse
+
+            // Verify with OTP code
             const verifyResponse = await scalekit.passwordless.verifyPasswordlessEmail(
-              // Verification Code (OTP)
-
               { code: '123456' },
-
-              // Magic Link Token
-
-              { linkToken: link_token },
-
               authRequestId,
             )
+
+            // Or verify with magic link token
+            const linkVerifyResponse = await scalekit.passwordless.verifyPasswordlessEmail({
+              linkToken: linkToken,
+            })
         - label: Python SDK
           lang: python
           source: |-
@@ -3120,19 +3290,20 @@ paths:
             verifyOptions.setCode("123456"); // OTP code
             verifyOptions.setAuthRequestId(authRequestId);
 
-            VerifyPasswordLessResponse verifyResponse = passwordlessClient.verifyPasswordlessEmail(verifyOptions);
+            VerifyPasswordLessResponse verifyResponse = scalekitClient.passwordless()
+                .verifyPasswordlessEmail(verifyOptions);
 
             // User verified successfully
             String userEmail = verifyResponse.getEmail();
 
             // Verify with magic link token
-            VerifyPasswordlessOptions verifyOptions = new VerifyPasswordlessOptions();
-            verifyOptions.setLinkToken(linkToken); // Magic link token
+            VerifyPasswordlessOptions linkVerifyOptions = new VerifyPasswordlessOptions();
+            linkVerifyOptions.setLinkToken(linkToken); // Magic link token
 
-            VerifyPasswordLessResponse verifyResponse = passwordlessClient.verifyPasswordlessEmail(verifyOptions);
+            VerifyPasswordLessResponse linkVerifyResponse = scalekitClient.passwordless()
+                .verifyPasswordlessEmail(linkVerifyOptions);
 
-            // User verified successfully
-            String userEmail = verifyResponse.getEmail();
+            String verifiedEmail = linkVerifyResponse.getEmail();
   /api/v1/permissions:
     get:
       description: Retrieves a comprehensive, paginated list of all permissions available within the environment. Use this endpoint to view all permission definitions for auditing, role management, or understanding the complete set of available access controls. The response includes pagination tokens to navigate through large sets of permissions efficiently. Each permission object contains the permission name, description, creation time, and last update time. This operation is useful for building permission selection interfaces, auditing permission usage, or understanding the scope of available access controls in your RBAC system.
@@ -3393,7 +3564,7 @@ paths:
       parameters:
         - schema:
             type: string
-          description: "Include additional data in the response. Valid values: 'permissions' (direct permissions only), 'permissions:all' (includes inherited permissions from role hierarchy)"
+          description: 'Include additional data in the response. Valid values: ''permissions'' (direct permissions only), ''permissions:all'' (includes inherited permissions from role hierarchy)'
           name: include
           in: query
       responses:
@@ -3526,7 +3697,7 @@ paths:
           required: true
         - schema:
             type: string
-          description: "Include additional data in the response. Valid values: 'permissions' (direct permissions only), 'permissions:all' (includes inherited permissions from role hierarchy)"
+          description: 'Include additional data in the response. Valid values: ''permissions'' (direct permissions only), ''permissions:all'' (includes inherited permissions from role hierarchy)'
           name: include
           in: query
       responses:
@@ -4076,17 +4247,18 @@ paths:
         - label: Python SDK
           lang: python
           source: |-
-            # pass empty org to fetch all users in environment
-            resp,_ = scalekit_client.users.list_users(organization_id="", page_size=100)
+            # List all users in the environment
+            response = scalekit_client.users.list_users(page_size=100)
         - label: Go SDK
           lang: go
           source: 'all, err := scalekitClient.User().ListUsers(ctx, &scalekit.ListUsersOptions{PageSize: 100})'
         - label: Java SDK
           lang: java
           source: |-
-            ListUsersRequest lur = ListUsersRequest.
-              newBuilder().setPageSize(100).build();
-            ListUsersResponse allUsers = users.listUsers(lur);
+            ListUsersRequest lur = ListUsersRequest.newBuilder()
+                .setPageSize(100)
+                .build();
+            ListUsersResponse allUsers = scalekitClient.users().listUsers(lur);
   /api/v1/users/{id}:
     get:
       description: Retrieves all details for a user by system-generated user ID. The response includes organization memberships and user metadata.
@@ -4155,9 +4327,7 @@ paths:
           source: await scalekit.user.deleteUser('usr_123')
         - label: Python SDK
           lang: python
-          source: |-
-            scalekit_client.users.delete_user(organization_id="org_123", 
-              user_id="usr_123")
+          source: scalekit_client.users.delete_user("usr_123")
         - label: Go SDK
           lang: go
           source: |-
@@ -4167,7 +4337,7 @@ paths:
             }
         - label: Java SDK
           lang: java
-          source: users.deleteUser("usr_123");
+          source: scalekitClient.users().deleteUser("usr_123");
     patch:
       description: Modifies user account information including profile details, metadata, and external ID. Use this endpoint to update a user's personal information, contact details, or custom metadata. You can update the user's profile, phone number, and metadata fields. Note that fields like user ID, email address, environment ID, and creation time cannot be modified.
       tags:
@@ -4214,24 +4384,17 @@ paths:
         - label: Python SDK
           lang: python
           source: |-
-            import os
-            from scalekit import ScalekitClient
             from scalekit.v1.users.users_pb2 import UpdateUser
             from scalekit.v1.commons.commons_pb2 import UserProfile
-            scalekit_client = ScalekitClient(
-                env_url=os.getenv("SCALEKIT_ENV_URL"),
-                client_id=os.getenv("SCALEKIT_CLIENT_ID"),
-                client_secret=os.getenv("SCALEKIT_CLIENT_SECRET"),
-            )
+
             update_user = UpdateUser(
                 user_profile=UserProfile(
                     first_name="John",
-                    last_name="Smith"
+                    last_name="Smith",
                 ),
-                metadata={"department": "sales"}
+                metadata={"department": "sales"},
             )
-            scalekit_client.users.update_user(organization_id="org_123", 
-              user=update_user)
+            response = scalekit_client.users.update_user("usr_123", update_user)
         - label: Go SDK
           lang: go
           source: |-
@@ -4249,16 +4412,17 @@ paths:
           lang: java
           source: |-
             UpdateUser upd = UpdateUser.newBuilder()
-                    .setUserProfile(
-                      UpdateUserProfile.newBuilder()
-                            .setFirstName("John")
-                            .setLastName("Smith")
-                            .build())
-                    .putMetadata("department", "sales")
-                    .build();
-            UpdateUserRequest updReq = UpdateUserRequest.
-              newBuilder().setUser(upd).build();
-            users.updateUser("usr_123", updReq);
+                .setUserProfile(
+                    UpdateUserProfile.newBuilder()
+                        .setFirstName("John")
+                        .setLastName("Smith")
+                        .build())
+                .putMetadata("department", "sales")
+                .build();
+            UpdateUserRequest updReq = UpdateUserRequest.newBuilder()
+                .setUser(upd)
+                .build();
+            scalekitClient.users().updateUser("usr_123", updReq);
   /api/v1/users/{user_id}/sessions:
     get:
       description: Retrieves a paginated list of all sessions associated with a specific user across all devices and browsers. Use this endpoint to audit user activity, display all active sessions in account management interfaces, or verify user authentication status across devices. Supports filtering by session status (active, expired, revoked, logout) and time range (creation date). Returns session details for each session including device information, IP address, geolocation, and current status. The response includes pagination metadata (page tokens and total count) to handle large session lists efficiently.
@@ -4290,7 +4454,7 @@ paths:
               type: string
           style: form
           explode: true
-          description: "Filter sessions by one or more status values. Possible values: 'active', 'expired', 'revoked', 'logout'. Leave empty to include all statuses. Multiple values use OR logic (e.g., status=['active', 'expired'] returns sessions that are either active OR expired)."
+          description: 'Filter sessions by one or more status values. Possible values: ''active'', ''expired'', ''revoked'', ''logout''. Leave empty to include all statuses. Multiple values use OR logic (e.g., status=[''active'', ''expired''] returns sessions that are either active OR expired).'
           name: filter.status
           in: query
         - schema:
@@ -4565,7 +4729,7 @@ paths:
             _ = resp
         - label: Java SDK
           lang: java
-          source: ListCredentialsResponse res = scalekitClient.webauthn().listCredentials("user_123");
+          source: ListCredentialsResponse res = scalekitClient.webAuthn().listCredentials("user_123");
   /api/v1/webauthn/credentials/{credential_id}:
     delete:
       description: Deletes a specific passkey credential for the current user. After removal, the authenticator can no longer be used for authentication.
@@ -4602,7 +4766,7 @@ paths:
             _ = resp
         - label: Java SDK
           lang: java
-          source: DeleteCredentialResponse res = scalekitClient.webauthn().deleteCredential("wac_123");
+          source: DeleteCredentialResponse res = scalekitClient.webAuthn().deleteCredential("wac_123");
     patch:
       description: Updates the display name of a passkey credential to help users identify their authenticators. Only the display name can be modified.
       tags:
@@ -4653,7 +4817,7 @@ paths:
         - label: Java SDK
           lang: java
           source: |-
-            UpdateCredentialResponse res = scalekitClient.webauthn()
+            UpdateCredentialResponse res = scalekitClient.webAuthn()
                 .updateCredential("wac_123", "Work Laptop Passkey");
 webhooks:
   organization.created:
@@ -4759,6 +4923,134 @@ webhooks:
                     - enabled: false
                       name: dir_sync
               display_name: Organization Deleted
+      responses:
+        '200':
+          description: Webhook received successfully
+  organization.domain_created:
+    post:
+      summary: Organization Domain Created
+      description: Triggered when a domain is added to an organization (organization domain or allowed email domain).
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScalekitEvent'
+            example:
+              spec_version: '1'
+              id: evt_4567890123
+              type: organization.domain_created
+              object: Organization
+              occurred_at: '2024-01-15T11:00:00.123456789Z'
+              environment_id: env_1234567890
+              organization_id: org_1234567890
+              data:
+                id: dom_1234567890
+                domain: acmecorp.com
+                domain_type: ORGANIZATION_DOMAIN
+                organization_id: org_1234567890
+                environment_id: env_1234567890
+                txt_record_key: scalekit-domain-verification
+                txt_record_secret: sk_dom_verify_abc123
+                verification_status: PENDING
+                verification_method: DNS
+                updated_at: '2024-01-15T11:00:00.123456789Z'
+              display_name: Organization Domain Created
+      responses:
+        '200':
+          description: Webhook received successfully
+  organization.domain_deleted:
+    post:
+      summary: Organization Domain Deleted
+      description: Triggered when a domain is removed from an organization.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScalekitEvent'
+            example:
+              spec_version: '1'
+              id: evt_4567890456
+              type: organization.domain_deleted
+              object: Organization
+              occurred_at: '2024-01-16T09:30:00.123456789Z'
+              environment_id: env_1234567890
+              organization_id: org_1234567890
+              data:
+                id: dom_1234567890
+                domain: acmecorp.com
+                domain_type: ORGANIZATION_DOMAIN
+                organization_id: org_1234567890
+                environment_id: env_1234567890
+                txt_record_key: scalekit-domain-verification
+                txt_record_secret: sk_dom_verify_abc123
+                verification_status: VERIFIED
+                verification_method: DNS
+                updated_at: '2024-01-16T09:30:00.123456789Z'
+              display_name: Organization Domain Deleted
+      responses:
+        '200':
+          description: Webhook received successfully
+  organization.domain_dns_verification_success:
+    post:
+      summary: Organization Domain DNS Verification Success
+      description: Triggered when DNS TXT record validation confirms ownership of an organization domain.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScalekitEvent'
+            example:
+              spec_version: '1'
+              id: evt_4567890789
+              type: organization.domain_dns_verification_success
+              object: Organization
+              occurred_at: '2024-01-15T12:15:00.123456789Z'
+              environment_id: env_1234567890
+              organization_id: org_1234567890
+              data:
+                id: dom_1234567890
+                domain: acmecorp.com
+                domain_type: ORGANIZATION_DOMAIN
+                organization_id: org_1234567890
+                environment_id: env_1234567890
+                txt_record_key: scalekit-domain-verification
+                txt_record_secret: sk_dom_verify_abc123
+                verification_status: VERIFIED
+                verification_method: DNS
+                updated_at: '2024-01-15T12:15:00.123456789Z'
+              display_name: Organization Domain DNS Verification Success
+      responses:
+        '200':
+          description: Webhook received successfully
+  organization.domain_dns_verification_failed:
+    post:
+      summary: Organization Domain DNS Verification Failed
+      description: Triggered when the DNS verification window expires without a successful TXT record match.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScalekitEvent'
+            example:
+              spec_version: '1'
+              id: evt_4567891012
+              type: organization.domain_dns_verification_failed
+              object: Organization
+              occurred_at: '2024-01-16T11:00:00.123456789Z'
+              environment_id: env_1234567890
+              organization_id: org_1234567890
+              data:
+                id: dom_1234567890
+                domain: acmecorp.com
+                domain_type: ORGANIZATION_DOMAIN
+                organization_id: org_1234567890
+                environment_id: env_1234567890
+                txt_record_key: scalekit-domain-verification
+                txt_record_secret: sk_dom_verify_abc123
+                verification_status: FAILED
+                verification_method: DNS
+                updated_at: '2024-01-16T11:00:00.123456789Z'
+              display_name: Organization Domain DNS Verification Failed
       responses:
         '200':
           description: Webhook received successfully
@@ -5798,7 +6090,7 @@ components:
           examples:
             - 360
         absolute_session_timeout_unit:
-          description: "Unit for absolute_session_timeout. Accepted values: 'MINUTES', 'HOURS', 'DAYS'. Defaults to MINUTES."
+          description: 'Unit for absolute_session_timeout. Accepted values: ''MINUTES'', ''HOURS'', ''DAYS''. Defaults to MINUTES.'
           $ref: '#/components/schemas/commonsTimeUnit'
           examples:
             - MINUTES
@@ -5814,7 +6106,7 @@ components:
           examples:
             - true
         idle_session_timeout_unit:
-          description: "Unit for idle_session_timeout. Accepted values: 'MINUTES', 'HOURS', 'DAYS'. Defaults to MINUTES."
+          description: 'Unit for idle_session_timeout. Accepted values: ''MINUTES'', ''HOURS'', ''DAYS''. Defaults to MINUTES.'
           $ref: '#/components/schemas/commonsTimeUnit'
           examples:
             - MINUTES
@@ -5892,7 +6184,7 @@ components:
           type: array
           items:
             type: string
-            default: "['ATTESTATION_KEY_COMPROMISE', 'USER_VERIFICATION_BYPASS', 'USER_KEY_REMOTE_COMPROMISE', 'USER_KEY_PHYSICAL_COMPROMISE', 'REVOKED']"
+            default: '[''ATTESTATION_KEY_COMPROMISE'', ''USER_VERIFICATION_BYPASS'', ''USER_KEY_REMOTE_COMPROMISE'', ''USER_KEY_PHYSICAL_COMPROMISE'', ''REVOKED'']'
         validate_anchors:
           description: when set to true enables the validation of the attestation statement against the trust anchor from the metadata statement.
           type: boolean
@@ -6622,7 +6914,7 @@ components:
       type: object
       properties:
         attribute_mapping:
-          description: "Maps identity provider attributes to user profile fields. For example, {'email': 'user.mail', 'name': 'user.displayName'}."
+          description: 'Maps identity provider attributes to user profile fields. For example, {''email'': ''user.mail'', ''name'': ''user.displayName''}.'
           type: object
           additionalProperties:
             type: string
@@ -8068,7 +8360,7 @@ components:
           examples:
             - 360
         absolute_session_timeout_unit:
-          description: "Unit for absolute_session_timeout. Accepted values: 'minutes', 'hours', 'days'. Responses always return 'minutes'."
+          description: 'Unit for absolute_session_timeout. Accepted values: ''minutes'', ''hours'', ''days''. Responses always return ''minutes''.'
           $ref: '#/components/schemas/commonsTimeUnit'
           examples:
             - minutes
@@ -8084,7 +8376,7 @@ components:
           examples:
             - true
         idle_session_timeout_unit:
-          description: "Unit for idle_session_timeout. Accepted values: 'minutes', 'hours', 'days'. Responses always return 'minutes'."
+          description: 'Unit for idle_session_timeout. Accepted values: ''minutes'', ''hours'', ''days''. Responses always return ''minutes''.'
           $ref: '#/components/schemas/commonsTimeUnit'
           examples:
             - minutes
@@ -8590,7 +8882,7 @@ components:
           examples:
             - 120.0.0.0
         device_type:
-          description: "Categorized device type classification. Possible values: 'desktop' (traditional computers), 'mobile' (smartphones and small tablets), 'tablet' (large tablets), 'other'. Useful for displaying session information by device category."
+          description: 'Categorized device type classification. Possible values: ''desktop'' (traditional computers), ''mobile'' (smartphones and small tablets), ''tablet'' (large tablets), ''other''. Useful for displaying session information by device category.'
           type: string
           examples:
             - desktop
@@ -8600,7 +8892,7 @@ components:
           examples:
             - 192.0.2.1
         location:
-          description: "Geographic location information derived from IP address geolocation. Includes country, region, city, and coordinates. Note: Based on IP location data and may not represent the user's exact physical location."
+          description: 'Geographic location information derived from IP address geolocation. Includes country, region, city, and coordinates. Note: Based on IP location data and may not represent the user''s exact physical location.'
           $ref: '#/components/schemas/v1sessionsLocation'
         os:
           description: 'Operating system name extracted from the user agent and device headers. Examples: macOS, Windows, Linux, iOS, Android.'
@@ -8765,7 +9057,7 @@ components:
           examples:
             - ses_1234567890123456
         status:
-          description: "Current operational status of the session. Possible values: 'active' (session is valid and requests are allowed), 'expired' (session terminated due to idle or absolute timeout), 'revoked' (session was administratively revoked), 'logout' (user explicitly logged out). Use this to determine if the session can be used for new requests."
+          description: 'Current operational status of the session. Possible values: ''active'' (session is valid and requests are allowed), ''expired'' (session terminated due to idle or absolute timeout), ''revoked'' (session was administratively revoked), ''logout'' (user explicitly logged out). Use this to determine if the session can be used for new requests.'
           type: string
           examples:
             - active
@@ -9132,7 +9424,7 @@ components:
           examples:
             - Doe
         first_name:
-          description: "[DEPRECATED] Use given_name instead. User's given name. Maximum 200 characters."
+          description: '[DEPRECATED] Use given_name instead. User''s given name. Maximum 200 characters.'
           type: string
           examples:
             - John
@@ -9155,7 +9447,7 @@ components:
             - - engineering
               - managers
         last_name:
-          description: "[DEPRECATED] Use family_name instead. User's family name. Maximum 200 characters."
+          description: '[DEPRECATED] Use family_name instead. User''s family name. Maximum 200 characters.'
           type: string
           examples:
             - Doe
@@ -9510,12 +9802,12 @@ components:
           examples:
             - San Francisco
         latitude:
-          description: "Latitude coordinate of the estimated location. Decimal format (e.g., '37.7749'). Note: Represents IP geolocation center and may not be precise."
+          description: 'Latitude coordinate of the estimated location. Decimal format (e.g., ''37.7749''). Note: Represents IP geolocation center and may not be precise.'
           type: string
           examples:
             - '37.7749'
         longitude:
-          description: "Longitude coordinate of the estimated location. Decimal format (e.g., '-122.4194'). Note: Represents IP geolocation center and may not be precise."
+          description: 'Longitude coordinate of the estimated location. Decimal format (e.g., ''-122.4194''). Note: Represents IP geolocation center and may not be precise.'
           type: string
           examples:
             - '-122.4194'
@@ -9737,6 +10029,10 @@ components:
             - organization.created
             - organization.updated
             - organization.deleted
+            - organization.domain_created
+            - organization.domain_deleted
+            - organization.domain_dns_verification_success
+            - organization.domain_dns_verification_failed
             - organization.sso_created
             - organization.sso_deleted
             - organization.sso_enabled

--- a/public/api/scalekit.scalar.json
+++ b/public/api/scalekit.scalar.json
@@ -53,7 +53,9 @@
     "/api/v1/connected_accounts": {
       "get": {
         "description": "Retrieves a paginated list of connected accounts for third-party integrations. Filter by organization, user, connector type, provider, or identifier. Returns OAuth tokens, API keys, and connection status for each account. Use pagination tokens to navigate through large result sets.",
-        "tags": ["Connected Accounts"],
+        "tags": [
+          "Connected Accounts"
+        ],
         "summary": "List connected accounts",
         "operationId": "ConnectedAccountService_ListConnectedAccounts",
         "parameters": [
@@ -168,18 +170,30 @@
           {
             "label": "Node.js SDK",
             "lang": "javascript",
-            "source": "// Coming soon — accurate SDK snippets for List connected accounts will be added via scalekit-code-doctor (SK-399)"
+            "source": "const response = await scalekit.connectedAccounts.listConnectedAccounts({\n  organizationId: 'org_123',\n  pageSize: 20,\n})\nconst connectedAccounts = response.connectedAccounts"
           },
           {
             "label": "Python SDK",
             "lang": "python",
-            "source": "# Coming soon — accurate SDK snippets for List connected accounts will be added via scalekit-code-doctor (SK-399)"
+            "source": "response = scalekit_client.connected_accounts.list_connected_accounts(\n    organization_id=\"org_123\",\n    page_size=20,\n)\n# with_call returns (response, call)\nconnected_accounts = response[0].connected_accounts"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "// Connected Accounts are not available in the Go SDK public API yet.\n// Use the REST API (GET /api/v1/connected_accounts) or the Node.js/Python SDKs."
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "// Connected Accounts are not part of the Java SDK public API yet.\n// Use the REST API (GET /api/v1/connected_accounts) or the Node.js/Python SDKs."
           }
         ]
       },
       "put": {
         "description": "Updates authentication credentials and configuration for an existing connected account. Modify OAuth tokens, refresh tokens, access scopes, or API configuration settings. Specify the account by ID, or by combination of organization/user, connector, and identifier. Returns the updated account with new token expiry and status information.",
-        "tags": ["Connected Accounts"],
+        "tags": [
+          "Connected Accounts"
+        ],
         "summary": "Update connected account credentials",
         "operationId": "ConnectedAccountService_UpdateConnectedAccount",
         "responses": {
@@ -231,7 +245,9 @@
       },
       "post": {
         "description": "Creates a new connected account with OAuth tokens or API credentials for third-party service integration. Supply authorization details including access tokens, refresh tokens, scopes, and optional API configuration. The account can be scoped to an organization or user. Returns the created account with its unique identifier and authentication status.",
-        "tags": ["Connected Accounts"],
+        "tags": [
+          "Connected Accounts"
+        ],
         "summary": "Create a connected account",
         "operationId": "ConnectedAccountService_CreateConnectedAccount",
         "responses": {
@@ -285,7 +301,9 @@
     "/api/v1/connected_accounts/auth": {
       "get": {
         "description": "Retrieves complete authentication details for a connected account including OAuth tokens, refresh tokens, scopes, and API configuration. Query by account ID or by combination of organization/user, connector, and identifier. Returns sensitive credential information - use appropriate access controls.",
-        "tags": ["Connected Accounts"],
+        "tags": [
+          "Connected Accounts"
+        ],
         "summary": "Get connected account auth credentials",
         "operationId": "ConnectedAccountService_GetConnectedAccountAuth",
         "parameters": [
@@ -371,7 +389,9 @@
     "/api/v1/connected_accounts/details": {
       "get": {
         "description": "Returns metadata for a connected account including status, connector type, provider, and configuration without exposing stored authorization credentials. Look up by account ID, or by a combination of organization (or user), connector, and external identifier.",
-        "tags": ["Connected Accounts"],
+        "tags": [
+          "Connected Accounts"
+        ],
         "summary": "Get connected account metadata",
         "operationId": "ConnectedAccountService_GetConnectedAccountDetails",
         "parameters": [
@@ -457,7 +477,9 @@
     "/api/v1/connected_accounts/magic_link": {
       "post": {
         "description": "Creates a time-limited magic link for connecting or re-authorizing a third-party account. The link directs users to the OAuth authorization flow for the specified connector. Returns the generated link URL and expiration timestamp. Links typically expire after a short duration for security.",
-        "tags": ["Connected Accounts"],
+        "tags": [
+          "Connected Accounts"
+        ],
         "summary": "Generate authentication magic link",
         "operationId": "ConnectedAccountService_GetMagicLinkForConnectedAccount",
         "responses": {
@@ -503,7 +525,9 @@
     "/api/v1/connected_accounts/user/verify": {
       "post": {
         "description": "Confirms the user assertion and activates the connected account after the user completes third-party OAuth. Called by the B2B app server with auth_request_id and identifier. Validates that the asserted identifier matches the one stored on the auth request and promotes pending tokens to live.",
-        "tags": ["Connected Accounts"],
+        "tags": [
+          "Connected Accounts"
+        ],
         "summary": "Verify connected account user",
         "operationId": "ConnectedAccountService_VerifyConnectedAccountUser",
         "responses": {
@@ -565,7 +589,9 @@
     "/api/v1/connected_accounts:delete": {
       "post": {
         "description": "Permanently removes a connected account and revokes all associated authentication credentials. Identify the account by ID, or by combination of organization/user, connector, and identifier. This action cannot be undone. All OAuth tokens and API keys for this account will be invalidated.",
-        "tags": ["Connected Accounts"],
+        "tags": [
+          "Connected Accounts"
+        ],
         "summary": "Delete a connected account",
         "operationId": "ConnectedAccountService_DeleteConnectedAccount",
         "responses": {
@@ -617,7 +643,9 @@
     "/api/v1/connected_accounts:search": {
       "get": {
         "description": "Search for connected accounts in your environment using a text query that matches against identifiers, providers, or connectors. The search performs case-insensitive matching across account details. Returns paginated results with account status and authentication type information.",
-        "tags": ["Connected Accounts"],
+        "tags": [
+          "Connected Accounts"
+        ],
         "summary": "Search connected accounts",
         "operationId": "ConnectedAccountService_SearchConnectedAccounts",
         "parameters": [
@@ -688,7 +716,9 @@
     "/api/v1/connections": {
       "get": {
         "description": "Retrieves a list of connections in the environment",
-        "tags": ["Connections"],
+        "tags": [
+          "Connections"
+        ],
         "summary": "List connections",
         "operationId": "ConnectionService_ListConnections",
         "parameters": [
@@ -756,7 +786,9 @@
     "/api/v1/custom-providers": {
       "post": {
         "description": "Creates an environment-scoped custom provider (connector) with authentication patterns and optional proxy configuration. The returned identifier must be used for all subsequent update and delete operations on this provider.",
-        "tags": ["Connectors"],
+        "tags": [
+          "Connectors"
+        ],
         "summary": "Create a custom provider",
         "operationId": "ProviderService_CreateCustomProvider",
         "responses": {
@@ -795,7 +827,9 @@
     "/api/v1/custom-providers/{identifier}": {
       "put": {
         "description": "Updates an existing environment-scoped custom provider (connector) by its identifier. Only the fields provided in the request are modified.",
-        "tags": ["Connectors"],
+        "tags": [
+          "Connectors"
+        ],
         "summary": "Update a custom provider",
         "operationId": "ProviderService_UpdateCustomProvider",
         "parameters": [
@@ -851,7 +885,9 @@
       },
       "delete": {
         "description": "Deletes an environment-scoped custom provider (connector) by its identifier. This operation is permanent and removes the provider definition from the environment.",
-        "tags": ["Connectors"],
+        "tags": [
+          "Connectors"
+        ],
         "summary": "Delete a custom provider",
         "operationId": "ProviderService_DeleteCustomProvider",
         "parameters": [
@@ -889,7 +925,9 @@
     "/api/v1/execute_tool": {
       "post": {
         "description": "Executes a tool action using authentication credentials from a connected account. Specify the tool by name and provide required parameters as JSON. The connected account can be identified by ID, or by combination of organization/user, connector, and identifier. Returns the execution result data and a unique execution ID for tracking. Use this endpoint to perform actions like sending emails, creating calendar events, or managing resources in external services.",
-        "tags": ["Tool Calling"],
+        "tags": [
+          "Tool Calling"
+        ],
         "summary": "Execute a tool using a connected account",
         "operationId": "ToolService_ExecuteTool",
         "responses": {
@@ -950,12 +988,22 @@
           {
             "label": "Node.js SDK",
             "lang": "javascript",
-            "source": "// Coming soon — accurate SDK snippets for Execute tool (Tool Calling) will be added via scalekit-code-doctor (SK-399)"
+            "source": "const response = await scalekit.tools.executeTool({\n  toolName: 'gmail_send_email',\n  identifier: 'user@example.com',\n  params: {\n    to: 'team@example.com',\n    subject: 'Hello from Scalekit',\n    body: 'Tool execution succeeded.',\n  },\n})"
           },
           {
             "label": "Python SDK",
             "lang": "python",
-            "source": "# Coming soon — accurate SDK snippets for Execute tool (Tool Calling) will be added via scalekit-code-doctor (SK-399)"
+            "source": "response = scalekit_client.tools.execute_tool(\n    tool_name=\"gmail_send_email\",\n    identifier=\"user@example.com\",\n    params={\n        \"to\": \"team@example.com\",\n        \"subject\": \"Hello from Scalekit\",\n        \"body\": \"Tool execution succeeded.\",\n    },\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "// Tool calling (execute_tool) is not available in the Go SDK public API yet.\n// Use the REST API (POST /api/v1/execute_tool) or the Node.js/Python SDKs."
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "// Tool calling (execute_tool) is not part of the Java SDK public API yet.\n// Use the REST API (POST /api/v1/execute_tool) or the Node.js/Python SDKs."
           }
         ]
       }
@@ -963,7 +1011,9 @@
     "/api/v1/invites/organizations/{organization_id}/users/{id}/resend": {
       "patch": {
         "description": "Resends an invitation email to a user who has a pending or expired invitation in the specified organization. If the invitation has expired, a new invitation will be automatically created and sent. If the invitation is still valid, a reminder email will be sent instead. Use this endpoint when a user hasn't responded to their initial invitation and you need to send them a reminder or when the original invitation has expired. The invitation email includes a secure magic link that allows the user to complete their account setup and join the organization. Each resend operation increments the resent counter.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Resend user invitation email",
         "operationId": "UserService_ResendInvite",
         "parameters": [
@@ -1043,7 +1093,9 @@
     "/api/v1/mcp/configs": {
       "get": {
         "description": "Lists MCP configurations for the current environment with optional filters for id, name prefix, and provider.",
-        "tags": ["MCP Configurations"],
+        "tags": [
+          "MCP Configurations"
+        ],
         "summary": "List MCP configurations",
         "operationId": "McpService_ListMcpConfigs",
         "parameters": [
@@ -1136,7 +1188,9 @@
       },
       "post": {
         "description": "Creates a new MCP configuration with a set of connections and tools.",
-        "tags": ["MCP Configurations"],
+        "tags": [
+          "MCP Configurations"
+        ],
         "summary": "Create a new MCP configuration",
         "operationId": "McpService_CreateMcpConfig",
         "responses": {
@@ -1183,7 +1237,9 @@
     "/api/v1/mcp/configs/{config_id}": {
       "get": {
         "description": "Returns a single MCP configuration for the current environment by ID.",
-        "tags": ["MCP Configurations"],
+        "tags": [
+          "MCP Configurations"
+        ],
         "summary": "Fetch an MCP configuration",
         "operationId": "McpService_GetMcpConfig",
         "parameters": [
@@ -1236,7 +1292,9 @@
       },
       "put": {
         "description": "Updates the description and connection-to-tool mappings for an existing MCP configuration. The configuration name cannot be changed after creation.",
-        "tags": ["MCP Configurations"],
+        "tags": [
+          "MCP Configurations"
+        ],
         "summary": "Update an existing MCP configuration",
         "operationId": "McpService_UpdateMcpConfig",
         "parameters": [
@@ -1299,7 +1357,9 @@
       },
       "delete": {
         "description": "Deletes the MCP configuration and any associated mappings and instances in the current environment.",
-        "tags": ["MCP Configurations"],
+        "tags": [
+          "MCP Configurations"
+        ],
         "summary": "Delete an MCP configuration",
         "operationId": "McpService_DeleteMcpConfig",
         "parameters": [
@@ -1352,7 +1412,9 @@
     "/api/v1/mcp/configs/{config_id}/connected_accounts": {
       "post": {
         "description": "Returns the connected account state for each connection in the MCP configuration for the given user identifier. When include_auth_link is true, creates connected accounts on the fly if they do not exist and returns a fresh authentication link per connection. When include_auth_link is false or omitted, returns the current status of existing connected accounts only — no accounts are created and authentication_link is always empty. Authentication links are only present when the connection has an associated key; if the connection has no key, authentication_link is empty regardless of include_auth_link.",
-        "tags": ["MCP Configurations"],
+        "tags": [
+          "MCP Configurations"
+        ],
         "summary": "List connected accounts for an MCP configuration",
         "operationId": "McpService_ListMcpConnectedAccounts",
         "parameters": [
@@ -1409,7 +1471,9 @@
     "/api/v1/mcp/configs/{mcp_config_id}/tokens": {
       "post": {
         "description": "Mints a short-lived JWT that represents a user identifier across the connected accounts associated with an MCP configuration. The supplied identifier becomes the token's `sub` claim; the token's `aud` claim is the MCP server URL bound to the configuration. Claims also carry the MCP configuration ID (`mcp_cfg`) and the list of resolved connected-account IDs (`ca_ids`). Use this operation to issue a single credential an MCP server can present on the user's behalf when calling provider tools. The mint fails if any connection mapped to the configuration has no active connected account for the identifier.",
-        "tags": ["MCP Configurations"],
+        "tags": [
+          "MCP Configurations"
+        ],
         "summary": "Create an MCP session token",
         "operationId": "McpService_CreateMcpSessionToken",
         "parameters": [
@@ -1466,7 +1530,9 @@
     "/api/v1/memberships/organizations/{organization_id}/users/{id}": {
       "post": {
         "description": "Adds an existing user to an organization and assigns them specific roles and permissions. Use this endpoint when you want to grant an existing user access to a particular organization. You can specify roles, metadata, and other membership details during the invitation process.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Add existing user to organization",
         "operationId": "UserService_CreateMembership",
         "parameters": [
@@ -1514,7 +1580,9 @@
             "application/json": {
               "schema": {
                 "description": "Membership details to create. Required fields must be provided.",
-                "required": ["membership"],
+                "required": [
+                  "membership"
+                ],
                 "$ref": "#/components/schemas/v1usersCreateMembership"
               }
             }
@@ -1525,7 +1593,7 @@
           {
             "label": "Node.js SDK",
             "lang": "javascript",
-            "source": "import { ScalekitClient } from '@scalekit-sdk/node'\nconst scalekit = new ScalekitClient(\n  process.env.SCALEKIT_ENV_URL,\n  process.env.SCALEKIT_CLIENT_ID,\n  process.env.SCALEKIT_CLIENT_SECRET,\n)\nawait scalekit.user.createMembership('org_123', 'usr_123', {\n  roles: ['admin'],\n  metadata: {\n    department: 'engineering',\n    location: 'nyc-office',\n  },\n})"
+            "source": "await scalekit.user.createMembership('org_123', 'usr_123', {\n  roles: ['admin'],\n  metadata: {\n    department: 'engineering',\n    location: 'nyc-office',\n  },\n})"
           },
           {
             "label": "Python SDK",
@@ -1535,18 +1603,20 @@
           {
             "label": "Go SDK",
             "lang": "go",
-            "source": "func main() {\n    scalekitClient := scalekit.NewScalekitClient(\n        os.Getenv(\"SCALEKIT_ENV_URL\"),\n        os.Getenv(\"SCALEKIT_CLIENT_ID\"),\n        os.Getenv(\"SCALEKIT_CLIENT_SECRET\"),\n    )\n    membership := &usersv1.CreateMembership{\n        Roles: []*usersv1.Role{{Name: \"admin\"}},\n        Metadata: map[string]string{\n            \"department\": \"engineering\",\n            \"location\":   \"nyc-office\",\n        },\n    }\n    resp, \n      err := scalekitClient.User().CreateMembership(\n        context.Background(), \"org_123\", \n          \"usr_123\", membership, false)\n    if err != nil {\n        panic(err)\n    }\n}"
+            "source": "membership := &usersv1.CreateMembership{\n  Roles: []*usersv1.Role{{Name: \"admin\"}},\n  Metadata: map[string]string{\n    \"department\": \"engineering\",\n    \"location\":   \"nyc-office\",\n  },\n}\nresp, err := scalekitClient.User().CreateMembership(\n  ctx,\n  \"org_123\",\n  \"usr_123\",\n  membership,\n  false,\n)\nif err != nil {\n  // handle error\n  return\n}\n_ = resp"
           },
           {
             "label": "Java SDK",
             "lang": "java",
-            "source": "import com.scalekit.ScalekitClient;\nimport com.scalekit.api.UserClient;\nimport com.scalekit.grpc.scalekit.v1.users.*;\nScalekitClient scalekitClient = new ScalekitClient(\n    System.getenv(\"SCALEKIT_ENV_URL\"),\n    System.getenv(\"SCALEKIT_CLIENT_ID\"),\n    System.getenv(\"SCALEKIT_CLIENT_SECRET\")\n);\nUserClient users = scalekitClient.users();\nCreateMembershipRequest membershipReq = CreateMemb\n  ershipRequest.newBuilder()\n        .setMembership(\n          CreateMembership.newBuilder()\n                .addRoles(Role.newBuilder(\n                  ).setName(\"admin\").build())\n                .putMetadata(\"department\", \"engineering\")\n                .putMetadata(\"location\", \"nyc-office\")\n                .build())\n        .build();\nCreateMembershipResponse res = users.\n  createMembership(\"org_123\", \"usr_123\", \n    membershipReq);"
+            "source": "CreateMembershipRequest membershipReq = CreateMembershipRequest.newBuilder()\n    .setMembership(\n        CreateMembership.newBuilder()\n            .addRoles(Role.newBuilder().setName(\"admin\").build())\n            .putMetadata(\"department\", \"engineering\")\n            .putMetadata(\"location\", \"nyc-office\")\n            .build())\n    .build();\nCreateMembershipResponse res = scalekitClient.users().createMembership(\n    \"org_123\",\n    \"usr_123\",\n    membershipReq\n);"
           }
         ]
       },
       "delete": {
         "description": "Removes a user from an organization by user ID. This action is irreversible and may also remove related group memberships.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Delete organization membership for user",
         "operationId": "UserService_DeleteMembership",
         "parameters": [
@@ -1581,15 +1651,32 @@
         },
         "x-codeSamples": [
           {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await scalekit.user.deleteMembership('org_123', 'usr_123')"
+          },
+          {
             "label": "Python SDK",
             "lang": "python",
-            "source": "response = scalekit_client.users.delete_membership(\n  organization_id=org_id,user_id=user_id\n)"
+            "source": "scalekit_client.users.delete_membership(\n    organization_id=\"org_123\",\n    user_id=\"usr_123\",\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "err := scalekitClient.User().DeleteMembership(\n  ctx,\n  \"org_123\",\n  \"usr_123\",\n  false, // cascade: also remove from nested groups when true\n)\nif err != nil {\n  // handle error\n  return\n}"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "scalekitClient.users().deleteMembership(\"org_123\", \"usr_123\");"
           }
         ]
       },
       "patch": {
         "description": "Updates a user's membership details within an organization by user ID. You can update roles and membership metadata.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Update organization membership for user",
         "operationId": "UserService_UpdateMembership",
         "parameters": [
@@ -1645,7 +1732,9 @@
     "/api/v1/memberships/organizations/{organization_id}/users:external/{external_id}": {
       "post": {
         "description": "Adds an existing user to an organization using your application's external identifier for the user. Use this endpoint when you store users in Scalekit using your own system's identifiers and need to manage their organization memberships without storing Scalekit's internal user ID.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Add existing user to organization by external ID",
         "operationId": "UserService_CreateMembership2",
         "parameters": [
@@ -1693,7 +1782,9 @@
             "application/json": {
               "schema": {
                 "description": "Membership details to create. Required fields must be provided.",
-                "required": ["membership"],
+                "required": [
+                  "membership"
+                ],
                 "$ref": "#/components/schemas/v1usersCreateMembership"
               }
             }
@@ -1703,7 +1794,9 @@
       },
       "delete": {
         "description": "Removes a user from an organization using your application's external identifier for the user. Use this endpoint to revoke organization access without needing to store Scalekit's internal user ID.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Delete organization membership by external ID",
         "operationId": "UserService_DeleteMembership2",
         "parameters": [
@@ -1739,7 +1832,9 @@
       },
       "patch": {
         "description": "Updates a user's membership details within an organization using your application's external identifier for the user. Use this endpoint to update roles and membership metadata without needing to store Scalekit's internal user ID.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Update organization membership by external ID",
         "operationId": "UserService_UpdateMembership2",
         "parameters": [
@@ -1795,7 +1890,9 @@
     "/api/v1/organizations": {
       "get": {
         "description": "Retrieve a paginated list of organizations within your environment. The response includes a `page_token` that can be used to access subsequent pages of results.",
-        "tags": ["Organizations"],
+        "tags": [
+          "Organizations"
+        ],
         "summary": "List organizations",
         "operationId": "OrganizationService_ListOrganization",
         "parameters": [
@@ -1859,7 +1956,7 @@
           {
             "label": "Go SDK",
             "lang": "go",
-            "source": "organizations, err := scalekitClient.Organization.ListOrganizations(\n  ctx,\n  &scalekit.ListOrganizationOptions{\n    PageSize: 10,\n  }\n)"
+            "source": "organizations, err := scalekitClient.Organization().ListOrganization(\n  ctx,\n  &scalekit.ListOrganizationOptions{\n    PageSize: 10,\n  },\n)"
           },
           {
             "label": "Java SDK",
@@ -1870,7 +1967,9 @@
       },
       "post": {
         "description": "Creates a new organization in your environment. Use this endpoint to add a new tenant that can be configured with various settings and metadata",
-        "tags": ["Organizations"],
+        "tags": [
+          "Organizations"
+        ],
         "summary": "Create an organization",
         "operationId": "OrganizationService_CreateOrganization",
         "responses": {
@@ -1916,7 +2015,7 @@
           {
             "label": "Go SDK",
             "lang": "go",
-            "source": "organization, err := ScalekitClient.Organization.CreateOrganization(\n  ctx,\n  name,\n  scalekit.CreateOrganizationOptions{\n    ExternalID: \"externalId\",\n  },\n)"
+            "source": "organization, err := scalekitClient.Organization().CreateOrganization(\n  ctx,\n  name,\n  scalekit.CreateOrganizationOptions{\n    ExternalId: \"externalId\",\n  },\n)"
           },
           {
             "label": "Java SDK",
@@ -1929,7 +2028,9 @@
     "/api/v1/organizations/{id}": {
       "get": {
         "description": "Retrieves organization details by Scalekit ID, including name, region, metadata, and settings",
-        "tags": ["Organizations"],
+        "tags": [
+          "Organizations"
+        ],
         "summary": "Get organization details",
         "operationId": "OrganizationService_GetOrganization",
         "parameters": [
@@ -1959,17 +2060,17 @@
           {
             "label": "Node.js SDK",
             "lang": "javascript",
-            "source": "import { ScalekitClient } from '@scalekit-sdk/node'\nconst scalekit = new ScalekitClient(\n  process.env.SCALEKIT_ENV_URL,\n  process.env.SCALEKIT_CLIENT_ID,\n  process.env.SCALEKIT_CLIENT_SECRET,\n)\nconst organization = await scalekit.organization.getOrganization(organization_id)"
+            "source": "const organization = await scalekit.organization.getOrganization(organizationId)"
           },
           {
             "label": "Python SDK",
             "lang": "python",
-            "source": "scalekit_client = ScalekitClient(\n  <SCALEKIT_ENVIRONMENT_URL>,\n  <SCALEKIT_CLIENT_ID>,\n  <SCALEKIT_CLIENT_SECRET>\n)\n\norganization = scalekit_client.organization.get_organization(\n  organization_id\n)"
+            "source": "organization = scalekit_client.organization.get_organization(organization_id)"
           },
           {
             "label": "Go SDK",
             "lang": "go",
-            "source": "scalekitClient := scalekit.NewScalekitClient(\n  <SCALEKIT_ENVIRONMENT_URL>,\n  <SCALEKIT_CLIENT_ID>,\n  <SCALEKIT_CLIENT_SECRET>\n)\n\norganization, err := scalekitClient.Organization.GetOrganization(\n  ctx,\n  organizationId\n)"
+            "source": "organization, err := scalekitClient.Organization().GetOrganization(\n  ctx,\n  organizationId,\n)"
           },
           {
             "label": "Java SDK",
@@ -1980,7 +2081,9 @@
       },
       "delete": {
         "description": "Remove an existing organization from the environment using its unique identifier",
-        "tags": ["Organizations"],
+        "tags": [
+          "Organizations"
+        ],
         "summary": "Delete an organization",
         "operationId": "OrganizationService_DeleteOrganization",
         "parameters": [
@@ -2018,7 +2121,7 @@
           {
             "label": "Go SDK",
             "lang": "go",
-            "source": "err := scalekitClient.Organization.DeleteOrganization(\n  ctx,\n  organizationId\n)"
+            "source": "err := scalekitClient.Organization().DeleteOrganization(\n  ctx,\n  organizationId,\n)"
           },
           {
             "label": "Java SDK",
@@ -2029,7 +2132,9 @@
       },
       "patch": {
         "description": "Updates an organization's display name, external ID, or metadata. Requires a valid organization identifier. Region code cannot be modified through this endpoint.",
-        "tags": ["Organizations"],
+        "tags": [
+          "Organizations"
+        ],
         "summary": "Update organization details",
         "operationId": "OrganizationService_UpdateOrganization",
         "parameters": [
@@ -2080,7 +2185,7 @@
           {
             "label": "Go SDK",
             "lang": "go",
-            "source": "organization, err := scalekitClient.Organization.UpdateOrganization(\n  ctx,\n  organizationId,\n  &scalekit.UpdateOrganization{\n    DisplayName: \"displayName\",\n    ExternalId: \"externalId\",\n  },\n)"
+            "source": "organization, err := scalekitClient.Organization().UpdateOrganization(\n  ctx,\n  organizationId,\n  &scalekit.UpdateOrganization{\n    DisplayName: \"displayName\",\n    ExternalId:  \"externalId\",\n  },\n)"
           },
           {
             "label": "Java SDK",
@@ -2093,7 +2198,9 @@
     "/api/v1/organizations/{id}/portal_links": {
       "put": {
         "description": "Creates a single use Admin Portal URL valid for 1 minute. Once the generated admin portal URL is accessed or rendered, a temporary session of 6 hours is created to allow the admin to update SSO/SCIM configuration.",
-        "tags": ["Organizations"],
+        "tags": [
+          "Organizations"
+        ],
         "summary": "Generate admin portal link",
         "operationId": "OrganizationService_GeneratePortalLink",
         "parameters": [
@@ -2110,7 +2217,10 @@
             "schema": {
               "type": "array",
               "items": {
-                "enum": ["dir_sync", "sso"],
+                "enum": [
+                  "dir_sync",
+                  "sso"
+                ],
                 "type": "string"
               }
             },
@@ -2147,7 +2257,7 @@
           {
             "label": "Go SDK",
             "lang": "go",
-            "source": "link, err := scalekitClient.Organization.GeneratePortalLink(\n  ctx,\n  organizationId\n)"
+            "source": "link, err := scalekitClient.Organization().GeneratePortalLink(\n  ctx,\n  organizationId,\n)"
           },
           {
             "label": "Java SDK",
@@ -2160,7 +2270,9 @@
     "/api/v1/organizations/{id}/settings": {
       "patch": {
         "description": "Updates configuration settings for an organization. Supports modifying SSO configuration, directory synchronization settings, and session parameters. Requires organization ID and the specific settings to update.",
-        "tags": ["Organizations"],
+        "tags": [
+          "Organizations"
+        ],
         "summary": "Toggle organization settings",
         "operationId": "OrganizationService_UpdateOrganizationSettings",
         "parameters": [
@@ -2254,7 +2366,9 @@
     "/api/v1/organizations/{org_id}/roles": {
       "get": {
         "description": "Retrieves all environment roles and organization specific roles. Use this endpoint to view all role definitions, including custom roles and their configurations. You can optionally include permission details for each role to understand their capabilities. This is useful for role management, auditing organization access controls, or understanding the available access levels within the organization.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "List organization roles",
         "operationId": "RolesService_ListOrganizationRoles",
         "parameters": [
@@ -2313,7 +2427,9 @@
       },
       "post": {
         "description": "Creates a new role within the specified organization with basic configuration including name, display name, description, and permissions. Use this endpoint to define custom roles that can be assigned to users within the organization. You can create hierarchical roles by extending existing roles and assign specific permissions to control access levels. The role will be scoped to the organization and can be used for organization-specific access control.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "Create organization role",
         "operationId": "RolesService_CreateOrganizationRole",
         "parameters": [
@@ -2377,7 +2493,9 @@
     "/api/v1/organizations/{org_id}/roles/{role_name}": {
       "get": {
         "description": "Retrieves complete information for a specific organization role including metadata, inheritance details, and optionally permissions. Use this endpoint to audit role configuration and understand the role's place in the organization's role hierarchy. You can include permission details to see what capabilities the role provides. This operation is useful for role management, user assignment decisions, or understanding organization access controls.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "Get organization role details",
         "operationId": "RolesService_GetOrganizationRole",
         "parameters": [
@@ -2445,7 +2563,9 @@
       },
       "put": {
         "description": "Modifies an existing organization role's properties including display name, description, permissions, and inheritance settings. Use this endpoint to update role metadata, change permission assignments, or modify role hierarchy within the organization. Only the fields you specify will be updated, leaving other properties unchanged. When updating permissions, the new list replaces all existing permissions for the role.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "Update organization role",
         "operationId": "RolesService_UpdateOrganizationRole",
         "parameters": [
@@ -2516,7 +2636,9 @@
       },
       "delete": {
         "description": "Permanently removes a role from the organization and optionally reassigns users who had that role to a different role. Use this endpoint when you need to clean up unused roles or restructure your organization's access control system. If users are assigned to the role being deleted, you can provide a reassign_role_name to move those users to a different role before deletion. This action cannot be undone, so ensure no critical users depend on the role before deletion.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "Delete organization role",
         "operationId": "RolesService_DeleteOrganizationRole",
         "parameters": [
@@ -2584,7 +2706,9 @@
     "/api/v1/organizations/{org_id}/roles:set_defaults": {
       "patch": {
         "description": "Updates the default member role for the specified organization. Use this endpoint to configure which role is automatically assigned to new users when they join the organization. The system will validate that the specified role exists and update the organization settings accordingly. This configuration affects all new user invitations and memberships within the organization.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "Set default organization roles",
         "operationId": "RolesService_UpdateDefaultOrganizationRoles",
         "parameters": [
@@ -2647,7 +2771,9 @@
     "/api/v1/organizations/{organization_id}/clients": {
       "get": {
         "description": "Retrieves a paginated list of API clients for a specific organization. Returns client details including metadata, scopes, and secret information (without exposing actual secret values).",
-        "tags": ["API Auth"],
+        "tags": [
+          "API Auth"
+        ],
         "summary": "List organization API clients",
         "operationId": "ClientService_ListOrganizationClients",
         "parameters": [
@@ -2692,15 +2818,32 @@
         },
         "x-codeSamples": [
           {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const response = await scalekit.m2m.listOrganizationClients('org_123', {\n  pageSize: 30,\n})\nconst clients = response.clients"
+          },
+          {
             "label": "Python SDK",
             "lang": "python",
-            "source": "# List clients for a specific organization\norg_id = 'SCALEKIT_ORGANIZATION_ID'\n\n# Retrieve all clients with default pagination\nresponse = scalekit_client.m2m_client.list_organization_clients(\n    organization_id=org_id,\n    page_size=30\n)\n\n# Access the clients list\nclients = response.clients\nfor client in clients:\n    print(f\"Client ID: {scalekit_client.id}, Name: {scalekit_client.name}\")"
+            "source": "# List clients for a specific organization\norg_id = \"org_123\"\n\nresponse = scalekit_client.m2m_client.list_organization_clients(\n    organization_id=org_id,\n    page_size=30,\n)\n\nclients = response.clients\nfor client in clients:\n    print(f\"Client ID: {client.id}, Name: {client.name}\")"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "response, err := scalekitClient.M2M().ListOrganizationClients(\n  ctx,\n  \"org_123\",\n  scalekit.ListOrganizationClientsOptions{\n    PageSize: 30,\n  },\n)\nif err != nil {\n  // handle error\n  return\n}\n_ = response"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "ListOrganizationClientsResponse response = scalekitClient.m2m()\n    .listOrganizationClients(\"org_123\", 30, \"\");"
           }
         ]
       },
       "post": {
         "description": "Creates a new API client for an organization. Returns the client details and a plain secret (available only once).",
-        "tags": ["API Auth"],
+        "tags": [
+          "API Auth"
+        ],
         "summary": "Create organization API client",
         "operationId": "ClientService_CreateOrganizationClient",
         "parameters": [
@@ -2739,9 +2882,24 @@
         },
         "x-codeSamples": [
           {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const response = await scalekit.m2m.createOrganizationClient('org_123', {\n  name: 'GitHub Actions Deployment Service',\n  description: 'Service account for GitHub Actions to deploy applications to production',\n  scopes: ['deploy:applications', 'read:deployments'],\n  audience: ['deployment-api.acmecorp.com'],\n})"
+          },
+          {
             "label": "Python SDK",
             "lang": "python",
-            "source": "from scalekit.v1.clients.clients_pb2 import OrganizationClient\n\nm2m_client = OrganizationClient(\n    name=\"GitHub Actions Deployment Service\",\n    description=\"Service account for GitHub Actions to deploy applications\nto production\",\n    custom_claims=[\n        {\"key\": \"github_repository\", \"value\": \"acmecorp/inventory-service\"},\n        {\"key\": \"environment\", \"value\": \"production_us\"}\n    ],\n    scopes=[\"deploy:applications\", \"read:deployments\"],\n    audience=[\"deployment-api.acmecorp.com\"],\n    expiry=3600\n)\n\nresponse = scalekit_client.m2m_client.create_organization_client(\n    organization_id=\"SCALEKIT_ORGANIZATION_ID\",\n    m2m_client=m2m_client\n)"
+            "source": "from scalekit.v1.clients.clients_pb2 import OrganizationClient\n\nm2m_client = OrganizationClient(\n    name=\"GitHub Actions Deployment Service\",\n    description=\"Service account for GitHub Actions to deploy applications to production\",\n    custom_claims=[\n        {\"key\": \"github_repository\", \"value\": \"acmecorp/inventory-service\"},\n        {\"key\": \"environment\", \"value\": \"production_us\"},\n    ],\n    scopes=[\"deploy:applications\", \"read:deployments\"],\n    audience=[\"deployment-api.acmecorp.com\"],\n    expiry=3600,\n)\n\nresponse = scalekit_client.m2m_client.create_organization_client(\n    organization_id=\"org_123\",\n    m2m_client=m2m_client,\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "response, err := scalekitClient.M2M().CreateOrganizationClient(\n  ctx,\n  \"org_123\",\n  scalekit.CreateOrganizationClientOptions{\n    Name:        \"GitHub Actions Deployment Service\",\n    Description: \"Service account for GitHub Actions to deploy applications to production\",\n    Scopes:      []string{\"deploy:applications\", \"read:deployments\"},\n    Audience:    []string{\"deployment-api.acmecorp.com\"},\n  },\n)\nif err != nil {\n  // handle error\n  return\n}\n_ = response"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "import com.scalekit.grpc.scalekit.v1.clients.OrganizationClient;\n\nOrganizationClient orgClient = OrganizationClient.newBuilder()\n    .setName(\"GitHub Actions Deployment Service\")\n    .setDescription(\"Service account for GitHub Actions to deploy applications to production\")\n    .addScopes(\"deploy:applications\")\n    .addScopes(\"read:deployments\")\n    .addAudience(\"deployment-api.acmecorp.com\")\n    .build();\n\nCreateOrganizationClientResponse response = scalekitClient.m2m()\n    .createOrganizationClient(\"org_123\", orgClient);"
           }
         ]
       }
@@ -2749,7 +2907,9 @@
     "/api/v1/organizations/{organization_id}/clients/{client_id}": {
       "get": {
         "description": "Retrieves details of a specific API client in an organization.",
-        "tags": ["API Auth"],
+        "tags": [
+          "API Auth"
+        ],
         "summary": "Get organization API client",
         "operationId": "ClientService_GetOrganizationClient",
         "parameters": [
@@ -2786,15 +2946,32 @@
         },
         "x-codeSamples": [
           {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const response = await scalekit.m2m.getOrganizationClient('org_123', 'skc_xxxxx')"
+          },
+          {
             "label": "Python SDK",
             "lang": "python",
-            "source": "# Get client ID from environment variables\norg_id = 'SCALEKIT_ORGANIZATION_ID'\nclient_id = os.environ['M2M_CLIENT_ID']\n\n# Fetch client details for the specified organization\nresponse = scalekit_client.m2m_client.get_organization_client(\n    organization_id=org_id,\n    client_id=client_id\n)"
+            "source": "import os\n\norg_id = \"org_123\"\nclient_id = os.environ[\"M2M_CLIENT_ID\"]\n\nresponse = scalekit_client.m2m_client.get_organization_client(\n    organization_id=org_id,\n    client_id=client_id,\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "response, err := scalekitClient.M2M().GetOrganizationClient(\n  ctx,\n  \"org_123\",\n  \"skc_xxxxx\",\n)\nif err != nil {\n  // handle error\n  return\n}\n_ = response"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "GetOrganizationClientResponse response = scalekitClient.m2m()\n    .getOrganizationClient(\"org_123\", \"skc_xxxxx\");"
           }
         ]
       },
       "delete": {
         "description": "Permanently deletes an API client from an organization. This operation cannot be undone and will revoke all access for the client. All associated secrets will also be invalidated. Use this endpoint to remove unused or compromised clients.",
-        "tags": ["API Auth"],
+        "tags": [
+          "API Auth"
+        ],
         "summary": "Delete organization API client",
         "operationId": "ClientService_DeleteOrganizationClient",
         "parameters": [
@@ -2829,15 +3006,32 @@
         },
         "x-codeSamples": [
           {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await scalekit.m2m.deleteOrganizationClient('org_123', 'skc_xxxxx')"
+          },
+          {
             "label": "Python SDK",
             "lang": "python",
-            "source": "# Get client ID from environment variables\norg_id = '<SCALEKIT_ORGANIZATION_ID>'\nclient_id = os.environ['M2M_CLIENT_ID']\n\n# Delete the specified client from the organization\nresponse = scalekit_client.m2m_client.delete_organization_client(\n    organization_id=org_id,\n    client_id=client_id\n)"
+            "source": "import os\n\norg_id = \"org_123\"\nclient_id = os.environ[\"M2M_CLIENT_ID\"]\n\nscalekit_client.m2m_client.delete_organization_client(\n    organization_id=org_id,\n    client_id=client_id,\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "err := scalekitClient.M2M().DeleteOrganizationClient(\n  ctx,\n  \"org_123\",\n  \"skc_xxxxx\",\n)\nif err != nil {\n  // handle error\n  return\n}"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "scalekitClient.m2m().deleteOrganizationClient(\"org_123\", \"skc_xxxxx\");"
           }
         ]
       },
       "patch": {
         "description": "Updates an existing organization API client. Only specified fields are modified.",
-        "tags": ["API Auth"],
+        "tags": [
+          "API Auth"
+        ],
         "summary": "Update organization API client",
         "operationId": "ClientService_UpdateOrganizationClient",
         "parameters": [
@@ -2885,9 +3079,24 @@
         },
         "x-codeSamples": [
           {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const response = await scalekit.m2m.updateOrganizationClient('org_123', 'skc_xxxxx', {\n  description: 'Service account for GitHub Actions to deploy applications to production_eu',\n})"
+          },
+          {
             "label": "Python SDK",
             "lang": "python",
-            "source": "from scalekit.v1.clients.clients_pb2 import OrganizationClient\n\norg_id = '<SCALEKIT_ORGANIZATION_ID>'\nclient_id = os.environ['M2M_CLIENT_ID']\n\nupdate_m2m_client = OrganizationClient(\n    description=\"Service account for GitHub Actions to deploy applications\nto production_eu\",\n    custom_claims=[\n        {\"key\": \"github_repository\", \"value\": \"acmecorp/inventory\"},\n        {\"key\": \"environment\", \"value\": \"production_eu\"}\n    ]\n)\n\nresponse = scalekit_client.m2m_client.update_organization_client(\n    organization_id=org_id,\n    client_id=client_id,\n    m2m_client=update_m2m_client\n)"
+            "source": "import os\nfrom scalekit.v1.clients.clients_pb2 import OrganizationClient\n\norg_id = \"org_123\"\nclient_id = os.environ[\"M2M_CLIENT_ID\"]\n\nupdate_m2m_client = OrganizationClient(\n    description=\"Service account for GitHub Actions to deploy applications to production_eu\",\n    custom_claims=[\n        {\"key\": \"github_repository\", \"value\": \"acmecorp/inventory\"},\n        {\"key\": \"environment\", \"value\": \"production_eu\"},\n    ],\n)\n\nresponse = scalekit_client.m2m_client.update_organization_client(\n    organization_id=org_id,\n    client_id=client_id,\n    m2m_client=update_m2m_client,\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "response, err := scalekitClient.M2M().UpdateOrganizationClient(\n  ctx,\n  \"org_123\",\n  \"skc_xxxxx\",\n  scalekit.UpdateOrganizationClientOptions{\n    Description: \"Service account for GitHub Actions to deploy applications to production_eu\",\n  },\n)\nif err != nil {\n  // handle error\n  return\n}\n_ = response"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "import com.scalekit.grpc.scalekit.v1.clients.OrganizationClient;\n\nOrganizationClient updates = OrganizationClient.newBuilder()\n    .setDescription(\"Service account for GitHub Actions to deploy applications to production_eu\")\n    .build();\n\nUpdateOrganizationClientResponse response = scalekitClient.m2m()\n    .updateOrganizationClient(\"org_123\", \"skc_xxxxx\", updates);"
           }
         ]
       }
@@ -2895,7 +3104,9 @@
     "/api/v1/organizations/{organization_id}/clients/{client_id}/secrets": {
       "post": {
         "description": "Creates a new secret for an organization API client. Returns the plain secret (available only once).",
-        "tags": ["API Auth"],
+        "tags": [
+          "API Auth"
+        ],
         "summary": "Create organization API client secret",
         "operationId": "ClientService_CreateOrganizationClientSecret",
         "parameters": [
@@ -2932,9 +3143,24 @@
         },
         "x-codeSamples": [
           {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "const response = await scalekit.m2m.addOrganizationClientSecret('org_123', 'skc_xxxxx')\nconst secretId = response.secret?.id"
+          },
+          {
             "label": "Python SDK",
             "lang": "python",
-            "source": "# Get client ID from environment variables\norg_id = 'SCALEKIT_ORGANIZATION_ID'\nclient_id = os.environ['M2M_CLIENT_ID']\n\n# Add a new secret to the specified client\nresponse = scalekit_client.m2m_client.add_organization_client_secret(\n    organization_id=org_id,\n    client_id=client_id\n)\n\n# Extract the secret ID from the response\nsecret_id = response[0].secret.id"
+            "source": "import os\n\norg_id = \"org_123\"\nclient_id = os.environ[\"M2M_CLIENT_ID\"]\n\nresponse = scalekit_client.m2m_client.add_organization_client_secret(\n    organization_id=org_id,\n    client_id=client_id,\n)\n\n# with_call returns (response, call)\nsecret_id = response[0].secret.id"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "response, err := scalekitClient.M2M().CreateOrganizationClientSecret(\n  ctx,\n  \"org_123\",\n  \"skc_xxxxx\",\n)\nif err != nil {\n  // handle error\n  return\n}\n_ = response"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "CreateOrganizationClientSecretResponse response = scalekitClient.m2m()\n    .createOrganizationClientSecret(\"org_123\", \"skc_xxxxx\");"
           }
         ]
       }
@@ -2942,7 +3168,9 @@
     "/api/v1/organizations/{organization_id}/clients/{client_id}/secrets/{secret_id}": {
       "delete": {
         "description": "Permanently deletes a secret from an organization API client. This operation cannot be undone.",
-        "tags": ["API Auth"],
+        "tags": [
+          "API Auth"
+        ],
         "summary": "Delete organization API client secret",
         "operationId": "ClientService_DeleteOrganizationClientSecret",
         "parameters": [
@@ -2986,9 +3214,24 @@
         },
         "x-codeSamples": [
           {
+            "label": "Node.js SDK",
+            "lang": "javascript",
+            "source": "await scalekit.m2m.removeOrganizationClientSecret('org_123', 'skc_xxxxx', 'sks_xxxxx')"
+          },
+          {
             "label": "Python SDK",
             "lang": "python",
-            "source": "# Get client and secret IDs from environment variables\norg_id = '<SCALEKIT_ORGANIZATION_ID>'\nclient_id = os.environ['M2M_CLIENT_ID']\nsecret_id = os.environ['M2M_SECRET_ID']\n\n# Remove the specified secret from the client\nresponse = scalekit_client.m2m_client.remove_organization_client_secret(\n    organization_id=org_id,\n    client_id=client_id,\n    secret_id=secret_id\n)"
+            "source": "import os\n\norg_id = \"org_123\"\nclient_id = os.environ[\"M2M_CLIENT_ID\"]\nsecret_id = os.environ[\"M2M_SECRET_ID\"]\n\nscalekit_client.m2m_client.remove_organization_client_secret(\n    organization_id=org_id,\n    client_id=client_id,\n    secret_id=secret_id,\n)"
+          },
+          {
+            "label": "Go SDK",
+            "lang": "go",
+            "source": "err := scalekitClient.M2M().DeleteOrganizationClientSecret(\n  ctx,\n  \"org_123\",\n  \"skc_xxxxx\",\n  \"sks_xxxxx\",\n)\nif err != nil {\n  // handle error\n  return\n}"
+          },
+          {
+            "label": "Java SDK",
+            "lang": "java",
+            "source": "scalekitClient.m2m().deleteOrganizationClientSecret(\n    \"org_123\",\n    \"skc_xxxxx\",\n    \"sks_xxxxx\"\n);"
           }
         ]
       }
@@ -2996,7 +3239,9 @@
     "/api/v1/organizations/{organization_id}/connections/{id}": {
       "get": {
         "description": "Retrieves the complete configuration and status details for a specific connection by its ID within an organization. Returns all connection properties including provider settings, protocols, and current status.",
-        "tags": ["Connections"],
+        "tags": [
+          "Connections"
+        ],
         "summary": "Get connection details",
         "operationId": "ConnectionService_GetConnection",
         "parameters": [
@@ -3045,7 +3290,7 @@
           {
             "label": "Go SDK",
             "lang": "go",
-            "source": "connection, err := scalekitClient.Connection.GetConnection(\n  ctx,\n  organizationId,\n  connectionId,\n)"
+            "source": "connection, err := scalekitClient.Connection().GetConnection(\n  ctx,\n  organizationId,\n  connectionId,\n)"
           },
           {
             "label": "Java SDK",
@@ -3056,7 +3301,9 @@
       },
       "delete": {
         "description": "Deletes an SSO connection from the specified organization by connection ID. Use this endpoint when an identity provider integration is no longer needed for the organization. Returns an empty response after the SSO connection is deleted successfully.",
-        "tags": ["Connections"],
+        "tags": [
+          "Connections"
+        ],
         "summary": "Delete SSO connection",
         "operationId": "ConnectionService_DeleteConnection",
         "parameters": [
@@ -3103,7 +3350,7 @@
           {
             "label": "Go SDK",
             "lang": "go",
-            "source": "err := scalekitClient.Connection.DeleteConnection(\n  ctx,\n  organizationId,\n  connectionId,\n)"
+            "source": "err := scalekitClient.Connection().DeleteConnection(\n  ctx,\n  organizationId,\n  connectionId,\n)"
           },
           {
             "label": "Java SDK",
@@ -3116,7 +3363,9 @@
     "/api/v1/organizations/{organization_id}/connections/{id}:disable": {
       "patch": {
         "description": "Deactivate an existing connection for the specified organization. When disabled, users cannot authenticate using this connection. This endpoint changes the connection state from enabled to disabled without modifying other configuration settings",
-        "tags": ["Connections"],
+        "tags": [
+          "Connections"
+        ],
         "summary": "Disable SSO connection",
         "operationId": "ConnectionService_DisableConnection",
         "parameters": [
@@ -3165,7 +3414,7 @@
           {
             "label": "Go SDK",
             "lang": "go",
-            "source": "err := scalekitClient.Connection.DisableConnection(\n  ctx,\n  organizationId,\n  connectionId,\n)"
+            "source": "err := scalekitClient.Connection().DisableConnection(\n  ctx,\n  organizationId,\n  connectionId,\n)"
           },
           {
             "label": "Java SDK",
@@ -3178,7 +3427,9 @@
     "/api/v1/organizations/{organization_id}/connections/{id}:enable": {
       "patch": {
         "description": "Activate an existing connection for the specified organization. When enabled, users can authenticate using this connection. This endpoint changes the connection state from disabled to enabled without modifying other configuration settings",
-        "tags": ["Connections"],
+        "tags": [
+          "Connections"
+        ],
         "summary": "Enable SSO connection",
         "operationId": "ConnectionService_EnableConnection",
         "parameters": [
@@ -3227,7 +3478,7 @@
           {
             "label": "Go SDK",
             "lang": "go",
-            "source": "err := scalekitClient.Connection.EnableConnection(\n  ctx,\n  organizationId,\n  connectionId,\n)"
+            "source": "err := scalekitClient.Connection().EnableConnection(\n  ctx,\n  organizationId,\n  connectionId,\n)"
           },
           {
             "label": "Java SDK",
@@ -3239,7 +3490,9 @@
     },
     "/api/v1/organizations/{organization_id}/directories": {
       "get": {
-        "tags": ["Directory"],
+        "tags": [
+          "Directory"
+        ],
         "summary": "List organization directories",
         "operationId": "DirectoryService_ListDirectories",
         "parameters": [
@@ -3292,7 +3545,9 @@
     "/api/v1/organizations/{organization_id}/directories/{directory_id}/groups": {
       "get": {
         "description": "Retrieves all groups from a specified directory. Use this endpoint to view group structures from your connected identity provider.",
-        "tags": ["Directory"],
+        "tags": [
+          "Directory"
+        ],
         "summary": "List directory groups",
         "operationId": "DirectoryService_ListDirectoryGroups",
         "parameters": [
@@ -3396,7 +3651,9 @@
     "/api/v1/organizations/{organization_id}/directories/{directory_id}/users": {
       "get": {
         "description": "Retrieves a list of all users within a specified directory for an organization. This endpoint allows you to view user accounts associated with your connected Directory Providers.",
-        "tags": ["Directory"],
+        "tags": [
+          "Directory"
+        ],
         "summary": "List directory users",
         "operationId": "DirectoryService_ListDirectoryUsers",
         "parameters": [
@@ -3500,7 +3757,9 @@
     "/api/v1/organizations/{organization_id}/directories/{id}": {
       "get": {
         "description": "Retrieves detailed information about a specific directory within an organization",
-        "tags": ["Directory"],
+        "tags": [
+          "Directory"
+        ],
         "summary": "Get directory details",
         "operationId": "DirectoryService_GetDirectory",
         "parameters": [
@@ -3562,7 +3821,9 @@
     "/api/v1/organizations/{organization_id}/directories/{id}:disable": {
       "patch": {
         "description": "Stops synchronization of users and groups from a specified directory within an organization. This operation prevents further updates from the connected Directory provider",
-        "tags": ["Directory"],
+        "tags": [
+          "Directory"
+        ],
         "summary": "Disable a directory",
         "operationId": "DirectoryService_DisableDirectory",
         "parameters": [
@@ -3624,7 +3885,9 @@
     "/api/v1/organizations/{organization_id}/directories/{id}:enable": {
       "patch": {
         "description": "Activates a directory within an organization, allowing it to synchronize users and groups with the connected Directory provider",
-        "tags": ["Directory"],
+        "tags": [
+          "Directory"
+        ],
         "summary": "Enable a directory",
         "operationId": "DirectoryService_EnableDirectory",
         "parameters": [
@@ -3686,7 +3949,9 @@
     "/api/v1/organizations/{organization_id}/domains": {
       "get": {
         "description": "Retrieves a paginated list of all domains configured for the specified organization.\n\nDomain types:\n- ALLOWED_EMAIL_DOMAIN: Trusted domains used to suggest the organization in the organization switcher during sign-in/sign-up (auth-method agnostic).\n- ORGANIZATION_DOMAIN: SSO discovery domains used to route users to the correct SSO provider and enforce SSO.\n\n",
-        "tags": ["Domains"],
+        "tags": [
+          "Domains"
+        ],
         "summary": "List Domains",
         "operationId": "DomainService_ListDomains",
         "parameters": [
@@ -3728,7 +3993,10 @@
           {
             "schema": {
               "type": "string",
-              "enum": ["ALLOWED_EMAIL_DOMAIN", "ORGANIZATION_DOMAIN"]
+              "enum": [
+                "ALLOWED_EMAIL_DOMAIN",
+                "ORGANIZATION_DOMAIN"
+              ]
             },
             "description": "The domain type.\n- ALLOWED_EMAIL_DOMAIN: trusted domain used to suggest the organization in the organization switcher during sign-in/sign-up.\n- ORGANIZATION_DOMAIN: SSO discovery domain used to route users to the correct SSO provider and enforce SSO.\n",
             "name": "domain_type",
@@ -3772,7 +4040,9 @@
       },
       "post": {
         "description": "Creates and associates a domain with an organization.\n\nUse one of the following domain types:\n- ALLOWED_EMAIL_DOMAIN: Adds a trusted email domain for organization suggestions in the organization switcher during sign-in/sign-up (auth-method agnostic).\n- ORGANIZATION_DOMAIN: Enables SSO domain discovery. If a user signs in with a matching email domain, Scalekit redirects them to the organization’s SSO provider and enforces SSO.\n\nThe domain must be a valid business domain that you control. Public/disposable domains (e.g., gmail.com) are blocked for security.\n\n",
-        "tags": ["Domains"],
+        "tags": [
+          "Domains"
+        ],
         "summary": "Create Domain",
         "operationId": "DomainService_CreateDomain",
         "parameters": [
@@ -3846,7 +4116,9 @@
     "/api/v1/organizations/{organization_id}/domains/{id}": {
       "get": {
         "description": "Retrieves complete details for a domain including domain type, timestamps, and configuration information.\n\n",
-        "tags": ["Domains"],
+        "tags": [
+          "Domains"
+        ],
         "summary": "Get Domain",
         "operationId": "DomainService_GetDomain",
         "parameters": [
@@ -3906,7 +4178,9 @@
       },
       "delete": {
         "description": "Permanently removes a domain record from an organization.\n\n- Deleting an ORGANIZATION_DOMAIN disables SSO routing/enforcement for that domain.\n- Deleting an ALLOWED_EMAIL_DOMAIN stops organization suggestions for users with that email domain.\n\n",
-        "tags": ["Domains"],
+        "tags": [
+          "Domains"
+        ],
         "summary": "Delete Domain",
         "operationId": "DomainService_DeleteDomain",
         "parameters": [
@@ -3966,7 +4240,9 @@
     "/api/v1/organizations/{organization_id}/session-policy": {
       "get": {
         "description": "Retrieves the session policy for an organization. Returns session_policy='APPLICATION' if the organization inherits the application-level defaults, or session_policy='CUSTOM' with the configured values if a custom policy is active.",
-        "tags": ["Organizations"],
+        "tags": [
+          "Organizations"
+        ],
         "summary": "Get organization session policy",
         "operationId": "OrganizationService_GetOrganizationSessionPolicy",
         "parameters": [
@@ -4003,7 +4279,9 @@
       },
       "patch": {
         "description": "Sets a custom session policy for an organization or reverts to application-level settings. Send session_policy='APPLICATION' to revert to application defaults. Send session_policy='CUSTOM' with timeout values to activate a custom policy.",
-        "tags": ["Organizations"],
+        "tags": [
+          "Organizations"
+        ],
         "summary": "Update organization session policy",
         "operationId": "OrganizationService_UpdateOrganizationSessionPolicy",
         "parameters": [
@@ -4052,7 +4330,9 @@
     "/api/v1/organizations/{organization_id}/settings/usermanagement": {
       "patch": {
         "description": "Upsert user management settings for an organization",
-        "tags": ["Organizations"],
+        "tags": [
+          "Organizations"
+        ],
         "summary": "Upsert organization user setting",
         "operationId": "OrganizationService_UpsertUserManagementSettings",
         "parameters": [
@@ -4093,7 +4373,9 @@
     "/api/v1/organizations/{organization_id}/users": {
       "get": {
         "description": "Retrieves a paginated list of all users who are members of the specified organization. Use this endpoint to view all users with access to a particular organization, including their roles, metadata, and membership details. Supports pagination for large user lists.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "List organization users",
         "operationId": "UserService_ListOrganizationUsers",
         "parameters": [
@@ -4145,7 +4427,7 @@
           {
             "label": "Python SDK",
             "lang": "python",
-            "source": "resp, _ = scalekit_client.users.list_users(organization_id=\"org_123\", page_size=50)"
+            "source": "response = scalekit_client.users.list_organization_users(\n    organization_id=\"org_123\",\n    page_size=50,\n)"
           },
           {
             "label": "Go SDK",
@@ -4161,7 +4443,9 @@
       },
       "post": {
         "description": "Creates a new user account and immediately adds them to the specified organization. Use this endpoint when you want to create a user and grant them access to an organization in a single operation. You can provide user profile information, assign roles, and configure membership metadata. The user receives an activation email unless this feature is disabled in the organization settings.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Create new user in organization",
         "operationId": "UserService_CreateUserAndMembership",
         "parameters": [
@@ -4231,7 +4515,9 @@
     "/api/v1/organizations/{organization_id}/users/{user_id}/permissions": {
       "get": {
         "description": "Retrieves all permissions a user has access to within a specific organization. This includes permissions from direct role assignments and inherited permissions from role hierarchy.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "List user permissions",
         "operationId": "UserService_ListUserPermissions",
         "parameters": [
@@ -4293,7 +4579,9 @@
     "/api/v1/organizations/{organization_id}/users/{user_id}/roles": {
       "get": {
         "description": "Retrieves all roles assigned to a user within a specific organization. This includes both direct role assignments and inherited roles from role hierarchy.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "List user roles",
         "operationId": "UserService_ListUserRoles",
         "parameters": [
@@ -4355,7 +4643,9 @@
     "/api/v1/organizations/{organization_id}/users:search": {
       "get": {
         "description": "Searches for users within a specific organization by email address, user ID, or external ID. The query must be at least 3 characters and is case-insensitive. Scopes results strictly to the given organization. Returns a paginated list of matching users with up to 30 results per page. Use the next_page_token from the response to retrieve subsequent pages.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Search organization users",
         "operationId": "UserService_SearchOrganizationUsers",
         "parameters": [
@@ -4432,7 +4722,9 @@
     "/api/v1/organizations:external/{external_id}": {
       "get": {
         "description": "Retrieves organization details by external ID, including name, region, metadata, and settings. Only provide external_id in the path. If the id query parameter is also supplied, it silently takes precedence over external_id due to protobuf oneof semantics, which causes the request to fail with a 400 Bad Request ('ExternalId is required').",
-        "tags": ["Organizations"],
+        "tags": [
+          "Organizations"
+        ],
         "summary": "Get organization details by external Id",
         "operationId": "OrganizationService_GetOrganizationByExternalId",
         "parameters": [
@@ -4487,7 +4779,9 @@
     "/api/v1/passwordless/email/resend": {
       "post": {
         "description": "Resend a verification email if the user didn't receive it or if the previous code/link has expired",
-        "tags": ["Magic link & OTP"],
+        "tags": [
+          "Magic link & OTP"
+        ],
         "summary": "Resend passwordless email",
         "operationId": "PasswordlessService_ResendPasswordlessEmail",
         "responses": {
@@ -4531,7 +4825,7 @@
           {
             "label": "Java SDK",
             "lang": "java",
-            "source": "SendPasswordlessResponse resendResponse = passwordlessClient.resendPasswordlessEmail(authRequestId);"
+            "source": "SendPasswordlessResponse resendResponse = scalekitClient.passwordless()\n    .resendPasswordlessEmail(authRequestId);"
           }
         ]
       }
@@ -4539,7 +4833,9 @@
     "/api/v1/passwordless/email/send": {
       "post": {
         "description": "Send a verification email containing either a verification code (OTP), magic link, or both to a user's email address",
-        "tags": ["Magic link & OTP"],
+        "tags": [
+          "Magic link & OTP"
+        ],
         "summary": "Send passwordless email",
         "operationId": "PasswordlessService_SendPasswordlessEmail",
         "responses": {
@@ -4568,22 +4864,22 @@
           {
             "label": "Node.js SDK",
             "lang": "javascript",
-            "source": "const response = await scalekit.passwordless.sendPasswordlessEmail('john.doe@example.com', {\n  template: 'SIGNIN',\n  expiresIn: 100,\n  magiclinkAuthUri: 'https://www.google.com',\n  templateVariables: {\n    employeeID: 'EMP523',\n    teamName: 'Alpha Team',\n    supportEmail: 'support@yourcompany.com',\n  },\n})"
+            "source": "const response = await scalekit.passwordless.sendPasswordlessEmail('john.doe@example.com', {\n  template: 'SIGNIN',\n  expiresIn: 100,\n  magiclinkAuthUri: 'https://yourapp.com/auth/passwordless/callback',\n  templateVariables: {\n    employeeID: 'EMP523',\n    teamName: 'Alpha Team',\n    supportEmail: 'support@yourcompany.com',\n  },\n})"
           },
           {
             "label": "Python SDK",
             "lang": "python",
-            "source": "response = scalekit_client.passwordless.send_passwordless_email(\n    email=\"john.doe@example.com\",\n    template=\"SIGNIN\",  # or \"SIGNUP\", \"UNSPECIFIED\"\n    expires_in=100,\n    magiclink_auth_uri=\"https://www.google.com\",\n    template_variables={\n        \"employeeID\": \"EMP523\",\n        \"teamName\": \"Alpha Team\",\n        \"supportEmail\": \"support@yourcompany.com\",\n    },\n)\n\n# Extract auth request ID from response\nauth_request_id = response[0].auth_request_id"
+            "source": "response = scalekit_client.passwordless.send_passwordless_email(\n    email=\"john.doe@example.com\",\n    template=\"SIGNIN\",  # or \"SIGNUP\", \"UNSPECIFIED\"\n    expires_in=100,\n    magiclink_auth_uri=\"https://yourapp.com/auth/passwordless/callback\",\n    template_variables={\n        \"employeeID\": \"EMP523\",\n        \"teamName\": \"Alpha Team\",\n        \"supportEmail\": \"support@yourcompany.com\",\n    },\n)\n\n# with_call returns (response, call)\nauth_request_id = response[0].auth_request_id"
           },
           {
             "label": "Go SDK",
             "lang": "go",
-            "source": "templateType := scalekit.TemplateTypeSignin\nresponse, err := scalekitClient.Passwordless().SendPasswordlessEmail(\n    ctx,\n    \"john.doe@example.com\",\n    &scalekit.SendPasswordlessOptions{\n        Template:         &templateType,\n        ExpiresIn:        100,\n        MagiclinkAuthUri: \"https://www.google.com\",\n        TemplateVariables: map[string]string{\n            \"employeeID\":    \"EMP523\",\n            \"teamName\":      \"Alpha Team\",\n            \"supportEmail\":  \"support@yourcompany.com\",\n        },\n    },\n)\n\nif err != nil {\n    // Handle error\n    return\n}\n\nauthRequestId := response.AuthRequestId"
+            "source": "templateType := scalekit.TemplateTypeSignin\nresponse, err := scalekitClient.Passwordless().SendPasswordlessEmail(\n  ctx,\n  \"john.doe@example.com\",\n  &scalekit.SendPasswordlessOptions{\n    Template:         &templateType,\n    ExpiresIn:        100,\n    MagiclinkAuthUri: \"https://yourapp.com/auth/passwordless/callback\",\n    TemplateVariables: map[string]string{\n      \"employeeID\":   \"EMP523\",\n      \"teamName\":     \"Alpha Team\",\n      \"supportEmail\": \"support@yourcompany.com\",\n    },\n  },\n)\nif err != nil {\n  // handle error\n  return\n}\nauthRequestId := response.AuthRequestId"
           },
           {
             "label": "Java SDK",
             "lang": "java",
-            "source": "TemplateType templateType = TemplateType.SIGNIN;\nMap<String, String> templateVariables = new HashMap<>();\ntemplateVariables.put(\"employeeID\", \"EMP523\");\ntemplateVariables.put(\"teamName\", \"Alpha Team\");\ntemplateVariables.put(\"supportEmail\", \"support@yourcompany.com\");\n\nSendPasswordlessOptions options = new SendPasswordlessOptions();\noptions.setTemplate(templateType);\noptions.setExpiresIn(100);\noptions.setMagiclinkAuthUri(\"https://www.example.com\");\noptions.setTemplateVariables(templateVariables);\n\nSendPasswordlessResponse response = passwordlessClient.sendPasswordlessEmail(\n    \"john.doe@example.com\",\n    options\n);\n\nString authRequestId = response.getAuthRequestId();"
+            "source": "TemplateType templateType = TemplateType.SIGNIN;\nMap<String, String> templateVariables = new HashMap<>();\ntemplateVariables.put(\"employeeID\", \"EMP523\");\ntemplateVariables.put(\"teamName\", \"Alpha Team\");\ntemplateVariables.put(\"supportEmail\", \"support@yourcompany.com\");\n\nSendPasswordlessOptions options = new SendPasswordlessOptions();\noptions.setTemplate(templateType);\noptions.setExpiresIn(100);\noptions.setMagiclinkAuthUri(\"https://yourapp.com/auth/passwordless/callback\");\noptions.setTemplateVariables(templateVariables);\n\nSendPasswordlessResponse response = scalekitClient.passwordless().sendPasswordlessEmail(\n    \"john.doe@example.com\",\n    options\n);\n\nString authRequestId = response.getAuthRequestId();"
           }
         ]
       }
@@ -4591,7 +4887,9 @@
     "/api/v1/passwordless/email/verify": {
       "post": {
         "description": "Verify a user's identity using either a verification code or magic link token",
-        "tags": ["Magic link & OTP"],
+        "tags": [
+          "Magic link & OTP"
+        ],
         "summary": "Verify passwordless email",
         "operationId": "PasswordlessService_VerifyPasswordlessEmail",
         "responses": {
@@ -4620,7 +4918,7 @@
           {
             "label": "Node.js SDK",
             "lang": "javascript",
-            "source": "const { authRequestId } = sendResponse\nconst verifyResponse = await scalekit.passwordless.verifyPasswordlessEmail(\n  // Verification Code (OTP)\n\n  { code: '123456' },\n\n  // Magic Link Token\n\n  { linkToken: link_token },\n\n  authRequestId,\n)"
+            "source": "const { authRequestId } = sendResponse\n\n// Verify with OTP code\nconst verifyResponse = await scalekit.passwordless.verifyPasswordlessEmail(\n  { code: '123456' },\n  authRequestId,\n)\n\n// Or verify with magic link token\nconst linkVerifyResponse = await scalekit.passwordless.verifyPasswordlessEmail({\n  linkToken: linkToken,\n})"
           },
           {
             "label": "Python SDK",
@@ -4635,7 +4933,7 @@
           {
             "label": "Java SDK",
             "lang": "java",
-            "source": "// Verify with OTP code\nVerifyPasswordlessOptions verifyOptions = new VerifyPasswordlessOptions();\nverifyOptions.setCode(\"123456\"); // OTP code\nverifyOptions.setAuthRequestId(authRequestId);\n\nVerifyPasswordLessResponse verifyResponse = passwordlessClient.verifyPasswordlessEmail(verifyOptions);\n\n// User verified successfully\nString userEmail = verifyResponse.getEmail();\n\n// Verify with magic link token\nVerifyPasswordlessOptions verifyOptions = new VerifyPasswordlessOptions();\nverifyOptions.setLinkToken(linkToken); // Magic link token\n\nVerifyPasswordLessResponse verifyResponse = passwordlessClient.verifyPasswordlessEmail(verifyOptions);\n\n// User verified successfully\nString userEmail = verifyResponse.getEmail();"
+            "source": "// Verify with OTP code\nVerifyPasswordlessOptions verifyOptions = new VerifyPasswordlessOptions();\nverifyOptions.setCode(\"123456\"); // OTP code\nverifyOptions.setAuthRequestId(authRequestId);\n\nVerifyPasswordLessResponse verifyResponse = scalekitClient.passwordless()\n    .verifyPasswordlessEmail(verifyOptions);\n\n// User verified successfully\nString userEmail = verifyResponse.getEmail();\n\n// Verify with magic link token\nVerifyPasswordlessOptions linkVerifyOptions = new VerifyPasswordlessOptions();\nlinkVerifyOptions.setLinkToken(linkToken); // Magic link token\n\nVerifyPasswordLessResponse linkVerifyResponse = scalekitClient.passwordless()\n    .verifyPasswordlessEmail(linkVerifyOptions);\n\nString verifiedEmail = linkVerifyResponse.getEmail();"
           }
         ]
       }
@@ -4643,7 +4941,9 @@
     "/api/v1/permissions": {
       "get": {
         "description": "Retrieves a comprehensive, paginated list of all permissions available within the environment. Use this endpoint to view all permission definitions for auditing, role management, or understanding the complete set of available access controls. The response includes pagination tokens to navigate through large sets of permissions efficiently. Each permission object contains the permission name, description, creation time, and last update time. This operation is useful for building permission selection interfaces, auditing permission usage, or understanding the scope of available access controls in your RBAC system.",
-        "tags": ["Permissions"],
+        "tags": [
+          "Permissions"
+        ],
         "summary": "List all permissions",
         "operationId": "RolesService_ListPermissions",
         "parameters": [
@@ -4667,7 +4967,10 @@
           {
             "schema": {
               "type": "string",
-              "enum": ["SCALEKIT", "ENVIRONMENT"]
+              "enum": [
+                "SCALEKIT",
+                "ENVIRONMENT"
+              ]
             },
             "description": "Filter permissions by type: ALL, SCALEKIT, or ENVIRONMENT, where SCALEKIT are predefined Scalekit permissions and ENVIRONMENT are custom permissions created in the environment, default is ALL",
             "name": "type",
@@ -4711,7 +5014,9 @@
       },
       "post": {
         "description": "Creates a new permission that represents a specific action users can perform within the environment. Use this endpoint to define granular access controls for your RBAC system. You can provide a unique permission name following the format 'action:resource' (for example, 'read:documents', 'write:users') and an optional description explaining the permission's purpose. The permission name must be unique across the environment and follows alphanumeric naming conventions with colons and underscores. Returns the created permission object including system-generated ID and timestamps.",
-        "tags": ["Permissions"],
+        "tags": [
+          "Permissions"
+        ],
         "summary": "Create new permission",
         "operationId": "RolesService_CreatePermission",
         "responses": {
@@ -4763,7 +5068,9 @@
     "/api/v1/permissions/{permission_name}": {
       "get": {
         "description": "Retrieves complete information for a specific permission by its unique name identifier. Use this endpoint to view permission details including description, creation time, and last update time. Provide the permission name in the path parameter following the format 'action:resource' (for example, 'read:documents'). This operation is useful for auditing permission definitions, understanding permission purposes, or verifying permission existence before assignment. Returns the complete permission object with all metadata and system-generated timestamps.",
-        "tags": ["Permissions"],
+        "tags": [
+          "Permissions"
+        ],
         "summary": "Retrieve permission details",
         "operationId": "RolesService_GetPermission",
         "parameters": [
@@ -4814,7 +5121,9 @@
       },
       "put": {
         "description": "Modifies an existing permission's attributes including description and metadata. Use this endpoint to update permission descriptions or clarify permission purposes after creation. The permission is identified by its unique name in the path parameter, and only the fields you specify in the request body will be updated. Note that the permission name itself cannot be changed as it serves as the immutable identifier. This operation is useful for maintaining clear documentation of permission purposes or updating descriptions to reflect changes in system functionality. Returns the updated permission object with modified timestamps.",
-        "tags": ["Permissions"],
+        "tags": [
+          "Permissions"
+        ],
         "summary": "Update permission details",
         "operationId": "RolesService_UpdatePermission",
         "parameters": [
@@ -4875,7 +5184,9 @@
       },
       "delete": {
         "description": "Permanently removes a permission from the environment using its unique name identifier. Use this endpoint when you need to clean up unused permissions or remove access controls that are no longer relevant. The permission is identified by its name in the path parameter following the format 'action:resource'. This operation cannot be undone, so ensure no active roles depend on the permission before deletion. If the permission is currently assigned to any roles, you may need to remove those assignments first or update the roles to use alternative permissions. Returns no content on successful deletion.",
-        "tags": ["Permissions"],
+        "tags": [
+          "Permissions"
+        ],
         "summary": "Delete permission",
         "operationId": "RolesService_DeletePermission",
         "parameters": [
@@ -4926,7 +5237,9 @@
     "/api/v1/roles": {
       "get": {
         "description": "Retrieves a comprehensive list of all roles available within the specified environment including organization roles. Use this endpoint to view all role definitions, including custom roles and their configurations. You can optionally include permission details for each role to understand their capabilities. This is useful for role management, auditing organization access controls, or understanding the available access levels within the organization.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "List all roles in environment",
         "operationId": "RolesService_ListRoles",
         "parameters": [
@@ -4976,7 +5289,9 @@
       },
       "post": {
         "description": "Creates a new role within the environment with specified permissions and metadata. Use this endpoint to define custom roles that can be assigned to users or groups. You can create hierarchical roles by extending existing roles, assign specific permissions, and configure display information. Roles are the foundation of your access control system and determine what actions users can perform.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "Create new role in environment",
         "operationId": "RolesService_CreateRole",
         "responses": {
@@ -5002,7 +5317,10 @@
                     "description": "Can edit content",
                     "display_name": "Content Editor",
                     "name": "content_editor",
-                    "permissions": ["read:content", "write:content"]
+                    "permissions": [
+                      "read:content",
+                      "write:content"
+                    ]
                   }
                 ]
               }
@@ -5037,7 +5355,9 @@
     "/api/v1/roles/default": {
       "patch": {
         "description": "Updates the default creator and member roles for the current environment. Use this endpoint to configure which roles are automatically assigned to new users when they join the environment. You can specify role names for both creator and member default roles. The system will validate that the specified roles exist and update the environment settings accordingly. Returns the updated default role objects including their complete role information and permissions.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "Set default creator and member roles",
         "operationId": "RolesService_UpdateDefaultRoles2",
         "responses": {
@@ -5067,7 +5387,9 @@
     "/api/v1/roles/{role_name}": {
       "get": {
         "description": "Retrieves complete information for a specific role including metadata and inheritance details (base role and dependent role count). Use this endpoint to audit role configuration and understand the role's place in the hierarchy. To view the role's permissions, use the ListRolePermissions endpoint.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "Get role details",
         "operationId": "RolesService_GetRole",
         "parameters": [
@@ -5126,7 +5448,9 @@
       },
       "put": {
         "description": "Modifies an existing role's properties including display name, description, permissions, and inheritance. Use this endpoint to update role metadata, change permission assignments, or modify role hierarchy. Only the fields you specify will be updated, leaving other properties unchanged. When updating permissions, the new list replaces all existing permissions for the role.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "Update role information",
         "operationId": "RolesService_UpdateRole",
         "parameters": [
@@ -5194,7 +5518,9 @@
       },
       "delete": {
         "description": "Permanently removes a role from the environment and reassigns users who had that role to a different role. Use this endpoint when you need to clean up unused roles or restructure your access control system. The role cannot be deleted if it has dependent roles (roles that extend it) unless you specify a replacement role. If users are assigned to the role being deleted, you must provide a reassign_role_name to move those users to a different role before deletion can proceed. This action cannot be undone, so ensure no critical users depend on the role before deletion.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "Delete role and reassign users",
         "operationId": "RolesService_DeleteRole",
         "parameters": [
@@ -5261,7 +5587,9 @@
     "/api/v1/roles/{role_name}/dependents": {
       "get": {
         "description": "Retrieves all roles that directly extend the specified base role through inheritance. Use this endpoint to understand the role hierarchy and identify which roles inherit permissions from a particular base role. Provide the base role name as a path parameter, and the response will include all dependent roles with their metadata and permission information. This operation is useful for auditing role inheritance relationships, understanding the impact of changes to base roles, or managing role hierarchies effectively. Returns a list of dependent role objects including their names, display names, descriptions, and permission details.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "List dependent roles",
         "operationId": "RolesService_ListDependentRoles",
         "parameters": [
@@ -5314,7 +5642,9 @@
     "/api/v1/roles/{role_name}/permissions": {
       "get": {
         "description": "Retrieves all permissions directly assigned to the specified role, excluding permissions inherited from base roles. Use this endpoint to view the explicit permission assignments for a role, which is useful for understanding direct role capabilities, auditing permission assignments, or managing role-permission relationships. Provide the role name as a path parameter, and the response will include only the permissions that are directly assigned to that role. This operation does not include inherited permissions from role hierarchies - use ListEffectiveRolePermissions to see the complete set of permissions including inheritance. Returns a list of permission objects with their names, descriptions, and assignment metadata.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "List permissions for role",
         "operationId": "RolesService_ListRolePermissions",
         "parameters": [
@@ -5365,7 +5695,9 @@
       },
       "post": {
         "description": "Adds one or more permissions to the specified role while preserving existing permission assignments. Use this endpoint to grant additional capabilities to a role without affecting its current permission set. Provide the role name as a path parameter and a list of permission names in the request body. The system will validate that all specified permissions exist in the environment and add them to the role. Existing permission assignments remain unchanged, making this operation safe for incremental permission management. This is useful for gradually expanding role capabilities or adding new permissions as your system evolves. Returns the updated list of all permissions now assigned to the role.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "Add permissions to role",
         "operationId": "RolesService_AddPermissionsToRole",
         "parameters": [
@@ -5428,7 +5760,9 @@
     "/api/v1/roles/{role_name}/permissions/{permission_name}": {
       "delete": {
         "description": "Removes a specific permission from the specified role, revoking that capability from all users assigned to the role. Use this endpoint to restrict role capabilities or remove unnecessary permissions. Provide both the role name and permission name as path parameters. This operation only affects the direct permission assignment and does not impact permissions inherited from base roles. If the permission is inherited through role hierarchy, you may need to modify the base role instead. This is useful for fine-tuning role permissions, implementing least-privilege access controls, or removing deprecated permissions. Returns no content on successful removal.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "Remove permission from role",
         "operationId": "RolesService_RemovePermissionFromRole",
         "parameters": [
@@ -5488,7 +5822,9 @@
     "/api/v1/roles/{role_name}/permissions:all": {
       "get": {
         "description": "Retrieves the complete set of effective permissions for a role, including both directly assigned permissions and permissions inherited from base roles through the role hierarchy. Use this endpoint to understand the full scope of capabilities available to users assigned to a specific role. Provide the role name as a path parameter, and the response will include all permissions that apply to the role, accounting for inheritance relationships. This operation is essential for auditing role capabilities, understanding permission inheritance, or verifying the complete access scope before role assignment. Returns a comprehensive list of permission names representing the full set of effective permissions for the specified role.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "List effective permissions for role",
         "operationId": "RolesService_ListEffectiveRolePermissions",
         "parameters": [
@@ -5519,7 +5855,9 @@
     "/api/v1/roles/{role_name}/users:count": {
       "get": {
         "description": "Retrieves the total number of users currently assigned to the specified role within the environment. Use this endpoint to monitor role usage, enforce user limits, or understand the scope of role assignments. Provide the role's unique name as a path parameter, and the response will include the current user count for that role. This operation is read-only and does not modify any data or user assignments. The count reflects all users who have the role either directly assigned or inherited through organization membership. This information is useful for capacity planning, security auditing, or understanding the impact of role changes across your user base.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "Retrieve user count for role",
         "operationId": "RolesService_GetRoleUsersCount",
         "parameters": [
@@ -5572,7 +5910,9 @@
     "/api/v1/roles:set_defaults": {
       "patch": {
         "description": "Updates the default creator and member roles for the current environment. Use this endpoint to configure which roles are automatically assigned to new users when they join the environment. You can specify role names for both creator and member default roles. The system will validate that the specified roles exist and update the environment settings accordingly. Returns the updated default role objects including their complete role information and permissions.",
-        "tags": ["Roles"],
+        "tags": [
+          "Roles"
+        ],
         "summary": "Set default creator and member roles",
         "operationId": "RolesService_UpdateDefaultRoles",
         "responses": {
@@ -5624,7 +5964,9 @@
     "/api/v1/sessions/{session_id}": {
       "get": {
         "description": "Retrieves comprehensive details for a specific user session including authentication status, device information, and expiration timelines. Use this endpoint to fetch current session metadata for security audits, session validation, or to display session information in user account management interfaces. Returns all session properties including the user ID, authenticated organizations, device details with browser/OS information, IP address and geolocation, and all relevant timestamps (creation, last activity, idle expiration, absolute expiration, and actual expiration if applicable).",
-        "tags": ["Sessions"],
+        "tags": [
+          "Sessions"
+        ],
         "summary": "Get session details",
         "operationId": "SessionService_GetSession",
         "parameters": [
@@ -5677,7 +6019,9 @@
     "/api/v1/sessions/{session_id}/revoke": {
       "post": {
         "description": "Immediately invalidates a specific user session by session ID, setting its status to 'revoked'. Once revoked, the session cannot be used for any future API requests or application access. Use this endpoint to implement session-level logout, force a user to reauthenticate on a specific device, or terminate suspicious sessions. The revocation is instantaneous and irreversible. Returns the revoked session details including the session ID, user ID, and the revocation timestamp.",
-        "tags": ["Sessions"],
+        "tags": [
+          "Sessions"
+        ],
         "summary": "Revoke user session",
         "operationId": "SessionService_RevokeSession",
         "parameters": [
@@ -5730,7 +6074,9 @@
     "/api/v1/users": {
       "get": {
         "description": "Retrieves a paginated list of all users across your entire environment. Use this endpoint to view all users regardless of their organization memberships. This is useful for administrative purposes, user audits, or when you need to see all users in your Scalekit environment. Supports pagination for large user bases.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "List all users in environment",
         "operationId": "UserService_ListUsers",
         "parameters": [
@@ -5773,7 +6119,7 @@
           {
             "label": "Python SDK",
             "lang": "python",
-            "source": "# pass empty org to fetch all users in environment\nresp,_ = scalekit_client.users.list_users(organization_id=\"\", page_size=100)"
+            "source": "# List all users in the environment\nresponse = scalekit_client.users.list_users(page_size=100)"
           },
           {
             "label": "Go SDK",
@@ -5783,7 +6129,7 @@
           {
             "label": "Java SDK",
             "lang": "java",
-            "source": "ListUsersRequest lur = ListUsersRequest.\n  newBuilder().setPageSize(100).build();\nListUsersResponse allUsers = users.listUsers(lur);"
+            "source": "ListUsersRequest lur = ListUsersRequest.newBuilder()\n    .setPageSize(100)\n    .build();\nListUsersResponse allUsers = scalekitClient.users().listUsers(lur);"
           }
         ]
       }
@@ -5791,7 +6137,9 @@
     "/api/v1/users/{id}": {
       "get": {
         "description": "Retrieves all details for a user by system-generated user ID. The response includes organization memberships and user metadata.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Get user",
         "operationId": "UserService_GetUser",
         "parameters": [
@@ -5842,7 +6190,9 @@
       },
       "delete": {
         "description": "Permanently removes a user from your environment and deletes all associated data. Use this endpoint when you need to completely remove a user account. This action deletes the user's profile, memberships, and all related data across all organizations. This operation cannot be undone, so use with caution.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Delete user permanently",
         "operationId": "UserService_DeleteUser",
         "parameters": [
@@ -5875,7 +6225,7 @@
           {
             "label": "Python SDK",
             "lang": "python",
-            "source": "scalekit_client.users.delete_user(organization_id=\"org_123\", \n  user_id=\"usr_123\")"
+            "source": "scalekit_client.users.delete_user(\"usr_123\")"
           },
           {
             "label": "Go SDK",
@@ -5885,13 +6235,15 @@
           {
             "label": "Java SDK",
             "lang": "java",
-            "source": "users.deleteUser(\"usr_123\");"
+            "source": "scalekitClient.users().deleteUser(\"usr_123\");"
           }
         ]
       },
       "patch": {
         "description": "Modifies user account information including profile details, metadata, and external ID. Use this endpoint to update a user's personal information, contact details, or custom metadata. You can update the user's profile, phone number, and metadata fields. Note that fields like user ID, email address, environment ID, and creation time cannot be modified.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Update user information",
         "operationId": "UserService_UpdateUser",
         "parameters": [
@@ -5943,7 +6295,7 @@
           {
             "label": "Python SDK",
             "lang": "python",
-            "source": "import os\nfrom scalekit import ScalekitClient\nfrom scalekit.v1.users.users_pb2 import UpdateUser\nfrom scalekit.v1.commons.commons_pb2 import UserProfile\nscalekit_client = ScalekitClient(\n    env_url=os.getenv(\"SCALEKIT_ENV_URL\"),\n    client_id=os.getenv(\"SCALEKIT_CLIENT_ID\"),\n    client_secret=os.getenv(\"SCALEKIT_CLIENT_SECRET\"),\n)\nupdate_user = UpdateUser(\n    user_profile=UserProfile(\n        first_name=\"John\",\n        last_name=\"Smith\"\n    ),\n    metadata={\"department\": \"sales\"}\n)\nscalekit_client.users.update_user(organization_id=\"org_123\", \n  user=update_user)"
+            "source": "from scalekit.v1.users.users_pb2 import UpdateUser\nfrom scalekit.v1.commons.commons_pb2 import UserProfile\n\nupdate_user = UpdateUser(\n    user_profile=UserProfile(\n        first_name=\"John\",\n        last_name=\"Smith\",\n    ),\n    metadata={\"department\": \"sales\"},\n)\nresponse = scalekit_client.users.update_user(\"usr_123\", update_user)"
           },
           {
             "label": "Go SDK",
@@ -5953,7 +6305,7 @@
           {
             "label": "Java SDK",
             "lang": "java",
-            "source": "UpdateUser upd = UpdateUser.newBuilder()\n        .setUserProfile(\n          UpdateUserProfile.newBuilder()\n                .setFirstName(\"John\")\n                .setLastName(\"Smith\")\n                .build())\n        .putMetadata(\"department\", \"sales\")\n        .build();\nUpdateUserRequest updReq = UpdateUserRequest.\n  newBuilder().setUser(upd).build();\nusers.updateUser(\"usr_123\", updReq);"
+            "source": "UpdateUser upd = UpdateUser.newBuilder()\n    .setUserProfile(\n        UpdateUserProfile.newBuilder()\n            .setFirstName(\"John\")\n            .setLastName(\"Smith\")\n            .build())\n    .putMetadata(\"department\", \"sales\")\n    .build();\nUpdateUserRequest updReq = UpdateUserRequest.newBuilder()\n    .setUser(upd)\n    .build();\nscalekitClient.users().updateUser(\"usr_123\", updReq);"
           }
         ]
       }
@@ -5961,7 +6313,9 @@
     "/api/v1/users/{user_id}/sessions": {
       "get": {
         "description": "Retrieves a paginated list of all sessions associated with a specific user across all devices and browsers. Use this endpoint to audit user activity, display all active sessions in account management interfaces, or verify user authentication status across devices. Supports filtering by session status (active, expired, revoked, logout) and time range (creation date). Returns session details for each session including device information, IP address, geolocation, and current status. The response includes pagination metadata (page tokens and total count) to handle large session lists efficiently.",
-        "tags": ["Sessions"],
+        "tags": [
+          "Sessions"
+        ],
         "summary": "List user sessions",
         "operationId": "SessionService_GetUserSessions",
         "parameters": [
@@ -6062,7 +6416,9 @@
     "/api/v1/users/{user_id}/sessions/revoke": {
       "post": {
         "description": "Immediately invalidates all active sessions for a specific user across all devices and browsers, setting their status to 'revoked'. Use this endpoint to implement global logout functionality, force re-authentication after security incidents, or terminate all sessions following a password reset or credential compromise. Only active sessions are revoked; already expired, logout, or previously revoked sessions remain unchanged. The revocation is atomic and instantaneous. Returns a list of all revoked sessions with their details and a total count of sessions revoked.",
-        "tags": ["Sessions"],
+        "tags": [
+          "Sessions"
+        ],
         "summary": "Revoke all user sessions",
         "operationId": "SessionService_RevokeAllUserSessions",
         "parameters": [
@@ -6115,7 +6471,9 @@
     "/api/v1/users:external/{external_id}": {
       "get": {
         "description": "Retrieves all details for a user by your application's external identifier. Use this endpoint when you store users in Scalekit using your own system's identifiers and need to retrieve the Scalekit user record. The response includes organization memberships and user metadata.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Get user by external ID",
         "operationId": "UserService_GetUser2",
         "parameters": [
@@ -6144,7 +6502,9 @@
       },
       "delete": {
         "description": "Permanently removes a user identified by your application's external identifier. This action deletes the user's profile, memberships, and all related data across all organizations. This operation cannot be undone.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Delete user by external ID",
         "operationId": "UserService_DeleteUser2",
         "parameters": [
@@ -6171,7 +6531,9 @@
       },
       "patch": {
         "description": "Modifies user account information for a user identified by your application's external identifier. Use this endpoint to keep user profile data in sync from your system without needing to store Scalekit's internal user ID. You can update the user's profile, phone number, and metadata fields.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Update user by external ID",
         "operationId": "UserService_UpdateUser2",
         "parameters": [
@@ -6219,7 +6581,9 @@
     "/api/v1/users:search": {
       "get": {
         "description": "Searches for users across the entire environment by email address, user ID, or external ID. The query must be at least 3 characters and is case-insensitive. Returns a paginated list of matching users with up to 30 results per page. Use the next_page_token from the response to retrieve subsequent pages.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Search users",
         "operationId": "UserService_SearchUsers",
         "parameters": [
@@ -6279,7 +6643,9 @@
     "/api/v1/webauthn/credentials": {
       "get": {
         "description": "Retrieves all registered passkeys for the current user, including device information, creation timestamps, and display names. Use this to show users their registered authenticators.",
-        "tags": ["Passkeys"],
+        "tags": [
+          "Passkeys"
+        ],
         "summary": "List user's passkeys",
         "operationId": "WebAuthnService_ListCredentials",
         "parameters": [
@@ -6323,7 +6689,7 @@
           {
             "label": "Java SDK",
             "lang": "java",
-            "source": "ListCredentialsResponse res = scalekitClient.webauthn().listCredentials(\"user_123\");"
+            "source": "ListCredentialsResponse res = scalekitClient.webAuthn().listCredentials(\"user_123\");"
           }
         ]
       }
@@ -6331,7 +6697,9 @@
     "/api/v1/webauthn/credentials/{credential_id}": {
       "delete": {
         "description": "Deletes a specific passkey credential for the current user. After removal, the authenticator can no longer be used for authentication.",
-        "tags": ["Passkeys"],
+        "tags": [
+          "Passkeys"
+        ],
         "summary": "Remove a passkey",
         "operationId": "WebAuthnService_DeleteCredential",
         "parameters": [
@@ -6376,13 +6744,15 @@
           {
             "label": "Java SDK",
             "lang": "java",
-            "source": "DeleteCredentialResponse res = scalekitClient.webauthn().deleteCredential(\"wac_123\");"
+            "source": "DeleteCredentialResponse res = scalekitClient.webAuthn().deleteCredential(\"wac_123\");"
           }
         ]
       },
       "patch": {
         "description": "Updates the display name of a passkey credential to help users identify their authenticators. Only the display name can be modified.",
-        "tags": ["Passkeys"],
+        "tags": [
+          "Passkeys"
+        ],
         "summary": "Rename a passkey",
         "operationId": "WebAuthnService_UpdateCredential",
         "parameters": [
@@ -6437,7 +6807,7 @@
           {
             "label": "Java SDK",
             "lang": "java",
-            "source": "UpdateCredentialResponse res = scalekitClient.webauthn()\n    .updateCredential(\"wac_123\", \"Work Laptop Passkey\");"
+            "source": "UpdateCredentialResponse res = scalekitClient.webAuthn()\n    .updateCredential(\"wac_123\", \"Work Laptop Passkey\");"
           }
         ]
       }
@@ -6598,6 +6968,174 @@
         }
       }
     },
+    "organization.domain_created": {
+      "post": {
+        "summary": "Organization Domain Created",
+        "description": "Triggered when a domain is added to an organization (organization domain or allowed email domain).",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScalekitEvent"
+              },
+              "example": {
+                "spec_version": "1",
+                "id": "evt_4567890123",
+                "type": "organization.domain_created",
+                "object": "Organization",
+                "occurred_at": "2024-01-15T11:00:00.123456789Z",
+                "environment_id": "env_1234567890",
+                "organization_id": "org_1234567890",
+                "data": {
+                  "id": "dom_1234567890",
+                  "domain": "acmecorp.com",
+                  "domain_type": "ORGANIZATION_DOMAIN",
+                  "organization_id": "org_1234567890",
+                  "environment_id": "env_1234567890",
+                  "txt_record_key": "scalekit-domain-verification",
+                  "txt_record_secret": "sk_dom_verify_abc123",
+                  "verification_status": "PENDING",
+                  "verification_method": "DNS",
+                  "updated_at": "2024-01-15T11:00:00.123456789Z"
+                },
+                "display_name": "Organization Domain Created"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Webhook received successfully"
+          }
+        }
+      }
+    },
+    "organization.domain_deleted": {
+      "post": {
+        "summary": "Organization Domain Deleted",
+        "description": "Triggered when a domain is removed from an organization.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScalekitEvent"
+              },
+              "example": {
+                "spec_version": "1",
+                "id": "evt_4567890456",
+                "type": "organization.domain_deleted",
+                "object": "Organization",
+                "occurred_at": "2024-01-16T09:30:00.123456789Z",
+                "environment_id": "env_1234567890",
+                "organization_id": "org_1234567890",
+                "data": {
+                  "id": "dom_1234567890",
+                  "domain": "acmecorp.com",
+                  "domain_type": "ORGANIZATION_DOMAIN",
+                  "organization_id": "org_1234567890",
+                  "environment_id": "env_1234567890",
+                  "txt_record_key": "scalekit-domain-verification",
+                  "txt_record_secret": "sk_dom_verify_abc123",
+                  "verification_status": "VERIFIED",
+                  "verification_method": "DNS",
+                  "updated_at": "2024-01-16T09:30:00.123456789Z"
+                },
+                "display_name": "Organization Domain Deleted"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Webhook received successfully"
+          }
+        }
+      }
+    },
+    "organization.domain_dns_verification_success": {
+      "post": {
+        "summary": "Organization Domain DNS Verification Success",
+        "description": "Triggered when DNS TXT record validation confirms ownership of an organization domain.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScalekitEvent"
+              },
+              "example": {
+                "spec_version": "1",
+                "id": "evt_4567890789",
+                "type": "organization.domain_dns_verification_success",
+                "object": "Organization",
+                "occurred_at": "2024-01-15T12:15:00.123456789Z",
+                "environment_id": "env_1234567890",
+                "organization_id": "org_1234567890",
+                "data": {
+                  "id": "dom_1234567890",
+                  "domain": "acmecorp.com",
+                  "domain_type": "ORGANIZATION_DOMAIN",
+                  "organization_id": "org_1234567890",
+                  "environment_id": "env_1234567890",
+                  "txt_record_key": "scalekit-domain-verification",
+                  "txt_record_secret": "sk_dom_verify_abc123",
+                  "verification_status": "VERIFIED",
+                  "verification_method": "DNS",
+                  "updated_at": "2024-01-15T12:15:00.123456789Z"
+                },
+                "display_name": "Organization Domain DNS Verification Success"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Webhook received successfully"
+          }
+        }
+      }
+    },
+    "organization.domain_dns_verification_failed": {
+      "post": {
+        "summary": "Organization Domain DNS Verification Failed",
+        "description": "Triggered when the DNS verification window expires without a successful TXT record match.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScalekitEvent"
+              },
+              "example": {
+                "spec_version": "1",
+                "id": "evt_4567891012",
+                "type": "organization.domain_dns_verification_failed",
+                "object": "Organization",
+                "occurred_at": "2024-01-16T11:00:00.123456789Z",
+                "environment_id": "env_1234567890",
+                "organization_id": "org_1234567890",
+                "data": {
+                  "id": "dom_1234567890",
+                  "domain": "acmecorp.com",
+                  "domain_type": "ORGANIZATION_DOMAIN",
+                  "organization_id": "org_1234567890",
+                  "environment_id": "env_1234567890",
+                  "txt_record_key": "scalekit-domain-verification",
+                  "txt_record_secret": "sk_dom_verify_abc123",
+                  "verification_status": "FAILED",
+                  "verification_method": "DNS",
+                  "updated_at": "2024-01-16T11:00:00.123456789Z"
+                },
+                "display_name": "Organization Domain DNS Verification Failed"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Webhook received successfully"
+          }
+        }
+      }
+    },
     "user.signup": {
       "post": {
         "summary": "User Signup",
@@ -6734,7 +7272,9 @@
                   },
                   "user_session": {
                     "absolute_expires_at": "2026-01-08T12:04:41.737394Z",
-                    "authenticated_organizations": ["org_102701193188409609"],
+                    "authenticated_organizations": [
+                      "org_102701193188409609"
+                    ],
                     "created_at": "2025-12-09T12:04:41.48Z",
                     "expired_at": null,
                     "idle_expires_at": "2025-12-16T12:04:41.737395Z",
@@ -6833,7 +7373,9 @@
                   },
                   "user_session": {
                     "absolute_expires_at": "2026-01-08T12:04:41.737394Z",
-                    "authenticated_organizations": ["org_102701193188409609"],
+                    "authenticated_organizations": [
+                      "org_102701193188409609"
+                    ],
                     "created_at": "2025-12-09T12:04:41.48Z",
                     "expired_at": null,
                     "idle_expires_at": "2025-12-16T12:04:41.737395Z",
@@ -8302,30 +8844,40 @@
       },
       "McpServiceCreateMcpSessionTokenBody": {
         "type": "object",
-        "required": ["identifier"],
+        "required": [
+          "identifier"
+        ],
         "properties": {
           "expiry": {
             "description": "Optional token lifetime. Must be between 60s and 24h. Defaults to 1h when omitted.",
             "type": "string",
-            "examples": ["3600s"]
+            "examples": [
+              "3600s"
+            ]
           },
           "identifier": {
             "description": "Upstream-provider identifier (typically the user's email or provider user-id) shared by the connected accounts the token represents. A single identifier can map to one connected account per connection in the MCP configuration.",
             "type": "string",
             "maxLength": 255,
             "minLength": 1,
-            "examples": ["alice@acme.com"]
+            "examples": [
+              "alice@acme.com"
+            ]
           }
         }
       },
       "McpServiceListMcpConnectedAccountsBody": {
         "type": "object",
-        "required": ["identifier"],
+        "required": [
+          "identifier"
+        ],
         "properties": {
           "identifier": {
             "description": "Identifier for the end user whose connected accounts to retrieve",
             "type": "string",
-            "examples": ["john.doe@example.com"]
+            "examples": [
+              "john.doe@example.com"
+            ]
           },
           "include_auth_link": {
             "description": "When true, generates a fresh authentication link for each connection and creates connected accounts if they do not exist. When false or omitted, returns existing connected account status without creating accounts or generating links.",
@@ -8347,7 +8899,9 @@
           "description": {
             "description": "Updated description for the MCP configuration",
             "type": "string",
-            "examples": ["Updated daily summarizer config"]
+            "examples": [
+              "Updated daily summarizer config"
+            ]
           }
         }
       },
@@ -8358,33 +8912,45 @@
             "description": "The absolute session timeout value. The unit is specified by absolute_session_timeout_unit. Omit when policy_source is APPLICATION.",
             "type": "integer",
             "format": "int32",
-            "examples": [360]
+            "examples": [
+              360
+            ]
           },
           "absolute_session_timeout_unit": {
             "description": "Unit for absolute_session_timeout. Accepted values: 'MINUTES', 'HOURS', 'DAYS'. Defaults to MINUTES.",
             "$ref": "#/components/schemas/commonsTimeUnit",
-            "examples": ["MINUTES"]
+            "examples": [
+              "MINUTES"
+            ]
           },
           "idle_session_timeout": {
             "description": "The idle session timeout value. The unit is specified by idle_session_timeout_unit. Omit when idle_session_timeout_enabled is false.",
             "type": "integer",
             "format": "int32",
-            "examples": [84]
+            "examples": [
+              84
+            ]
           },
           "idle_session_timeout_enabled": {
             "description": "Whether idle session timeout is enabled. Omit when policy_source is APPLICATION.",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "idle_session_timeout_unit": {
             "description": "Unit for idle_session_timeout. Accepted values: 'MINUTES', 'HOURS', 'DAYS'. Defaults to MINUTES.",
             "$ref": "#/components/schemas/commonsTimeUnit",
-            "examples": ["MINUTES"]
+            "examples": [
+              "MINUTES"
+            ]
           },
           "policy_source": {
             "description": "Policy source. Send 'APPLICATION' to revert to application defaults. Send 'CUSTOM' with timeout values to activate a custom policy.",
             "$ref": "#/components/schemas/organizationsSessionPolicyType",
-            "examples": ["CUSTOM"]
+            "examples": [
+              "CUSTOM"
+            ]
           }
         }
       },
@@ -8415,7 +8981,9 @@
           "default_member_role": {
             "description": "Unique name of the default member role",
             "type": "string",
-            "examples": ["member"]
+            "examples": [
+              "member"
+            ]
           }
         }
       },
@@ -8563,7 +9131,9 @@
           "attachment": {
             "description": "Attachment type: \"platform\" (built-in) or \"cross-platform\"",
             "type": "string",
-            "examples": ["platform"]
+            "examples": [
+              "platform"
+            ]
           },
           "icon_dark": {
             "description": "Icon URL for dark theme display",
@@ -8576,7 +9146,9 @@
           "name": {
             "description": "Human-readable name of the authenticator model",
             "type": "string",
-            "examples": ["Apple Touch ID"]
+            "examples": [
+              "Apple Touch ID"
+            ]
           }
         }
       },
@@ -8607,22 +9179,30 @@
           "city": {
             "description": "City name",
             "type": "string",
-            "examples": ["San Francisco"]
+            "examples": [
+              "San Francisco"
+            ]
           },
           "ip": {
             "description": "IP address from which credential was registered",
             "type": "string",
-            "examples": ["192.0.2.1"]
+            "examples": [
+              "192.0.2.1"
+            ]
           },
           "region": {
             "description": "Geographic region (e.g., \"US\")",
             "type": "string",
-            "examples": ["US"]
+            "examples": [
+              "US"
+            ]
           },
           "region_subdivision": {
             "description": "Regional subdivision (e.g., \"CA\")",
             "type": "string",
-            "examples": ["CA"]
+            "examples": [
+              "CA"
+            ]
           }
         }
       },
@@ -8632,32 +9212,44 @@
           "browser": {
             "description": "Browser name (e.g., \"Chrome\", \"Safari\")",
             "type": "string",
-            "examples": ["Chrome"]
+            "examples": [
+              "Chrome"
+            ]
           },
           "browser_version": {
             "description": "Browser version number",
             "type": "string",
-            "examples": ["120.0.6099.129"]
+            "examples": [
+              "120.0.6099.129"
+            ]
           },
           "device_model": {
             "description": "Device model if available",
             "type": "string",
-            "examples": ["iPhone15,2"]
+            "examples": [
+              "iPhone15,2"
+            ]
           },
           "device_type": {
             "description": "Device type: \"desktop\", \"mobile\", or \"tablet\"",
             "type": "string",
-            "examples": ["mobile"]
+            "examples": [
+              "mobile"
+            ]
           },
           "os": {
             "description": "Operating system name (e.g., \"Windows\", \"iOS\")",
             "type": "string",
-            "examples": ["macOS"]
+            "examples": [
+              "macOS"
+            ]
           },
           "os_version": {
             "description": "Operating system version",
             "type": "string",
-            "examples": ["14.2"]
+            "examples": [
+              "14.2"
+            ]
           },
           "raw": {
             "description": "Raw user agent string from the browser",
@@ -8675,13 +9267,19 @@
           "display_name": {
             "description": "Human-friendly name for this credential (1-120 characters)",
             "type": "string",
-            "examples": ["My iPhone 15 Pro"]
+            "examples": [
+              "My iPhone 15 Pro"
+            ]
           }
         }
       },
       "authpasswordlessPasswordlessType": {
         "type": "string",
-        "enum": ["OTP", "LINK", "LINK_OTP"]
+        "enum": [
+          "OTP",
+          "LINK",
+          "LINK_OTP"
+        ]
       },
       "clientsClientSecret": {
         "description": "A secure credential used for authenticating an API client. Each client can have multiple secrets for key rotation purposes.",
@@ -8692,57 +9290,77 @@
             "description": "The timestamp when this secret was created. This field is automatically set by the server and cannot be modified.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-01-05T14:48:00Z"]
+            "examples": [
+              "2024-01-05T14:48:00Z"
+            ]
           },
           "created_by": {
             "description": "The identifier of the user or system that created this secret. This field helps track who created the secret for audit and compliance purposes.",
             "type": "string",
-            "examples": ["user_12345"]
+            "examples": [
+              "user_12345"
+            ]
           },
           "expire_time": {
             "description": "The timestamp when this secret will expire. After this time, the secret cannot be used for authentication regardless of its status. If not set, the secret does not expire.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-05T14:48:00Z"]
+            "examples": [
+              "2025-01-05T14:48:00Z"
+            ]
           },
           "id": {
             "description": "The unique identifier for this client secret. This ID is used to reference the secret in API requests for management operations like updating or deleting the secret.",
             "type": "string",
-            "examples": ["sec_1234abcd5678efgh"]
+            "examples": [
+              "sec_1234abcd5678efgh"
+            ]
           },
           "last_used_time": {
             "description": "The timestamp when this secret was last used for authentication. This field helps track secret usage for security monitoring and identifying unused secrets that may be candidates for rotation.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-02-15T10:30:00Z"]
+            "examples": [
+              "2024-02-15T10:30:00Z"
+            ]
           },
           "plain_secret": {
             "description": "The full plaintext secret value. This field is only populated when the secret is first created and is never stored by the server. It must be securely stored by the client application as it cannot be retrieved again.",
             "type": "string",
-            "examples": ["sec_1234567890abcdefghijklmnopqrstuvwxyz"]
+            "examples": [
+              "sec_1234567890abcdefghijklmnopqrstuvwxyz"
+            ]
           },
           "secret_suffix": {
             "description": "A suffix that helps identify this secret. This is the last few characters of the full secret value but is not sufficient for authentication. Helps identify which secret is being used in logs and debugging.",
             "type": "string",
-            "examples": ["xyzw"]
+            "examples": [
+              "xyzw"
+            ]
           },
           "status": {
             "description": "The current status of this secret. A secret must be ACTIVE to be used for authentication. INACTIVE secrets cannot be used for authentication but are retained for audit purposes.",
             "$ref": "#/components/schemas/clientsClientSecretStatus",
-            "examples": ["INACTIVE"]
+            "examples": [
+              "INACTIVE"
+            ]
           },
           "update_time": {
             "description": "The timestamp when this secret was last updated. This field is automatically updated by the server when the secret's status changes or other properties are modified.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-01-10T09:12:00Z"]
+            "examples": [
+              "2024-01-10T09:12:00Z"
+            ]
           }
         }
       },
       "clientsClientSecretStatus": {
         "description": "ClientSecretStatus indicates whether a client secret can be used for authentication.\nACTIVE secrets can be used for authentication while INACTIVE secrets cannot.\n\n - INACTIVE: The secret is inactive and cannot be used for authentication",
         "type": "string",
-        "enum": ["INACTIVE"]
+        "enum": [
+          "INACTIVE"
+        ]
       },
       "clientsCreateOrganizationClientResponse": {
         "type": "object",
@@ -8754,7 +9372,9 @@
           "plain_secret": {
             "description": "Client secret value (only returned once at creation)",
             "type": "string",
-            "examples": ["CdExsdErfccxDDssddfffgfeFHH1"]
+            "examples": [
+              "CdExsdErfccxDDssddfffgfeFHH1"
+            ]
           }
         }
       },
@@ -8764,7 +9384,9 @@
           "plain_secret": {
             "description": "Client secret value (only returned once at creation)",
             "type": "string",
-            "examples": ["m2morg_client_secret_xyz123"]
+            "examples": [
+              "m2morg_client_secret_xyz123"
+            ]
           },
           "secret": {
             "description": "Details of the created client secret",
@@ -8778,12 +9400,16 @@
           "key": {
             "description": "The name of the custom claim. Must be between 1 and 128 characters. Use descriptive names that clearly indicate the claim's purpose.",
             "type": "string",
-            "examples": ["environment"]
+            "examples": [
+              "environment"
+            ]
           },
           "value": {
             "description": "The value of the custom claim. This value will be included in access tokens issued to the client.",
             "type": "string",
-            "examples": ["production"]
+            "examples": [
+              "production"
+            ]
           }
         }
       },
@@ -8814,20 +9440,26 @@
             "description": "Pagination token for the next page of results. Use this token to fetch the next page.",
             "type": "string",
             "title": "Pagination token for the next page of results",
-            "examples": ["<next_page_token>"]
+            "examples": [
+              "<next_page_token>"
+            ]
           },
           "prev_page_token": {
             "description": "Pagination token for the previous page of results. Use this token to fetch the previous page.",
             "type": "string",
             "title": "Pagination token for the previous page of results",
-            "examples": ["<prev_page_token>"]
+            "examples": [
+              "<prev_page_token>"
+            ]
           },
           "total_size": {
             "description": "Total number of API clients in the organization.",
             "type": "integer",
             "format": "int64",
             "title": "Total number of clients in the organization",
-            "examples": [30]
+            "examples": [
+              30
+            ]
           }
         }
       },
@@ -8840,18 +9472,26 @@
             "items": {
               "type": "string"
             },
-            "examples": [["https://api.example.com"]]
+            "examples": [
+              [
+                "https://api.example.com"
+              ]
+            ]
           },
           "client_id": {
             "description": "The unique identifier for this API client. This ID is used to identify the client in API requests and logs. It is automatically generated when the client is created and cannot be modified.",
             "type": "string",
-            "examples": ["m2morg_1231234233424344"]
+            "examples": [
+              "m2morg_1231234233424344"
+            ]
           },
           "create_time": {
             "description": "The timestamp when this API client was created. This field is automatically set by the server and cannot be modified.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-01-05T14:48:00Z"]
+            "examples": [
+              "2024-01-05T14:48:00Z"
+            ]
           },
           "custom_claims": {
             "description": "Additional claims included in access tokens issued to this client. These claims provide context about the client and can be used for authorization decisions.",
@@ -8864,38 +9504,52 @@
           "description": {
             "description": "A detailed description of the client's purpose and usage. This helps administrators understand what the client is used for.",
             "type": "string",
-            "examples": ["Service account for automated deployment processes"]
+            "examples": [
+              "Service account for automated deployment processes"
+            ]
           },
           "expiry": {
             "description": "Expiry time in seconds for the token generated by the client",
             "type": "string",
             "format": "int64",
-            "examples": [3600]
+            "examples": [
+              3600
+            ]
           },
           "is_cimd": {
             "description": "Indicates if the client was created via Client ID Metadata Document (CIMD). CIMD clients can update their own configuration according to the CIMD specification.",
             "type": "boolean",
-            "examples": [false]
+            "examples": [
+              false
+            ]
           },
           "is_dcr": {
             "description": "Indicates if the client was created via Dynamic Client Registration (DCR). Clients created through DCR may have different management and lifecycle policies compared to those created manually.",
             "type": "boolean",
-            "examples": [false]
+            "examples": [
+              false
+            ]
           },
           "metadata_uri": {
             "description": "The URI to the client's metadata, which is utilized to obtain the client's configuration details",
             "type": "string",
-            "examples": ["https://example.com/client-metadata.json"]
+            "examples": [
+              "https://example.com/client-metadata.json"
+            ]
           },
           "name": {
             "description": "The display name of the API client. This name helps identify the client in the dashboard and logs.",
             "type": "string",
-            "examples": ["GitHub Actions Deployment Service"]
+            "examples": [
+              "GitHub Actions Deployment Service"
+            ]
           },
           "organization_id": {
             "description": "The ID of the organization that owns this API client. This ID is used to associate the client with the correct organization and enforce organization-specific access controls.",
             "type": "string",
-            "examples": ["org_1231234233424344"]
+            "examples": [
+              "org_1231234233424344"
+            ]
           },
           "redirect_uris": {
             "description": "The redirect URI for this API client. This URI is used in the OAuth 2.0 authorization flow to redirect users after authentication.",
@@ -8903,12 +9557,18 @@
             "items": {
               "type": "string"
             },
-            "examples": [["https://example.com/callback"]]
+            "examples": [
+              [
+                "https://example.com/callback"
+              ]
+            ]
           },
           "resource_id": {
             "description": "The ID of the resource associated with this M2M client. This field is used to link the client to a specific resource in the system.",
             "type": "string",
-            "examples": ["app_1231234233424344"]
+            "examples": [
+              "app_1231234233424344"
+            ]
           },
           "scopes": {
             "description": "The OAuth 2.0 scopes granted to this client. These scopes determine what resources and actions the client can access.",
@@ -8916,7 +9576,12 @@
             "items": {
               "type": "string"
             },
-            "examples": [["deploy:resources", "read:deployments"]]
+            "examples": [
+              [
+                "deploy:resources",
+                "read:deployments"
+              ]
+            ]
           },
           "secrets": {
             "description": "List of client secrets associated with this client. Each secret can be used for authentication, but only the most recently created secret is typically active. Secrets are stored securely and their values are never returned after creation.",
@@ -8930,7 +9595,9 @@
             "description": "The timestamp when this API client was last updated. This field is automatically updated by the server whenever the client's configuration changes.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-01-05T14:48:00Z"]
+            "examples": [
+              "2024-01-05T14:48:00Z"
+            ]
           }
         }
       },
@@ -8944,7 +9611,10 @@
               "type": "string"
             },
             "examples": [
-              ["https://api.example.com/api/analytics", "https://deployment-api.acmecorp.com"]
+              [
+                "https://api.example.com/api/analytics",
+                "https://deployment-api.acmecorp.com"
+              ]
             ]
           },
           "custom_claims": {
@@ -8970,18 +9640,24 @@
           "description": {
             "description": "A detailed explanation of the client's purpose and usage. This helps administrators understand what the client is used for and who manages it.",
             "type": "string",
-            "examples": ["Service account for GitHub Actions to deploy resources to production"]
+            "examples": [
+              "Service account for GitHub Actions to deploy resources to production"
+            ]
           },
           "expiry": {
             "description": "Expiry time in seconds for the token generated by the client",
             "type": "string",
             "format": "int64",
-            "examples": [3600]
+            "examples": [
+              3600
+            ]
           },
           "name": {
             "description": "A descriptive name for the API client that helps identify its purpose. This name is displayed in the dashboard and logs. Must be between 1 and 128 characters.",
             "type": "string",
-            "examples": ["GitHub Actions Deployment Service"]
+            "examples": [
+              "GitHub Actions Deployment Service"
+            ]
           },
           "scopes": {
             "description": "OAuth 2.0 scopes that define the permissions granted to this client. Each scope represents a specific permission or set of permissions. The client can only access resources that match its granted scopes.",
@@ -8989,7 +9665,12 @@
             "items": {
               "type": "string"
             },
-            "examples": [["deploy:resources", "read:deployments"]]
+            "examples": [
+              [
+                "deploy:resources",
+                "read:deployments"
+              ]
+            ]
           }
         }
       },
@@ -9009,25 +9690,33 @@
             "description": "Unique identifier for the external identity connection. Immutable and read-only.",
             "type": "string",
             "readOnly": true,
-            "examples": ["conn_1234abcd5678efgh"]
+            "examples": [
+              "conn_1234abcd5678efgh"
+            ]
           },
           "connection_provider": {
             "description": "Type of the identity provider.",
             "$ref": "#/components/schemas/commonsIdentityProviderType",
             "readOnly": true,
-            "examples": ["GOOGLE"]
+            "examples": [
+              "GOOGLE"
+            ]
           },
           "connection_type": {
             "description": "Name of the external identity connection.",
             "type": "string",
             "readOnly": true,
-            "examples": ["OAUTH"]
+            "examples": [
+              "OAUTH"
+            ]
           },
           "connection_user_id": {
             "description": "Unique identifier for the user in the external identity provider system. Immutable and read-only.",
             "type": "string",
             "readOnly": true,
-            "examples": ["ext_user_12345"]
+            "examples": [
+              "ext_user_12345"
+            ]
           },
           "created_time": {
             "description": "Timestamp when this external identity connection was first created. Immutable and read-only.",
@@ -9039,7 +9728,9 @@
             "description": "Indicates if the identity provider is a social provider (true) or enterprise/custom provider (false). Read-only.",
             "type": "boolean",
             "readOnly": true,
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "last_login_time": {
             "description": "Timestamp of the user's last successful login via this external identity provider. Automatically updated by the system.",
@@ -9078,7 +9769,12 @@
       },
       "commonsMembershipStatus": {
         "type": "string",
-        "enum": ["ACTIVE", "INACTIVE", "PENDING_INVITE", "INVITE_EXPIRED"]
+        "enum": [
+          "ACTIVE",
+          "INACTIVE",
+          "PENDING_INVITE",
+          "INVITE_EXPIRED"
+        ]
       },
       "commonsOrganizationMembership": {
         "type": "object",
@@ -9096,7 +9792,9 @@
           "display_name": {
             "description": "Organization display name. This field stores a user-friendly name for the organization that may be different from the formal name, often used for UI display purposes.",
             "type": "string",
-            "examples": ["Acme Corporation"]
+            "examples": [
+              "Acme Corporation"
+            ]
           },
           "expires_at": {
             "description": "Timestamp when the invitation expired.",
@@ -9131,12 +9829,16 @@
           "name": {
             "description": "Organization name. This field stores the formal organization name used for identification and display purposes.",
             "type": "string",
-            "examples": ["AcmeCorp"]
+            "examples": [
+              "AcmeCorp"
+            ]
           },
           "organization_id": {
             "description": "Unique identifier for the organization. Immutable and read-only.",
             "type": "string",
-            "examples": ["org_1234abcd5678efgh"]
+            "examples": [
+              "org_1234abcd5678efgh"
+            ]
           },
           "permissions": {
             "description": "Effective permissions granted to the user within the organization (including inherited permissions from assigned roles). Lists the specific actions and access rights the user can perform.",
@@ -9144,7 +9846,13 @@
             "items": {
               "type": "string"
             },
-            "examples": [["read_projects", "write_tasks", "manage_users"]]
+            "examples": [
+              [
+                "read_projects",
+                "write_tasks",
+                "manage_users"
+              ]
+            ]
           },
           "provisioning_method": {
             "description": "How the user was provisioned. \nPossible values: \n- `jit_using_sso` (Just-in-time provisioning during SSO login)\n- `allowed_email_domain` (User joined via allowed email domain matching)\n- `org_creator` (User created the organization)\n- `direct_provision` (User was directly provisioned via API or SCIM)\n- `invitation` (User was invited and accepted an invitation)",
@@ -9161,7 +9869,10 @@
       },
       "commonsRegionCode": {
         "type": "string",
-        "enum": ["US", "EU"]
+        "enum": [
+          "US",
+          "EU"
+        ]
       },
       "commonsRole": {
         "type": "object",
@@ -9169,24 +9880,34 @@
           "display_name": {
             "description": "Human-readable name for the role",
             "type": "string",
-            "examples": ["Dev Team"]
+            "examples": [
+              "Dev Team"
+            ]
           },
           "id": {
             "description": "Role ID",
             "type": "string",
             "readOnly": true,
-            "examples": ["role_79643236410327240"]
+            "examples": [
+              "role_79643236410327240"
+            ]
           },
           "name": {
             "description": "Attribute name/identifier for the role used in system operations and API calls. This should be a machine-readable identifier that follows naming conventions.",
             "type": "string",
-            "examples": ["team_dev"]
+            "examples": [
+              "team_dev"
+            ]
           }
         }
       },
       "commonsTimeUnit": {
         "type": "string",
-        "enum": ["MINUTES", "HOURS", "DAYS"]
+        "enum": [
+          "MINUTES",
+          "HOURS",
+          "DAYS"
+        ]
       },
       "commonsUserProfile": {
         "type": "object",
@@ -9208,7 +9929,9 @@
             "description": "Indicates if the user's email address has been verified. Automatically updated by the system.",
             "type": "boolean",
             "readOnly": true,
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "external_identities": {
             "description": "List of external identity connections associated with the user profile.",
@@ -9222,17 +9945,23 @@
           "family_name": {
             "description": "The user's family name (last name or surname). This field stores the user's last name and is combined with the given name to create the full display name. The family name is used in formal communications, user listings, and organizational directories throughout the system. Maximum 255 characters allowed.",
             "type": "string",
-            "examples": ["Doe"]
+            "examples": [
+              "Doe"
+            ]
           },
           "gender": {
             "description": "The user's gender identity information. This field stores the user's gender identity for personalization, compliance reporting, or organizational analytics purposes. This field supports any string value to accommodate diverse gender identities and should be handled with appropriate privacy considerations according to your organization's policies and applicable regulations.",
             "type": "string",
-            "examples": ["male"]
+            "examples": [
+              "male"
+            ]
           },
           "given_name": {
             "description": "The user's given name (first name). This field stores the user's first name and is used for personalization, display purposes, and when generating the full display name. The given name appears in user interfaces, formal communications, and user listings throughout the system. Maximum 255 characters allowed.",
             "type": "string",
-            "examples": ["John"]
+            "examples": [
+              "John"
+            ]
           },
           "groups": {
             "description": "The list of group names the user belongs to within the organization. This field stores the user's group memberships for role-based access control, team assignments, and organizational structure. Groups are typically used for permission management, collaborative access, and organizational hierarchy. Each group name represents a distinct organizational unit or team that the user is associated with.",
@@ -9240,18 +9969,27 @@
             "items": {
               "type": "string"
             },
-            "examples": [["admin", "developer"]]
+            "examples": [
+              [
+                "admin",
+                "developer"
+              ]
+            ]
           },
           "id": {
             "description": "Unique system-generated identifier for the user profile. Immutable and read-only.",
             "type": "string",
             "readOnly": true,
-            "examples": ["usr_profile_1234abcd5678efgh"]
+            "examples": [
+              "usr_profile_1234abcd5678efgh"
+            ]
           },
           "locale": {
             "description": "The user's preferred language and region settings using BCP-47 format codes. This field customizes the user's experience with localized content, date formats, number formatting, and UI language throughout the system. When not specified, the user inherits the organization's default locale settings. Common values include `en-US`, `en-GB`, `fr-FR`, `de-DE`, and `es-ES`.",
             "type": "string",
-            "examples": ["en-US"]
+            "examples": [
+              "en-US"
+            ]
           },
           "metadata": {
             "description": "Raw attributes received from identity providers during authentication. This field stores the original user profile data as received from external IdP systems (SAML, OIDC, etc.) including provider-specific claims and attributes. These fields preserve the complete set of attributes received from the identity source and are used for mapping, synchronization, and audit purposes. Keys must be 3-25 characters, values must be 1-256 characters, with a maximum of 20 key-value pairs.",
@@ -9270,28 +10008,38 @@
           "name": {
             "description": "The user's complete display name in formatted form. This field stores the full name as a single string and is typically used when you want to set the complete name rather than using separate given and family names. This name appears in user interfaces, reports, directory listings, and anywhere a formatted display name is needed. This field serves as a formatted display name that complements the individual given_name and family_name fields.",
             "type": "string",
-            "examples": ["John Michael Doe"]
+            "examples": [
+              "John Michael Doe"
+            ]
           },
           "phone_number": {
             "description": "The user's phone number in E.164 international format. This field stores the phone number for user contact and identification purposes. The phone number must include the country code and be formatted according to E.164 standards (e.g., `+1` for US numbers). This field is optional.",
             "type": "string",
-            "examples": ["+14155552671"]
+            "examples": [
+              "+14155552671"
+            ]
           },
           "phone_number_verified": {
             "description": "Indicates if the user's phone number has been verified. Automatically updated by the system.",
             "type": "boolean",
             "readOnly": true,
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "picture": {
             "description": "The URL to the user's profile picture or avatar image. This field stores the location of the user's profile photo that appears in user interfaces, directory listings, and collaborative features throughout the system. The URL should point to a publicly accessible image file. Supported formats typically include JPEG, PNG, and GIF. This image is used for visual identification and personalization across the platform.",
             "type": "string",
-            "examples": ["https://example.com/avatar.jpg"]
+            "examples": [
+              "https://example.com/avatar.jpg"
+            ]
           },
           "preferred_username": {
             "description": "The user's preferred username for display and identification purposes. This field stores a custom username that the user prefers to be known by, which may differ from their email or formal name. This username appears in user interfaces, mentions, informal communications, and collaborative features throughout the system. Maximum 512 characters allowed.",
             "type": "string",
-            "examples": ["johndoe"]
+            "examples": [
+              "johndoe"
+            ]
           }
         }
       },
@@ -9342,33 +10090,45 @@
           "connection_id": {
             "description": "Reference to the parent connection configuration. Links this account to a specific connector setup in your environment.",
             "type": "string",
-            "examples": ["conn_24834495392086178"]
+            "examples": [
+              "conn_24834495392086178"
+            ]
           },
           "connector": {
             "description": "Connector identifier (e.g., 'notion', 'slack', 'salesforce'). Indicates which third-party application this account connects to.",
             "type": "string",
-            "examples": ["notion"]
+            "examples": [
+              "notion"
+            ]
           },
           "id": {
             "description": "Unique Scalekit-generated identifier for this connected account. Always prefixed with 'ca_'.",
             "type": "string",
-            "examples": ["ca_24834495392086178"]
+            "examples": [
+              "ca_24834495392086178"
+            ]
           },
           "identifier": {
             "description": "The unique identifier for this account in the third-party service. Typically an email address, user ID, or workspace identifier.",
             "type": "string",
-            "examples": ["user@example.com"]
+            "examples": [
+              "user@example.com"
+            ]
           },
           "last_used_at": {
             "description": "Timestamp when this connected account was last used to make an API call. Useful for tracking active connections.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-03-20T14:30:00Z"]
+            "examples": [
+              "2024-03-20T14:30:00Z"
+            ]
           },
           "provider": {
             "description": "OAuth provider name (e.g., 'google', 'microsoft', 'github'). Identifies which authentication service manages this connection.",
             "type": "string",
-            "examples": ["google"]
+            "examples": [
+              "google"
+            ]
           },
           "status": {
             "description": "Current status of the connected account. Indicates if the account is active, expired, pending authorization, or pending user identity verification.",
@@ -9378,13 +10138,17 @@
             "description": "Expiration timestamp for the access token. After this time, the token must be refreshed or re-authorized.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-12-31T23:59:59Z"]
+            "examples": [
+              "2024-12-31T23:59:59Z"
+            ]
           },
           "updated_at": {
             "description": "Timestamp when this connected account was last modified. Updated whenever credentials or configuration changes.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-03-20T15:04:05Z"]
+            "examples": [
+              "2024-03-20T15:04:05Z"
+            ]
           }
         }
       },
@@ -9399,33 +10163,45 @@
           "connection_id": {
             "description": "Parent connection configuration reference.",
             "type": "string",
-            "examples": ["conn_24834495392086178"]
+            "examples": [
+              "conn_24834495392086178"
+            ]
           },
           "connector": {
             "description": "Connector identifier.",
             "type": "string",
-            "examples": ["notion"]
+            "examples": [
+              "notion"
+            ]
           },
           "id": {
             "description": "Unique connected account identifier.",
             "type": "string",
-            "examples": ["ca_24834495392086178"]
+            "examples": [
+              "ca_24834495392086178"
+            ]
           },
           "identifier": {
             "description": "The unique identifier for this account in the third-party service.",
             "type": "string",
-            "examples": ["user@example.com"]
+            "examples": [
+              "user@example.com"
+            ]
           },
           "last_used_at": {
             "description": "Last usage timestamp.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-03-20T14:30:00Z"]
+            "examples": [
+              "2024-03-20T14:30:00Z"
+            ]
           },
           "provider": {
             "description": "OAuth provider name (e.g., 'google', 'microsoft').",
             "type": "string",
-            "examples": ["google"]
+            "examples": [
+              "google"
+            ]
           },
           "status": {
             "description": "Current connection status.",
@@ -9435,13 +10211,17 @@
             "description": "Token expiration timestamp.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-12-31T23:59:59Z"]
+            "examples": [
+              "2024-12-31T23:59:59Z"
+            ]
           },
           "updated_at": {
             "description": "Last modification timestamp.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-03-20T15:04:05Z"]
+            "examples": [
+              "2024-03-20T15:04:05Z"
+            ]
           }
         }
       },
@@ -9449,7 +10229,13 @@
         "description": "- ACTIVE: Account is connected and credentials are valid\n - EXPIRED: Access token has expired and needs refresh\n - PENDING_AUTH: Account awaiting user authorization (re-auth initiated)\n - PENDING_VERIFICATION: OAuth complete; awaiting user identity verification\nbefore activation\n - DISCONNECTED: Account has been manually disconnected",
         "type": "string",
         "title": "Status of a connected account indicating its current state",
-        "enum": ["ACTIVE", "EXPIRED", "PENDING_AUTH", "PENDING_VERIFICATION", "DISCONNECTED"]
+        "enum": [
+          "ACTIVE",
+          "EXPIRED",
+          "PENDING_AUTH",
+          "PENDING_VERIFICATION",
+          "DISCONNECTED"
+        ]
       },
       "connected_accountsConnectorType": {
         "description": "- OAUTH: OAuth 2.0 authorization with access and refresh tokens\n - API_KEY: Static API key authentication\n - BASIC_AUTH: HTTP Basic Authentication (username/password)\n - BEARER_TOKEN: Bearer token authentication\n - CUSTOM: Custom authentication mechanism\n - BASIC: Basic authentication (alias)\n - OAUTH_M2M: OAuth 2.0 client credentials (machine-to-machine)\n - TRELLO_OAUTH1: Trello token-based OAuth1-style browser authorization\n - GOOGLE_DWD: Google Domain-Wide Delegation\n - TRUSTED_IDP: Trusted Identity Provider federation (e.g. AWS STS AssumeRoleWithWebIdentity)\n - SMART_FHIR: SMART on FHIR (SMART App Launch) — OAuth 2.0 authorization\nfor FHIR servers",
@@ -9481,7 +10267,10 @@
                   "oauth_token": {
                     "access_token": "...",
                     "refresh_token": "...",
-                    "scopes": ["read", "write"]
+                    "scopes": [
+                      "read",
+                      "write"
+                    ]
                   }
                 },
                 "authorization_type": "OAUTH2"
@@ -9491,22 +10280,30 @@
           "connector": {
             "description": "Connector identifier (e.g., 'notion', 'slack', 'google'). Alphanumeric characters, spaces, hyphens, underscores, and colons are allowed.",
             "type": "string",
-            "examples": ["notion"]
+            "examples": [
+              "notion"
+            ]
           },
           "identifier": {
             "description": "The unique identifier for the connected account within the third-party service (e.g., email address, user ID, workspace identifier).",
             "type": "string",
-            "examples": ["user@example.com"]
+            "examples": [
+              "user@example.com"
+            ]
           },
           "organization_id": {
             "description": "Organization ID for the connector",
             "type": "string",
-            "examples": ["org_121312434123312"]
+            "examples": [
+              "org_121312434123312"
+            ]
           },
           "user_id": {
             "description": "User ID for the connector",
             "type": "string",
-            "examples": ["user_121312434123312"]
+            "examples": [
+              "user_121312434123312"
+            ]
           }
         }
       },
@@ -9525,27 +10322,37 @@
           "connector": {
             "description": "Connector identifier (e.g., 'notion', 'slack', 'google'). Alphanumeric characters, spaces, hyphens, underscores, and colons are allowed.",
             "type": "string",
-            "examples": ["notion"]
+            "examples": [
+              "notion"
+            ]
           },
           "id": {
             "description": "Unique identifier for the connected account to delete",
             "type": "string",
-            "examples": ["ca_123"]
+            "examples": [
+              "ca_123"
+            ]
           },
           "identifier": {
             "description": "The unique identifier for the connected account within the third-party service (e.g., email address, user ID, workspace identifier).",
             "type": "string",
-            "examples": ["user@example.com"]
+            "examples": [
+              "user@example.com"
+            ]
           },
           "organization_id": {
             "description": "Organization ID for the connector",
             "type": "string",
-            "examples": ["org_121312434123312"]
+            "examples": [
+              "org_121312434123312"
+            ]
           },
           "user_id": {
             "description": "User ID for the connector",
             "type": "string",
-            "examples": ["user_121312434123312"]
+            "examples": [
+              "user_121312434123312"
+            ]
           }
         }
       },
@@ -9564,37 +10371,51 @@
           "connector": {
             "description": "Connector identifier (e.g., 'notion', 'slack', 'google'). Alphanumeric characters, spaces, hyphens, underscores, and colons are allowed.",
             "type": "string",
-            "examples": ["notion"]
+            "examples": [
+              "notion"
+            ]
           },
           "id": {
             "description": "Unique identifier for the connected account",
             "type": "string",
-            "examples": ["ca_123"]
+            "examples": [
+              "ca_123"
+            ]
           },
           "identifier": {
             "description": "The unique identifier for the connected account within the third-party service (e.g., email address, user ID, workspace identifier).",
             "type": "string",
-            "examples": ["user@example.com"]
+            "examples": [
+              "user@example.com"
+            ]
           },
           "organization_id": {
             "description": "Organization ID for the connector",
             "type": "string",
-            "examples": ["org_121312434123312"]
+            "examples": [
+              "org_121312434123312"
+            ]
           },
           "state": {
             "description": "Optional opaque state value. State added to the user verify redirect URL query params to validate the user verification",
             "type": "string",
-            "examples": ["QVNDSUFyY2hhYml0dGVyXzE2ODQ5NzIwNzI0NTY="]
+            "examples": [
+              "QVNDSUFyY2hhYml0dGVyXzE2ODQ5NzIwNzI0NTY="
+            ]
           },
           "user_id": {
             "description": "User ID for the connector",
             "type": "string",
-            "examples": ["user_121312434123312"]
+            "examples": [
+              "user_121312434123312"
+            ]
           },
           "user_verify_url": {
             "description": "B2B app's user verify redirect URL",
             "type": "string",
-            "examples": ["https://app.yourapp.com/user/verify/callback"]
+            "examples": [
+              "https://app.yourapp.com/user/verify/callback"
+            ]
           }
         }
       },
@@ -9605,12 +10426,16 @@
             "description": "Expiry timestamp for the authentication link",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-03-20T15:04:05Z"]
+            "examples": [
+              "2024-03-20T15:04:05Z"
+            ]
           },
           "link": {
             "description": "Authentication link for the connector",
             "type": "string",
-            "examples": ["https://notion.com/oauth/authorize?client_id=..."]
+            "examples": [
+              "https://notion.com/oauth/authorize?client_id=..."
+            ]
           }
         }
       },
@@ -9622,7 +10447,9 @@
             "description": "OAuth access token acquired via the jwt-bearer grant. Present in responses only.",
             "type": "string",
             "readOnly": true,
-            "examples": ["ya29.a0AfH6SMBx..."]
+            "examples": [
+              "ya29.a0AfH6SMBx..."
+            ]
           },
           "scopes": {
             "description": "OAuth scopes granted to this token. Present in responses only.",
@@ -9631,12 +10458,19 @@
               "type": "string"
             },
             "readOnly": true,
-            "examples": [["openid", "https://www.googleapis.com/auth/userinfo.email"]]
+            "examples": [
+              [
+                "openid",
+                "https://www.googleapis.com/auth/userinfo.email"
+              ]
+            ]
           },
           "subject": {
             "description": "Email address of the Google Workspace user to impersonate via Domain-Wide Delegation.",
             "type": "string",
-            "examples": ["user@example.com"]
+            "examples": [
+              "user@example.com"
+            ]
           },
           "token_expires_at": {
             "description": "When the access token expires. Present in responses only.",
@@ -9660,18 +10494,24 @@
           "next_page_token": {
             "description": "Pagination token for retrieving the next page. Empty if this is the last page. Pass this value to page_token in the next request.",
             "type": "string",
-            "examples": ["eyJvZmZzZXQiOjIwfQ=="]
+            "examples": [
+              "eyJvZmZzZXQiOjIwfQ=="
+            ]
           },
           "prev_page_token": {
             "description": "Pagination token for retrieving the previous page. Empty if this is the first page. Pass this value to page_token to go back.",
             "type": "string",
-            "examples": ["eyJvZmZzZXQiOjB9"]
+            "examples": [
+              "eyJvZmZzZXQiOjB9"
+            ]
           },
           "total_size": {
             "description": "Total count of connected accounts matching the filter criteria across all pages. Use for calculating pagination.",
             "type": "integer",
             "format": "int64",
-            "examples": [100]
+            "examples": [
+              100
+            ]
           }
         }
       },
@@ -9682,17 +10522,23 @@
           "access_token": {
             "description": "OAuth access token for API requests. Typically short-lived and must be refreshed after expiration.",
             "type": "string",
-            "examples": ["ya29.a0AfH6SMBx..."]
+            "examples": [
+              "ya29.a0AfH6SMBx..."
+            ]
           },
           "domain": {
             "description": "Associated domain for workspace or organization-scoped OAuth connections (e.g., Google Workspace domain).",
             "type": "string",
-            "examples": ["example.com"]
+            "examples": [
+              "example.com"
+            ]
           },
           "refresh_token": {
             "description": "OAuth refresh token for obtaining new access tokens. Long-lived and used to maintain persistent authorization.",
             "type": "string",
-            "examples": ["1//0gHJxZ-Lb2..."]
+            "examples": [
+              "1//0gHJxZ-Lb2..."
+            ]
           },
           "scopes": {
             "description": "List of granted OAuth scopes defining the permissions and access levels for this connection.",
@@ -9723,18 +10569,24 @@
           "next_page_token": {
             "description": "Pagination token for the next page. Empty if this is the last page.",
             "type": "string",
-            "examples": ["eyJvZmZzZXQiOjMwfQ=="]
+            "examples": [
+              "eyJvZmZzZXQiOjMwfQ=="
+            ]
           },
           "prev_page_token": {
             "description": "Pagination token for the previous page. Empty if this is the first page.",
             "type": "string",
-            "examples": ["eyJvZmZzZXQiOjB9"]
+            "examples": [
+              "eyJvZmZzZXQiOjB9"
+            ]
           },
           "total_size": {
             "description": "Total count of accounts matching the search query across all pages.",
             "type": "integer",
             "format": "int64",
-            "examples": [100]
+            "examples": [
+              100
+            ]
           }
         }
       },
@@ -9762,12 +10614,16 @@
             "description": "Federated access key ID issued by the trusted identity provider. Present in responses only.",
             "type": "string",
             "readOnly": true,
-            "examples": ["ASIA..."]
+            "examples": [
+              "ASIA..."
+            ]
           },
           "db_user": {
             "description": "Target database user for the federated session (required for provisioned Redshift clusters; ignored for serverless workgroups).",
             "type": "string",
-            "examples": ["analytics_reader"]
+            "examples": [
+              "analytics_reader"
+            ]
           },
           "expiry": {
             "description": "When the federated credentials expire. Present in responses only.",
@@ -9799,7 +10655,10 @@
                   "oauth_token": {
                     "access_token": "...",
                     "refresh_token": "...",
-                    "scopes": ["read", "write"]
+                    "scopes": [
+                      "read",
+                      "write"
+                    ]
                   }
                 },
                 "authorization_type": "OAUTH2"
@@ -9809,27 +10668,37 @@
           "connector": {
             "description": "Connector identifier (e.g., 'notion', 'slack', 'google'). Alphanumeric characters, spaces, hyphens, underscores, and colons are allowed.",
             "type": "string",
-            "examples": ["notion"]
+            "examples": [
+              "notion"
+            ]
           },
           "id": {
             "description": "Unique identifier for the connected account to update",
             "type": "string",
-            "examples": ["ca_123"]
+            "examples": [
+              "ca_123"
+            ]
           },
           "identifier": {
             "description": "The unique identifier for the connected account within the third-party service (e.g., email address, user ID, workspace identifier).",
             "type": "string",
-            "examples": ["user@example.com"]
+            "examples": [
+              "user@example.com"
+            ]
           },
           "organization_id": {
             "description": "Organization ID for the connector",
             "type": "string",
-            "examples": ["org_121312434123312"]
+            "examples": [
+              "org_121312434123312"
+            ]
           },
           "user_id": {
             "description": "User ID for the connector",
             "type": "string",
-            "examples": ["user_121312434123312"]
+            "examples": [
+              "user_121312434123312"
+            ]
           }
         }
       },
@@ -9844,17 +10713,24 @@
       },
       "connected_accountsVerifyConnectedAccountUserRequest": {
         "type": "object",
-        "required": ["auth_request_id", "identifier"],
+        "required": [
+          "auth_request_id",
+          "identifier"
+        ],
         "properties": {
           "auth_request_id": {
             "description": "Auth request ID as base64url-encoded opaque token from the user verify redirect URL query params",
             "type": "string",
-            "examples": ["QVNDSUFyY2hhYml0dGVyXzE2ODQ5NzIwNzI0NTY="]
+            "examples": [
+              "QVNDSUFyY2hhYml0dGVyXzE2ODQ5NzIwNzI0NTY="
+            ]
           },
           "identifier": {
             "description": "Current logged in user's connected account identifier",
             "type": "string",
-            "examples": ["user@example.com"]
+            "examples": [
+              "user@example.com"
+            ]
           }
         }
       },
@@ -9864,17 +10740,25 @@
           "post_user_verify_redirect_url": {
             "description": "URL to redirect the user to after successful verification",
             "type": "string",
-            "examples": ["https://env1.example.com/connect/success"]
+            "examples": [
+              "https://env1.example.com/connect/success"
+            ]
           }
         }
       },
       "connectionsCodeChallengeType": {
         "type": "string",
-        "enum": ["NUMERIC", "ALPHANUMERIC"]
+        "enum": [
+          "NUMERIC",
+          "ALPHANUMERIC"
+        ]
       },
       "connectionsConfigurationType": {
         "type": "string",
-        "enum": ["DISCOVERY", "MANUAL"]
+        "enum": [
+          "DISCOVERY",
+          "MANUAL"
+        ]
       },
       "connectionsConnection": {
         "type": "object",
@@ -9889,12 +10773,16 @@
           "configuration_type": {
             "description": "How the connection was configured: DISCOVERY (automatic configuration) or MANUAL (administrator configured)",
             "$ref": "#/components/schemas/connectionsConfigurationType",
-            "examples": ["MANUAL"]
+            "examples": [
+              "MANUAL"
+            ]
           },
           "debug_enabled": {
             "description": "Enables testing mode that allows non-HTTPS endpoints. Should only be enabled in development environments, never in production.",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "domains": {
             "description": "Domain associated with this connection, used for domain-based authentication flows.",
@@ -9914,7 +10802,9 @@
           "enabled": {
             "description": "Controls whether users can sign in using this connection. When false, the connection exists but cannot be used for authentication.",
             "type": "boolean",
-            "examples": [false]
+            "examples": [
+              false
+            ]
           },
           "google_dwd_config": {
             "description": "Configuration details for Google Domain-Wide Delegation. Present only when type is GOOGLE_DWD.",
@@ -9923,7 +10813,9 @@
           "id": {
             "description": "Unique identifier for this connection. Used in API calls to reference this specific connection.",
             "type": "string",
-            "examples": ["conn_2123312131125533"]
+            "examples": [
+              "conn_2123312131125533"
+            ]
           },
           "key_id": {
             "description": "Alternative identifier for this connection, typically used in frontend applications or URLs.",
@@ -9933,7 +10825,9 @@
             "description": "URL of the MCP server for this connection. Agents can point directly at this URL to access only the tools for this connection, without needing to call list_connections or execute_tool with a connection_name. Empty when the MCP virtual servers feature is not enabled for this environment.",
             "type": "string",
             "readOnly": true,
-            "examples": ["https://acmecorp.scalekit.dev/mcp/v3/connections/gmail_work"]
+            "examples": [
+              "https://acmecorp.scalekit.dev/mcp/v3/connections/gmail_work"
+            ]
           },
           "oauth_config": {
             "description": "Configuration details for OAuth connections. Present only when type is OAUTH.",
@@ -9946,7 +10840,9 @@
           "organization_id": {
             "description": "Identifier of the organization that owns this connection. Connections are typically scoped to a single organization.",
             "type": "string",
-            "examples": ["org_2123312131125533"]
+            "examples": [
+              "org_2123312131125533"
+            ]
           },
           "passwordless_config": {
             "description": "Configuration details for Magic Link authentication. Present only when type is MAGIC_LINK.",
@@ -9955,12 +10851,16 @@
           "provider": {
             "description": "Identity provider service that handles authentication (such as OKTA, Google, Azure AD, or a custom provider)",
             "$ref": "#/components/schemas/connectionsConnectionProvider",
-            "examples": ["OKTA"]
+            "examples": [
+              "OKTA"
+            ]
           },
           "provider_key": {
             "description": "Key ID of the identity provider service that handles authentication",
             "type": "string",
-            "examples": ["google"]
+            "examples": [
+              "google"
+            ]
           },
           "saml_config": {
             "description": "Configuration details for SAML connections. Present only when type is SAML.",
@@ -9974,17 +10874,23 @@
             "description": "Current configuration status of the connection. Possible values include IN_PROGRESS, CONFIGURED, and ERROR.",
             "$ref": "#/components/schemas/connectionsConnectionStatus",
             "readOnly": true,
-            "examples": ["IN_PROGRESS"]
+            "examples": [
+              "IN_PROGRESS"
+            ]
           },
           "test_connection_uri": {
             "description": "URI that can be used to test this connection. Visit this URL to verify the connection works correctly.",
             "type": "string",
-            "examples": ["https://auth.example.com/test-connection/conn_2123312131125533"]
+            "examples": [
+              "https://auth.example.com/test-connection/conn_2123312131125533"
+            ]
           },
           "type": {
             "description": "Authentication protocol used by this connection. Can be OIDC (OpenID Connect), SAML, OAUTH, or MAGIC_LINK.",
             "$ref": "#/components/schemas/connectionsConnectionType",
-            "examples": ["OIDC"]
+            "examples": [
+              "OIDC"
+            ]
           },
           "webauthn_config": {
             "description": "Configuration details for WebAuthn (passkeys). Present only when type is WEBAUTHN.",
@@ -10015,7 +10921,11 @@
       },
       "connectionsConnectionStatus": {
         "type": "string",
-        "enum": ["DRAFT", "IN_PROGRESS", "COMPLETED"]
+        "enum": [
+          "DRAFT",
+          "IN_PROGRESS",
+          "COMPLETED"
+        ]
       },
       "connectionsConnectionType": {
         "type": "string",
@@ -10076,23 +10986,31 @@
             "description": "Certificate Creation Time",
             "type": "string",
             "format": "date-time",
-            "examples": ["2021-09-01T00:00:00Z"]
+            "examples": [
+              "2021-09-01T00:00:00Z"
+            ]
           },
           "expiry_time": {
             "description": "Certificate Expiry Time",
             "type": "string",
             "format": "date-time",
-            "examples": ["2021-09-01T00:00:00Z"]
+            "examples": [
+              "2021-09-01T00:00:00Z"
+            ]
           },
           "id": {
             "description": "Certificate ID",
             "type": "string",
-            "examples": ["cert_123123123123"]
+            "examples": [
+              "cert_123123123123"
+            ]
           },
           "issuer": {
             "description": "Certificate Issuer",
             "type": "string",
-            "examples": ["https://youridp.com/service/saml"]
+            "examples": [
+              "https://youridp.com/service/saml"
+            ]
           }
         }
       },
@@ -10105,59 +11023,84 @@
             "items": {
               "type": "string"
             },
-            "examples": [["yourapp.com", "yourworkspace.com"]]
+            "examples": [
+              [
+                "yourapp.com",
+                "yourworkspace.com"
+              ]
+            ]
           },
           "enabled": {
             "description": "Whether the connection is currently active for organization users",
             "type": "boolean",
-            "examples": [false]
+            "examples": [
+              false
+            ]
           },
           "id": {
             "description": "Unique identifier of the connection",
             "type": "string",
-            "examples": ["conn_2123312131125533"]
+            "examples": [
+              "conn_2123312131125533"
+            ]
           },
           "key_id": {
             "description": "Alternative identifier for this connection, typically used in frontend applications or URLs",
             "type": "string",
-            "examples": ["conn_2123312131125533"]
+            "examples": [
+              "conn_2123312131125533"
+            ]
           },
           "mcp_server_url": {
             "description": "MCP virtual server URL for this connection. Agents can point directly at this URL to access only the tools for this connection, without needing to call list_connections or execute_tool with a connection_name. Empty when the MCP virtual servers feature is not enabled for this environment.",
             "type": "string",
             "readOnly": true,
-            "examples": ["https://acmecorp.scalekit.dev/mcp/v3/connections/gmail_work"]
+            "examples": [
+              "https://acmecorp.scalekit.dev/mcp/v3/connections/gmail_work"
+            ]
           },
           "organization_id": {
             "description": "Unique identifier of the organization that owns this connection",
             "type": "string",
-            "examples": ["org_2123312131125533"]
+            "examples": [
+              "org_2123312131125533"
+            ]
           },
           "organization_name": {
             "description": "Name of the organization of the connection",
             "type": "string",
-            "examples": ["Your Organization"]
+            "examples": [
+              "Your Organization"
+            ]
           },
           "provider": {
             "description": "Identity provider type (e.g., OKTA, Google, Azure AD)",
             "$ref": "#/components/schemas/connectionsConnectionProvider",
-            "examples": ["CUSTOM"]
+            "examples": [
+              "CUSTOM"
+            ]
           },
           "provider_key": {
             "description": "Key ID of the identity provider service that handles authentication",
             "type": "string",
-            "examples": ["google"]
+            "examples": [
+              "google"
+            ]
           },
           "status": {
             "description": "Current configuration status of the connection",
             "$ref": "#/components/schemas/connectionsConnectionStatus",
             "readOnly": true,
-            "examples": ["IN_PROGRESS"]
+            "examples": [
+              "IN_PROGRESS"
+            ]
           },
           "type": {
             "description": "Authentication protocol used by the connection",
             "$ref": "#/components/schemas/connectionsConnectionType",
-            "examples": ["OIDC"]
+            "examples": [
+              "OIDC"
+            ]
           }
         }
       },
@@ -10176,7 +11119,12 @@
       },
       "connectionsNameIdFormat": {
         "type": "string",
-        "enum": ["UNSPECIFIED", "EMAIL", "TRANSIENT", "PERSISTENT"]
+        "enum": [
+          "UNSPECIFIED",
+          "EMAIL",
+          "TRANSIENT",
+          "PERSISTENT"
+        ]
       },
       "connectionsOAuthConnectionConfig": {
         "type": "object",
@@ -10184,32 +11132,44 @@
           "access_type": {
             "description": "Access Type",
             "type": "string",
-            "examples": ["offline"]
+            "examples": [
+              "offline"
+            ]
           },
           "app_name": {
             "description": "Application name used by providers that require it as an authorize query parameter (e.g., Trello's app_name).",
             "type": "string",
-            "examples": ["My Trello App"]
+            "examples": [
+              "My Trello App"
+            ]
           },
           "authorize_uri": {
             "description": "Authorize URI",
             "type": "string",
-            "examples": ["https://youridp.com/service/oauth/authorize"]
+            "examples": [
+              "https://youridp.com/service/oauth/authorize"
+            ]
           },
           "client_id": {
             "description": "Client ID",
             "type": "string",
-            "examples": ["oauth_client_id"]
+            "examples": [
+              "oauth_client_id"
+            ]
           },
           "client_secret": {
             "description": "Client Secret",
             "type": "string",
-            "examples": ["oauth_client_secret"]
+            "examples": [
+              "oauth_client_secret"
+            ]
           },
           "custom_scope_name": {
             "description": "Custom Scope Name",
             "type": "string",
-            "examples": ["user_scope"]
+            "examples": [
+              "user_scope"
+            ]
           },
           "extensions": {
             "description": "OAuth extension profiles for this connection, such as SMART on FHIR. Carries typed extension configuration plus a generic escape hatch for provider-specific authorize query parameters.",
@@ -10219,7 +11179,9 @@
             "description": "Indicates whether this connection was registered using Client ID Metadata Document (CIMD) instead of Dynamic Client Registration.",
             "type": "boolean",
             "readOnly": true,
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "optional_scopes": {
             "description": "Optional scopes configuration for identity providers that support or require additional scopes to be sent in a custom field during authentication requests.",
@@ -10228,17 +11190,23 @@
           "pkce_enabled": {
             "description": "PKCE Enabled",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "prompt": {
             "description": "Prompt for the user",
             "type": "string",
-            "examples": ["none"]
+            "examples": [
+              "none"
+            ]
           },
           "redirect_uri": {
             "description": "Redirect URI",
             "type": "string",
-            "examples": ["https://yourapp.com/service/oauth/redirect"]
+            "examples": [
+              "https://yourapp.com/service/oauth/redirect"
+            ]
           },
           "scopes": {
             "description": "OIDC Scopes",
@@ -10246,37 +11214,54 @@
             "items": {
               "type": "string"
             },
-            "examples": [["openid", "profile"]]
+            "examples": [
+              [
+                "openid",
+                "profile"
+              ]
+            ]
           },
           "sync_user_profile_on_login": {
             "description": "Indicates whether user profiles should be synchronized with the identity provider upon each log-in.",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "tenant_id": {
             "description": "Microsoft Entra tenant ID. Required when using a single-tenant or multi-tenant app registered in Microsoft Entra. Leave empty to use the common endpoint.",
             "type": "string",
-            "examples": ["xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"]
+            "examples": [
+              "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+            ]
           },
           "token_access_type": {
             "description": "Token Access Type",
             "type": "string",
-            "examples": ["offline"]
+            "examples": [
+              "offline"
+            ]
           },
           "token_uri": {
             "description": "Token URI",
             "type": "string",
-            "examples": ["https://youridp.com/service/oauth/token"]
+            "examples": [
+              "https://youridp.com/service/oauth/token"
+            ]
           },
           "use_platform_creds": {
             "description": "Use Scalekit credentials",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "user_info_uri": {
             "description": "User Info URI",
             "type": "string",
-            "examples": ["https://youridp.com/service/oauth/userinfo"]
+            "examples": [
+              "https://youridp.com/service/oauth/userinfo"
+            ]
           }
         }
       },
@@ -10286,64 +11271,88 @@
           "authorize_uri": {
             "description": "Authorize URI",
             "type": "string",
-            "examples": ["https://youridp.com/service/oauth/authorize"]
+            "examples": [
+              "https://youridp.com/service/oauth/authorize"
+            ]
           },
           "backchannel_logout_redirect_uri": {
             "description": "backchannel logout redirect uri where idp sends logout_token",
             "type": "string",
             "readOnly": true,
-            "examples": ["https://yourapp.com/sso/v1/oidc/conn_1234/backchannel-logout"]
+            "examples": [
+              "https://yourapp.com/sso/v1/oidc/conn_1234/backchannel-logout"
+            ]
           },
           "client_id": {
             "description": "Client ID",
             "type": "string",
-            "examples": ["oauth_client_id"]
+            "examples": [
+              "oauth_client_id"
+            ]
           },
           "client_secret": {
             "description": "Client Secret",
             "type": "string",
-            "examples": ["oauth_client_secret"]
+            "examples": [
+              "oauth_client_secret"
+            ]
           },
           "discovery_endpoint": {
             "description": "Discovery Endpoint",
             "type": "string",
-            "examples": ["https://youridp.com/service/oauth/.well-known/openid-configuration"]
+            "examples": [
+              "https://youridp.com/service/oauth/.well-known/openid-configuration"
+            ]
           },
           "idp_logout_required": {
             "description": "Enable IDP logout",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "issuer": {
             "description": "Issuer URL",
             "type": "string",
-            "examples": ["https://youridp.com/service/oauth"]
+            "examples": [
+              "https://youridp.com/service/oauth"
+            ]
           },
           "jit_provisioning_with_sso_enabled": {
             "description": "Indicates if Just In Time user provisioning is enabled for the connection",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "jwks_uri": {
             "description": "JWKS URI",
             "type": "string",
-            "examples": ["https://youridp.com/service/oauth/jwks"]
+            "examples": [
+              "https://youridp.com/service/oauth/jwks"
+            ]
           },
           "pkce_enabled": {
             "description": "PKCE Enabled",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "post_logout_redirect_uri": {
             "description": "post logout redirect uri",
             "type": "string",
             "readOnly": true,
-            "examples": ["https://yourapp.com/sso/v1/oidc/conn_1234/logout/callback"]
+            "examples": [
+              "https://yourapp.com/sso/v1/oidc/conn_1234/logout/callback"
+            ]
           },
           "redirect_uri": {
             "description": "Redirect URI",
             "type": "string",
-            "examples": ["https://yourapp.com/sso/v1/oidc/conn_1234/callback"]
+            "examples": [
+              "https://yourapp.com/sso/v1/oidc/conn_1234/callback"
+            ]
           },
           "scopes": {
             "description": "OIDC Scopes",
@@ -10351,33 +11360,52 @@
             "items": {
               "$ref": "#/components/schemas/connectionsOIDCScope"
             },
-            "examples": [["openid", "profile"]]
+            "examples": [
+              [
+                "openid",
+                "profile"
+              ]
+            ]
           },
           "sync_user_profile_on_login": {
             "description": "Indicates whether user profiles should be synchronized with the identity provider upon each log-in.",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "token_auth_type": {
             "description": "Token Auth Type",
             "$ref": "#/components/schemas/connectionsTokenAuthType",
-            "examples": ["URL_PARAMS"]
+            "examples": [
+              "URL_PARAMS"
+            ]
           },
           "token_uri": {
             "description": "Token URI",
             "type": "string",
-            "examples": ["https://youridp.com/service/oauth/token"]
+            "examples": [
+              "https://youridp.com/service/oauth/token"
+            ]
           },
           "user_info_uri": {
             "description": "User Info URI",
             "type": "string",
-            "examples": ["https://youridp.com/service/oauth/userinfo"]
+            "examples": [
+              "https://youridp.com/service/oauth/userinfo"
+            ]
           }
         }
       },
       "connectionsOIDCScope": {
         "type": "string",
-        "enum": ["openid", "profile", "email", "address", "phone"]
+        "enum": [
+          "openid",
+          "profile",
+          "email",
+          "address",
+          "phone"
+        ]
       },
       "connectionsOauthExtensions": {
         "description": "OauthExtensions groups OAuth extension-profile configuration for a connection.\nSignificant profiles (e.g. SMART on FHIR) get a typed sub-message; the long tail\nof one-off authorize parameters uses extra_authorize_params.",
@@ -10407,7 +11435,9 @@
           "field_name": {
             "description": "Name of the field in which scope should be sent in the authentication request. This is required by some identity providers that expect scopes to be sent in a custom field instead of the standard 'scope' parameter.",
             "type": "string",
-            "examples": ["optional_scope or bot_scope"]
+            "examples": [
+              "optional_scope or bot_scope"
+            ]
           },
           "scopes": {
             "description": "List of optional scopes that can be requested during authentication",
@@ -10415,7 +11445,12 @@
             "items": {
               "type": "string"
             },
-            "examples": [["scope1", "scope2"]]
+            "examples": [
+              [
+                "scope1",
+                "scope2"
+              ]
+            ]
           }
         }
       },
@@ -10426,49 +11461,70 @@
             "description": "Code Challenge Length",
             "type": "integer",
             "format": "int64",
-            "examples": [6]
+            "examples": [
+              6
+            ]
           },
           "code_challenge_type": {
             "description": "Code Challenge Type",
             "$ref": "#/components/schemas/connectionsCodeChallengeType",
-            "examples": ["NUMERIC"]
+            "examples": [
+              "NUMERIC"
+            ]
           },
           "enforce_same_browser_origin": {
             "description": "Enforce Same Browser Origin",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "frequency": {
             "description": "Link Frequency",
             "type": "integer",
             "format": "int64",
-            "examples": [1]
+            "examples": [
+              1
+            ]
           },
           "regenerate_passwordless_credentials_on_resend": {
             "description": "Regenerate the ",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "type": {
             "description": "Passwordless Type",
             "$ref": "#/components/schemas/connectionsPasswordlessType",
-            "examples": ["LINK"]
+            "examples": [
+              "LINK"
+            ]
           },
           "validity": {
             "description": "Link Validity in Seconds",
             "type": "integer",
             "format": "int64",
-            "examples": [600]
+            "examples": [
+              600
+            ]
           }
         }
       },
       "connectionsPasswordlessType": {
         "type": "string",
-        "enum": ["LINK", "OTP", "LINK_OTP"]
+        "enum": [
+          "LINK",
+          "OTP",
+          "LINK_OTP"
+        ]
       },
       "connectionsRequestBinding": {
         "type": "string",
-        "enum": ["HTTP_POST", "HTTP_REDIRECT"]
+        "enum": [
+          "HTTP_POST",
+          "HTTP_REDIRECT"
+        ]
       },
       "connectionsSAMLConnectionConfigResponse": {
         "type": "object",
@@ -10476,27 +11532,37 @@
           "allow_idp_initiated_login": {
             "description": "Allow IDP Initiated Login",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "assertion_encrypted": {
             "description": "Assertion Encrypted",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "certificate_id": {
             "description": "Certificate ID",
             "type": "string",
-            "examples": ["cer_35585423166144613"]
+            "examples": [
+              "cer_35585423166144613"
+            ]
           },
           "default_redirect_uri": {
             "description": "Default Redirect URI",
             "type": "string",
-            "examples": ["https://yourapp.com/service/saml/redirect"]
+            "examples": [
+              "https://yourapp.com/service/saml/redirect"
+            ]
           },
           "force_authn": {
             "description": "Force Authn",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "idp_certificates": {
             "description": "IDP Certificates",
@@ -10509,88 +11575,122 @@
           "idp_entity_id": {
             "description": "IDP Entity ID",
             "type": "string",
-            "examples": ["https://youridp.com/service/saml"]
+            "examples": [
+              "https://youridp.com/service/saml"
+            ]
           },
           "idp_metadata_url": {
             "description": "IDP Metadata URL",
             "type": "string",
-            "examples": ["https://youridp.com/service/saml/metadata"]
+            "examples": [
+              "https://youridp.com/service/saml/metadata"
+            ]
           },
           "idp_name_id_format": {
             "description": "IDP Name ID Format",
             "$ref": "#/components/schemas/connectionsNameIdFormat",
-            "examples": ["EMAIL"]
+            "examples": [
+              "EMAIL"
+            ]
           },
           "idp_slo_request_binding": {
             "description": "IDP SLO Request Binding",
             "$ref": "#/components/schemas/connectionsRequestBinding",
-            "examples": ["HTTP_POST"]
+            "examples": [
+              "HTTP_POST"
+            ]
           },
           "idp_slo_required": {
             "description": "Enable IDP logout",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "idp_slo_url": {
             "description": "IDP SLO URL",
             "type": "string",
-            "examples": ["https://youridp.com/service/saml/slo"]
+            "examples": [
+              "https://youridp.com/service/saml/slo"
+            ]
           },
           "idp_sso_request_binding": {
             "description": "IDP SSO Request Binding",
             "$ref": "#/components/schemas/connectionsRequestBinding",
-            "examples": ["HTTP_POST"]
+            "examples": [
+              "HTTP_POST"
+            ]
           },
           "idp_sso_url": {
             "description": "IDP SSO URL",
             "type": "string",
-            "examples": ["https://youridp.com/service/saml/sso"]
+            "examples": [
+              "https://youridp.com/service/saml/sso"
+            ]
           },
           "jit_provisioning_with_sso_enabled": {
             "description": "Indicates if Just In Time user provisioning is enabled for the connection",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "saml_signing_option": {
             "description": "SAML Signing Option",
             "$ref": "#/components/schemas/connectionsSAMLSigningOptions",
-            "examples": ["SAML_ONLY_RESPONSE_SIGNING"]
+            "examples": [
+              "SAML_ONLY_RESPONSE_SIGNING"
+            ]
           },
           "sp_assertion_url": {
             "description": "SP Assertion URL",
             "type": "string",
-            "examples": ["https://youridp.com/service/saml/assertion"]
+            "examples": [
+              "https://youridp.com/service/saml/assertion"
+            ]
           },
           "sp_entity_id": {
             "description": "SP Entity ID",
             "type": "string",
-            "examples": ["https://yourapp.com/service/saml"]
+            "examples": [
+              "https://yourapp.com/service/saml"
+            ]
           },
           "sp_metadata_url": {
             "description": "SP Metadata URL",
             "type": "string",
-            "examples": ["https://youridp.com/service/saml/metadata"]
+            "examples": [
+              "https://youridp.com/service/saml/metadata"
+            ]
           },
           "sp_slo_url": {
             "description": "Service Provider SLO url",
             "type": "string",
             "readOnly": true,
-            "examples": ["https://yourapp.com/sso/v1/saml/conn_1234/slo/callback"]
+            "examples": [
+              "https://yourapp.com/sso/v1/saml/conn_1234/slo/callback"
+            ]
           },
           "sync_user_profile_on_login": {
             "description": "Indicates whether user profiles should be synchronized with the identity provider upon each log-in.",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "ui_button_title": {
             "description": "UI Button Title",
             "type": "string",
-            "examples": ["Login with SSO"]
+            "examples": [
+              "Login with SSO"
+            ]
           },
           "want_request_signed": {
             "description": "Want Request Signed",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           }
         }
       },
@@ -10612,12 +11712,16 @@
           "aud": {
             "description": "FHIR resource server base URL, sent as the required 'aud' authorization parameter per the SMART App Launch specification. Binds the issued token to the intended FHIR server.",
             "type": "string",
-            "examples": ["https://fhir.example.com/r4"]
+            "examples": [
+              "https://fhir.example.com/r4"
+            ]
           },
           "domain": {
             "description": "FHIR server domain for the SMART on FHIR connection. Stored alongside the audience and editable through the connection update API.",
             "type": "string",
-            "examples": ["fhir.example.com"]
+            "examples": [
+              "fhir.example.com"
+            ]
           }
         }
       },
@@ -10635,18 +11739,25 @@
           "enabled": {
             "description": "Current state of the connection after the operation. True means the connection is now enabled and can be used for authentication.",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "error_message": {
             "description": "Error message if the operation fails",
             "type": "string",
-            "examples": ["placeholder"]
+            "examples": [
+              "placeholder"
+            ]
           }
         }
       },
       "connectionsTokenAuthType": {
         "type": "string",
-        "enum": ["URL_PARAMS", "BASIC_AUTH"]
+        "enum": [
+          "URL_PARAMS",
+          "BASIC_AUTH"
+        ]
       },
       "connectionsWebAuthConfiguration": {
         "type": "object",
@@ -10714,53 +11825,73 @@
           "directory_endpoint": {
             "description": "The endpoint URL generated by Scalekit for synchronizing users and groups from the Directory Provider",
             "type": "string",
-            "examples": ["https://yourapp.scalekit.com/api/v1/directoies/dir_123212312/scim/v2"]
+            "examples": [
+              "https://yourapp.scalekit.com/api/v1/directoies/dir_123212312/scim/v2"
+            ]
           },
           "directory_provider": {
             "description": "Identity provider connected to this directory",
             "$ref": "#/components/schemas/directoriesDirectoryProvider",
-            "examples": ["OKTA"]
+            "examples": [
+              "OKTA"
+            ]
           },
           "directory_type": {
             "description": "Type of the directory, indicating the protocol or standard used for synchronization",
             "$ref": "#/components/schemas/directoriesDirectoryType",
-            "examples": ["SCIM"]
+            "examples": [
+              "SCIM"
+            ]
           },
           "email": {
             "description": "Email Id associated with Directory whose access will be used for polling",
             "type": "string",
-            "examples": ["john.doe@scalekit.cloud"]
+            "examples": [
+              "john.doe@scalekit.cloud"
+            ]
           },
           "enabled": {
             "description": "Indicates whether the directory is currently enabled and actively synchronizing users and groups",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "groups_tracked": {
             "description": "It indicates if all groups are tracked or select groups are tracked",
             "type": "string",
-            "examples": ["ALL"]
+            "examples": [
+              "ALL"
+            ]
           },
           "id": {
             "description": "Unique identifier of the directory",
             "type": "string",
-            "examples": ["dir_121312434123312"]
+            "examples": [
+              "dir_121312434123312"
+            ]
           },
           "last_synced_at": {
             "description": "Timestamp of the last successful synchronization of users and groups from the Directory Provider",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-10-01T00:00:00Z"]
+            "examples": [
+              "2024-10-01T00:00:00Z"
+            ]
           },
           "name": {
             "description": "Name of the directory, typically representing the connected Directory provider",
             "type": "string",
-            "examples": ["Azure AD"]
+            "examples": [
+              "Azure AD"
+            ]
           },
           "organization_id": {
             "description": "Unique identifier of the organization to which the directory belongs",
             "type": "string",
-            "examples": ["org_121312434123312"]
+            "examples": [
+              "org_121312434123312"
+            ]
           },
           "role_assignments": {
             "description": "Role assignments associated with the directory, defining group based role assignments",
@@ -10781,19 +11912,25 @@
           "status": {
             "description": "Directory Status",
             "type": "string",
-            "examples": ["IN_PROGRESS"]
+            "examples": [
+              "IN_PROGRESS"
+            ]
           },
           "total_groups": {
             "description": "Total number of groups in the directory",
             "type": "integer",
             "format": "int32",
-            "examples": [10]
+            "examples": [
+              10
+            ]
           },
           "total_users": {
             "description": "Total number of users in the directory",
             "type": "integer",
             "format": "int32",
-            "examples": [10]
+            "examples": [
+              10
+            ]
           }
         }
       },
@@ -10803,7 +11940,9 @@
           "display_name": {
             "description": "Display Name",
             "type": "string",
-            "examples": ["Admins"]
+            "examples": [
+              "Admins"
+            ]
           },
           "group_detail": {
             "description": "Complete Group Details Payload",
@@ -10812,19 +11951,25 @@
           "id": {
             "description": "Group ID",
             "type": "string",
-            "examples": ["dirgroup_121312434123312"]
+            "examples": [
+              "dirgroup_121312434123312"
+            ]
           },
           "total_users": {
             "description": "Total Users in the Group",
             "type": "integer",
             "format": "int32",
-            "examples": [10]
+            "examples": [
+              10
+            ]
           },
           "updated_at": {
             "description": "Updated At",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-10-01T00:00:00Z"]
+            "examples": [
+              "2024-10-01T00:00:00Z"
+            ]
           }
         }
       },
@@ -10842,7 +11987,11 @@
       },
       "directoriesDirectoryType": {
         "type": "string",
-        "enum": ["SCIM", "LDAP", "POLL"]
+        "enum": [
+          "SCIM",
+          "LDAP",
+          "POLL"
+        ]
       },
       "directoriesDirectoryUser": {
         "type": "object",
@@ -10850,7 +11999,9 @@
           "email": {
             "description": "Email",
             "type": "string",
-            "examples": ["johndoe"]
+            "examples": [
+              "johndoe"
+            ]
           },
           "emails": {
             "description": "Emails",
@@ -10862,12 +12013,16 @@
           "family_name": {
             "description": "Last Name",
             "type": "string",
-            "examples": ["Doe"]
+            "examples": [
+              "Doe"
+            ]
           },
           "given_name": {
             "description": "First Name",
             "type": "string",
-            "examples": ["John"]
+            "examples": [
+              "John"
+            ]
           },
           "groups": {
             "description": "Groups",
@@ -10880,18 +12035,24 @@
           "id": {
             "description": "User ID",
             "type": "string",
-            "examples": ["diruser_121312434123312"]
+            "examples": [
+              "diruser_121312434123312"
+            ]
           },
           "preferred_username": {
             "description": "Preferred Username",
             "type": "string",
-            "examples": ["johndoe"]
+            "examples": [
+              "johndoe"
+            ]
           },
           "updated_at": {
             "description": "Updated At",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-10-01T00:00:00Z"]
+            "examples": [
+              "2024-10-01T00:00:00Z"
+            ]
           },
           "user_detail": {
             "description": "Complete User Details Payload",
@@ -10979,7 +12140,9 @@
           "group_id": {
             "description": "group ID for the role mapping",
             "type": "string",
-            "examples": ["dirgroup_121312434123"]
+            "examples": [
+              "dirgroup_121312434123"
+            ]
           },
           "role_name": {
             "type": "string"
@@ -11005,18 +12168,24 @@
             "description": "Creation Time",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-10-01T00:00:00Z"]
+            "examples": [
+              "2024-10-01T00:00:00Z"
+            ]
           },
           "directory_id": {
             "description": "Directory ID",
             "type": "string",
-            "examples": ["dir_12362474900684814"]
+            "examples": [
+              "dir_12362474900684814"
+            ]
           },
           "expire_time": {
             "description": "Expiry Time",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-10-01T00:00:00Z"]
+            "examples": [
+              "2025-10-01T00:00:00Z"
+            ]
           },
           "id": {
             "type": "string"
@@ -11025,23 +12194,31 @@
             "description": "Last Used Time",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-10-01T00:00:00Z"]
+            "examples": [
+              "2024-10-01T00:00:00Z"
+            ]
           },
           "secret_suffix": {
             "description": "Secret Suffix",
             "type": "string",
-            "examples": ["Nzg5"]
+            "examples": [
+              "Nzg5"
+            ]
           },
           "status": {
             "description": "Secret Status",
             "$ref": "#/components/schemas/directoriesSecretStatus",
-            "examples": ["INACTIVE"]
+            "examples": [
+              "INACTIVE"
+            ]
           }
         }
       },
       "directoriesSecretStatus": {
         "type": "string",
-        "enum": ["INACTIVE"]
+        "enum": [
+          "INACTIVE"
+        ]
       },
       "directoriesStats": {
         "type": "object",
@@ -11050,25 +12227,33 @@
             "description": "Max time of Group Updated At for Directory",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-10-01T00:00:00Z"]
+            "examples": [
+              "2024-10-01T00:00:00Z"
+            ]
           },
           "total_groups": {
             "description": "Total Groups in the Directory",
             "type": "integer",
             "format": "int32",
-            "examples": [10]
+            "examples": [
+              10
+            ]
           },
           "total_users": {
             "description": "Total Users in the Directory",
             "type": "integer",
             "format": "int32",
-            "examples": [10]
+            "examples": [
+              10
+            ]
           },
           "user_updated_at": {
             "description": "Max time of User Updated At for Directory",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-10-01T00:00:00Z"]
+            "examples": [
+              "2024-10-01T00:00:00Z"
+            ]
           }
         }
       },
@@ -11078,12 +12263,16 @@
           "enabled": {
             "description": "Specifies the directory's state after the toggle operation. A value of `true` indicates that the directory is enabled and actively synchronizing users and groups. A value of `false` means the directory is disabled, halting synchronization",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "error_message": {
             "description": "Contains a human-readable error message if the toggle operation encountered an issue. If the operation was successful, this field will be empty",
             "type": "string",
-            "examples": ["The directory is already enabled"]
+            "examples": [
+              "The directory is already enabled"
+            ]
           }
         }
       },
@@ -11103,12 +12292,16 @@
             "description": "Timestamp when the domain was first created.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-09-01T12:14:43.100000Z"]
+            "examples": [
+              "2025-09-01T12:14:43.100000Z"
+            ]
           },
           "domain": {
             "description": "The business domain name that was configured for allowed email domain functionality (e.g., company.com, subdomain.company.com).",
             "type": "string",
-            "examples": ["customerdomain.com"]
+            "examples": [
+              "customerdomain.com"
+            ]
           },
           "domain_type": {
             "example": "ORGANIZATION_DOMAIN"
@@ -11116,40 +12309,58 @@
           "environment_id": {
             "description": "The environment ID where this domain is configured.",
             "type": "string",
-            "examples": ["env_58345499215790610"]
+            "examples": [
+              "env_58345499215790610"
+            ]
           },
           "id": {
             "description": "Scalekit-generated unique identifier for this domain record.",
             "type": "string",
-            "examples": ["dom_88351643129225005"]
+            "examples": [
+              "dom_88351643129225005"
+            ]
           },
           "organization_id": {
             "description": "The organization to which the domain belongs.",
             "type": "string",
-            "examples": ["org_81667076086825451"]
+            "examples": [
+              "org_81667076086825451"
+            ]
           },
           "update_time": {
             "description": "Timestamp when the domain was last updated.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-09-01T12:14:43.110455Z"]
+            "examples": [
+              "2025-09-01T12:14:43.110455Z"
+            ]
           },
           "verification_method": {
             "description": "Method that determines how domain ownership is verified.\n- ADMIN: domain is marked verified without DNS validation, typically by an admin.\n- DNS: domain must be verified by adding a TXT record to your DNS configuration.\n- NOT_APPLICABLE: verification does not apply to this domain type.",
             "$ref": "#/components/schemas/domainsVerificationMethod",
-            "examples": ["ADMIN"]
+            "examples": [
+              "ADMIN"
+            ]
           },
           "verification_status": {
             "description": "Verification status of the domain.\n- PENDING: DNS TXT record has not been validated yet.\n- VERIFIED: domain confirmed via DNS TXT record validation or admin approval.\n- AUTO_VERIFIED: domain verified automatically without DNS changes.\n- FAILED: DNS TXT record was not validated within the verification window.",
             "$ref": "#/components/schemas/domainsVerificationStatus",
-            "examples": ["AUTO_VERIFIED"]
+            "examples": [
+              "AUTO_VERIFIED"
+            ]
           }
         }
       },
       "domainsDomainType": {
         "type": "string",
-        "enum": ["ALLOWED_EMAIL_DOMAIN", "ORGANIZATION_DOMAIN"],
-        "x-enum-varnames": ["ORGANIZATION_DOMAIN", "ALLOWED_EMAIL_DOMAIN"]
+        "enum": [
+          "ALLOWED_EMAIL_DOMAIN",
+          "ORGANIZATION_DOMAIN"
+        ],
+        "x-enum-varnames": [
+          "ORGANIZATION_DOMAIN",
+          "ALLOWED_EMAIL_DOMAIN"
+        ]
       },
       "domainsGetDomainResponse": {
         "type": "object",
@@ -11175,23 +12386,36 @@
             "description": "Current page number in the pagination sequence.",
             "type": "integer",
             "format": "int32",
-            "examples": [1]
+            "examples": [
+              1
+            ]
           },
           "page_size": {
             "description": "Number of domains returned in this page.",
             "type": "integer",
             "format": "int32",
-            "examples": [1]
+            "examples": [
+              1
+            ]
           }
         }
       },
       "domainsVerificationMethod": {
         "type": "string",
-        "enum": ["ADMIN", "DNS", "NOT_APPLICABLE"]
+        "enum": [
+          "ADMIN",
+          "DNS",
+          "NOT_APPLICABLE"
+        ]
       },
       "domainsVerificationStatus": {
         "type": "string",
-        "enum": ["PENDING", "VERIFIED", "FAILED", "AUTO_VERIFIED"]
+        "enum": [
+          "PENDING",
+          "VERIFIED",
+          "FAILED",
+          "AUTO_VERIFIED"
+        ]
       },
       "errdetailsDebugInfo": {
         "description": "Describes additional debugging info.",
@@ -11422,13 +12646,17 @@
           "description": {
             "description": "Description of the MCP configuration",
             "type": "string",
-            "examples": ["Summarizes daily emails and posts to Slack"]
+            "examples": [
+              "Summarizes daily emails and posts to Slack"
+            ]
           },
           "id": {
             "description": "Unique ID of the MCP config",
             "type": "string",
             "readOnly": true,
-            "examples": ["cfg_85630864460904897"]
+            "examples": [
+              "cfg_85630864460904897"
+            ]
           },
           "mcp_server_url": {
             "description": "URL of the MCP server for this configuration. Empty when the MCP config server URL feature is not enabled for this environment.",
@@ -11443,7 +12671,9 @@
             "type": "string",
             "maxLength": 100,
             "minLength": 1,
-            "examples": ["daily-summarizer"]
+            "examples": [
+              "daily-summarizer"
+            ]
           }
         }
       },
@@ -11564,17 +12794,23 @@
             "description": "Expiry time of the link. The link is valid for 1 minute.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2024-02-06T14:48:00Z"]
+            "examples": [
+              "2024-02-06T14:48:00Z"
+            ]
           },
           "id": {
             "description": "Unique Identifier for the link",
             "type": "string",
-            "examples": ["lnk_123123123123123"]
+            "examples": [
+              "lnk_123123123123123"
+            ]
           },
           "location": {
             "description": "Location of the link. This is the URL that can be used to access the Admin portal. The link is valid for 1 minute",
             "type": "string",
-            "examples": ["https://scalekit.com/portal/lnk_123123123123123"]
+            "examples": [
+              "https://scalekit.com/portal/lnk_123123123123123"
+            ]
           }
         }
       },
@@ -11584,7 +12820,9 @@
           "next_page_token": {
             "description": "Pagination token for the next page of results. Use this token to fetch the next page.",
             "type": "string",
-            "examples": ["<next_page_token>"]
+            "examples": [
+              "<next_page_token>"
+            ]
           },
           "organizations": {
             "description": "List of organization objects",
@@ -11597,44 +12835,58 @@
           "prev_page_token": {
             "description": "Pagination token for the previous page of results. Use this token to fetch the previous page.",
             "type": "string",
-            "examples": ["<prev_page_token>"]
+            "examples": [
+              "<prev_page_token>"
+            ]
           },
           "total_size": {
             "description": "Total number of organizations in the environment.",
             "type": "integer",
             "format": "int64",
-            "examples": [30]
+            "examples": [
+              30
+            ]
           }
         }
       },
       "organizationsOrganization": {
         "type": "object",
-        "required": ["create_time"],
+        "required": [
+          "create_time"
+        ],
         "properties": {
           "create_time": {
             "description": "Timestamp when the organization was created",
             "type": "string",
             "format": "date-time",
             "title": "Created Time",
-            "examples": ["2025-02-15T06:23:44.560000Z"]
+            "examples": [
+              "2025-02-15T06:23:44.560000Z"
+            ]
           },
           "display_name": {
             "description": "Name of the organization. Must be between 1 and 200 characters",
             "type": "string",
             "title": "Name of the org to be used in display",
-            "examples": ["Megasoft"]
+            "examples": [
+              "Megasoft"
+            ]
           },
           "external_id": {
             "description": "Your application's unique identifier for this organization, used to link Scalekit with your system.",
             "type": "string",
             "title": "External Id is useful to store a unique identifier for a given Org that. The unique Identifier can be the id of your tenant / org in your SaaSApp",
-            "examples": ["my_unique_id"]
+            "examples": [
+              "my_unique_id"
+            ]
           },
           "id": {
             "description": "Unique scalekit-generated identifier that uniquely references an organization",
             "type": "string",
             "title": "Id",
-            "examples": ["org_59615193906282635"]
+            "examples": [
+              "org_59615193906282635"
+            ]
           },
           "logo_url": {
             "description": "HTTPS URL of the organization's logo image. Maximum 1024 characters. Must use the https scheme.",
@@ -11642,7 +12894,9 @@
             "format": "uri",
             "maxLength": 1024,
             "pattern": "^https://",
-            "examples": ["https://cdn.example.com/acme-logo.png"]
+            "examples": [
+              "https://cdn.example.com/acme-logo.png"
+            ]
           },
           "metadata": {
             "description": "Key value pairs extension attributes.",
@@ -11655,7 +12909,9 @@
             "description": "Geographic region code for the organization. Currently limited to US.",
             "title": "Optional regioncode",
             "$ref": "#/components/schemas/commonsRegionCode",
-            "examples": ["US"]
+            "examples": [
+              "US"
+            ]
           },
           "settings": {
             "title": "Organization Settings",
@@ -11667,14 +12923,18 @@
             "maxLength": 253,
             "minLength": 1,
             "pattern": "^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$",
-            "examples": ["acme"]
+            "examples": [
+              "acme"
+            ]
           },
           "update_time": {
             "description": "Timestamp when the organization was last updated",
             "type": "string",
             "format": "date-time",
             "title": "Updated time",
-            "examples": ["2025-02-15T06:23:44.560000Z"]
+            "examples": [
+              "2025-02-15T06:23:44.560000Z"
+            ]
           }
         }
       },
@@ -11685,33 +12945,45 @@
             "description": "The absolute session timeout value. The unit is specified by absolute_session_timeout_unit. Omitted when policy_source is 'environment'.",
             "type": "integer",
             "format": "int32",
-            "examples": [360]
+            "examples": [
+              360
+            ]
           },
           "absolute_session_timeout_unit": {
             "description": "Unit for absolute_session_timeout. Accepted values: 'minutes', 'hours', 'days'. Responses always return 'minutes'.",
             "$ref": "#/components/schemas/commonsTimeUnit",
-            "examples": ["minutes"]
+            "examples": [
+              "minutes"
+            ]
           },
           "idle_session_timeout": {
             "description": "The idle session timeout value. The unit is specified by idle_session_timeout_unit. Omitted when idle_session_timeout_enabled is false or policy_source is 'environment'.",
             "type": "integer",
             "format": "int32",
-            "examples": [84]
+            "examples": [
+              84
+            ]
           },
           "idle_session_timeout_enabled": {
             "description": "Whether idle session timeout is enabled for this organization. Omitted when policy_source is 'environment'.",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "idle_session_timeout_unit": {
             "description": "Unit for idle_session_timeout. Accepted values: 'minutes', 'hours', 'days'. Responses always return 'minutes'.",
             "$ref": "#/components/schemas/commonsTimeUnit",
-            "examples": ["minutes"]
+            "examples": [
+              "minutes"
+            ]
           },
           "policy_source": {
             "description": "Policy source. 'APPLICATION' means the organization inherits the application-level session policy. 'CUSTOM' means organization-specific timeout values are active.",
             "$ref": "#/components/schemas/organizationsSessionPolicyType",
-            "examples": ["CUSTOM"]
+            "examples": [
+              "CUSTOM"
+            ]
           }
         }
       },
@@ -11760,17 +13032,24 @@
         "description": "Controls the activation state of a specific organization feature",
         "type": "object",
         "title": "Organization Feature Toggle",
-        "required": ["name", "enabled"],
+        "required": [
+          "name",
+          "enabled"
+        ],
         "properties": {
           "enabled": {
             "description": "Whether the feature is enabled (true) or disabled (false) for this organization",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "name": {
             "description": "Feature identifier. Supported values include: \"sso\" (Single Sign-On), \"directory_sync\" (Directory Synchronization), \"domain_verification\" (Domain Verification), \"session_policy\" (Organization-level session policy override)",
             "type": "string",
-            "examples": ["sso"]
+            "examples": [
+              "sso"
+            ]
           }
         }
       },
@@ -11781,13 +13060,18 @@
             "description": "Maximum number of users allowed in the organization. When nil (not set), there feature is not enabled. When explicitly set to zero, it also means no limit. When set to a positive integer, it enforces the maximum user limit.",
             "type": "integer",
             "format": "int32",
-            "examples": [100]
+            "examples": [
+              100
+            ]
           }
         }
       },
       "organizationsSessionPolicyType": {
         "type": "string",
-        "enum": ["APPLICATION", "CUSTOM"]
+        "enum": [
+          "APPLICATION",
+          "CUSTOM"
+        ]
       },
       "organizationsUpdateOrganizationResponse": {
         "type": "object",
@@ -11822,7 +13106,9 @@
           "auth_request_id": {
             "description": "The authentication request identifier from the original send passwordless email request. Use this to resend the Verification Code (OTP) or Magic Link to the same email address.",
             "type": "string",
-            "examples": ["h5Y8kT5RVwaea5WEgW4n-6C-aO_-fuTUW7Vb9-Rh3AcY9qxZqQ"]
+            "examples": [
+              "h5Y8kT5RVwaea5WEgW4n-6C-aO_-fuTUW7Vb9-Rh3AcY9qxZqQ"
+            ]
           }
         }
       },
@@ -11832,28 +13118,38 @@
           "email": {
             "description": "Email address where the passwordless authentication credentials will be sent. Must be a valid email format.",
             "type": "string",
-            "examples": ["john.doe@example.com"]
+            "examples": [
+              "john.doe@example.com"
+            ]
           },
           "expires_in": {
             "description": "Time in seconds until the passwordless authentication expires. If not specified, defaults to 300 seconds (5 minutes)",
             "type": "integer",
             "format": "int64",
-            "examples": [300]
+            "examples": [
+              300
+            ]
           },
           "magiclink_auth_uri": {
             "description": "Your application's callback URL where users will be redirected after clicking the magic link in their email. The link token will be appended as a query parameter as link_token",
             "type": "string",
-            "examples": ["https://yourapp.com/auth/passwordless/callback"]
+            "examples": [
+              "https://yourapp.com/auth/passwordless/callback"
+            ]
           },
           "state": {
             "description": "Custom state parameter that will be returned unchanged in the verification response. Use this to maintain application state between the authentication request and callback, such as the intended destination after login",
             "type": "string",
-            "examples": ["d62ivasry29lso"]
+            "examples": [
+              "d62ivasry29lso"
+            ]
           },
           "template": {
             "description": "Specifies the authentication intent for the passwordless request. Use SIGNIN for existing users or SIGNUP for new user registration. This affects the email template and user experience flow.",
             "$ref": "#/components/schemas/passwordlessTemplateType",
-            "examples": ["SIGNIN"]
+            "examples": [
+              "SIGNIN"
+            ]
           },
           "template_variables": {
             "description": "A set of key-value pairs to personalize the email template.\n\n* You may include up to 30 key-value pairs.\n* The following variable names are reserved by the system and cannot be supplied: `otp`, `expiry_time_relative`, `link`, `expire_time`, `expiry_time`.\n* Every variable referenced in your email template must be included as a key-value pair.\n\nUse these variables to insert custom information, such as a team name, URL or the user's employee ID. All variables are interpolated before the email is sent, regardless of the email provider.",
@@ -11876,32 +13172,43 @@
             "description": "Unique identifier for this passwordless authentication request. Use this ID to resend emails.",
             "type": "string",
             "readOnly": true,
-            "examples": ["h5Y8kT5RVwaea5WEgW4n-6C-aO_-fuTUW7Vb9-Rh3AcY9qxZqQ"]
+            "examples": [
+              "h5Y8kT5RVwaea5WEgW4n-6C-aO_-fuTUW7Vb9-Rh3AcY9qxZqQ"
+            ]
           },
           "expires_at": {
             "description": "Unix timestamp (seconds since epoch) when the passwordless authentication will expire. After this time, the OTP or magic link will no longer be valid.",
             "type": "string",
             "format": "int64",
             "readOnly": true,
-            "examples": [1748696575]
+            "examples": [
+              1748696575
+            ]
           },
           "expires_in": {
             "description": "Number of seconds from now until the passwordless authentication expires. This is a convenience field calculated from the expires_at timestamp.",
             "type": "integer",
             "format": "int64",
             "readOnly": true,
-            "examples": [300]
+            "examples": [
+              300
+            ]
           },
           "passwordless_type": {
             "description": "Type of passwordless authentication that was sent via email. OTP sends a numeric code, LINK sends a clickable magic link, and LINK_OTP provides both options for user convenience.",
             "$ref": "#/components/schemas/authpasswordlessPasswordlessType",
-            "examples": ["OTP"]
+            "examples": [
+              "OTP"
+            ]
           }
         }
       },
       "passwordlessTemplateType": {
         "type": "string",
-        "enum": ["SIGNIN", "SIGNUP"]
+        "enum": [
+          "SIGNIN",
+          "SIGNUP"
+        ]
       },
       "passwordlessVerifyPasswordLessRequest": {
         "type": "object",
@@ -11909,17 +13216,23 @@
           "auth_request_id": {
             "description": "The authentication request identifier returned from the send passwordless email endpoint. Required when verifying OTP codes to link the verification with the original request.",
             "type": "string",
-            "examples": ["h5Y8kT5RVwaea5WEgW4n-6C-aO_-fuTUW7Vb9-Rh3AcY9qxZqQ"]
+            "examples": [
+              "h5Y8kT5RVwaea5WEgW4n-6C-aO_-fuTUW7Vb9-Rh3AcY9qxZqQ"
+            ]
           },
           "code": {
             "description": "The Verification Code (OTP) received via email. This is typically a 6-digit numeric code that users enter manually to verify their identity.",
             "type": "string",
-            "examples": ["123456"]
+            "examples": [
+              "123456"
+            ]
           },
           "link_token": {
             "description": "The unique token from the magic link URL received via email. Extract this token when users click the magic link and are redirected to your application to later verify the user.",
             "type": "string",
-            "examples": ["afe9d61c-d80d-4020-a8ee-61765ab71cb3"]
+            "examples": [
+              "afe9d61c-d80d-4020-a8ee-61765ab71cb3"
+            ]
           }
         }
       },
@@ -11930,23 +13243,31 @@
             "description": "Email address of the successfully authenticated user. This confirms which email account was verified through the passwordless flow.",
             "type": "string",
             "readOnly": true,
-            "examples": ["john.doe@example.com"]
+            "examples": [
+              "john.doe@example.com"
+            ]
           },
           "passwordless_type": {
             "description": "The type of passwordless authentication that was successfully verified, confirming which method the user completed.",
             "$ref": "#/components/schemas/authpasswordlessPasswordlessType",
-            "examples": ["OTP"]
+            "examples": [
+              "OTP"
+            ]
           },
           "state": {
             "description": "The custom state parameter that was provided in the original authentication request, returned unchanged. Use this to restore your application's context after authentication.",
             "type": "string",
             "readOnly": true,
-            "examples": ["kdt7yiag28t341fr1"]
+            "examples": [
+              "kdt7yiag28t341fr1"
+            ]
           },
           "template": {
             "description": "Specifies which email template to choose. For User Signin choose SIGNIN and for User Signup use SIGNUP",
             "$ref": "#/components/schemas/passwordlessTemplateType",
-            "examples": ["SIGNIN"]
+            "examples": [
+              "SIGNIN"
+            ]
           }
         }
       },
@@ -12002,12 +13323,16 @@
           "is_custom": {
             "description": "Indicates whether the provider is environment-scoped (custom provider)",
             "type": "boolean",
-            "examples": [false]
+            "examples": [
+              false
+            ]
           },
           "is_custom_mcp": {
             "description": "Indicates whether this is an environment-scoped MCP-based custom provider",
             "type": "boolean",
-            "examples": [false]
+            "examples": [
+              false
+            ]
           },
           "metadata": {
             "description": "Custom key-value metadata stored for this provider. Returned for all providers; defaults to {} when no metadata has been set.",
@@ -12129,7 +13454,9 @@
             "description": "Number of users associated with the role",
             "type": "string",
             "format": "int64",
-            "examples": [10]
+            "examples": [
+              10
+            ]
           }
         }
       },
@@ -12178,7 +13505,9 @@
           "next_page_token": {
             "description": "Token to retrieve next page of results",
             "type": "string",
-            "examples": ["token_def456"]
+            "examples": [
+              "token_def456"
+            ]
           },
           "permissions": {
             "type": "array",
@@ -12190,13 +13519,17 @@
           "prev_page_token": {
             "description": "Token to retrieve previous page of results",
             "type": "string",
-            "examples": ["token_def456"]
+            "examples": [
+              "token_def456"
+            ]
           },
           "total_size": {
             "description": "Total number of permissions available",
             "type": "integer",
             "format": "int64",
-            "examples": [150]
+            "examples": [
+              150
+            ]
           }
         }
       },
@@ -12257,7 +13590,9 @@
           "is_scalekit_permission": {
             "description": "Indicates whether this permission is predefined by Scalekit",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "name": {
             "type": "string"
@@ -12288,7 +13623,9 @@
           "role_name": {
             "description": "Name of the role from which this permission was sourced",
             "type": "string",
-            "examples": ["admin_role"]
+            "examples": [
+              "admin_role"
+            ]
           },
           "update_time": {
             "type": "string",
@@ -12322,7 +13659,9 @@
           "name": {
             "description": "Unique name of the role",
             "type": "string",
-            "examples": ["creator"]
+            "examples": [
+              "creator"
+            ]
           }
         }
       },
@@ -12344,7 +13683,9 @@
           "default_creator_role": {
             "description": "Name of the role to set as the default creator role. This role will be automatically assigned to users who create new resources in the environment. Must be a valid role name that exists in the environment.",
             "type": "string",
-            "examples": ["creator"]
+            "examples": [
+              "creator"
+            ]
           },
           "default_member": {
             "description": "Default member role (deprecated - use default_member_role field instead)",
@@ -12361,7 +13702,9 @@
           "default_member_role": {
             "description": "Name of the role to set as the default member role. This role will be automatically assigned to new users when they join the environment. Must be a valid role name that exists in the environment.",
             "type": "string",
-            "examples": ["member"]
+            "examples": [
+              "member"
+            ]
           }
         }
       },
@@ -12434,12 +13777,16 @@
           "client_id": {
             "description": "Unique identifier of the authenticated client application.",
             "type": "string",
-            "examples": ["skc_1234567890"]
+            "examples": [
+              "skc_1234567890"
+            ]
           },
           "organization_id": {
             "description": "Active or last active Organization ID associated with the authenticated client.",
             "type": "string",
-            "examples": ["org_1234567890"]
+            "examples": [
+              "org_1234567890"
+            ]
           }
         }
       },
@@ -12449,22 +13796,30 @@
           "browser": {
             "description": "Browser name and family extracted from the user agent. Examples: Chrome, Safari, Firefox, Edge, Mobile Safari.",
             "type": "string",
-            "examples": ["Chrome"]
+            "examples": [
+              "Chrome"
+            ]
           },
           "browser_version": {
             "description": "Version of the browser application. Represents the specific release version of the browser being used.",
             "type": "string",
-            "examples": ["120.0.0.0"]
+            "examples": [
+              "120.0.0.0"
+            ]
           },
           "device_type": {
             "description": "Categorized device type classification. Possible values: 'desktop' (traditional computers), 'mobile' (smartphones and small tablets), 'tablet' (large tablets), 'other'. Useful for displaying session information by device category.",
             "type": "string",
-            "examples": ["desktop"]
+            "examples": [
+              "desktop"
+            ]
           },
           "ip": {
             "description": "IP address of the device that initiated the session. This is the public-facing IP address used to connect to the application. Useful for security audits and geographic distribution analysis.",
             "type": "string",
-            "examples": ["192.0.2.1"]
+            "examples": [
+              "192.0.2.1"
+            ]
           },
           "location": {
             "description": "Geographic location information derived from IP address geolocation. Includes country, region, city, and coordinates. Note: Based on IP location data and may not represent the user's exact physical location.",
@@ -12473,12 +13828,16 @@
           "os": {
             "description": "Operating system name extracted from the user agent and device headers. Examples: macOS, Windows, Linux, iOS, Android.",
             "type": "string",
-            "examples": ["macOS"]
+            "examples": [
+              "macOS"
+            ]
           },
           "os_version": {
             "description": "Version of the operating system. Represents the specific OS release the device is running.",
             "type": "string",
-            "examples": ["14.2"]
+            "examples": [
+              "14.2"
+            ]
           },
           "user_agent": {
             "description": "Complete HTTP User-Agent header string from the client request. Contains browser type, version, and operating system information. Used for detailed device fingerprinting and user agent analysis.",
@@ -12504,7 +13863,9 @@
             "description": "Total count of active sessions that were revoked. Useful for confirmation and audit logging.",
             "type": "integer",
             "format": "int64",
-            "examples": [5]
+            "examples": [
+              5
+            ]
           }
         }
       },
@@ -12524,58 +13885,78 @@
             "description": "The absolute expiration timestamp that was configured for this session before revocation. Represents the hard deadline regardless of activity.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-22T10:30:00Z"]
+            "examples": [
+              "2025-01-22T10:30:00Z"
+            ]
           },
           "created_at": {
             "description": "Timestamp indicating when the session was originally created before revocation.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-15T10:30:00Z"]
+            "examples": [
+              "2025-01-15T10:30:00Z"
+            ]
           },
           "expired_at": {
             "description": "Timestamp when the session was actually terminated. Set to the revocation time when the session is revoked.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-15T12:00:00Z"]
+            "examples": [
+              "2025-01-15T12:00:00Z"
+            ]
           },
           "idle_expires_at": {
             "description": "The idle expiration timestamp that was configured for this session before revocation. Represents when the session would have expired due to inactivity.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-15T11:30:00Z"]
+            "examples": [
+              "2025-01-15T11:30:00Z"
+            ]
           },
           "last_active_at": {
             "description": "Timestamp of the last recorded user activity in this session before revocation. Helps identify inactive sessions that were revoked.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-15T10:55:30Z"]
+            "examples": [
+              "2025-01-15T10:55:30Z"
+            ]
           },
           "logout_at": {
             "description": "Timestamp when the user explicitly logged out (if applicable). Null if the session was revoked without prior logout.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-15T14:00:00Z"]
+            "examples": [
+              "2025-01-15T14:00:00Z"
+            ]
           },
           "session_id": {
             "description": "Unique identifier for the revoked session. System-generated read-only field.",
             "type": "string",
-            "examples": ["ses_1234567890123456"]
+            "examples": [
+              "ses_1234567890123456"
+            ]
           },
           "status": {
             "description": "Status of the session after revocation. Always 'revoked' since only active sessions can be revoked. Sessions that were already expired or logged out are not included in the revocation response.",
             "type": "string",
-            "examples": ["revoked"]
+            "examples": [
+              "revoked"
+            ]
           },
           "updated_at": {
             "description": "Timestamp indicating when the session was last modified before revocation.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-15T10:45:00Z"]
+            "examples": [
+              "2025-01-15T10:45:00Z"
+            ]
           },
           "user_id": {
             "description": "Unique identifier for the user who owned this session.",
             "type": "string",
-            "examples": ["usr_1234567890123456"]
+            "examples": [
+              "usr_1234567890123456"
+            ]
           }
         }
       },
@@ -12586,7 +13967,9 @@
             "description": "Hard expiration timestamp for the session regardless of user activity. The session will be forcibly terminated at this time. This represents the maximum session lifetime from creation.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-22T10:30:00Z"]
+            "examples": [
+              "2025-01-22T10:30:00Z"
+            ]
           },
           "authenticated_clients": {
             "description": "Details of the authenticated clients for this session: client ID and organization context.",
@@ -12602,13 +13985,20 @@
             "items": {
               "type": "string"
             },
-            "examples": [["org_123", "org_456"]]
+            "examples": [
+              [
+                "org_123",
+                "org_456"
+              ]
+            ]
           },
           "created_at": {
             "description": "Timestamp indicating when the session was created. This is set once at session creation and remains constant throughout the session lifetime.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-15T10:30:00Z"]
+            "examples": [
+              "2025-01-15T10:30:00Z"
+            ]
           },
           "device": {
             "description": "Complete device metadata associated with this session including browser, operating system, device type, and geographic location based on IP address.",
@@ -12618,51 +14008,69 @@
             "description": "Timestamp when the session was terminated. Null if the session is still active. Set when the session expires due to reaching idle_expires_at or absolute_expires_at timeout, or when administratively revoked. Not set for user-initiated logout (see logout_at instead).",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-15T12:00:00Z"]
+            "examples": [
+              "2025-01-15T12:00:00Z"
+            ]
           },
           "idle_expires_at": {
             "description": "Projected expiration timestamp if the session remains idle without user activity. This timestamp is recalculated with each user activity. Session will be automatically terminated at this time if no activity occurs.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-15T11:30:00Z"]
+            "examples": [
+              "2025-01-15T11:30:00Z"
+            ]
           },
           "last_active_at": {
             "description": "Timestamp of the most recent user activity detected in this session. Updated on each API request or user interaction. Used to determine if a session has exceeded the idle timeout threshold.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-15T10:55:30Z"]
+            "examples": [
+              "2025-01-15T10:55:30Z"
+            ]
           },
           "logout_at": {
             "description": "Timestamp when the user explicitly logged out from the session. Null if the user has not logged out. When set, indicates the session ended due to explicit user logout rather than timeout.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-15T14:00:00Z"]
+            "examples": [
+              "2025-01-15T14:00:00Z"
+            ]
           },
           "organization_id": {
             "description": "Organization ID for the user's most recently active organization within this session. This represents the primary organization context for the current session.",
             "type": "string",
-            "examples": ["org_1234567890123456"]
+            "examples": [
+              "org_1234567890123456"
+            ]
           },
           "session_id": {
             "description": "Unique identifier for the session. System-generated read-only field used to reference this session.",
             "type": "string",
-            "examples": ["ses_1234567890123456"]
+            "examples": [
+              "ses_1234567890123456"
+            ]
           },
           "status": {
             "description": "Current operational status of the session. Possible values: 'active' (session is valid and requests are allowed), 'expired' (session terminated due to idle or absolute timeout), 'revoked' (session was administratively revoked), 'logout' (user explicitly logged out). Use this to determine if the session can be used for new requests.",
             "type": "string",
-            "examples": ["active"]
+            "examples": [
+              "active"
+            ]
           },
           "updated_at": {
             "description": "Timestamp indicating when the session was last updated. Updated whenever session state changes such as organization context changes or metadata updates.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-01-15T10:45:00Z"]
+            "examples": [
+              "2025-01-15T10:45:00Z"
+            ]
           },
           "user_id": {
             "description": "Unique identifier for the user who owns and is authenticated within this session.",
             "type": "string",
-            "examples": ["usr_1234567890123456"]
+            "examples": [
+              "usr_1234567890123456"
+            ]
           }
         }
       },
@@ -12672,12 +14080,16 @@
           "next_page_token": {
             "description": "Pagination token for retrieving the next page of results. Empty string if there are no more pages (you have reached the final page of results).",
             "type": "string",
-            "examples": ["eyJwYWdlIjogMiwgImxhc3RfaWQiOiAic2VzXzEyMzQ1In0="]
+            "examples": [
+              "eyJwYWdlIjogMiwgImxhc3RfaWQiOiAic2VzXzEyMzQ1In0="
+            ]
           },
           "prev_page_token": {
             "description": "Pagination token for retrieving the previous page of results. Empty string for the first page. Use this to navigate backward through result pages.",
             "type": "string",
-            "examples": ["eyJwYWdlIjogMCwgImZpcnN0X2lkIjogInNlc183OTAxIn0="]
+            "examples": [
+              "eyJwYWdlIjogMCwgImZpcnN0X2lkIjogInNlc183OTAxIn0="
+            ]
           },
           "sessions": {
             "description": "Array of session objects for the requested user. May contain fewer entries than the requested page_size when reaching the final page of results.",
@@ -12691,7 +14103,9 @@
             "description": "Total number of sessions matching the applied filter criteria, regardless of pagination. This represents the complete result set size before pagination is applied.",
             "type": "integer",
             "format": "int64",
-            "examples": [42]
+            "examples": [
+              42
+            ]
           }
         }
       },
@@ -12701,27 +14115,37 @@
           "agent_run_id": {
             "description": "Optional. Customer-supplied identifier grouping multiple tool calls into a single agent run. Useful for correlating logs across an agentic workflow.",
             "type": "string",
-            "examples": ["run_abc123"]
+            "examples": [
+              "run_abc123"
+            ]
           },
           "connected_account_id": {
             "description": "Optional. The unique ID of the connected account. Use this to directly identify the connected account instead of using identifier + connector combination.",
             "type": "string",
-            "examples": ["ca_123"]
+            "examples": [
+              "ca_123"
+            ]
           },
           "connector": {
             "description": "Optional. The name of the connector/provider (e.g., 'Google Workspace', 'Slack', 'Notion'). Alphanumeric characters, spaces, hyphens, underscores, and colons are allowed. Use this in combination with identifier to identify the connected account.",
             "type": "string",
-            "examples": ["Google Workspace"]
+            "examples": [
+              "Google Workspace"
+            ]
           },
           "identifier": {
             "description": "Optional. The unique identifier for the connected account within the third-party service (e.g., email address, user ID, workspace identifier). Use this in combination with connector to identify the connected account.",
             "type": "string",
-            "examples": ["user@example.com"]
+            "examples": [
+              "user@example.com"
+            ]
           },
           "organization_id": {
             "description": "Optional. The organization ID to scope the connected account lookup. Use this to narrow down the search when the same identifier exists across multiple organizations.",
             "type": "string",
-            "examples": ["org_123"]
+            "examples": [
+              "org_123"
+            ]
           },
           "params": {
             "description": "JSON object containing the parameters required for tool execution. The structure depends on the specific tool being executed.",
@@ -12737,12 +14161,16 @@
           "tool_name": {
             "description": "Name of the tool to execute",
             "type": "string",
-            "examples": ["send_email"]
+            "examples": [
+              "send_email"
+            ]
           },
           "user_id": {
             "description": "Optional. The user ID to scope the connected account lookup. Use this to narrow down the search when the same identifier exists across multiple users.",
             "type": "string",
-            "examples": ["user_123"]
+            "examples": [
+              "user_123"
+            ]
           }
         }
       },
@@ -12763,7 +14191,9 @@
           "execution_id": {
             "description": "Unique identifier for the tool execution",
             "type": "string",
-            "examples": ["123456789"]
+            "examples": [
+              "123456789"
+            ]
           }
         }
       },
@@ -12781,12 +14211,16 @@
           "email": {
             "description": "Primary email address for the user. Must be unique across the environment and valid per RFC 5322.",
             "type": "string",
-            "examples": ["user@example.com"]
+            "examples": [
+              "user@example.com"
+            ]
           },
           "external_id": {
             "description": "Your application's unique identifier for this organization, used to link Scalekit with your system.",
             "type": "string",
-            "examples": ["ext_12345a67b89c"]
+            "examples": [
+              "ext_12345a67b89c"
+            ]
           },
           "membership": {
             "description": "List of organization memberships. Automatically populated based on group assignments.",
@@ -12838,17 +14272,23 @@
           "family_name": {
             "description": "User's family name. Maximum 255 characters.",
             "type": "string",
-            "examples": ["Doe"]
+            "examples": [
+              "Doe"
+            ]
           },
           "gender": {
             "description": "User's gender identity.",
             "type": "string",
-            "examples": ["male"]
+            "examples": [
+              "male"
+            ]
           },
           "given_name": {
             "description": "User's given name. Maximum 255 characters.",
             "type": "string",
-            "examples": ["John"]
+            "examples": [
+              "John"
+            ]
           },
           "groups": {
             "description": "List of group names the user belongs to. Each group name must be 1-250 characters",
@@ -12856,12 +14296,19 @@
             "items": {
               "type": "string"
             },
-            "examples": [["engineering", "managers"]]
+            "examples": [
+              [
+                "engineering",
+                "managers"
+              ]
+            ]
           },
           "locale": {
             "description": "User's localization preference in BCP-47 format. Defaults to organization settings.",
             "type": "string",
-            "examples": ["en-US"]
+            "examples": [
+              "en-US"
+            ]
           },
           "metadata": {
             "description": "System-managed key-value pairs for internal tracking. Keys (3-25 chars), values (1-256 chars).",
@@ -12879,22 +14326,30 @@
           "name": {
             "description": "Full name in display format. Typically combines first_name and last_name.",
             "type": "string",
-            "examples": ["John Michael Doe"]
+            "examples": [
+              "John Michael Doe"
+            ]
           },
           "phone_number": {
             "description": "Phone number in E.164 international format. Required for SMS-based authentication.",
             "type": "string",
-            "examples": ["+14155552671"]
+            "examples": [
+              "+14155552671"
+            ]
           },
           "picture": {
             "description": "URL to the user's profile picture or avatar.",
             "type": "string",
-            "examples": ["https://example.com/avatar.jpg"]
+            "examples": [
+              "https://example.com/avatar.jpg"
+            ]
           },
           "preferred_username": {
             "description": "User's preferred username for display purposes.",
             "type": "string",
-            "examples": ["John Michael Doe"]
+            "examples": [
+              "John Michael Doe"
+            ]
           }
         }
       },
@@ -12913,45 +14368,61 @@
             "description": "Timestamp when the invite was originally created.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-07-10T08:00:00Z"]
+            "examples": [
+              "2025-07-10T08:00:00Z"
+            ]
           },
           "expires_at": {
             "description": "The time at which the invite expires.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-12-31T23:59:59Z"]
+            "examples": [
+              "2025-12-31T23:59:59Z"
+            ]
           },
           "inviter_email": {
             "description": "Identifier of the user or system that initiated the invite.",
             "type": "string",
-            "examples": ["admin@example.com"]
+            "examples": [
+              "admin@example.com"
+            ]
           },
           "organization_id": {
             "description": "The organization to which the invite belongs.",
             "type": "string",
-            "examples": ["org_987654321"]
+            "examples": [
+              "org_987654321"
+            ]
           },
           "resent_at": {
             "description": "Timestamp when the invite was last resent, if applicable.",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-07-15T09:30:00Z"]
+            "examples": [
+              "2025-07-15T09:30:00Z"
+            ]
           },
           "resent_count": {
             "description": "Number of times the invite has been resent.",
             "type": "integer",
             "format": "int32",
-            "examples": [2]
+            "examples": [
+              2
+            ]
           },
           "status": {
             "description": "Current status of the invite (e.g., pending, accepted, expired, revoked).",
             "type": "string",
-            "examples": ["pending_invite"]
+            "examples": [
+              "pending_invite"
+            ]
           },
           "user_id": {
             "description": "User ID to whom the invite is sent. May be empty if the user has not signed up yet.",
             "type": "string",
-            "examples": ["usr_123456"]
+            "examples": [
+              "usr_123456"
+            ]
           }
         }
       },
@@ -12961,18 +14432,24 @@
           "next_page_token": {
             "description": "Opaque token for retrieving the next page of results. Empty if there are no more pages.",
             "type": "string",
-            "examples": ["eyJwYWdlIjogMiwgImxhc3RfaWQiOiAidXNyXzEyMzQ1In0="]
+            "examples": [
+              "eyJwYWdlIjogMiwgImxhc3RfaWQiOiAidXNyXzEyMzQ1In0="
+            ]
           },
           "prev_page_token": {
             "description": "Opaque token for retrieving the previous page of results. Empty for the first page.",
             "type": "string",
-            "examples": ["eyJwYWdlIjogMCwgImZpcnN0X2lkIjogInVzcl85ODc2NSJ9"]
+            "examples": [
+              "eyJwYWdlIjogMCwgImZpcnN0X2lkIjogInVzcl85ODc2NSJ9"
+            ]
           },
           "total_size": {
             "description": "Total number of users matching the request criteria, regardless of pagination.",
             "type": "integer",
             "format": "int64",
-            "examples": [1042]
+            "examples": [
+              1042
+            ]
           },
           "users": {
             "description": "List of user objects for the current page. May contain fewer entries than requested page_size.",
@@ -13016,18 +14493,24 @@
           "next_page_token": {
             "description": "Token for retrieving the next page of results. Empty if there are no more pages.",
             "type": "string",
-            "examples": ["eyJwYWdlIjogMiwgImxhc3RfaWQiOiAidXNyXzEyMzQ1In0="]
+            "examples": [
+              "eyJwYWdlIjogMiwgImxhc3RfaWQiOiAidXNyXzEyMzQ1In0="
+            ]
           },
           "prev_page_token": {
             "description": "Token for retrieving the previous page of results. Empty if this is the first page.",
             "type": "string",
-            "examples": ["eyJwYWdlIjogMCwgImZpcnN0X2lkIjogInVzcl85ODc2NSJ9"]
+            "examples": [
+              "eyJwYWdlIjogMCwgImZpcnN0X2lkIjogInVzcl85ODc2NSJ9"
+            ]
           },
           "total_size": {
             "description": "Total number of users matching the request criteria, regardless of pagination.",
             "type": "integer",
             "format": "int64",
-            "examples": [1042]
+            "examples": [
+              1042
+            ]
           },
           "users": {
             "description": "List of users.",
@@ -13045,18 +14528,24 @@
           "description": {
             "description": "Description of what the permission allows",
             "type": "string",
-            "examples": ["Allows creating new user accounts"]
+            "examples": [
+              "Allows creating new user accounts"
+            ]
           },
           "id": {
             "description": "Unique identifier for the permission",
             "type": "string",
             "readOnly": true,
-            "examples": ["perm_1234abcd5678efgh"]
+            "examples": [
+              "perm_1234abcd5678efgh"
+            ]
           },
           "name": {
             "description": "Unique name identifier for the permission",
             "type": "string",
-            "examples": ["users:create"]
+            "examples": [
+              "users:create"
+            ]
           }
         }
       },
@@ -13084,18 +14573,24 @@
           "next_page_token": {
             "description": "Token for retrieving the next page of results. Empty if there are no more pages.",
             "type": "string",
-            "examples": ["eyJwYWdlIjogMiwgImxhc3RfaWQiOiAidXNyXzEyMzQ1In0="]
+            "examples": [
+              "eyJwYWdlIjogMiwgImxhc3RfaWQiOiAidXNyXzEyMzQ1In0="
+            ]
           },
           "prev_page_token": {
             "description": "Token for retrieving the previous page of results. Empty if this is the first page.",
             "type": "string",
-            "examples": ["eyJwYWdlIjogMCwgImZpcnN0X2lkIjogInVzcl85ODc2NSJ9"]
+            "examples": [
+              "eyJwYWdlIjogMCwgImZpcnN0X2lkIjogInVzcl85ODc2NSJ9"
+            ]
           },
           "total_size": {
             "description": "Total number of users matching the request criteria, regardless of pagination.",
             "type": "integer",
             "format": "int64",
-            "examples": [1042]
+            "examples": [
+              1042
+            ]
           },
           "users": {
             "description": "List of matching users.",
@@ -13113,18 +14608,24 @@
           "next_page_token": {
             "description": "Token for retrieving the next page of results. Empty if there are no more pages.",
             "type": "string",
-            "examples": ["eyJwYWdlIjogMiwgImxhc3RfaWQiOiAidXNyXzEyMzQ1In0="]
+            "examples": [
+              "eyJwYWdlIjogMiwgImxhc3RfaWQiOiAidXNyXzEyMzQ1In0="
+            ]
           },
           "prev_page_token": {
             "description": "Token for retrieving the previous page of results. Empty if this is the first page.",
             "type": "string",
-            "examples": ["eyJwYWdlIjogMCwgImZpcnN0X2lkIjogInVzcl85ODc2NSJ9"]
+            "examples": [
+              "eyJwYWdlIjogMCwgImZpcnN0X2lkIjogInVzcl85ODc2NSJ9"
+            ]
           },
           "total_size": {
             "description": "Total number of users matching the request criteria, regardless of pagination.",
             "type": "integer",
             "format": "int64",
-            "examples": [1042]
+            "examples": [
+              1042
+            ]
           },
           "users": {
             "description": "List of matching users.",
@@ -13163,22 +14664,30 @@
           "family_name": {
             "description": "Updates the user's family name (last name or surname). Use this field to modify how the user's last name appears throughout the system. Maximum 255 characters allowed.",
             "type": "string",
-            "examples": ["Doe"]
+            "examples": [
+              "Doe"
+            ]
           },
           "first_name": {
             "description": "[DEPRECATED] Use given_name instead. User's given name. Maximum 200 characters.",
             "type": "string",
-            "examples": ["John"]
+            "examples": [
+              "John"
+            ]
           },
           "gender": {
             "description": "Updates the user's gender identity information. Use this field to store the user's gender identity for personalization, compliance, or reporting purposes. This field supports any string value to accommodate diverse gender identities and should be handled with appropriate privacy considerations according to your organization's policies.",
             "type": "string",
-            "examples": ["male"]
+            "examples": [
+              "male"
+            ]
           },
           "given_name": {
             "description": "Updates the user's given name (first name). Use this field to modify how the user's first name appears in the system and user interfaces. Maximum 255 characters allowed.",
             "type": "string",
-            "examples": ["John"]
+            "examples": [
+              "John"
+            ]
           },
           "groups": {
             "description": "Updates the list of group names the user belongs to within the organization. Use this field to manage the user's group memberships for role-based access control, team assignments, or organizational structure. Groups are typically used for permission management and collaborative access. Each group name must be unique within the list, 1-250 characters long, with a maximum of 50 groups per user.",
@@ -13186,17 +14695,26 @@
             "items": {
               "type": "string"
             },
-            "examples": [["engineering", "managers"]]
+            "examples": [
+              [
+                "engineering",
+                "managers"
+              ]
+            ]
           },
           "last_name": {
             "description": "[DEPRECATED] Use family_name instead. User's family name. Maximum 200 characters.",
             "type": "string",
-            "examples": ["Doe"]
+            "examples": [
+              "Doe"
+            ]
           },
           "locale": {
             "description": "Updates the user's preferred language and region settings using BCP-47 format codes. Use this field to customize the user's experience with localized content, date formats, number formatting, and UI language. When not specified, the user inherits the organization's default locale settings. Common values include `en-US`, `en-GB`, `fr-FR`, `de-DE`, and `es-ES`.",
             "type": "string",
-            "examples": ["en-US"]
+            "examples": [
+              "en-US"
+            ]
           },
           "metadata": {
             "description": "Updates system-managed key-value pairs for internal tracking and operational data. Use this field to store system-generated metadata like account status, signup source, last activity tracking, or integration-specific identifiers. These fields are typically managed by automated processes rather than direct user input. Keys must be 3-25 characters, values must be 1-256 characters, with a maximum of 20 key-value pairs.",
@@ -13214,22 +14732,30 @@
           "name": {
             "description": "Updates the user's complete display name. Use this field when you want to set the full name as a single string rather than using separate given and family names. This name appears in user interfaces, reports, and anywhere a formatted display name is needed.",
             "type": "string",
-            "examples": ["John Doe"]
+            "examples": [
+              "John Doe"
+            ]
           },
           "phone_number": {
             "description": "Updates the user's phone number in E.164 international format. Use this field to enable SMS-based authentication methods, two-factor authentication, or phone-based account recovery. The phone number must include the country code and be formatted according to E.164 standards (e.g., `+1` for US numbers). This field is required when enabling SMS authentication features.",
             "type": "string",
-            "examples": ["+14155552671"]
+            "examples": [
+              "+14155552671"
+            ]
           },
           "picture": {
             "description": "Updates the URL to the user's profile picture or avatar image. Use this field to set or change the user's profile photo that appears in user interfaces, directory listings, and collaborative features. The URL should point to a publicly accessible image file. Supported formats typically include JPEG, PNG, and GIF. Maximum URL length is 2048 characters.",
             "type": "string",
-            "examples": ["https://example.com/avatar.jpg"]
+            "examples": [
+              "https://example.com/avatar.jpg"
+            ]
           },
           "preferred_username": {
             "description": "Updates the user's preferred username for display and identification purposes. Use this field to set a custom username that the user prefers to be known by, which may differ from their email or formal name. This username appears in user interfaces, mentions, and informal communications. Maximum 512 characters allowed.",
             "type": "string",
-            "examples": ["John Michael Doe"]
+            "examples": [
+              "John Michael Doe"
+            ]
           }
         }
       },
@@ -13253,17 +14779,23 @@
           "email": {
             "description": "Primary email address for the user. Must be unique across the environment and valid per RFC 5322.",
             "type": "string",
-            "examples": ["user@example.com"]
+            "examples": [
+              "user@example.com"
+            ]
           },
           "external_id": {
             "description": "Your application's unique identifier for this organization, used to link Scalekit with your system.",
             "type": "string",
-            "examples": ["ext_12345a67b89c"]
+            "examples": [
+              "ext_12345a67b89c"
+            ]
           },
           "id": {
             "description": "Unique system-generated identifier for the user. Immutable once created.",
             "type": "string",
-            "examples": ["usr_1234abcd5678efgh"]
+            "examples": [
+              "usr_1234abcd5678efgh"
+            ]
           },
           "last_login_time": {
             "description": "Timestamp of the user's most recent successful authentication. Updated automatically.",
@@ -13327,7 +14859,10 @@
                 "oauth_token": {
                   "access_token": "ya29.a0...",
                   "refresh_token": "1//0g...",
-                  "scopes": ["email", "profile"]
+                  "scopes": [
+                    "email",
+                    "profile"
+                  ]
                 }
               }
             ]
@@ -13356,7 +14891,11 @@
                 "oauth_token": {
                   "access_token": "ya29.new_token...",
                   "refresh_token": "1//0g...",
-                  "scopes": ["email", "profile", "calendar"]
+                  "scopes": [
+                    "email",
+                    "profile",
+                    "calendar"
+                  ]
                 }
               }
             ]
@@ -13369,28 +14908,38 @@
           "domain": {
             "description": "The domain name to be configured. Must be a valid business domain you control. Public and disposable domains (gmail.com, outlook.com, etc.) are automatically blocked for security.",
             "type": "string",
-            "examples": ["customerdomain.com"]
+            "examples": [
+              "customerdomain.com"
+            ]
           },
           "domain_type": {
             "description": "The domain type.\n- ALLOWED_EMAIL_DOMAIN: trusted domain used to suggest the organization in the organization switcher during sign-in/sign-up.\n- ORGANIZATION_DOMAIN: SSO discovery domain used to route users to the correct SSO provider and enforce SSO.\n",
             "$ref": "#/components/schemas/domainsDomainType",
-            "examples": ["ORGANIZATION_DOMAIN"]
+            "examples": [
+              "ORGANIZATION_DOMAIN"
+            ]
           }
         }
       },
       "v1organizationsCreateOrganization": {
         "type": "object",
-        "required": ["display_name"],
+        "required": [
+          "display_name"
+        ],
         "properties": {
           "display_name": {
             "description": "Name of the organization. Must be between 1 and 200 characters.",
             "type": "string",
-            "examples": ["Megasoft Inc"]
+            "examples": [
+              "Megasoft Inc"
+            ]
           },
           "external_id": {
             "description": "Your application's unique identifier for this organization, used to link Scalekit with your system.",
             "type": "string",
-            "examples": ["my_unique_id"]
+            "examples": [
+              "my_unique_id"
+            ]
           },
           "logo_url": {
             "description": "HTTPS URL of the organization's logo image. Maximum 1024 characters. Must use the https scheme.",
@@ -13398,7 +14947,9 @@
             "format": "uri",
             "maxLength": 1024,
             "pattern": "^https://",
-            "examples": ["https://cdn.example.com/acme-logo.png"]
+            "examples": [
+              "https://cdn.example.com/acme-logo.png"
+            ]
           },
           "metadata": {
             "type": "object",
@@ -13412,7 +14963,9 @@
             "maxLength": 253,
             "minLength": 1,
             "pattern": "^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$",
-            "examples": ["acme"]
+            "examples": [
+              "acme"
+            ]
           }
         }
       },
@@ -13423,12 +14976,16 @@
           "display_name": {
             "description": "Name of the organization to display in the UI. Must be between 1 and 200 characters",
             "type": "string",
-            "examples": ["Acme Corporation"]
+            "examples": [
+              "Acme Corporation"
+            ]
           },
           "external_id": {
             "description": "Your application's unique identifier for this organization, used to link Scalekit with your system",
             "type": "string",
-            "examples": ["tenant_12345"]
+            "examples": [
+              "tenant_12345"
+            ]
           },
           "logo_url": {
             "description": "HTTPS URL of the organization's logo image. Maximum 1024 characters. Must use the https scheme.",
@@ -13436,7 +14993,9 @@
             "format": "uri",
             "maxLength": 1024,
             "pattern": "^https://",
-            "examples": ["https://cdn.example.com/acme-logo.png"]
+            "examples": [
+              "https://cdn.example.com/acme-logo.png"
+            ]
           },
           "metadata": {
             "description": "Custom key-value pairs to store with the organization. Keys must be 3-25 characters, values must be 1-256 characters. Maximum 10 pairs allowed.",
@@ -13455,7 +15014,9 @@
             "type": "string",
             "maxLength": 253,
             "pattern": "^$|^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$",
-            "examples": ["acme"]
+            "examples": [
+              "acme"
+            ]
           }
         }
       },
@@ -13472,17 +15033,23 @@
           "description": {
             "description": "Description of the connected app provider",
             "type": "string",
-            "examples": ["Connect to Google Workspace for email and calendar integration"]
+            "examples": [
+              "Connect to Google Workspace for email and calendar integration"
+            ]
           },
           "display_name": {
             "description": "Display name for the connected app provider",
             "type": "string",
-            "examples": ["Google Workspace"]
+            "examples": [
+              "Google Workspace"
+            ]
           },
           "icon_src": {
             "description": "URL for the provider icon. Should be an SVG image sized 800x800 pixels for best rendering experience.",
             "type": "string",
-            "examples": ["https://example.com/images/my-connector.svg"]
+            "examples": [
+              "https://example.com/images/my-connector.svg"
+            ]
           },
           "metadata": {
             "description": "Custom key-value metadata for this provider. Keys must be 3-25 characters, values must be 1-256 characters, with a maximum of 20 key-value pairs.",
@@ -13500,12 +15067,16 @@
           "proxy_enabled": {
             "description": "This flag indicates whether proxying is turned on for the connected app provider. When enabled, requests are routed through the provider proxy instead of being sent directly.",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "proxy_url": {
             "description": "Proxy URL for the connected app provider. Must start with https://",
             "type": "string",
-            "examples": ["https://mcp.example.com/mcp"]
+            "examples": [
+              "https://mcp.example.com/mcp"
+            ]
           }
         }
       },
@@ -13522,17 +15093,23 @@
           "description": {
             "description": "Description of the connected app provider",
             "type": "string",
-            "examples": ["Connect to Google Workspace for email and calendar integration"]
+            "examples": [
+              "Connect to Google Workspace for email and calendar integration"
+            ]
           },
           "display_name": {
             "description": "Display name for the connected app provider",
             "type": "string",
-            "examples": ["Google Workspace"]
+            "examples": [
+              "Google Workspace"
+            ]
           },
           "icon_src": {
             "description": "URL for the provider icon. Should be an SVG image sized 800x800 pixels for best rendering experience.",
             "type": "string",
-            "examples": ["https://example.com/images/my-connector.svg"]
+            "examples": [
+              "https://example.com/images/my-connector.svg"
+            ]
           },
           "metadata": {
             "description": "Custom key-value metadata for this provider. Keys must be 3-25 characters, values must be 1-256 characters, with a maximum of 20 key-value pairs.",
@@ -13550,12 +15127,16 @@
           "proxy_enabled": {
             "description": "This flag indicates whether proxying is turned on for the connected app provider. When enabled, requests are routed through the provider proxy instead of being sent directly.",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "proxy_url": {
             "description": "Proxy URL for the connected app provider. Must start with https://",
             "type": "string",
-            "examples": ["https://mcp.example.com/mcp"]
+            "examples": [
+              "https://mcp.example.com/mcp"
+            ]
           }
         }
       },
@@ -13565,22 +15146,30 @@
           "description": {
             "description": "Description of the organization's role",
             "type": "string",
-            "examples": ["Organization Viewer Role will be used only for viewing the objects"]
+            "examples": [
+              "Organization Viewer Role will be used only for viewing the objects"
+            ]
           },
           "display_name": {
             "description": "Display name of the organization's role",
             "type": "string",
-            "examples": ["Organization Viewer Role"]
+            "examples": [
+              "Organization Viewer Role"
+            ]
           },
           "extends": {
             "description": "Base role name for hierarchical roles",
             "type": "string",
-            "examples": ["admin_role"]
+            "examples": [
+              "admin_role"
+            ]
           },
           "name": {
             "description": "Unique name of the organization's role",
             "type": "string",
-            "examples": ["org_viewer_role"]
+            "examples": [
+              "org_viewer_role"
+            ]
           },
           "permissions": {
             "description": "List of permission names to assign to this role. Permissions must exist in the current environment.",
@@ -13588,7 +15177,12 @@
             "items": {
               "type": "string"
             },
-            "examples": [["read:users", "write:documents"]]
+            "examples": [
+              [
+                "read:users",
+                "write:documents"
+              ]
+            ]
           }
         }
       },
@@ -13598,12 +15192,16 @@
           "description": {
             "description": "Description of the permission",
             "type": "string",
-            "examples": ["Allows user to read documents from the system"]
+            "examples": [
+              "Allows user to read documents from the system"
+            ]
           },
           "name": {
             "description": "Unique name/ID of the permission. Must be 1–64 characters using only letters, numbers, underscores (_), and colons (:).",
             "type": "string",
-            "examples": ["read:documents"]
+            "examples": [
+              "read:documents"
+            ]
           }
         }
       },
@@ -13620,17 +15218,23 @@
           "display_name": {
             "description": "Human-readable display name for the role. Used in user interfaces, reports, and user-facing communications.",
             "type": "string",
-            "examples": ["Content Editor"]
+            "examples": [
+              "Content Editor"
+            ]
           },
           "extends": {
             "description": "Name of the base role that this role extends. Enables hierarchical role inheritance where this role inherits all permissions from the base role.",
             "type": "string",
-            "examples": ["viewer"]
+            "examples": [
+              "viewer"
+            ]
           },
           "name": {
             "description": "Unique name identifier for the role. Must be alphanumeric with underscores, 1-64 characters. This name is used in API calls and cannot be changed after creation.",
             "type": "string",
-            "examples": ["content_editor"]
+            "examples": [
+              "content_editor"
+            ]
           },
           "permissions": {
             "description": "List of permission names to assign to this role. Permissions must exist in the current environment. Maximum 100 permissions per role.",
@@ -13638,7 +15242,13 @@
             "items": {
               "type": "string"
             },
-            "examples": [["read:content", "write:content", "publish:content"]]
+            "examples": [
+              [
+                "read:content",
+                "write:content",
+                "publish:content"
+              ]
+            ]
           }
         }
       },
@@ -13648,49 +15258,67 @@
           "default_creator": {
             "description": "Indicates if this role is the default creator role for new organizations.",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "default_member": {
             "description": "Indicates if this role is the default member role for new users.",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "dependent_roles_count": {
             "description": "Number of roles that extend from this role (dependent roles count). Read-only field.",
             "type": "integer",
             "format": "int32",
-            "examples": [3]
+            "examples": [
+              3
+            ]
           },
           "description": {
             "description": "Detailed description of the role's purpose and capabilities. Maximum 2000 characters.",
             "type": "string",
-            "examples": ["Can create, edit, and publish content but cannot delete or manage users"]
+            "examples": [
+              "Can create, edit, and publish content but cannot delete or manage users"
+            ]
           },
           "display_name": {
             "description": "Human-readable display name for the role. Used in user interfaces and reports.",
             "type": "string",
-            "examples": ["Content Editor"]
+            "examples": [
+              "Content Editor"
+            ]
           },
           "extends": {
             "description": "Name of the base role that this role extends. Enables hierarchical role inheritance.",
             "type": "string",
-            "examples": ["admin_role"]
+            "examples": [
+              "admin_role"
+            ]
           },
           "id": {
             "description": "Unique system-generated identifier for the role. Immutable once created.",
             "type": "string",
             "readOnly": true,
-            "examples": ["role_1234abcd5678efgh"]
+            "examples": [
+              "role_1234abcd5678efgh"
+            ]
           },
           "is_org_role": {
             "description": "Indicates if this role is an organization role.",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "name": {
             "description": "Unique name identifier for the role. Must be alphanumeric with underscores, 1-100 characters.",
             "type": "string",
-            "examples": ["content_editor"]
+            "examples": [
+              "content_editor"
+            ]
           },
           "permissions": {
             "description": "List of permissions with role source information. Only included when 'include' parameter is specified in the request.",
@@ -13729,12 +15357,16 @@
           "display_name": {
             "description": "Human-readable display name for the role. Used in user interfaces, reports, and user-facing communications.",
             "type": "string",
-            "examples": ["Senior Content Editor"]
+            "examples": [
+              "Senior Content Editor"
+            ]
           },
           "extends": {
             "description": "Name of the base role that this role extends. Enables hierarchical role inheritance where this role inherits all permissions from the base role.",
             "type": "string",
-            "examples": ["content_editor"]
+            "examples": [
+              "content_editor"
+            ]
           },
           "permissions": {
             "description": "List of permission names to assign to this role. When provided, this replaces all existing role-permission mappings. Permissions must exist in the current environment. Maximum 100 permissions per role.",
@@ -13742,7 +15374,14 @@
             "items": {
               "type": "string"
             },
-            "examples": [["read:content", "write:content", "publish:content", "approve:content"]]
+            "examples": [
+              [
+                "read:content",
+                "write:content",
+                "publish:content",
+                "approve:content"
+              ]
+            ]
           }
         }
       },
@@ -13752,27 +15391,37 @@
           "city": {
             "description": "City name where the session originated based on IP geolocation. Approximate location derived from IP address.",
             "type": "string",
-            "examples": ["San Francisco"]
+            "examples": [
+              "San Francisco"
+            ]
           },
           "latitude": {
             "description": "Latitude coordinate of the estimated location. Decimal format (e.g., '37.7749'). Note: Represents IP geolocation center and may not be precise.",
             "type": "string",
-            "examples": ["37.7749"]
+            "examples": [
+              "37.7749"
+            ]
           },
           "longitude": {
             "description": "Longitude coordinate of the estimated location. Decimal format (e.g., '-122.4194'). Note: Represents IP geolocation center and may not be precise.",
             "type": "string",
-            "examples": ["-122.4194"]
+            "examples": [
+              "-122.4194"
+            ]
           },
           "region": {
             "description": "Geographic region name derived from IP geolocation. Represents the country-level location (e.g., 'United States', 'France').",
             "type": "string",
-            "examples": ["United States"]
+            "examples": [
+              "United States"
+            ]
           },
           "region_subdivision": {
             "description": "Regional subdivision code or name (e.g., state abbreviation for US, province for Canada). Two-letter ISO format when applicable.",
             "type": "string",
-            "examples": ["CA"]
+            "examples": [
+              "CA"
+            ]
           }
         }
       },
@@ -13782,7 +15431,9 @@
           "inviter_email": {
             "description": "Email address of the user who invited this member. Must be a valid email address.",
             "type": "string",
-            "examples": ["john.doe@example.com"]
+            "examples": [
+              "john.doe@example.com"
+            ]
           },
           "metadata": {
             "description": "Custom key-value pairs for storing additional user context. Keys (3-25 chars), values (1-256 chars).",
@@ -13853,7 +15504,9 @@
           "external_id": {
             "description": "Your application's unique identifier for this organization, used to link Scalekit with your system.",
             "type": "string",
-            "examples": ["ext_12345a67b89c"]
+            "examples": [
+              "ext_12345a67b89c"
+            ]
           },
           "metadata": {
             "description": "Custom key-value pairs for storing additional user context. Keys (3-25 chars), values (1-256 chars).",
@@ -13887,12 +15540,16 @@
           "rp_id": {
             "description": "Relying Party ID for credential operations",
             "type": "string",
-            "examples": ["example.com"]
+            "examples": [
+              "example.com"
+            ]
           },
           "user_id": {
             "description": "User ID for credential verification",
             "type": "string",
-            "examples": ["user_xyz789"]
+            "examples": [
+              "user_xyz789"
+            ]
           }
         }
       },
@@ -13902,7 +15559,9 @@
           "success": {
             "description": "Whether the credential was successfully deleted",
             "type": "boolean",
-            "examples": [true]
+            "examples": [
+              true
+            ]
           },
           "unknown_credential_options": {
             "description": "Options for handling unknown credentials in client applications",
@@ -13933,12 +15592,16 @@
           "credential_id": {
             "description": "The deleted credential ID",
             "type": "string",
-            "examples": ["cred_abc123"]
+            "examples": [
+              "cred_abc123"
+            ]
           },
           "rp_id": {
             "description": "The RP ID for this credential",
             "type": "string",
-            "examples": ["example.com"]
+            "examples": [
+              "example.com"
+            ]
           }
         }
       },
@@ -13957,7 +15620,9 @@
           "attestation_type": {
             "description": "Type of attestation: \"none\", \"indirect\", or \"direct\"",
             "type": "string",
-            "examples": ["direct"]
+            "examples": [
+              "direct"
+            ]
           },
           "authenticator": {
             "description": "Authenticator information including model and name",
@@ -13975,7 +15640,9 @@
             "description": "Timestamp when the credential was created",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-02-15T06:23:44.560000Z"]
+            "examples": [
+              "2025-02-15T06:23:44.560000Z"
+            ]
           },
           "credential_id": {
             "description": "The actual credential ID bytes from the authenticator",
@@ -13985,12 +15652,16 @@
           "display_name": {
             "description": "Optional user-friendly name for this passkey",
             "type": "string",
-            "examples": ["My Yubikey"]
+            "examples": [
+              "My Yubikey"
+            ]
           },
           "id": {
             "description": "Credential unique identifier",
             "type": "string",
-            "examples": ["cred_abc123"]
+            "examples": [
+              "cred_abc123"
+            ]
           },
           "transports": {
             "description": "Supported transports for this credential",
@@ -14003,7 +15674,9 @@
             "description": "Timestamp of last update",
             "type": "string",
             "format": "date-time",
-            "examples": ["2025-02-15T06:23:44.560000Z"]
+            "examples": [
+              "2025-02-15T06:23:44.560000Z"
+            ]
           },
           "user_agent": {
             "description": "Browser and device information from registration",
@@ -14012,13 +15685,22 @@
           "user_id": {
             "description": "User ID this credential belongs to",
             "type": "string",
-            "examples": ["user_xyz789"]
+            "examples": [
+              "user_xyz789"
+            ]
           }
         }
       },
       "ScalekitEvent": {
         "type": "object",
-        "required": ["spec_version", "id", "type", "occurred_at", "environment_id", "object"],
+        "required": [
+          "spec_version",
+          "id",
+          "type",
+          "occurred_at",
+          "environment_id",
+          "object"
+        ],
         "properties": {
           "spec_version": {
             "type": "string",
@@ -14042,6 +15724,10 @@
               "organization.created",
               "organization.updated",
               "organization.deleted",
+              "organization.domain_created",
+              "organization.domain_deleted",
+              "organization.domain_dns_verification_success",
+              "organization.domain_dns_verification_failed",
               "organization.sso_created",
               "organization.sso_deleted",
               "organization.sso_enabled",
@@ -14156,7 +15842,9 @@
           "type": {
             "type": "string",
             "description": "The event type",
-            "enum": ["connected_account.status_updated"],
+            "enum": [
+              "connected_account.status_updated"
+            ],
             "example": "connected_account.status_updated"
           },
           "occurred_at": {
@@ -14176,7 +15864,9 @@
           "object": {
             "type": "string",
             "description": "The type of object that triggered the webhook",
-            "enum": ["ConnectedAccount"],
+            "enum": [
+              "ConnectedAccount"
+            ],
             "example": "ConnectedAccount"
           },
           "data": {
@@ -14225,17 +15915,43 @@
             "description": "The provider of the connected account"
           },
           "authorization_type": {
-            "$ref": "#/components/schemas/connected_accountsConnectorType",
+            "type": "string",
+            "enum": [
+              "OAUTH",
+              "API_KEY",
+              "BASIC_AUTH",
+              "BEARER_TOKEN",
+              "BASIC",
+              "OAUTH_M2M",
+              "TRELLO_OAUTH1",
+              "GOOGLE_DWD",
+              "TRUSTED_IDP",
+              "SMART_FHIR"
+            ],
             "example": "OAUTH",
             "description": "The authorization type of the connected account"
           },
           "status": {
-            "$ref": "#/components/schemas/connected_accountsConnectorStatus",
+            "type": "string",
+            "enum": [
+              "ACTIVE",
+              "EXPIRED",
+              "PENDING_AUTH",
+              "PENDING_VERIFICATION",
+              "DISCONNECTED"
+            ],
             "example": "EXPIRED",
             "description": "The new status of the connected account"
           },
           "old_status": {
-            "$ref": "#/components/schemas/connected_accountsConnectorStatus",
+            "type": "string",
+            "enum": [
+              "ACTIVE",
+              "EXPIRED",
+              "PENDING_AUTH",
+              "PENDING_VERIFICATION",
+              "DISCONNECTED"
+            ],
             "example": "ACTIVE",
             "description": "The previous status of the connected account"
           }

--- a/public/api/scalekit.scalar.yaml
+++ b/public/api/scalekit.scalar.yaml
@@ -154,10 +154,31 @@ paths:
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
-          source: // Coming soon — accurate SDK snippets for List connected accounts will be added via scalekit-code-doctor (SK-399)
+          source: |-
+            const response = await scalekit.connectedAccounts.listConnectedAccounts({
+              organizationId: 'org_123',
+              pageSize: 20,
+            })
+            const connectedAccounts = response.connectedAccounts
         - label: Python SDK
           lang: python
-          source: '# Coming soon — accurate SDK snippets for List connected accounts will be added via scalekit-code-doctor (SK-399)'
+          source: |-
+            response = scalekit_client.connected_accounts.list_connected_accounts(
+                organization_id="org_123",
+                page_size=20,
+            )
+            # with_call returns (response, call)
+            connected_accounts = response[0].connected_accounts
+        - label: Go SDK
+          lang: go
+          source: |-
+            // Connected Accounts are not available in the Go SDK public API yet.
+            // Use the REST API (GET /api/v1/connected_accounts) or the Node.js/Python SDKs.
+        - label: Java SDK
+          lang: java
+          source: |-
+            // Connected Accounts are not part of the Java SDK public API yet.
+            // Use the REST API (GET /api/v1/connected_accounts) or the Node.js/Python SDKs.
     put:
       description: Updates authentication credentials and configuration for an existing connected account. Modify OAuth tokens, refresh tokens, access scopes, or API configuration settings. Specify the account by ID, or by combination of organization/user, connector, and identifier. Returns the updated account with new token expiry and status information.
       tags:
@@ -688,10 +709,38 @@ paths:
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
-          source: // Coming soon — accurate SDK snippets for Execute tool (Tool Calling) will be added via scalekit-code-doctor (SK-399)
+          source: |-
+            const response = await scalekit.tools.executeTool({
+              toolName: 'gmail_send_email',
+              identifier: 'user@example.com',
+              params: {
+                to: 'team@example.com',
+                subject: 'Hello from Scalekit',
+                body: 'Tool execution succeeded.',
+              },
+            })
         - label: Python SDK
           lang: python
-          source: '# Coming soon — accurate SDK snippets for Execute tool (Tool Calling) will be added via scalekit-code-doctor (SK-399)'
+          source: |-
+            response = scalekit_client.tools.execute_tool(
+                tool_name="gmail_send_email",
+                identifier="user@example.com",
+                params={
+                    "to": "team@example.com",
+                    "subject": "Hello from Scalekit",
+                    "body": "Tool execution succeeded.",
+                },
+            )
+        - label: Go SDK
+          lang: go
+          source: |-
+            // Tool calling (execute_tool) is not available in the Go SDK public API yet.
+            // Use the REST API (POST /api/v1/execute_tool) or the Node.js/Python SDKs.
+        - label: Java SDK
+          lang: java
+          source: |-
+            // Tool calling (execute_tool) is not part of the Java SDK public API yet.
+            // Use the REST API (POST /api/v1/execute_tool) or the Node.js/Python SDKs.
   /api/v1/invites/organizations/{organization_id}/users/{id}/resend:
     patch:
       description: Resends an invitation email to a user who has a pending or expired invitation in the specified organization. If the invitation has expired, a new invitation will be automatically created and sent. If the invitation is still valid, a reminder email will be sent instead. Use this endpoint when a user hasn't responded to their initial invitation and you need to send them a reminder or when the original invitation has expired. The invitation email includes a secure magic link that allows the user to complete their account setup and join the organization. Each resend operation increments the resent counter.
@@ -1064,12 +1113,6 @@ paths:
         - label: Node.js SDK
           lang: javascript
           source: |-
-            import { ScalekitClient } from '@scalekit-sdk/node'
-            const scalekit = new ScalekitClient(
-              process.env.SCALEKIT_ENV_URL,
-              process.env.SCALEKIT_CLIENT_ID,
-              process.env.SCALEKIT_CLIENT_SECRET,
-            )
             await scalekit.user.createMembership('org_123', 'usr_123', {
               roles: ['admin'],
               metadata: {
@@ -1095,52 +1138,41 @@ paths:
         - label: Go SDK
           lang: go
           source: |-
-            func main() {
-                scalekitClient := scalekit.NewScalekitClient(
-                    os.Getenv("SCALEKIT_ENV_URL"),
-                    os.Getenv("SCALEKIT_CLIENT_ID"),
-                    os.Getenv("SCALEKIT_CLIENT_SECRET"),
-                )
-                membership := &usersv1.CreateMembership{
-                    Roles: []*usersv1.Role{{Name: "admin"}},
-                    Metadata: map[string]string{
-                        "department": "engineering",
-                        "location":   "nyc-office",
-                    },
-                }
-                resp, 
-                  err := scalekitClient.User().CreateMembership(
-                    context.Background(), "org_123", 
-                      "usr_123", membership, false)
-                if err != nil {
-                    panic(err)
-                }
+            membership := &usersv1.CreateMembership{
+              Roles: []*usersv1.Role{{Name: "admin"}},
+              Metadata: map[string]string{
+                "department": "engineering",
+                "location":   "nyc-office",
+              },
             }
+            resp, err := scalekitClient.User().CreateMembership(
+              ctx,
+              "org_123",
+              "usr_123",
+              membership,
+              false,
+            )
+            if err != nil {
+              // handle error
+              return
+            }
+            _ = resp
         - label: Java SDK
           lang: java
           source: |-
-            import com.scalekit.ScalekitClient;
-            import com.scalekit.api.UserClient;
-            import com.scalekit.grpc.scalekit.v1.users.*;
-            ScalekitClient scalekitClient = new ScalekitClient(
-                System.getenv("SCALEKIT_ENV_URL"),
-                System.getenv("SCALEKIT_CLIENT_ID"),
-                System.getenv("SCALEKIT_CLIENT_SECRET")
+            CreateMembershipRequest membershipReq = CreateMembershipRequest.newBuilder()
+                .setMembership(
+                    CreateMembership.newBuilder()
+                        .addRoles(Role.newBuilder().setName("admin").build())
+                        .putMetadata("department", "engineering")
+                        .putMetadata("location", "nyc-office")
+                        .build())
+                .build();
+            CreateMembershipResponse res = scalekitClient.users().createMembership(
+                "org_123",
+                "usr_123",
+                membershipReq
             );
-            UserClient users = scalekitClient.users();
-            CreateMembershipRequest membershipReq = CreateMemb
-              ershipRequest.newBuilder()
-                    .setMembership(
-                      CreateMembership.newBuilder()
-                            .addRoles(Role.newBuilder(
-                              ).setName("admin").build())
-                            .putMetadata("department", "engineering")
-                            .putMetadata("location", "nyc-office")
-                            .build())
-                    .build();
-            CreateMembershipResponse res = users.
-              createMembership("org_123", "usr_123", 
-                membershipReq);
     delete:
       description: Removes a user from an organization by user ID. This action is irreversible and may also remove related group memberships.
       tags:
@@ -1167,12 +1199,32 @@ paths:
             application/json:
               schema: {}
       x-codeSamples:
+        - label: Node.js SDK
+          lang: javascript
+          source: await scalekit.user.deleteMembership('org_123', 'usr_123')
         - label: Python SDK
           lang: python
           source: |-
-            response = scalekit_client.users.delete_membership(
-              organization_id=org_id,user_id=user_id
+            scalekit_client.users.delete_membership(
+                organization_id="org_123",
+                user_id="usr_123",
             )
+        - label: Go SDK
+          lang: go
+          source: |-
+            err := scalekitClient.User().DeleteMembership(
+              ctx,
+              "org_123",
+              "usr_123",
+              false, // cascade: also remove from nested groups when true
+            )
+            if err != nil {
+              // handle error
+              return
+            }
+        - label: Java SDK
+          lang: java
+          source: scalekitClient.users().deleteMembership("org_123", "usr_123");
     patch:
       description: Updates a user's membership details within an organization by user ID. You can update roles and membership metadata.
       tags:
@@ -1364,11 +1416,11 @@ paths:
         - label: Go SDK
           lang: go
           source: |-
-            organizations, err := scalekitClient.Organization.ListOrganizations(
+            organizations, err := scalekitClient.Organization().ListOrganization(
               ctx,
               &scalekit.ListOrganizationOptions{
                 PageSize: 10,
-              }
+              },
             )
         - label: Java SDK
           lang: java
@@ -1415,11 +1467,11 @@ paths:
         - label: Go SDK
           lang: go
           source: |-
-            organization, err := ScalekitClient.Organization.CreateOrganization(
+            organization, err := scalekitClient.Organization().CreateOrganization(
               ctx,
               name,
               scalekit.CreateOrganizationOptions{
-                ExternalID: "externalId",
+                ExternalId: "externalId",
               },
             )
         - label: Java SDK
@@ -1454,38 +1506,16 @@ paths:
       x-codeSamples:
         - label: Node.js SDK
           lang: javascript
-          source: |-
-            import { ScalekitClient } from '@scalekit-sdk/node'
-            const scalekit = new ScalekitClient(
-              process.env.SCALEKIT_ENV_URL,
-              process.env.SCALEKIT_CLIENT_ID,
-              process.env.SCALEKIT_CLIENT_SECRET,
-            )
-            const organization = await scalekit.organization.getOrganization(organization_id)
+          source: const organization = await scalekit.organization.getOrganization(organizationId)
         - label: Python SDK
           lang: python
-          source: |-
-            scalekit_client = ScalekitClient(
-              <SCALEKIT_ENVIRONMENT_URL>,
-              <SCALEKIT_CLIENT_ID>,
-              <SCALEKIT_CLIENT_SECRET>
-            )
-
-            organization = scalekit_client.organization.get_organization(
-              organization_id
-            )
+          source: organization = scalekit_client.organization.get_organization(organization_id)
         - label: Go SDK
           lang: go
           source: |-
-            scalekitClient := scalekit.NewScalekitClient(
-              <SCALEKIT_ENVIRONMENT_URL>,
-              <SCALEKIT_CLIENT_ID>,
-              <SCALEKIT_CLIENT_SECRET>
-            )
-
-            organization, err := scalekitClient.Organization.GetOrganization(
+            organization, err := scalekitClient.Organization().GetOrganization(
               ctx,
-              organizationId
+              organizationId,
             )
         - label: Java SDK
           lang: java
@@ -1526,9 +1556,9 @@ paths:
         - label: Go SDK
           lang: go
           source: |-
-            err := scalekitClient.Organization.DeleteOrganization(
+            err := scalekitClient.Organization().DeleteOrganization(
               ctx,
-              organizationId
+              organizationId,
             )
         - label: Java SDK
           lang: java
@@ -1585,12 +1615,12 @@ paths:
         - label: Go SDK
           lang: go
           source: |-
-            organization, err := scalekitClient.Organization.UpdateOrganization(
+            organization, err := scalekitClient.Organization().UpdateOrganization(
               ctx,
               organizationId,
               &scalekit.UpdateOrganization{
                 DisplayName: "displayName",
-                ExternalId: "externalId",
+                ExternalId:  "externalId",
               },
             )
         - label: Java SDK
@@ -1657,9 +1687,9 @@ paths:
         - label: Go SDK
           lang: go
           source: |-
-            link, err := scalekitClient.Organization.GeneratePortalLink(
+            link, err := scalekitClient.Organization().GeneratePortalLink(
               ctx,
-              organizationId
+              organizationId,
             )
         - label: Java SDK
           lang: java
@@ -1781,7 +1811,7 @@ paths:
           required: true
         - schema:
             type: string
-          description: "Include additional data in the response. Valid values: 'permissions' (direct permissions only), 'permissions:all' (includes inherited permissions)"
+          description: 'Include additional data in the response. Valid values: ''permissions'' (direct permissions only), ''permissions:all'' (includes inherited permissions)'
           name: include
           in: query
       responses:
@@ -1906,7 +1936,7 @@ paths:
           required: true
         - schema:
             type: string
-          description: "Include additional data in the response. Valid values: 'permissions' (direct permissions only), 'permissions:all' (includes inherited permissions)"
+          description: 'Include additional data in the response. Valid values: ''permissions'' (direct permissions only), ''permissions:all'' (includes inherited permissions)'
           name: include
           in: query
       responses:
@@ -2184,22 +2214,47 @@ paths:
               schema:
                 $ref: '#/components/schemas/clientsListOrganizationClientsResponse'
       x-codeSamples:
+        - label: Node.js SDK
+          lang: javascript
+          source: |-
+            const response = await scalekit.m2m.listOrganizationClients('org_123', {
+              pageSize: 30,
+            })
+            const clients = response.clients
         - label: Python SDK
           lang: python
           source: |-
             # List clients for a specific organization
-            org_id = 'SCALEKIT_ORGANIZATION_ID'
+            org_id = "org_123"
 
-            # Retrieve all clients with default pagination
             response = scalekit_client.m2m_client.list_organization_clients(
                 organization_id=org_id,
-                page_size=30
+                page_size=30,
             )
 
-            # Access the clients list
             clients = response.clients
             for client in clients:
-                print(f"Client ID: {scalekit_client.id}, Name: {scalekit_client.name}")
+                print(f"Client ID: {client.id}, Name: {client.name}")
+        - label: Go SDK
+          lang: go
+          source: |-
+            response, err := scalekitClient.M2M().ListOrganizationClients(
+              ctx,
+              "org_123",
+              scalekit.ListOrganizationClientsOptions{
+                PageSize: 30,
+              },
+            )
+            if err != nil {
+              // handle error
+              return
+            }
+            _ = response
+        - label: Java SDK
+          lang: java
+          source: |-
+            ListOrganizationClientsResponse response = scalekitClient.m2m()
+                .listOrganizationClients("org_123", 30, "");
     post:
       description: Creates a new API client for an organization. Returns the client details and a plain secret (available only once).
       tags:
@@ -2228,6 +2283,15 @@ paths:
               $ref: '#/components/schemas/clientsOrganizationClient'
         required: true
       x-codeSamples:
+        - label: Node.js SDK
+          lang: javascript
+          source: |-
+            const response = await scalekit.m2m.createOrganizationClient('org_123', {
+              name: 'GitHub Actions Deployment Service',
+              description: 'Service account for GitHub Actions to deploy applications to production',
+              scopes: ['deploy:applications', 'read:deployments'],
+              audience: ['deployment-api.acmecorp.com'],
+            })
         - label: Python SDK
           lang: python
           source: |-
@@ -2235,21 +2299,53 @@ paths:
 
             m2m_client = OrganizationClient(
                 name="GitHub Actions Deployment Service",
-                description="Service account for GitHub Actions to deploy applications
-            to production",
+                description="Service account for GitHub Actions to deploy applications to production",
                 custom_claims=[
                     {"key": "github_repository", "value": "acmecorp/inventory-service"},
-                    {"key": "environment", "value": "production_us"}
+                    {"key": "environment", "value": "production_us"},
                 ],
                 scopes=["deploy:applications", "read:deployments"],
                 audience=["deployment-api.acmecorp.com"],
-                expiry=3600
+                expiry=3600,
             )
 
             response = scalekit_client.m2m_client.create_organization_client(
-                organization_id="SCALEKIT_ORGANIZATION_ID",
-                m2m_client=m2m_client
+                organization_id="org_123",
+                m2m_client=m2m_client,
             )
+        - label: Go SDK
+          lang: go
+          source: |-
+            response, err := scalekitClient.M2M().CreateOrganizationClient(
+              ctx,
+              "org_123",
+              scalekit.CreateOrganizationClientOptions{
+                Name:        "GitHub Actions Deployment Service",
+                Description: "Service account for GitHub Actions to deploy applications to production",
+                Scopes:      []string{"deploy:applications", "read:deployments"},
+                Audience:    []string{"deployment-api.acmecorp.com"},
+              },
+            )
+            if err != nil {
+              // handle error
+              return
+            }
+            _ = response
+        - label: Java SDK
+          lang: java
+          source: |-
+            import com.scalekit.grpc.scalekit.v1.clients.OrganizationClient;
+
+            OrganizationClient orgClient = OrganizationClient.newBuilder()
+                .setName("GitHub Actions Deployment Service")
+                .setDescription("Service account for GitHub Actions to deploy applications to production")
+                .addScopes("deploy:applications")
+                .addScopes("read:deployments")
+                .addAudience("deployment-api.acmecorp.com")
+                .build();
+
+            CreateOrganizationClientResponse response = scalekitClient.m2m()
+                .createOrganizationClient("org_123", orgClient);
   /api/v1/organizations/{organization_id}/clients/{client_id}:
     get:
       description: Retrieves details of a specific API client in an organization.
@@ -2278,18 +2374,39 @@ paths:
               schema:
                 $ref: '#/components/schemas/clientsGetOrganizationClientResponse'
       x-codeSamples:
+        - label: Node.js SDK
+          lang: javascript
+          source: const response = await scalekit.m2m.getOrganizationClient('org_123', 'skc_xxxxx')
         - label: Python SDK
           lang: python
           source: |-
-            # Get client ID from environment variables
-            org_id = 'SCALEKIT_ORGANIZATION_ID'
-            client_id = os.environ['M2M_CLIENT_ID']
+            import os
 
-            # Fetch client details for the specified organization
+            org_id = "org_123"
+            client_id = os.environ["M2M_CLIENT_ID"]
+
             response = scalekit_client.m2m_client.get_organization_client(
                 organization_id=org_id,
-                client_id=client_id
+                client_id=client_id,
             )
+        - label: Go SDK
+          lang: go
+          source: |-
+            response, err := scalekitClient.M2M().GetOrganizationClient(
+              ctx,
+              "org_123",
+              "skc_xxxxx",
+            )
+            if err != nil {
+              // handle error
+              return
+            }
+            _ = response
+        - label: Java SDK
+          lang: java
+          source: |-
+            GetOrganizationClientResponse response = scalekitClient.m2m()
+                .getOrganizationClient("org_123", "skc_xxxxx");
     delete:
       description: Permanently deletes an API client from an organization. This operation cannot be undone and will revoke all access for the client. All associated secrets will also be invalidated. Use this endpoint to remove unused or compromised clients.
       tags:
@@ -2316,18 +2433,36 @@ paths:
             application/json:
               schema: {}
       x-codeSamples:
+        - label: Node.js SDK
+          lang: javascript
+          source: await scalekit.m2m.deleteOrganizationClient('org_123', 'skc_xxxxx')
         - label: Python SDK
           lang: python
           source: |-
-            # Get client ID from environment variables
-            org_id = '<SCALEKIT_ORGANIZATION_ID>'
-            client_id = os.environ['M2M_CLIENT_ID']
+            import os
 
-            # Delete the specified client from the organization
-            response = scalekit_client.m2m_client.delete_organization_client(
+            org_id = "org_123"
+            client_id = os.environ["M2M_CLIENT_ID"]
+
+            scalekit_client.m2m_client.delete_organization_client(
                 organization_id=org_id,
-                client_id=client_id
+                client_id=client_id,
             )
+        - label: Go SDK
+          lang: go
+          source: |-
+            err := scalekitClient.M2M().DeleteOrganizationClient(
+              ctx,
+              "org_123",
+              "skc_xxxxx",
+            )
+            if err != nil {
+              // handle error
+              return
+            }
+        - label: Java SDK
+          lang: java
+          source: scalekitClient.m2m().deleteOrganizationClient("org_123", "skc_xxxxx");
     patch:
       description: Updates an existing organization API client. Only specified fields are modified.
       tags:
@@ -2362,28 +2497,61 @@ paths:
               $ref: '#/components/schemas/clientsOrganizationClient'
         required: true
       x-codeSamples:
+        - label: Node.js SDK
+          lang: javascript
+          source: |-
+            const response = await scalekit.m2m.updateOrganizationClient('org_123', 'skc_xxxxx', {
+              description: 'Service account for GitHub Actions to deploy applications to production_eu',
+            })
         - label: Python SDK
           lang: python
           source: |-
+            import os
             from scalekit.v1.clients.clients_pb2 import OrganizationClient
 
-            org_id = '<SCALEKIT_ORGANIZATION_ID>'
-            client_id = os.environ['M2M_CLIENT_ID']
+            org_id = "org_123"
+            client_id = os.environ["M2M_CLIENT_ID"]
 
             update_m2m_client = OrganizationClient(
-                description="Service account for GitHub Actions to deploy applications
-            to production_eu",
+                description="Service account for GitHub Actions to deploy applications to production_eu",
                 custom_claims=[
                     {"key": "github_repository", "value": "acmecorp/inventory"},
-                    {"key": "environment", "value": "production_eu"}
-                ]
+                    {"key": "environment", "value": "production_eu"},
+                ],
             )
 
             response = scalekit_client.m2m_client.update_organization_client(
                 organization_id=org_id,
                 client_id=client_id,
-                m2m_client=update_m2m_client
+                m2m_client=update_m2m_client,
             )
+        - label: Go SDK
+          lang: go
+          source: |-
+            response, err := scalekitClient.M2M().UpdateOrganizationClient(
+              ctx,
+              "org_123",
+              "skc_xxxxx",
+              scalekit.UpdateOrganizationClientOptions{
+                Description: "Service account for GitHub Actions to deploy applications to production_eu",
+              },
+            )
+            if err != nil {
+              // handle error
+              return
+            }
+            _ = response
+        - label: Java SDK
+          lang: java
+          source: |-
+            import com.scalekit.grpc.scalekit.v1.clients.OrganizationClient;
+
+            OrganizationClient updates = OrganizationClient.newBuilder()
+                .setDescription("Service account for GitHub Actions to deploy applications to production_eu")
+                .build();
+
+            UpdateOrganizationClientResponse response = scalekitClient.m2m()
+                .updateOrganizationClient("org_123", "skc_xxxxx", updates);
   /api/v1/organizations/{organization_id}/clients/{client_id}/secrets:
     post:
       description: Creates a new secret for an organization API client. Returns the plain secret (available only once).
@@ -2412,21 +2580,44 @@ paths:
               schema:
                 $ref: '#/components/schemas/clientsCreateOrganizationClientSecretResponse'
       x-codeSamples:
+        - label: Node.js SDK
+          lang: javascript
+          source: |-
+            const response = await scalekit.m2m.addOrganizationClientSecret('org_123', 'skc_xxxxx')
+            const secretId = response.secret?.id
         - label: Python SDK
           lang: python
           source: |-
-            # Get client ID from environment variables
-            org_id = 'SCALEKIT_ORGANIZATION_ID'
-            client_id = os.environ['M2M_CLIENT_ID']
+            import os
 
-            # Add a new secret to the specified client
+            org_id = "org_123"
+            client_id = os.environ["M2M_CLIENT_ID"]
+
             response = scalekit_client.m2m_client.add_organization_client_secret(
                 organization_id=org_id,
-                client_id=client_id
+                client_id=client_id,
             )
 
-            # Extract the secret ID from the response
+            # with_call returns (response, call)
             secret_id = response[0].secret.id
+        - label: Go SDK
+          lang: go
+          source: |-
+            response, err := scalekitClient.M2M().CreateOrganizationClientSecret(
+              ctx,
+              "org_123",
+              "skc_xxxxx",
+            )
+            if err != nil {
+              // handle error
+              return
+            }
+            _ = response
+        - label: Java SDK
+          lang: java
+          source: |-
+            CreateOrganizationClientSecretResponse response = scalekitClient.m2m()
+                .createOrganizationClientSecret("org_123", "skc_xxxxx");
   /api/v1/organizations/{organization_id}/clients/{client_id}/secrets/{secret_id}:
     delete:
       description: Permanently deletes a secret from an organization API client. This operation cannot be undone.
@@ -2460,20 +2651,44 @@ paths:
             application/json:
               schema: {}
       x-codeSamples:
+        - label: Node.js SDK
+          lang: javascript
+          source: await scalekit.m2m.removeOrganizationClientSecret('org_123', 'skc_xxxxx', 'sks_xxxxx')
         - label: Python SDK
           lang: python
           source: |-
-            # Get client and secret IDs from environment variables
-            org_id = '<SCALEKIT_ORGANIZATION_ID>'
-            client_id = os.environ['M2M_CLIENT_ID']
-            secret_id = os.environ['M2M_SECRET_ID']
+            import os
 
-            # Remove the specified secret from the client
-            response = scalekit_client.m2m_client.remove_organization_client_secret(
+            org_id = "org_123"
+            client_id = os.environ["M2M_CLIENT_ID"]
+            secret_id = os.environ["M2M_SECRET_ID"]
+
+            scalekit_client.m2m_client.remove_organization_client_secret(
                 organization_id=org_id,
                 client_id=client_id,
-                secret_id=secret_id
+                secret_id=secret_id,
             )
+        - label: Go SDK
+          lang: go
+          source: |-
+            err := scalekitClient.M2M().DeleteOrganizationClientSecret(
+              ctx,
+              "org_123",
+              "skc_xxxxx",
+              "sks_xxxxx",
+            )
+            if err != nil {
+              // handle error
+              return
+            }
+        - label: Java SDK
+          lang: java
+          source: |-
+            scalekitClient.m2m().deleteOrganizationClientSecret(
+                "org_123",
+                "skc_xxxxx",
+                "sks_xxxxx"
+            );
   /api/v1/organizations/{organization_id}/connections/{id}:
     get:
       description: Retrieves the complete configuration and status details for a specific connection by its ID within an organization. Returns all connection properties including provider settings, protocols, and current status.
@@ -2515,7 +2730,7 @@ paths:
         - label: Go SDK
           lang: go
           source: |-
-            connection, err := scalekitClient.Connection.GetConnection(
+            connection, err := scalekitClient.Connection().GetConnection(
               ctx,
               organizationId,
               connectionId,
@@ -2562,7 +2777,7 @@ paths:
         - label: Go SDK
           lang: go
           source: |-
-            err := scalekitClient.Connection.DeleteConnection(
+            err := scalekitClient.Connection().DeleteConnection(
               ctx,
               organizationId,
               connectionId,
@@ -2611,7 +2826,7 @@ paths:
         - label: Go SDK
           lang: go
           source: |-
-            err := scalekitClient.Connection.DisableConnection(
+            err := scalekitClient.Connection().DisableConnection(
               ctx,
               organizationId,
               connectionId,
@@ -2660,7 +2875,7 @@ paths:
         - label: Go SDK
           lang: go
           source: |-
-            err := scalekitClient.Connection.EnableConnection(
+            err := scalekitClient.Connection().EnableConnection(
               ctx,
               organizationId,
               connectionId,
@@ -3377,7 +3592,11 @@ paths:
             console.log(response.users)
         - label: Python SDK
           lang: python
-          source: resp, _ = scalekit_client.users.list_users(organization_id="org_123", page_size=50)
+          source: |-
+            response = scalekit_client.users.list_organization_users(
+                organization_id="org_123",
+                page_size=50,
+            )
         - label: Go SDK
           lang: go
           source: |-
@@ -3744,7 +3963,9 @@ paths:
             }
         - label: Java SDK
           lang: java
-          source: SendPasswordlessResponse resendResponse = passwordlessClient.resendPasswordlessEmail(authRequestId);
+          source: |-
+            SendPasswordlessResponse resendResponse = scalekitClient.passwordless()
+                .resendPasswordlessEmail(authRequestId);
   /api/v1/passwordless/email/send:
     post:
       description: Send a verification email containing either a verification code (OTP), magic link, or both to a user's email address
@@ -3772,7 +3993,7 @@ paths:
             const response = await scalekit.passwordless.sendPasswordlessEmail('john.doe@example.com', {
               template: 'SIGNIN',
               expiresIn: 100,
-              magiclinkAuthUri: 'https://www.google.com',
+              magiclinkAuthUri: 'https://yourapp.com/auth/passwordless/callback',
               templateVariables: {
                 employeeID: 'EMP523',
                 teamName: 'Alpha Team',
@@ -3786,7 +4007,7 @@ paths:
                 email="john.doe@example.com",
                 template="SIGNIN",  # or "SIGNUP", "UNSPECIFIED"
                 expires_in=100,
-                magiclink_auth_uri="https://www.google.com",
+                magiclink_auth_uri="https://yourapp.com/auth/passwordless/callback",
                 template_variables={
                     "employeeID": "EMP523",
                     "teamName": "Alpha Team",
@@ -3794,32 +4015,30 @@ paths:
                 },
             )
 
-            # Extract auth request ID from response
+            # with_call returns (response, call)
             auth_request_id = response[0].auth_request_id
         - label: Go SDK
           lang: go
           source: |-
             templateType := scalekit.TemplateTypeSignin
             response, err := scalekitClient.Passwordless().SendPasswordlessEmail(
-                ctx,
-                "john.doe@example.com",
-                &scalekit.SendPasswordlessOptions{
-                    Template:         &templateType,
-                    ExpiresIn:        100,
-                    MagiclinkAuthUri: "https://www.google.com",
-                    TemplateVariables: map[string]string{
-                        "employeeID":    "EMP523",
-                        "teamName":      "Alpha Team",
-                        "supportEmail":  "support@yourcompany.com",
-                    },
+              ctx,
+              "john.doe@example.com",
+              &scalekit.SendPasswordlessOptions{
+                Template:         &templateType,
+                ExpiresIn:        100,
+                MagiclinkAuthUri: "https://yourapp.com/auth/passwordless/callback",
+                TemplateVariables: map[string]string{
+                  "employeeID":   "EMP523",
+                  "teamName":     "Alpha Team",
+                  "supportEmail": "support@yourcompany.com",
                 },
+              },
             )
-
             if err != nil {
-                // Handle error
-                return
+              // handle error
+              return
             }
-
             authRequestId := response.AuthRequestId
         - label: Java SDK
           lang: java
@@ -3833,10 +4052,10 @@ paths:
             SendPasswordlessOptions options = new SendPasswordlessOptions();
             options.setTemplate(templateType);
             options.setExpiresIn(100);
-            options.setMagiclinkAuthUri("https://www.example.com");
+            options.setMagiclinkAuthUri("https://yourapp.com/auth/passwordless/callback");
             options.setTemplateVariables(templateVariables);
 
-            SendPasswordlessResponse response = passwordlessClient.sendPasswordlessEmail(
+            SendPasswordlessResponse response = scalekitClient.passwordless().sendPasswordlessEmail(
                 "john.doe@example.com",
                 options
             );
@@ -3867,17 +4086,17 @@ paths:
           lang: javascript
           source: |-
             const { authRequestId } = sendResponse
+
+            // Verify with OTP code
             const verifyResponse = await scalekit.passwordless.verifyPasswordlessEmail(
-              // Verification Code (OTP)
-
               { code: '123456' },
-
-              // Magic Link Token
-
-              { linkToken: link_token },
-
               authRequestId,
             )
+
+            // Or verify with magic link token
+            const linkVerifyResponse = await scalekit.passwordless.verifyPasswordlessEmail({
+              linkToken: linkToken,
+            })
         - label: Python SDK
           lang: python
           source: |-
@@ -3934,19 +4153,20 @@ paths:
             verifyOptions.setCode("123456"); // OTP code
             verifyOptions.setAuthRequestId(authRequestId);
 
-            VerifyPasswordLessResponse verifyResponse = passwordlessClient.verifyPasswordlessEmail(verifyOptions);
+            VerifyPasswordLessResponse verifyResponse = scalekitClient.passwordless()
+                .verifyPasswordlessEmail(verifyOptions);
 
             // User verified successfully
             String userEmail = verifyResponse.getEmail();
 
             // Verify with magic link token
-            VerifyPasswordlessOptions verifyOptions = new VerifyPasswordlessOptions();
-            verifyOptions.setLinkToken(linkToken); // Magic link token
+            VerifyPasswordlessOptions linkVerifyOptions = new VerifyPasswordlessOptions();
+            linkVerifyOptions.setLinkToken(linkToken); // Magic link token
 
-            VerifyPasswordLessResponse verifyResponse = passwordlessClient.verifyPasswordlessEmail(verifyOptions);
+            VerifyPasswordLessResponse linkVerifyResponse = scalekitClient.passwordless()
+                .verifyPasswordlessEmail(linkVerifyOptions);
 
-            // User verified successfully
-            String userEmail = verifyResponse.getEmail();
+            String verifiedEmail = linkVerifyResponse.getEmail();
   /api/v1/permissions:
     get:
       description: Retrieves a comprehensive, paginated list of all permissions available within the environment. Use this endpoint to view all permission definitions for auditing, role management, or understanding the complete set of available access controls. The response includes pagination tokens to navigate through large sets of permissions efficiently. Each permission object contains the permission name, description, creation time, and last update time. This operation is useful for building permission selection interfaces, auditing permission usage, or understanding the scope of available access controls in your RBAC system.
@@ -4207,7 +4427,7 @@ paths:
       parameters:
         - schema:
             type: string
-          description: "Include additional data in the response. Valid values: 'permissions' (direct permissions only), 'permissions:all' (includes inherited permissions from role hierarchy)"
+          description: 'Include additional data in the response. Valid values: ''permissions'' (direct permissions only), ''permissions:all'' (includes inherited permissions from role hierarchy)'
           name: include
           in: query
       responses:
@@ -4340,7 +4560,7 @@ paths:
           required: true
         - schema:
             type: string
-          description: "Include additional data in the response. Valid values: 'permissions' (direct permissions only), 'permissions:all' (includes inherited permissions from role hierarchy)"
+          description: 'Include additional data in the response. Valid values: ''permissions'' (direct permissions only), ''permissions:all'' (includes inherited permissions from role hierarchy)'
           name: include
           in: query
       responses:
@@ -4890,17 +5110,18 @@ paths:
         - label: Python SDK
           lang: python
           source: |-
-            # pass empty org to fetch all users in environment
-            resp,_ = scalekit_client.users.list_users(organization_id="", page_size=100)
+            # List all users in the environment
+            response = scalekit_client.users.list_users(page_size=100)
         - label: Go SDK
           lang: go
           source: 'all, err := scalekitClient.User().ListUsers(ctx, &scalekit.ListUsersOptions{PageSize: 100})'
         - label: Java SDK
           lang: java
           source: |-
-            ListUsersRequest lur = ListUsersRequest.
-              newBuilder().setPageSize(100).build();
-            ListUsersResponse allUsers = users.listUsers(lur);
+            ListUsersRequest lur = ListUsersRequest.newBuilder()
+                .setPageSize(100)
+                .build();
+            ListUsersResponse allUsers = scalekitClient.users().listUsers(lur);
   /api/v1/users/{id}:
     get:
       description: Retrieves all details for a user by system-generated user ID. The response includes organization memberships and user metadata.
@@ -4969,9 +5190,7 @@ paths:
           source: await scalekit.user.deleteUser('usr_123')
         - label: Python SDK
           lang: python
-          source: |-
-            scalekit_client.users.delete_user(organization_id="org_123", 
-              user_id="usr_123")
+          source: scalekit_client.users.delete_user("usr_123")
         - label: Go SDK
           lang: go
           source: |-
@@ -4981,7 +5200,7 @@ paths:
             }
         - label: Java SDK
           lang: java
-          source: users.deleteUser("usr_123");
+          source: scalekitClient.users().deleteUser("usr_123");
     patch:
       description: Modifies user account information including profile details, metadata, and external ID. Use this endpoint to update a user's personal information, contact details, or custom metadata. You can update the user's profile, phone number, and metadata fields. Note that fields like user ID, email address, environment ID, and creation time cannot be modified.
       tags:
@@ -5028,24 +5247,17 @@ paths:
         - label: Python SDK
           lang: python
           source: |-
-            import os
-            from scalekit import ScalekitClient
             from scalekit.v1.users.users_pb2 import UpdateUser
             from scalekit.v1.commons.commons_pb2 import UserProfile
-            scalekit_client = ScalekitClient(
-                env_url=os.getenv("SCALEKIT_ENV_URL"),
-                client_id=os.getenv("SCALEKIT_CLIENT_ID"),
-                client_secret=os.getenv("SCALEKIT_CLIENT_SECRET"),
-            )
+
             update_user = UpdateUser(
                 user_profile=UserProfile(
                     first_name="John",
-                    last_name="Smith"
+                    last_name="Smith",
                 ),
-                metadata={"department": "sales"}
+                metadata={"department": "sales"},
             )
-            scalekit_client.users.update_user(organization_id="org_123", 
-              user=update_user)
+            response = scalekit_client.users.update_user("usr_123", update_user)
         - label: Go SDK
           lang: go
           source: |-
@@ -5063,16 +5275,17 @@ paths:
           lang: java
           source: |-
             UpdateUser upd = UpdateUser.newBuilder()
-                    .setUserProfile(
-                      UpdateUserProfile.newBuilder()
-                            .setFirstName("John")
-                            .setLastName("Smith")
-                            .build())
-                    .putMetadata("department", "sales")
-                    .build();
-            UpdateUserRequest updReq = UpdateUserRequest.
-              newBuilder().setUser(upd).build();
-            users.updateUser("usr_123", updReq);
+                .setUserProfile(
+                    UpdateUserProfile.newBuilder()
+                        .setFirstName("John")
+                        .setLastName("Smith")
+                        .build())
+                .putMetadata("department", "sales")
+                .build();
+            UpdateUserRequest updReq = UpdateUserRequest.newBuilder()
+                .setUser(upd)
+                .build();
+            scalekitClient.users().updateUser("usr_123", updReq);
   /api/v1/users/{user_id}/sessions:
     get:
       description: Retrieves a paginated list of all sessions associated with a specific user across all devices and browsers. Use this endpoint to audit user activity, display all active sessions in account management interfaces, or verify user authentication status across devices. Supports filtering by session status (active, expired, revoked, logout) and time range (creation date). Returns session details for each session including device information, IP address, geolocation, and current status. The response includes pagination metadata (page tokens and total count) to handle large session lists efficiently.
@@ -5104,7 +5317,7 @@ paths:
               type: string
           style: form
           explode: true
-          description: "Filter sessions by one or more status values. Possible values: 'active', 'expired', 'revoked', 'logout'. Leave empty to include all statuses. Multiple values use OR logic (e.g., status=['active', 'expired'] returns sessions that are either active OR expired)."
+          description: 'Filter sessions by one or more status values. Possible values: ''active'', ''expired'', ''revoked'', ''logout''. Leave empty to include all statuses. Multiple values use OR logic (e.g., status=[''active'', ''expired''] returns sessions that are either active OR expired).'
           name: filter.status
           in: query
         - schema:
@@ -5379,7 +5592,7 @@ paths:
             _ = resp
         - label: Java SDK
           lang: java
-          source: ListCredentialsResponse res = scalekitClient.webauthn().listCredentials("user_123");
+          source: ListCredentialsResponse res = scalekitClient.webAuthn().listCredentials("user_123");
   /api/v1/webauthn/credentials/{credential_id}:
     delete:
       description: Deletes a specific passkey credential for the current user. After removal, the authenticator can no longer be used for authentication.
@@ -5416,7 +5629,7 @@ paths:
             _ = resp
         - label: Java SDK
           lang: java
-          source: DeleteCredentialResponse res = scalekitClient.webauthn().deleteCredential("wac_123");
+          source: DeleteCredentialResponse res = scalekitClient.webAuthn().deleteCredential("wac_123");
     patch:
       description: Updates the display name of a passkey credential to help users identify their authenticators. Only the display name can be modified.
       tags:
@@ -5467,7 +5680,7 @@ paths:
         - label: Java SDK
           lang: java
           source: |-
-            UpdateCredentialResponse res = scalekitClient.webauthn()
+            UpdateCredentialResponse res = scalekitClient.webAuthn()
                 .updateCredential("wac_123", "Work Laptop Passkey");
 webhooks:
   organization.created:
@@ -5573,6 +5786,134 @@ webhooks:
                     - enabled: false
                       name: dir_sync
               display_name: Organization Deleted
+      responses:
+        '200':
+          description: Webhook received successfully
+  organization.domain_created:
+    post:
+      summary: Organization Domain Created
+      description: Triggered when a domain is added to an organization (organization domain or allowed email domain).
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScalekitEvent'
+            example:
+              spec_version: '1'
+              id: evt_4567890123
+              type: organization.domain_created
+              object: Organization
+              occurred_at: '2024-01-15T11:00:00.123456789Z'
+              environment_id: env_1234567890
+              organization_id: org_1234567890
+              data:
+                id: dom_1234567890
+                domain: acmecorp.com
+                domain_type: ORGANIZATION_DOMAIN
+                organization_id: org_1234567890
+                environment_id: env_1234567890
+                txt_record_key: scalekit-domain-verification
+                txt_record_secret: sk_dom_verify_abc123
+                verification_status: PENDING
+                verification_method: DNS
+                updated_at: '2024-01-15T11:00:00.123456789Z'
+              display_name: Organization Domain Created
+      responses:
+        '200':
+          description: Webhook received successfully
+  organization.domain_deleted:
+    post:
+      summary: Organization Domain Deleted
+      description: Triggered when a domain is removed from an organization.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScalekitEvent'
+            example:
+              spec_version: '1'
+              id: evt_4567890456
+              type: organization.domain_deleted
+              object: Organization
+              occurred_at: '2024-01-16T09:30:00.123456789Z'
+              environment_id: env_1234567890
+              organization_id: org_1234567890
+              data:
+                id: dom_1234567890
+                domain: acmecorp.com
+                domain_type: ORGANIZATION_DOMAIN
+                organization_id: org_1234567890
+                environment_id: env_1234567890
+                txt_record_key: scalekit-domain-verification
+                txt_record_secret: sk_dom_verify_abc123
+                verification_status: VERIFIED
+                verification_method: DNS
+                updated_at: '2024-01-16T09:30:00.123456789Z'
+              display_name: Organization Domain Deleted
+      responses:
+        '200':
+          description: Webhook received successfully
+  organization.domain_dns_verification_success:
+    post:
+      summary: Organization Domain DNS Verification Success
+      description: Triggered when DNS TXT record validation confirms ownership of an organization domain.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScalekitEvent'
+            example:
+              spec_version: '1'
+              id: evt_4567890789
+              type: organization.domain_dns_verification_success
+              object: Organization
+              occurred_at: '2024-01-15T12:15:00.123456789Z'
+              environment_id: env_1234567890
+              organization_id: org_1234567890
+              data:
+                id: dom_1234567890
+                domain: acmecorp.com
+                domain_type: ORGANIZATION_DOMAIN
+                organization_id: org_1234567890
+                environment_id: env_1234567890
+                txt_record_key: scalekit-domain-verification
+                txt_record_secret: sk_dom_verify_abc123
+                verification_status: VERIFIED
+                verification_method: DNS
+                updated_at: '2024-01-15T12:15:00.123456789Z'
+              display_name: Organization Domain DNS Verification Success
+      responses:
+        '200':
+          description: Webhook received successfully
+  organization.domain_dns_verification_failed:
+    post:
+      summary: Organization Domain DNS Verification Failed
+      description: Triggered when the DNS verification window expires without a successful TXT record match.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScalekitEvent'
+            example:
+              spec_version: '1'
+              id: evt_4567891012
+              type: organization.domain_dns_verification_failed
+              object: Organization
+              occurred_at: '2024-01-16T11:00:00.123456789Z'
+              environment_id: env_1234567890
+              organization_id: org_1234567890
+              data:
+                id: dom_1234567890
+                domain: acmecorp.com
+                domain_type: ORGANIZATION_DOMAIN
+                organization_id: org_1234567890
+                environment_id: env_1234567890
+                txt_record_key: scalekit-domain-verification
+                txt_record_secret: sk_dom_verify_abc123
+                verification_status: FAILED
+                verification_method: DNS
+                updated_at: '2024-01-16T11:00:00.123456789Z'
+              display_name: Organization Domain DNS Verification Failed
       responses:
         '200':
           description: Webhook received successfully
@@ -6901,7 +7242,7 @@ components:
           examples:
             - 360
         absolute_session_timeout_unit:
-          description: "Unit for absolute_session_timeout. Accepted values: 'MINUTES', 'HOURS', 'DAYS'. Defaults to MINUTES."
+          description: 'Unit for absolute_session_timeout. Accepted values: ''MINUTES'', ''HOURS'', ''DAYS''. Defaults to MINUTES.'
           $ref: '#/components/schemas/commonsTimeUnit'
           examples:
             - MINUTES
@@ -6917,7 +7258,7 @@ components:
           examples:
             - true
         idle_session_timeout_unit:
-          description: "Unit for idle_session_timeout. Accepted values: 'MINUTES', 'HOURS', 'DAYS'. Defaults to MINUTES."
+          description: 'Unit for idle_session_timeout. Accepted values: ''MINUTES'', ''HOURS'', ''DAYS''. Defaults to MINUTES.'
           $ref: '#/components/schemas/commonsTimeUnit'
           examples:
             - MINUTES
@@ -6995,7 +7336,7 @@ components:
           type: array
           items:
             type: string
-            default: "['ATTESTATION_KEY_COMPROMISE', 'USER_VERIFICATION_BYPASS', 'USER_KEY_REMOTE_COMPROMISE', 'USER_KEY_PHYSICAL_COMPROMISE', 'REVOKED']"
+            default: '[''ATTESTATION_KEY_COMPROMISE'', ''USER_VERIFICATION_BYPASS'', ''USER_KEY_REMOTE_COMPROMISE'', ''USER_KEY_PHYSICAL_COMPROMISE'', ''REVOKED'']'
         validate_anchors:
           description: when set to true enables the validation of the attestation statement against the trust anchor from the metadata statement.
           type: boolean
@@ -8247,7 +8588,7 @@ components:
       type: object
       properties:
         attribute_mapping:
-          description: "Maps identity provider attributes to user profile fields. For example, {'email': 'user.mail', 'name': 'user.displayName'}."
+          description: 'Maps identity provider attributes to user profile fields. For example, {''email'': ''user.mail'', ''name'': ''user.displayName''}.'
           type: object
           additionalProperties:
             type: string
@@ -9834,7 +10175,7 @@ components:
           examples:
             - 360
         absolute_session_timeout_unit:
-          description: "Unit for absolute_session_timeout. Accepted values: 'minutes', 'hours', 'days'. Responses always return 'minutes'."
+          description: 'Unit for absolute_session_timeout. Accepted values: ''minutes'', ''hours'', ''days''. Responses always return ''minutes''.'
           $ref: '#/components/schemas/commonsTimeUnit'
           examples:
             - minutes
@@ -9850,7 +10191,7 @@ components:
           examples:
             - true
         idle_session_timeout_unit:
-          description: "Unit for idle_session_timeout. Accepted values: 'minutes', 'hours', 'days'. Responses always return 'minutes'."
+          description: 'Unit for idle_session_timeout. Accepted values: ''minutes'', ''hours'', ''days''. Responses always return ''minutes''.'
           $ref: '#/components/schemas/commonsTimeUnit'
           examples:
             - minutes
@@ -10417,7 +10758,7 @@ components:
           examples:
             - 120.0.0.0
         device_type:
-          description: "Categorized device type classification. Possible values: 'desktop' (traditional computers), 'mobile' (smartphones and small tablets), 'tablet' (large tablets), 'other'. Useful for displaying session information by device category."
+          description: 'Categorized device type classification. Possible values: ''desktop'' (traditional computers), ''mobile'' (smartphones and small tablets), ''tablet'' (large tablets), ''other''. Useful for displaying session information by device category.'
           type: string
           examples:
             - desktop
@@ -10427,7 +10768,7 @@ components:
           examples:
             - 192.0.2.1
         location:
-          description: "Geographic location information derived from IP address geolocation. Includes country, region, city, and coordinates. Note: Based on IP location data and may not represent the user's exact physical location."
+          description: 'Geographic location information derived from IP address geolocation. Includes country, region, city, and coordinates. Note: Based on IP location data and may not represent the user''s exact physical location.'
           $ref: '#/components/schemas/v1sessionsLocation'
         os:
           description: 'Operating system name extracted from the user agent and device headers. Examples: macOS, Windows, Linux, iOS, Android.'
@@ -10592,7 +10933,7 @@ components:
           examples:
             - ses_1234567890123456
         status:
-          description: "Current operational status of the session. Possible values: 'active' (session is valid and requests are allowed), 'expired' (session terminated due to idle or absolute timeout), 'revoked' (session was administratively revoked), 'logout' (user explicitly logged out). Use this to determine if the session can be used for new requests."
+          description: 'Current operational status of the session. Possible values: ''active'' (session is valid and requests are allowed), ''expired'' (session terminated due to idle or absolute timeout), ''revoked'' (session was administratively revoked), ''logout'' (user explicitly logged out). Use this to determine if the session can be used for new requests.'
           type: string
           examples:
             - active
@@ -11019,7 +11360,7 @@ components:
           examples:
             - Doe
         first_name:
-          description: "[DEPRECATED] Use given_name instead. User's given name. Maximum 200 characters."
+          description: '[DEPRECATED] Use given_name instead. User''s given name. Maximum 200 characters.'
           type: string
           examples:
             - John
@@ -11042,7 +11383,7 @@ components:
             - - engineering
               - managers
         last_name:
-          description: "[DEPRECATED] Use family_name instead. User's family name. Maximum 200 characters."
+          description: '[DEPRECATED] Use family_name instead. User''s family name. Maximum 200 characters.'
           type: string
           examples:
             - Doe
@@ -11521,12 +11862,12 @@ components:
           examples:
             - San Francisco
         latitude:
-          description: "Latitude coordinate of the estimated location. Decimal format (e.g., '37.7749'). Note: Represents IP geolocation center and may not be precise."
+          description: 'Latitude coordinate of the estimated location. Decimal format (e.g., ''37.7749''). Note: Represents IP geolocation center and may not be precise.'
           type: string
           examples:
             - '37.7749'
         longitude:
-          description: "Longitude coordinate of the estimated location. Decimal format (e.g., '-122.4194'). Note: Represents IP geolocation center and may not be precise."
+          description: 'Longitude coordinate of the estimated location. Decimal format (e.g., ''-122.4194''). Note: Represents IP geolocation center and may not be precise.'
           type: string
           examples:
             - '-122.4194'
@@ -11748,6 +12089,10 @@ components:
             - organization.created
             - organization.updated
             - organization.deleted
+            - organization.domain_created
+            - organization.domain_deleted
+            - organization.domain_dns_verification_success
+            - organization.domain_dns_verification_failed
             - organization.sso_created
             - organization.sso_deleted
             - organization.sso_enabled
@@ -11905,15 +12250,38 @@ components:
           example: GMAIL
           description: The provider of the connected account
         authorization_type:
-          $ref: '#/components/schemas/connected_accountsConnectorType'
+          type: string
+          enum:
+            - OAUTH
+            - API_KEY
+            - BASIC_AUTH
+            - BEARER_TOKEN
+            - BASIC
+            - OAUTH_M2M
+            - TRELLO_OAUTH1
+            - GOOGLE_DWD
+            - TRUSTED_IDP
+            - SMART_FHIR
           example: OAUTH
           description: The authorization type of the connected account
         status:
-          $ref: '#/components/schemas/connected_accountsConnectorStatus'
+          type: string
+          enum:
+            - ACTIVE
+            - EXPIRED
+            - PENDING_AUTH
+            - PENDING_VERIFICATION
+            - DISCONNECTED
           example: EXPIRED
           description: The new status of the connected account
         old_status:
-          $ref: '#/components/schemas/connected_accountsConnectorStatus'
+          type: string
+          enum:
+            - ACTIVE
+            - EXPIRED
+            - PENDING_AUTH
+            - PENDING_VERIFICATION
+            - DISCONNECTED
           example: ACTIVE
           description: The previous status of the connected account
   securitySchemes:

--- a/src/content/docs/authenticate/manage-users-orgs/organization-domains.mdx
+++ b/src/content/docs/authenticate/manage-users-orgs/organization-domains.mdx
@@ -366,7 +366,7 @@ All four events share the same `data` shape:
 {
   "environment_id": "env_1234567890",
   "id": "evt_4567890123",
-  "object": "OrganizationDomain",
+  "object": "Organization",
   "occurred_at": "2024-01-15T11:00:00.123456789Z",
   "organization_id": "org_1234567890",
   "spec_version": "1",
@@ -375,10 +375,13 @@ All four events share the same `data` shape:
     "id": "dom_1234567890",
     "domain": "acmecorp.com",
     "domain_type": "ORGANIZATION_DOMAIN",
-    "verification_status": "VERIFIED",
-    "verification_method": "ADMIN",
-    "create_time": "2024-01-15T11:00:00.123456789Z",
-    "update_time": "2024-01-15T11:00:00.123456789Z"
+    "organization_id": "org_1234567890",
+    "environment_id": "env_1234567890",
+    "txt_record_key": "scalekit-domain-verification",
+    "txt_record_secret": "sk_dom_verify_abc123",
+    "verification_status": "PENDING",
+    "verification_method": "DNS",
+    "updated_at": "2024-01-15T11:00:00.123456789Z"
   }
 }
 ```
@@ -388,10 +391,13 @@ All four events share the same `data` shape:
 | `id` | string | Unique identifier for the domain (`dom_` prefix) |
 | `domain` | string | The domain name |
 | `domain_type` | string | `ORGANIZATION_DOMAIN` for SSO/SCIM domains; `ALLOWED_EMAIL_DOMAIN` for auto-join domains |
-| `verification_status` | string | `PENDING`, `VERIFIED`, or `FAILED` |
+| `organization_id` | string | Organization that owns the domain (`org_` prefix) |
+| `environment_id` | string | Environment where the domain is configured (`env_` prefix) |
+| `txt_record_key` | string | DNS TXT record host used for ownership verification |
+| `txt_record_secret` | string | DNS TXT record value Scalekit expects during verification |
+| `verification_status` | string | `PENDING`, `VERIFIED`, `FAILED`, or `AUTO_VERIFIED` |
 | `verification_method` | string | `DNS` (TXT record), `ADMIN` (added by the B2B app team), or `NOT_APPLICABLE` (allowed email domains) |
-| `create_time` | string | When the domain was added |
-| `update_time` | string | When the status last changed |
+| `updated_at` | string | When the domain status last changed |
 
 Configure handlers with the [webhooks guide](/authenticate/implement-workflows/implement-webhooks/).
 


### PR DESCRIPTION
## Summary

- Adds four organization domain webhook events to the Scalar API reference (`openapi/scalekit.yaml` → `webhooks:`):
  - `organization.domain_created`
  - `organization.domain_deleted`
  - `organization.domain_dns_verification_success`
  - `organization.domain_dns_verification_failed`
- Updates the `ScalekitEvent.type` enum and regenerates `public/api/*` bundles.
- Aligns the organization domains guide sample payload with the backend `DomainDataEvent` shape.

Closes SK-958.

## Preview

- Combined APIs: https://deploy-preview-892--scalekit-starlight.netlify.app/apis/#webhook
- SaaSKit APIs: https://deploy-preview-892--scalekit-starlight.netlify.app/saaskit/apis/
- Org domains guide: https://deploy-preview-892--scalekit-starlight.netlify.app/authenticate/manage-users-orgs/organization-domains/

## Test plan

- [ ] Confirm the four domain webhooks appear under Webhooks on `/apis` and `/saaskit/apis`
- [ ] Confirm example payloads use `object: Organization` and domain `data` fields (`txt_record_*`, `verification_status`, etc.)
- [ ] Confirm domain webhook ops do not appear as AgentKit webhook operations
- [ ] Confirm organization domains guide table + sample match the API examples
- [ ] `organization.domain_update` is intentionally omitted (not published by backend)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added webhook events for organization domain creation, deletion, and DNS verification success or failure.
  * Expanded webhook payload documentation with domain, organization, environment, and DNS verification details.

* **Documentation**
  * Added updated multi-language SDK code samples across key API operations.
  * Clarified webhook schemas, allowed values, examples, and request requirements.
  * Improved descriptions and formatting throughout the API reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->