### PR TITLE
Improve hackathon hub flow and AgentKit snippet accuracy

### DIFF
--- a/public/hackathon/index.html
+++ b/public/hackathon/index.html
@@ -929,16 +929,13 @@ scalekit setup</code></pre>
             </p>
 
             <div class="templates" id="templates">
-              <h3>Popular templates</h3>
+              <h3>Start here</h3>
               <div class="template-row">
                 <a class="chip" href="https://docs.scalekit.com/agentkit/quickstart" target="_blank" rel="noopener">
                   Gmail agent <span class="time">~15 min</span>
                 </a>
-                <a class="chip" href="https://docs.scalekit.com/cookbooks/daily-briefing-agent" target="_blank" rel="noopener">
-                  Daily briefing <span class="time">~30 min</span>
-                </a>
-                <a class="chip" href="https://docs.scalekit.com/cookbooks/schedule-meeting-and-draft-email" target="_blank" rel="noopener">
-                  Meeting + email <span class="time">~30 min</span>
+                <a class="chip" href="https://docs.scalekit.com/agentkit/examples/" target="_blank" rel="noopener">
+                  Framework examples <span class="time">LangChain, CrewAI, more</span>
                 </a>
                 <a class="chip" href="https://docs.scalekit.com/agentkit/mcp/overview" target="_blank" rel="noopener">
                   Virtual MCP <span class="time">~25 min</span>
@@ -980,95 +977,9 @@ scalekit setup</code></pre>
           <a class="btn btn-outline" href="https://join.slack.com/t/scalekit-community/shared_invite/zt-3gsxwr4hc-0tvhwT2b_qgVSIZQBQCWRw" target="_blank" rel="noopener">Join Slack</a>
         </div>
         <p class="free-note">
-          Free plan: $0/month, 5,000 tool calls/month, unlimited connected accounts, 324 pre-built connectors.
+          Free plan: $0/month, 5,000 tool calls/month, unlimited connected accounts, 300+ pre-built connectors.
           No credit card required &mdash; see <a href="https://www.scalekit.com/pricing" target="_blank" rel="noopener">pricing</a>.
         </p>
-      </div>
-    </section>
-
-    <!-- FAQ early -->
-    <section class="section section-dark" id="faq" aria-labelledby="faq-title">
-      <div class="wrap faq-layout">
-        <div>
-          <p class="eyebrow">FAQ</p>
-          <h2 id="faq-title">Common questions</h2>
-        </div>
-        <div class="accordion" data-accordion>
-          <div class="acc-item">
-            <h3 style="margin:0">
-              <button class="acc-trigger" type="button" aria-expanded="false" aria-controls="faq-1" id="faq-1-btn">
-                Is the Free plan actually free? Do I need a coupon?
-                <svg class="acc-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M1.5 8h13M8 14.5v-13"/></svg>
-              </button>
-            </h3>
-            <div class="acc-panel" id="faq-1" role="region" aria-labelledby="faq-1-btn" hidden>
-              <p style="margin:0">
-                No coupon and no credit card needed. The Free plan is permanent, not a timed trial:
-                $0/month, 5,000 tool calls a month, unlimited connected accounts, and community + email support.
-                See <a href="https://www.scalekit.com/pricing" target="_blank" rel="noopener">pricing</a> for details.
-              </p>
-            </div>
-          </div>
-          <div class="acc-item">
-            <h3 style="margin:0">
-              <button class="acc-trigger" type="button" aria-expanded="false" aria-controls="faq-2" id="faq-2-btn">
-                Where can I get hackathon support?
-                <svg class="acc-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M1.5 8h13M8 14.5v-13"/></svg>
-              </button>
-            </h3>
-            <div class="acc-panel" id="faq-2" role="region" aria-labelledby="faq-2-btn" hidden>
-              <p style="margin:0">
-                Ask in the <a href="https://join.slack.com/t/scalekit-community/shared_invite/zt-3gsxwr4hc-0tvhwT2b_qgVSIZQBQCWRw" target="_blank" rel="noopener">Scalekit Slack community</a> for the fastest response,
-                email <a href="mailto:support@scalekit.com">support@scalekit.com</a>,
-                or search <a href="https://docs.scalekit.com" target="_blank" rel="noopener">docs.scalekit.com</a>.
-              </p>
-            </div>
-          </div>
-          <div class="acc-item">
-            <h3 style="margin:0">
-              <button class="acc-trigger" type="button" aria-expanded="false" aria-controls="faq-3" id="faq-3-btn">
-                What can I build with AgentKit?
-                <svg class="acc-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M1.5 8h13M8 14.5v-13"/></svg>
-              </button>
-            </h3>
-            <div class="acc-panel" id="faq-3" role="region" aria-labelledby="faq-3-btn" hidden>
-              <p style="margin:0">
-                Inbox triage, daily briefings (Calendar + Gmail), meeting booking, multi-agent crews,
-                Virtual MCP endpoints, GitHub PR agents, and more. Start with one connector and add a second only if your demo needs it.
-              </p>
-            </div>
-          </div>
-          <div class="acc-item">
-            <h3 style="margin:0">
-              <button class="acc-trigger" type="button" aria-expanded="false" aria-controls="faq-4" id="faq-4-btn">
-                How do I install the Scalekit CLI?
-                <svg class="acc-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M1.5 8h13M8 14.5v-13"/></svg>
-              </button>
-            </h3>
-            <div class="acc-panel" id="faq-4" role="region" aria-labelledby="faq-4-btn" hidden>
-              <p style="margin:0">
-                Run <code>npx @scalekit-inc/cli setup</code>, or install globally with
-                <code>npm install -g @scalekit-inc/cli</code> and run <code>scalekit setup</code>.
-                The wizard lets you pick your coding agent. For the full walkthrough, see the
-                <a href="https://docs.scalekit.com/cookbooks/set-up-agentkit-with-your-coding-agent" target="_blank" rel="noopener">coding-agent cookbook</a>.
-              </p>
-            </div>
-          </div>
-          <div class="acc-item">
-            <h3 style="margin:0">
-              <button class="acc-trigger" type="button" aria-expanded="false" aria-controls="faq-5" id="faq-5-btn">
-                What happens when I hit 5,000 tool calls?
-                <svg class="acc-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M1.5 8h13M8 14.5v-13"/></svg>
-              </button>
-            </h3>
-            <div class="acc-panel" id="faq-5" role="region" aria-labelledby="faq-5-btn" hidden>
-              <p style="margin:0">
-                On the Free plan, tool calls pause until the next billing cycle or until you upgrade &mdash;
-                there is no silent overage bill. For a weekend hackathon, 5,000 is usually plenty if you avoid tight polling loops.
-              </p>
-            </div>
-          </div>
-        </div>
       </div>
     </section>
 
@@ -1188,7 +1099,7 @@ fetch the last 5 unread emails using Scalekit's tool API.</code></pre>
         <p class="eyebrow">Resources</p>
         <h2 id="resources-title">Build with AgentKit</h2>
         <p class="lead" style="margin-inline:auto">
-          The shortest path to a working agent first &mdash; cookbooks and advanced topics when you expand.
+          Start with the quickstart and core AgentKit docs. Expand only after your first tool call works.
         </p>
 
         <div class="col-grid" style="text-align:left">
@@ -1204,30 +1115,30 @@ fetch the last 5 unread emails using Scalekit's tool API.</code></pre>
             </a>
             <a class="res-card" href="https://docs.scalekit.com/agentkit/connectors/" target="_blank" rel="noopener">
               <strong>Connectors catalog</strong>
-              <span>Browse 324 pre-built connectors and their tool libraries.</span>
+              <span>Browse 300+ pre-built connectors and their tool libraries.</span>
             </a>
             <a class="res-card" href="https://docs.scalekit.com/cookbooks/set-up-agentkit-with-your-coding-agent" target="_blank" rel="noopener">
-              <strong>Coding agents cookbook</strong>
+              <strong>Coding agents setup</strong>
               <span>CLI, plugins, and skills for 40+ agents.</span>
             </a>
           </div>
           <div>
-            <h3>Examples</h3>
-            <a class="res-card" href="https://docs.scalekit.com/cookbooks/daily-briefing-agent" target="_blank" rel="noopener">
-              <strong>Daily briefing agent</strong>
-              <span>Vercel AI SDK + Calendar + Gmail patterns.</span>
-            </a>
-            <a class="res-card" href="https://docs.scalekit.com/cookbooks/mastra-agentkit" target="_blank" rel="noopener">
-              <strong>Mastra + AgentKit</strong>
-              <span>Gmail and connectors without manual OAuth handling.</span>
-            </a>
-            <a class="res-card" href="https://docs.scalekit.com/cookbooks/crewai-agentkit-email-triage" target="_blank" rel="noopener">
-              <strong>CrewAI email triage</strong>
-              <span>Multi-agent crew with authenticated Gmail tools.</span>
+            <h3>Code samples</h3>
+            <a class="res-card" href="https://docs.scalekit.com/agentkit/examples/" target="_blank" rel="noopener">
+              <strong>Framework examples</strong>
+              <span>LangChain, CrewAI, Mastra, Vercel AI, OpenAI, and more.</span>
             </a>
             <a class="res-card" href="https://github.com/scalekit-developers/agent-auth-examples" target="_blank" rel="noopener">
               <strong>agent-auth-examples</strong>
               <span>Core AgentKit auth patterns on GitHub.</span>
+            </a>
+            <a class="res-card" href="https://docs.scalekit.com/agentkit/tools/scalekit-optimized-tools/" target="_blank" rel="noopener">
+              <strong>Optimized tools</strong>
+              <span>Call tools through Scalekit without managing provider endpoints.</span>
+            </a>
+            <a class="res-card" href="https://docs.scalekit.com/agentkit/sdks/" target="_blank" rel="noopener">
+              <strong>SDKs</strong>
+              <span>Node and Python SDK reference for AgentKit.</span>
             </a>
           </div>
           <div>
@@ -1236,6 +1147,10 @@ fetch the last 5 unread emails using Scalekit's tool API.</code></pre>
               <strong>Virtual MCP servers</strong>
               <span>Least-privilege tools and per-user session tokens.</span>
             </a>
+            <a class="res-card" href="https://docs.scalekit.com/agentkit/mcp/configure-mcp-server" target="_blank" rel="noopener">
+              <strong>Set up Virtual MCP</strong>
+              <span>Create a config, mint session tokens, connect an agent.</span>
+            </a>
             <a class="res-card" href="https://docs.scalekit.com/agentkit/user-verification/" target="_blank" rel="noopener">
               <strong>User verification</strong>
               <span>Confirm OAuth identity matches your logged-in user.</span>
@@ -1243,10 +1158,6 @@ fetch the last 5 unread emails using Scalekit's tool API.</code></pre>
             <a class="res-card" href="https://docs.scalekit.com/agentkit/bring-your-own-connector/overview" target="_blank" rel="noopener">
               <strong>Bring your own connector</strong>
               <span>Custom connectors when the catalog is not enough.</span>
-            </a>
-            <a class="res-card" href="https://docs.scalekit.com/agentkit/tools/scalekit-optimized-tools/" target="_blank" rel="noopener">
-              <strong>Optimized tools</strong>
-              <span>Call APIs through Scalekit without managing endpoints.</span>
             </a>
           </div>
         </div>
@@ -1268,22 +1179,22 @@ fetch the last 5 unread emails using Scalekit's tool API.</code></pre>
           Project shapes that fit a hackathon weekend. One connector first.
         </p>
         <div class="grid-2" style="text-align:left;max-width:56rem;margin-inline:auto">
-          <a class="callout" style="margin:0;text-decoration:none;display:block" href="https://docs.scalekit.com/cookbooks/daily-briefing-agent" target="_blank" rel="noopener">
-            <h3>Personal ops agent</h3>
-            <p class="muted" style="margin:0;font-size:0.88rem">Calendar + Gmail briefing. Start from the daily briefing cookbook.</p>
-          </a>
-          <a class="callout" style="margin:0;text-decoration:none;display:block" href="https://docs.scalekit.com/cookbooks/crewai-agentkit-email-triage" target="_blank" rel="noopener">
-            <h3>Inbox triage crew</h3>
-            <p class="muted" style="margin:0;font-size:0.88rem">CrewAI or LiteLLM: classify, draft, open GitHub issues with approval gates.</p>
-          </a>
-          <a class="callout" style="margin:0;text-decoration:none;display:block" href="https://docs.scalekit.com/cookbooks/schedule-meeting-and-draft-email" target="_blank" rel="noopener">
-            <h3>Meeting + follow-up</h3>
-            <p class="muted" style="margin:0;font-size:0.88rem">Find free slots, book meetings, draft confirmation emails.</p>
-          </a>
-          <a class="callout" style="margin:0;text-decoration:none;display:block" href="https://docs.scalekit.com/agentkit/mcp/overview" target="_blank" rel="noopener">
+          <div class="callout" style="margin:0">
+            <h3>Gmail-powered agent</h3>
+            <p class="muted" style="margin:0;font-size:0.88rem">Fetch unread mail, summarize, or draft replies. Start from the <a href="https://docs.scalekit.com/agentkit/quickstart" target="_blank" rel="noopener">AgentKit quickstart</a>.</p>
+          </div>
+          <div class="callout" style="margin:0">
+            <h3>Multi-connector demo</h3>
+            <p class="muted" style="margin:0;font-size:0.88rem">Add Calendar, Slack, or GitHub after Gmail works. Browse the <a href="https://docs.scalekit.com/agentkit/connectors/" target="_blank" rel="noopener">connectors catalog</a>.</p>
+          </div>
+          <div class="callout" style="margin:0">
+            <h3>Framework agent</h3>
+            <p class="muted" style="margin:0;font-size:0.88rem">Wire AgentKit tools into LangChain, CrewAI, Mastra, or Vercel AI. See <a href="https://docs.scalekit.com/agentkit/examples/" target="_blank" rel="noopener">framework examples</a>.</p>
+          </div>
+          <div class="callout" style="margin:0">
             <h3>Virtual MCP endpoint</h3>
-            <p class="muted" style="margin:0;font-size:0.88rem">Least-privilege MCP server with per-user session tokens.</p>
-          </a>
+            <p class="muted" style="margin:0;font-size:0.88rem">Expose least-privilege tools over MCP. Read the <a href="https://docs.scalekit.com/agentkit/mcp/overview" target="_blank" rel="noopener">Virtual MCP overview</a> and <a href="https://docs.scalekit.com/agentkit/mcp/configure-mcp-server" target="_blank" rel="noopener">setup guide</a>.</p>
+          </div>
         </div>
       </div>
     </section>
@@ -1319,10 +1230,11 @@ GMAIL_CONNECTION_NAME=your-exact-connection-name</code></pre>
 import { ConnectorStatus } from '@scalekit-sdk/node/lib/pkg/grpc/scalekit/v1/connected_accounts/connected_accounts_pb';
 import 'dotenv/config';
 
+// Constructor: envUrl, clientId, clientSecret
 const scalekit = new ScalekitClient(
-  process.env.SCALEKIT_ENV_URL,
-  process.env.SCALEKIT_CLIENT_ID,
-  process.env.SCALEKIT_CLIENT_SECRET
+  process.env.SCALEKIT_ENV_URL!,
+  process.env.SCALEKIT_CLIENT_ID!,
+  process.env.SCALEKIT_CLIENT_SECRET!
 );
 
 const actions = scalekit.actions;
@@ -1332,37 +1244,57 @@ const response = await actions.getOrCreateConnectedAccount({
   connectionName,
   identifier: 'user_123',
 });
-const connectedAccount = response.connectedAccount;
+let connectedAccount = response.connectedAccount;
 
+// Do not call tools until the user finishes OAuth and status is ACTIVE.
 if (connectedAccount?.status !== ConnectorStatus.ACTIVE) {
   const linkResponse = await actions.getAuthorizationLink({
     connectionName,
     identifier: 'user_123',
   });
   console.log('Authorize Gmail:', linkResponse.link);
+  console.log('Press Enter after authorizing Gmail...');
+  await new Promise((resolve) => {
+    process.stdin.resume();
+    process.stdin.once('data', () => {
+      process.stdin.pause();
+      resolve();
+    });
+  });
+
+  const refreshed = await actions.getOrCreateConnectedAccount({
+    connectionName,
+    identifier: 'user_123',
+  });
+  connectedAccount = refreshed.connectedAccount;
+}
+
+if (connectedAccount?.status !== ConnectorStatus.ACTIVE) {
+  throw new Error('Gmail is still not ACTIVE. Complete authorization and try again.');
 }
 
 const toolResponse = await actions.executeTool({
   toolName: 'gmail_fetch_mails',
-  connectedAccountId: connectedAccount?.id,
+  connectedAccountId: connectedAccount.id,
   toolInput: { query: 'is:unread', max_results: 5 },
 });
 console.log(toolResponse.data);</code></pre>
           </div>
           <div class="tabpanel" role="tabpanel" id="panel-python" aria-labelledby="tab-python" hidden>
             <p class="code-label">Install</p>
-            <pre><code>pip install scalekit-sdk-python python-dotenv requests</code></pre>
+            <pre><code>pip install scalekit-sdk-python python-dotenv</code></pre>
             <p class="code-label">Client + connected account + authorize + execute tool</p>
             <pre><code>import os
-import scalekit.client
+from scalekit import ScalekitClient
 from dotenv import load_dotenv
 
 load_dotenv()
 
-scalekit_client = scalekit.client.ScalekitClient(
-    client_id=os.getenv("SCALEKIT_CLIENT_ID"),
-    client_secret=os.getenv("SCALEKIT_CLIENT_SECRET"),
-    env_url=os.getenv("SCALEKIT_ENV_URL"),
+# Constructor order: env_url, client_id, client_secret (or use keywords)
+scalekit_client = ScalekitClient(
+    os.getenv("SCALEKIT_ENV_URL"),
+    os.getenv("SCALEKIT_CLIENT_ID"),
+    os.getenv("SCALEKIT_CLIENT_SECRET"),
 )
 actions = scalekit_client.actions
 connection_name = os.getenv("GMAIL_CONNECTION_NAME")
@@ -1373,6 +1305,7 @@ response = actions.get_or_create_connected_account(
 )
 connected_account = response.connected_account
 
+# Do not call tools until the user finishes OAuth and status is ACTIVE.
 if connected_account.status != "ACTIVE":
     link_response = actions.get_authorization_link(
         connection_name=connection_name,
@@ -1380,13 +1313,23 @@ if connected_account.status != "ACTIVE":
     )
     print("Authorize Gmail:", link_response.link)
     input("Press Enter after authorizing...")
+    response = actions.get_or_create_connected_account(
+        connection_name=connection_name,
+        identifier="user_123",
+    )
+    connected_account = response.connected_account
 
-response = actions.execute_tool(
+if connected_account.status != "ACTIVE":
+    raise RuntimeError("Gmail is still not ACTIVE. Complete authorization and try again.")
+
+# Prefer connected_account_id after authorize. If you use identifier instead,
+# also pass connection_name — the pair is required for account resolution.
+tool_response = actions.execute_tool(
     tool_name="gmail_fetch_mails",
-    identifier="user_123",
+    connected_account_id=connected_account.id,
     tool_input={"query": "is:unread", "max_results": 5},
 )
-print(response)</code></pre>
+print(tool_response.data)</code></pre>
           </div>
         </div>
       </div>
@@ -1464,6 +1407,92 @@ print(response)</code></pre>
             <h3>Enterprise SSO &amp; SCIM</h3>
             <p>SAML/OIDC SSO and directory sync for enterprise-facing products.</p>
           </a>
+        </div>
+      </div>
+    </section>
+
+    <!-- FAQ at end so the main journey finishes first -->
+    <section class="section section-dark" id="faq" aria-labelledby="faq-title">
+      <div class="wrap faq-layout">
+        <div>
+          <p class="eyebrow">FAQ</p>
+          <h2 id="faq-title">Common questions</h2>
+        </div>
+        <div class="accordion" data-accordion>
+          <div class="acc-item">
+            <h3 style="margin:0">
+              <button class="acc-trigger" type="button" aria-expanded="false" aria-controls="faq-1" id="faq-1-btn">
+                Is the Free plan actually free? Do I need a coupon?
+                <svg class="acc-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M1.5 8h13M8 14.5v-13"/></svg>
+              </button>
+            </h3>
+            <div class="acc-panel" id="faq-1" role="region" aria-labelledby="faq-1-btn" hidden>
+              <p style="margin:0">
+                No coupon and no credit card needed. The Free plan is permanent, not a timed trial:
+                $0/month, 5,000 tool calls a month, unlimited connected accounts, and community + email support.
+                See <a href="https://www.scalekit.com/pricing" target="_blank" rel="noopener">pricing</a> for details.
+              </p>
+            </div>
+          </div>
+          <div class="acc-item">
+            <h3 style="margin:0">
+              <button class="acc-trigger" type="button" aria-expanded="false" aria-controls="faq-2" id="faq-2-btn">
+                Where can I get hackathon support?
+                <svg class="acc-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M1.5 8h13M8 14.5v-13"/></svg>
+              </button>
+            </h3>
+            <div class="acc-panel" id="faq-2" role="region" aria-labelledby="faq-2-btn" hidden>
+              <p style="margin:0">
+                Ask in the <a href="https://join.slack.com/t/scalekit-community/shared_invite/zt-3gsxwr4hc-0tvhwT2b_qgVSIZQBQCWRw" target="_blank" rel="noopener">Scalekit Slack community</a> for the fastest response,
+                email <a href="mailto:support@scalekit.com">support@scalekit.com</a>,
+                or search <a href="https://docs.scalekit.com" target="_blank" rel="noopener">docs.scalekit.com</a>.
+              </p>
+            </div>
+          </div>
+          <div class="acc-item">
+            <h3 style="margin:0">
+              <button class="acc-trigger" type="button" aria-expanded="false" aria-controls="faq-3" id="faq-3-btn">
+                What can I build with AgentKit?
+                <svg class="acc-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M1.5 8h13M8 14.5v-13"/></svg>
+              </button>
+            </h3>
+            <div class="acc-panel" id="faq-3" role="region" aria-labelledby="faq-3-btn" hidden>
+              <p style="margin:0">
+                Inbox triage, daily briefings (Calendar + Gmail), meeting booking, multi-agent crews,
+                Virtual MCP endpoints, GitHub PR agents, and more. Start with one connector and add a second only if your demo needs it.
+              </p>
+            </div>
+          </div>
+          <div class="acc-item">
+            <h3 style="margin:0">
+              <button class="acc-trigger" type="button" aria-expanded="false" aria-controls="faq-4" id="faq-4-btn">
+                How do I install the Scalekit CLI?
+                <svg class="acc-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M1.5 8h13M8 14.5v-13"/></svg>
+              </button>
+            </h3>
+            <div class="acc-panel" id="faq-4" role="region" aria-labelledby="faq-4-btn" hidden>
+              <p style="margin:0">
+                Run <code>npx @scalekit-inc/cli setup</code>, or install globally with
+                <code>npm install -g @scalekit-inc/cli</code> and run <code>scalekit setup</code>.
+                The wizard lets you pick your coding agent. For the full walkthrough, see the
+                <a href="https://docs.scalekit.com/cookbooks/set-up-agentkit-with-your-coding-agent" target="_blank" rel="noopener">coding-agent cookbook</a>.
+              </p>
+            </div>
+          </div>
+          <div class="acc-item">
+            <h3 style="margin:0">
+              <button class="acc-trigger" type="button" aria-expanded="false" aria-controls="faq-5" id="faq-5-btn">
+                What happens when I hit 5,000 tool calls?
+                <svg class="acc-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M1.5 8h13M8 14.5v-13"/></svg>
+              </button>
+            </h3>
+            <div class="acc-panel" id="faq-5" role="region" aria-labelledby="faq-5-btn" hidden>
+              <p style="margin:0">
+                On the Free plan, tool calls pause until the next billing cycle or until you upgrade &mdash;
+                there is no silent overage bill. For a weekend hackathon, 5,000 is usually plenty if you avoid tight polling loops.
+              </p>
+            </div>
+          </div>
         </div>
       </div>
     </section>

--- a/public/hackathon/index.html
+++ b/public/hackathon/index.html
@@ -1254,9 +1254,9 @@ if (connectedAccount?.status !== ConnectorStatus.ACTIVE) {
   });
   console.log('Authorize Gmail:', linkResponse.link);
   console.log('Press Enter after authorizing Gmail...');
-  await new Promise((resolve) => {
+  await new Promise((resolve) =&gt; {
     process.stdin.resume();
-    process.stdin.once('data', () => {
+    process.stdin.once('data', () =&gt; {
       process.stdin.pause();
       resolve();
     });

--- a/src/content/docs/agentkit/quickstart.mdx
+++ b/src/content/docs/agentkit/quickstart.mdx
@@ -90,9 +90,9 @@ Complete these steps in the Scalekit dashboard before writing any code:
 
         # Constructor: env_url, client_id, client_secret
         scalekit_client = ScalekitClient(
-            os.getenv("SCALEKIT_ENV_URL"),
-            os.getenv("SCALEKIT_CLIENT_ID"),
-            os.getenv("SCALEKIT_CLIENT_SECRET"),
+            os.environ["SCALEKIT_ENV_URL"],
+            os.environ["SCALEKIT_CLIENT_ID"],
+            os.environ["SCALEKIT_CLIENT_SECRET"],
         )
         actions = scalekit_client.actions
         connection_name = os.getenv("GMAIL_CONNECTION_NAME")  # must match the Connection name in the dashboard exactly
@@ -171,6 +171,11 @@ Complete these steps in the Scalekit dashboard before writing any code:
             )
             connected_account = response.connected_account
             # In production, redirect the user to this URL and resume after the OAuth callback
+
+        if connected_account.status != "ACTIVE":
+            raise RuntimeError(
+                "Gmail is still not ACTIVE. Complete authorization and try again."
+            )
         ```
       </TabItem>
       <TabItem label="Node.js">
@@ -199,6 +204,10 @@ Complete these steps in the Scalekit dashboard before writing any code:
           });
           connectedAccount = refreshed.connectedAccount;
           // In production, redirect the user to this URL and resume after the OAuth callback
+        }
+
+        if (connectedAccount?.status !== ConnectorStatus.ACTIVE) {
+          throw new Error('Gmail is still not ACTIVE. Complete authorization and try again.');
         }
         ```
       </TabItem>

--- a/src/content/docs/agentkit/quickstart.mdx
+++ b/src/content/docs/agentkit/quickstart.mdx
@@ -71,7 +71,7 @@ Complete these steps in the Scalekit dashboard before writing any code:
     <Tabs syncKey="tech-stack">
       <TabItem label="Python">
         ```sh showLineNumbers=false frame="none"
-        pip install scalekit-sdk-python python-dotenv requests
+        pip install scalekit-sdk-python python-dotenv
         ```
       </TabItem>
       <TabItem label="Node.js">
@@ -83,16 +83,16 @@ Complete these steps in the Scalekit dashboard before writing any code:
     <Tabs syncKey="tech-stack">
       <TabItem label="Python">
         ```python showLineNumbers=false frame="none" wrap
-        import scalekit.client
         import os
-        import requests
+        from scalekit import ScalekitClient
         from dotenv import load_dotenv
         load_dotenv()
 
-        scalekit_client = scalekit.client.ScalekitClient(
-            client_id=os.getenv("SCALEKIT_CLIENT_ID"),
-            client_secret=os.getenv("SCALEKIT_CLIENT_SECRET"),
-            env_url=os.getenv("SCALEKIT_ENV_URL"),
+        # Constructor: env_url, client_id, client_secret
+        scalekit_client = ScalekitClient(
+            os.getenv("SCALEKIT_ENV_URL"),
+            os.getenv("SCALEKIT_CLIENT_ID"),
+            os.getenv("SCALEKIT_CLIENT_SECRET"),
         )
         actions = scalekit_client.actions
         connection_name = os.getenv("GMAIL_CONNECTION_NAME")  # must match the Connection name in the dashboard exactly
@@ -104,10 +104,11 @@ Complete these steps in the Scalekit dashboard before writing any code:
         import { ConnectorStatus } from '@scalekit-sdk/node/lib/pkg/grpc/scalekit/v1/connected_accounts/connected_accounts_pb';
         import 'dotenv/config';
 
+        // Constructor: envUrl, clientId, clientSecret
         const scalekit = new ScalekitClient(
-          process.env.SCALEKIT_ENV_URL,
-          process.env.SCALEKIT_CLIENT_ID,
-          process.env.SCALEKIT_CLIENT_SECRET
+          process.env.SCALEKIT_ENV_URL!,
+          process.env.SCALEKIT_CLIENT_ID!,
+          process.env.SCALEKIT_CLIENT_SECRET!
         );
 
         const actions = scalekit.actions;
@@ -140,7 +141,7 @@ Complete these steps in the Scalekit dashboard before writing any code:
           identifier: 'user_123',  // Replace with your system's unique user ID
         });
 
-        const connectedAccount = response.connectedAccount;
+        let connectedAccount = response.connectedAccount;
         console.log('Connected account created:', connectedAccount?.id);
         ```
       </TabItem>
@@ -153,22 +154,29 @@ Complete these steps in the Scalekit dashboard before writing any code:
     <Tabs syncKey="tech-stack">
       <TabItem label="Python">
         ```python showLineNumbers=false frame="none" wrap
-        # Generate authorization link if user hasn't authorized or token is expired
-        if(connected_account.status != "ACTIVE"):
-              print(f"Gmail is not connected: {connected_account.status}")
-              link_response = actions.get_authorization_link(
-                  connection_name=connection_name,
-                  identifier="user_123"
-              )
-              print(f"🔗 click on the link to authorize Gmail", link_response.link)
-              input(f"⎆ Press Enter after authorizing Gmail...")
-
-        # In production, redirect user to this URL to complete OAuth flow
+        # Generate authorization link if user hasn't authorized or token is expired.
+        # Do not call tools until status is ACTIVE — wait for the user to finish OAuth first.
+        if connected_account.status != "ACTIVE":
+            print(f"Gmail is not connected: {connected_account.status}")
+            link_response = actions.get_authorization_link(
+                connection_name=connection_name,
+                identifier="user_123",
+            )
+            print("🔗 click on the link to authorize Gmail", link_response.link)
+            input("⎆ Press Enter after authorizing Gmail...")
+            # Re-fetch so connected_account reflects ACTIVE status and a valid id
+            response = actions.get_or_create_connected_account(
+                connection_name=connection_name,
+                identifier="user_123",
+            )
+            connected_account = response.connected_account
+            # In production, redirect the user to this URL and resume after the OAuth callback
         ```
       </TabItem>
       <TabItem label="Node.js">
         ```typescript showLineNumbers=false frame="none" wrap
-        // Generate authorization link if user hasn't authorized or token is expired
+        // Generate authorization link if user hasn't authorized or token is expired.
+        // Do not call tools until status is ACTIVE — wait for the user to finish OAuth first.
         if (connectedAccount?.status !== ConnectorStatus.ACTIVE) {
           console.log('gmail is not connected:', connectedAccount?.status);
           const linkResponse = await actions.getAuthorizationLink({
@@ -176,13 +184,27 @@ Complete these steps in the Scalekit dashboard before writing any code:
             identifier: 'user_123',
           });
           console.log('🔗 click on the link to authorize gmail', linkResponse.link);
-          // In production, redirect user to this URL to complete OAuth flow
+          console.log('Press Enter after authorizing Gmail...');
+          await new Promise<void>((resolve) => {
+            process.stdin.resume();
+            process.stdin.once('data', () => {
+              process.stdin.pause();
+              resolve();
+            });
+          });
+          // Re-fetch so connectedAccount reflects ACTIVE status and a valid id
+          const refreshed = await actions.getOrCreateConnectedAccount({
+            connectionName,
+            identifier: 'user_123',
+          });
+          connectedAccount = refreshed.connectedAccount;
+          // In production, redirect the user to this URL and resume after the OAuth callback
         }
         ```
       </TabItem>
     </Tabs>
 
-    Open the link in a browser and authorize the Gmail connection. Once complete, the connected account status updates to `ACTIVE` and your agent can act on the user's behalf.
+    Open the link in a browser and authorize the Gmail connection. Once complete, the connected account status updates to `ACTIVE` and your agent can act on the user's behalf. In CLI samples, wait for that step (for example with `input()` or stdin) before calling tools — otherwise the first run fails because the account is still inactive.
 
     ### 4. Fetch emails via tool call
 
@@ -191,15 +213,18 @@ Complete these steps in the Scalekit dashboard before writing any code:
     <Tabs syncKey="tech-stack">
       <TabItem label="Python">
         ```python showLineNumbers=false frame="none" wrap
-        response = actions.execute_tool(
+        # Prefer connected_account_id after authorize. If you use identifier instead,
+        # also pass connection_name — the pair is required for account resolution.
+        tool_response = actions.execute_tool(
             tool_name="gmail_fetch_mails",
-            identifier="user_123",
+            connected_account_id=connected_account.id,
             tool_input={
                 "query": "is:unread",
                 "max_results": 5,
             },
         )
-        print(response)
+        # Tool output lives under data
+        print(tool_response.data)
         ```
       </TabItem>
       <TabItem label="Node.js">
@@ -212,6 +237,7 @@ Complete these steps in the Scalekit dashboard before writing any code:
             max_results: 5,
           },
         });
+        // Tool output lives under data
         console.log('Recent emails:', toolResponse.data);
         ```
       </TabItem>

--- a/src/content/docs/cookbooks/crewai-agentkit-email-triage.mdx
+++ b/src/content/docs/cookbooks/crewai-agentkit-email-triage.mdx
@@ -36,13 +36,19 @@ This cookbook builds a three-agent email triage crew: one agent scans unread ema
 
 The complete source is available in the [crewai-scalekit-example](https://github.com/scalekit-developers/crewai-scalekit-example) repository.
 
-### 1. Set up a Gmail connection in Scalekit
+### 1. Set up Gmail and a Virtual MCP server
+
+New environments do not ship with a Virtual MCP server. Create the Gmail connection and the MCP config **before** you run the sample — otherwise `list_configs` returns an empty list.
 
 In the [Scalekit Dashboard](https://app.scalekit.com):
 
 1. Go to **AgentKit** → **Connections** → **Create Connection** and select **Gmail**.
-2. Note the **Connection name** — your code references it by this exact string.
-3. Go to **AgentKit** → **MCP Configs** and create a config (for example `gmail-user-tools`) that includes Gmail tools. This config name goes into your environment variables.
+2. Note the **Connection name** — your code references it by this exact string (for example `gmail`).
+3. Go to **AgentKit** → **MCP Configs** → **Create** and create a Virtual MCP config (for example `gmail-user-tools`).
+4. Attach the Gmail connection and include the tools the crew needs (at least `gmail_fetch_mails`).
+5. Copy the **config name** into `SCALEKIT_MCP_CONFIG_NAME` below.
+
+For the full API path (create config, mint session tokens, connect agents), see [Set up and connect a Virtual MCP server](/agentkit/mcp/configure-mcp-server/).
 
 ### 2. Install dependencies
 
@@ -67,7 +73,10 @@ SCALEKIT_CLIENT_SECRET=your-secret
 # User identifier from your application
 SCALEKIT_USER_IDENTIFIER=user_123
 
-# MCP config name — must match the config in the Scalekit Dashboard
+# Exact Connection name from AgentKit → Connections
+GMAIL_CONNECTION_NAME=gmail
+
+# MCP config name — must match the Virtual MCP config created in step 1
 SCALEKIT_MCP_CONFIG_NAME=gmail-user-tools
 
 # LLM — any OpenAI-compatible endpoint
@@ -83,10 +92,11 @@ from dotenv import find_dotenv, load_dotenv
 
 load_dotenv(find_dotenv())
 
+# Constructor: env_url, client_id, client_secret
 scalekit_client = ScalekitClient(
-    env_url=os.environ["SCALEKIT_ENV_URL"],
-    client_id=os.environ["SCALEKIT_CLIENT_ID"],
-    client_secret=os.environ["SCALEKIT_CLIENT_SECRET"],
+    os.environ["SCALEKIT_ENV_URL"],
+    os.environ["SCALEKIT_CLIENT_ID"],
+    os.environ["SCALEKIT_CLIENT_SECRET"],
 )
 actions = scalekit_client.actions
 
@@ -96,32 +106,59 @@ USER_ID = os.getenv("SCALEKIT_USER_IDENTIFIER", "user_123")
 Before calling any Gmail tool, check whether the user has an active connected account. If not, print an authorization link and wait for them to complete OAuth in the browser:
 
 ```python
+# Use the exact Connection name from AgentKit → Connections (not a guessed slug).
+CONNECTION_NAME = os.getenv("GMAIL_CONNECTION_NAME", "gmail")
+
 response = actions.get_or_create_connected_account(
-    connection_name="gmail",
+    connection_name=CONNECTION_NAME,
     identifier=USER_ID,
 )
-if response.connected_account.status != "ACTIVE":
+connected_account = response.connected_account
+
+# Do not start the crew until status is ACTIVE.
+if connected_account.status != "ACTIVE":
     link = actions.get_authorization_link(
-        connection_name="gmail",
+        connection_name=CONNECTION_NAME,
         identifier=USER_ID,
     )
-    print(f"\n[gmail] Authorization required.")
+    print(f"\n[{CONNECTION_NAME}] Authorization required.")
     print(f"Open this link:\n\n  {link.link}\n")
     input("Press Enter after authorizing...")
+    response = actions.get_or_create_connected_account(
+        connection_name=CONNECTION_NAME,
+        identifier=USER_ID,
+    )
+    connected_account = response.connected_account
+
+if connected_account.status != "ACTIVE":
+    raise RuntimeError(
+        f"{CONNECTION_NAME} is still not ACTIVE. Complete authorization and try again."
+    )
 ```
 
 After the first successful authorization, `get_or_create_connected_account` returns an active account on all subsequent runs. Scalekit refreshes expired tokens automatically.
 
 ### 5. Connect to Gmail tools via MCP
 
-Get the Virtual MCP Server URL and mint a session token, then pass both to `MCPServerAdapter`:
+Look up the Virtual MCP config you created in step 1, mint a session token, then pass both to `MCPServerAdapter`.
+
+If `list_configs` returns no results, stop and create the config first (dashboard or [configure-mcp-server](/agentkit/mcp/configure-mcp-server/)). Do not assume a default Virtual MCP server exists.
 
 ```python
 from crewai_tools import MCPServerAdapter
 from datetime import timedelta
 
+mcp_config_name = os.getenv("SCALEKIT_MCP_CONFIG_NAME", "gmail-user-tools")
+
 # Retrieve config_id by listing Virtual MCP Servers filtered by name
-list_response = actions.mcp.list_configs(filter_name=os.getenv("SCALEKIT_MCP_CONFIG_NAME", "gmail-user-tools"))
+list_response = actions.mcp.list_configs(filter_name=mcp_config_name)
+if not list_response.configs:
+    raise RuntimeError(
+        f"No Virtual MCP config named '{mcp_config_name}'. "
+        "Create one under AgentKit → MCP Configs (include Gmail tools), "
+        "or follow https://docs.scalekit.com/agentkit/mcp/configure-mcp-server/"
+    )
+
 mcp_server_url = list_response.configs[0].mcp_server_url
 mcp_id = list_response.configs[0].id
 
@@ -320,9 +357,9 @@ On subsequent runs, the authorization step is skipped entirely.
 <details>
 <summary>MCP config not found</summary>
 
-- **Symptom**: `list_configs` returns an empty list
-- **Cause**: `SCALEKIT_MCP_CONFIG_NAME` does not match any config in the dashboard
-- **Fix**: Go to **AgentKit → MCP Configs** and verify the config name. Create one if it doesn't exist — it needs to include the Gmail tools you want exposed.
+- **Symptom**: `list_configs` returns an empty list, or `configs[0]` raises `IndexError`
+- **Cause**: No Virtual MCP server exists yet, or `SCALEKIT_MCP_CONFIG_NAME` does not match the dashboard name
+- **Fix**: Create a config under **AgentKit → MCP Configs** that includes Gmail tools, then set `SCALEKIT_MCP_CONFIG_NAME` to that exact name. See [Set up and connect a Virtual MCP server](/agentkit/mcp/configure-mcp-server/).
 
 </details>
 

--- a/src/content/docs/cookbooks/crewai-agentkit-email-triage.mdx
+++ b/src/content/docs/cookbooks/crewai-agentkit-email-triage.mdx
@@ -105,7 +105,7 @@ USER_ID = os.getenv("SCALEKIT_USER_IDENTIFIER", "user_123")
 
 Before calling any Gmail tool, check whether the user has an active connected account. If not, print an authorization link and wait for them to complete OAuth in the browser:
 
-```python
+```python title="agent.py"
 # Use the exact Connection name from AgentKit → Connections (not a guessed slug).
 CONNECTION_NAME = os.getenv("GMAIL_CONNECTION_NAME", "gmail")
 
@@ -144,7 +144,7 @@ Look up the Virtual MCP config you created in step 1, mint a session token, then
 
 If `list_configs` returns no results, stop and create the config first (dashboard or [configure-mcp-server](/agentkit/mcp/configure-mcp-server/)). Do not assume a default Virtual MCP server exists.
 
-```python
+```python title="agent.py"
 from crewai_tools import MCPServerAdapter
 from datetime import timedelta
 
@@ -357,7 +357,7 @@ On subsequent runs, the authorization step is skipped entirely.
 <details>
 <summary>MCP config not found</summary>
 
-- **Symptom**: `list_configs` returns an empty list, or `configs[0]` raises `IndexError`
+- **Symptom**: `list_configs` returns an empty list
 - **Cause**: No Virtual MCP server exists yet, or `SCALEKIT_MCP_CONFIG_NAME` does not match the dashboard name
 - **Fix**: Create a config under **AgentKit → MCP Configs** that includes Gmail tools, then set `SCALEKIT_MCP_CONFIG_NAME` to that exact name. See [Set up and connect a Virtual MCP server](/agentkit/mcp/configure-mcp-server/).
 

--- a/src/content/docs/cookbooks/crewai-agentkit-email-triage.mdx
+++ b/src/content/docs/cookbooks/crewai-agentkit-email-triage.mdx
@@ -105,7 +105,7 @@ USER_ID = os.getenv("SCALEKIT_USER_IDENTIFIER", "user_123")
 
 Before calling any Gmail tool, check whether the user has an active connected account. If not, print an authorization link and wait for them to complete OAuth in the browser:
 
-```python title="agent.py"
+```python
 # Use the exact Connection name from AgentKit → Connections (not a guessed slug).
 CONNECTION_NAME = os.getenv("GMAIL_CONNECTION_NAME", "gmail")
 
@@ -144,7 +144,7 @@ Look up the Virtual MCP config you created in step 1, mint a session token, then
 
 If `list_configs` returns no results, stop and create the config first (dashboard or [configure-mcp-server](/agentkit/mcp/configure-mcp-server/)). Do not assume a default Virtual MCP server exists.
 
-```python title="agent.py"
+```python
 from crewai_tools import MCPServerAdapter
 from datetime import timedelta
 

--- a/src/content/docs/cookbooks/daily-briefing-agent.mdx
+++ b/src/content/docs/cookbooks/daily-briefing-agent.mdx
@@ -1,11 +1,11 @@
 ---
 title: 'Build a daily briefing agent with Vercel AI SDK and Scalekit Agent Auth'
-description: 'Connect a TypeScript or Python agent via Vercel AI SDK and Scalekit Agent Auth to Google Calendar and Gmail using two integration patterns.'
+description: 'Connect a TypeScript or Python agent via Vercel AI SDK and Scalekit AgentKit to Google Calendar and Gmail with authenticated tool calls.'
 date: 2026-03-27
 sidebar:
   label: 'Daily briefing agent'
 excerpt: >
-  Connecting an agent to two external APIs means handling two separate OAuth tokens, two authorization flows, and two different error surfaces. This recipe shows how Scalekit manages the OAuth lifecycle for both connectors, then demonstrates two patterns for calling those APIs: fetching a token and calling the REST API directly, versus letting Scalekit execute the call through a built-in action.
+  Connecting an agent to two external APIs means handling two separate OAuth tokens, two authorization flows, and two different error surfaces. This recipe shows how Scalekit manages the OAuth lifecycle for both connectors and how you call Calendar and Gmail through built-in tools — without talking to provider APIs yourself.
 featured: false
 authors:
   - name: 'Saif'
@@ -18,12 +18,13 @@ import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 A daily briefing agent needs two things: today's calendar events and the latest unread emails. Both live behind OAuth-protected APIs, and each requires its own token, its own authorization flow, and its own refresh logic. Before you write any scheduling logic, you're already maintaining two parallel token lifecycles.
 
-Scalekit eliminates that overhead. It stores one OAuth session per connector per user, handles token refresh automatically, and gives you a single API surface regardless of which provider you're talking to. This recipe shows how to use it with Google Calendar and Gmail — and demonstrates two patterns for consuming those credentials in your agent.
+Scalekit eliminates that overhead. It stores one OAuth session per connector per user, refreshes tokens automatically, and exposes **built-in tools** such as `googlecalendar_list_events` and `gmail_fetch_mails`. Your agent calls those tools through Scalekit; it never talks to the Google Calendar or Gmail REST APIs directly.
 
 **What this recipe covers:**
 
-- **OAuth token pattern** — Scalekit provides a valid token; your agent calls the Google Calendar REST API directly. Use this when you need full control over the request.
-- **Built-in action pattern** — Your agent calls `execute_tool("gmail_fetch_mails")`; Scalekit executes the Gmail API call and returns structured data. Use this when you want speed and don't need to customize the request.
+- **Authorize once per connector** — create connected accounts for Calendar and Gmail, open the OAuth link if needed, and wait until status is `ACTIVE`
+- **Built-in tool calls** — `execute_tool("googlecalendar_list_events")` and `execute_tool("gmail_fetch_mails")` so Scalekit runs the provider call and returns structured data
+- **Wire both tools into an agent** — Vercel AI SDK (TypeScript) or Anthropic messages (Python)
 
 The complete source used here is available in the [vercel-ai-agent-toolkit](https://github.com/scalekit-developers/vercel-ai-agent-toolkit) repository, with a TypeScript implementation using the Vercel AI SDK and a Python implementation using the Anthropic SDK directly.
 
@@ -74,7 +75,6 @@ The connection names are identifiers your code references directly. They must ma
    ```text
    scalekit-sdk-python
    anthropic
-   requests
    python-dotenv
    ```
 
@@ -117,6 +117,7 @@ Get your Scalekit credentials at **app.scalekit.com → Settings → API Credent
       process.env.SCALEKIT_CLIENT_ID!,
       process.env.SCALEKIT_CLIENT_SECRET!,
     );
+    const actions = scalekit.actions;
 
     const USER_ID = 'user_123'; // Replace with the real user ID from your session
     ```
@@ -128,27 +129,27 @@ Get your Scalekit credentials at **app.scalekit.com → Settings → API Credent
     ```python
     import os
     import json
-    import requests
-    from datetime import datetime, timezone
+    from datetime import datetime
     from dotenv import load_dotenv
     import anthropic
-    import scalekit.client
+    from scalekit import ScalekitClient
 
     load_dotenv()
 
     # Never hard-code credentials — they would be exposed in source control.
     # Pull them from environment variables at runtime.
-    scalekit_client = scalekit.client.ScalekitClient(
-        client_id=os.environ["SCALEKIT_CLIENT_ID"],
-        client_secret=os.environ["SCALEKIT_CLIENT_SECRET"],
-        env_url=os.environ["SCALEKIT_ENV_URL"],
+    # Constructor: env_url, client_id, client_secret
+    scalekit_client = ScalekitClient(
+        os.environ["SCALEKIT_ENV_URL"],
+        os.environ["SCALEKIT_CLIENT_ID"],
+        os.environ["SCALEKIT_CLIENT_SECRET"],
     )
     actions = scalekit_client.actions
 
     USER_ID = "user_123"  # Replace with the real user ID from your session
     ```
 
-    `scalekit_client.actions` is the entry point for all connected-account operations: creating accounts, generating auth links, fetching tokens, and executing built-in tools.
+    `scalekit_client.actions` is the entry point for connected-account operations and built-in tool execution.
   </TabItem>
 </Tabs>
 
@@ -160,26 +161,35 @@ Before calling any API, check whether the user has an active connected account. 
   <TabItem value="typescript" label="TypeScript">
 
     ```typescript
-    async function ensureConnected(connector: string) {
-      const { connectedAccount } =
-        await scalekit.connectedAccounts.getOrCreateConnectedAccount({
-          connector,
+    async function ensureConnected(connectionName: string) {
+      let { connectedAccount } = await actions.getOrCreateConnectedAccount({
+        connectionName,
+        identifier: USER_ID,
+      });
+
+      // Do not call tools until the user finishes OAuth and status is ACTIVE.
+      if (connectedAccount?.status !== ConnectorStatus.ACTIVE) {
+        const { link } = await actions.getAuthorizationLink({
+          connectionName,
           identifier: USER_ID,
         });
-
-      if (connectedAccount?.status !== ConnectorStatus.ACTIVE) {
-        const { link } =
-          await scalekit.connectedAccounts.getMagicLinkForConnectedAccount({
-            connector,
-            identifier: USER_ID,
-          });
-        console.log(`\n[${connector}] Authorization required.`);
+        console.log(`\n[${connectionName}] Authorization required.`);
         console.log(`Open this link:\n\n  ${link}\n`);
         console.log('Press Enter once you have completed the OAuth flow...');
         await new Promise<void>(resolve => {
           process.stdin.resume();
           process.stdin.once('data', () => { process.stdin.pause(); resolve(); });
         });
+
+        const refreshed = await actions.getOrCreateConnectedAccount({
+          connectionName,
+          identifier: USER_ID,
+        });
+        connectedAccount = refreshed.connectedAccount;
+      }
+
+      if (connectedAccount?.status !== ConnectorStatus.ACTIVE) {
+        throw new Error(`${connectionName} is still not ACTIVE. Complete authorization and try again.`);
       }
 
       return connectedAccount;
@@ -189,21 +199,32 @@ Before calling any API, check whether the user has an active connected account. 
   <TabItem value="python" label="Python">
 
     ```python
-    def ensure_connected(connector: str):
+    def ensure_connected(connection_name: str):
         response = actions.get_or_create_connected_account(
-            connection_name=connector,
+            connection_name=connection_name,
             identifier=USER_ID,
         )
         connected_account = response.connected_account
 
+        # Do not call tools until the user finishes OAuth and status is ACTIVE.
         if connected_account.status != "ACTIVE":
             link_response = actions.get_authorization_link(
-                connection_name=connector,
+                connection_name=connection_name,
                 identifier=USER_ID,
             )
-            print(f"\n[{connector}] Authorization required.")
+            print(f"\n[{connection_name}] Authorization required.")
             print(f"Open this link:\n\n  {link_response.link}\n")
             input("Press Enter once you have completed the OAuth flow...")
+            response = actions.get_or_create_connected_account(
+                connection_name=connection_name,
+                identifier=USER_ID,
+            )
+            connected_account = response.connected_account
+
+        if connected_account.status != "ACTIVE":
+            raise RuntimeError(
+                f"{connection_name} is still not ACTIVE. Complete authorization and try again."
+            )
 
         return connected_account
     ```
@@ -212,59 +233,32 @@ Before calling any API, check whether the user has an active connected account. 
 
 After the first successful authorization, `getOrCreateConnectedAccount` / `get_or_create_connected_account` returns an active account on all subsequent calls. Scalekit refreshes expired tokens automatically — your code never calls a token-refresh endpoint.
 
-### 6. Fetch calendar events using the OAuth token pattern
+### 6. Fetch calendar events with a built-in tool
 
-For Google Calendar, retrieve a valid access token from Scalekit and call the Google Calendar REST API directly. This pattern gives you full control over query parameters, pagination, and error handling.
+Call `execute_tool` with `googlecalendar_list_events`. Scalekit uses the stored OAuth session, calls Google Calendar, and returns structured event data. Your agent never handles a Google access token or the Calendar REST API.
 
 <Tabs syncKey="tech-stack">
   <TabItem value="typescript" label="TypeScript">
 
     ```typescript
-    async function getAccessToken(connector: string): Promise<string> {
-      const response =
-        await scalekit.connectedAccounts.getConnectedAccountByIdentifier({
-          connector,
-          identifier: USER_ID,
-        });
-      const details = response?.connectedAccount?.authorizationDetails?.details;
-      if (details?.case === 'oauthToken' && details.value?.accessToken) {
-        return details.value.accessToken;
-      }
-      throw new Error(`No access token found for ${connector}`);
-    }
-    ```
-
-    Use this token in a tool that the LLM can call:
-
-    ```typescript
     import { tool } from 'ai';
     import { z } from 'zod';
 
-    const today = new Date();
-    const timeMin = new Date(today.getFullYear(), today.getMonth(), today.getDate()).toISOString();
-    const timeMax = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 23, 59, 59).toISOString();
-
-    const calendarToken = await getAccessToken('googlecalendar');
-
     const getCalendarEvents = tool({
-      description: "Fetch today's events from Google Calendar",
+      description: "Fetch today's events from Google Calendar via Scalekit",
       parameters: z.object({
         maxResults: z.number().optional().default(5),
       }),
       execute: async ({ maxResults }) => {
-        const url = new URL('https://www.googleapis.com/calendar/v3/calendars/primary/events');
-        url.searchParams.set('timeMin', timeMin);
-        url.searchParams.set('timeMax', timeMax);
-        url.searchParams.set('maxResults', String(maxResults));
-        url.searchParams.set('orderBy', 'startTime');
-        url.searchParams.set('singleEvents', 'true');
-
-        const res = await fetch(url.toString(), {
-          headers: { Authorization: `Bearer ${calendarToken}` },
+        const response = await actions.executeTool({
+          toolName: 'googlecalendar_list_events',
+          connectedAccountId: calendarAccount?.id,
+          toolInput: {
+            max_results: maxResults,
+          },
         });
-        if (!res.ok) throw new Error(`Calendar API error: ${res.status}`);
-        const data = await res.json() as { items?: unknown[] };
-        return data.items ?? [];
+        // Tool output lives under data — log once when integrating a new tool.
+        return response.data ?? {};
       },
     });
     ```
@@ -272,47 +266,23 @@ For Google Calendar, retrieve a valid access token from Scalekit and call the Go
   <TabItem value="python" label="Python">
 
     ```python
-    def get_access_token(connector: str) -> str:
-        # Use get_or_create_connected_account as the safe default so
-        # first-time users do not hit RESOURCE_NOT_FOUND.
-        response = actions.get_or_create_connected_account(
-            connection_name=connector,
-            identifier=USER_ID,
-        )
-        connected_account = response.connected_account
-        if connected_account.status != "ACTIVE":
-            raise RuntimeError(
-                f"{connector} is not active yet. Complete authorization first."
-            )
-
-        tokens = connected_account.authorization_details["oauth_token"]
-        return tokens["access_token"]
-
-    def fetch_calendar_events(access_token: str, max_results: int = 5) -> list:
-        today = datetime.now(timezone.utc).astimezone()
-        time_min = today.replace(hour=0, minute=0, second=0, microsecond=0).isoformat()
-        time_max = today.replace(hour=23, minute=59, second=59, microsecond=0).isoformat()
-
-        resp = requests.get(
-            "https://www.googleapis.com/calendar/v3/calendars/primary/events",
-            headers={"Authorization": f"Bearer {access_token}"},
-            params={
-                "timeMin": time_min,
-                "timeMax": time_max,
-                "maxResults": max_results,
-                "orderBy": "startTime",
-                "singleEvents": "true",
+    def fetch_calendar_events(connected_account_id: str, max_results: int = 5) -> dict:
+        response = actions.execute_tool(
+            tool_name="googlecalendar_list_events",
+            connected_account_id=connected_account_id,
+            tool_input={
+                "max_results": max_results,
             },
         )
-        resp.raise_for_status()
-        return resp.json().get("items", [])
+        # Tool output lives under data — log once when integrating a new tool.
+        return response.data
     ```
   </TabItem>
 </Tabs>
 
-### 7. Fetch emails using the built-in action pattern
+### 7. Fetch emails with a built-in tool
 
-For Gmail, call `execute_tool` with the built-in `gmail_fetch_mails` action. Scalekit executes the Gmail API call using the stored token and returns structured data. You don't need to build the request, handle the token, or parse the response format.
+Use the same `execute_tool` pattern for Gmail with `gmail_fetch_mails`. Scalekit runs the Gmail API call and returns structured data.
 
 <Tabs syncKey="tech-stack">
   <TabItem value="typescript" label="TypeScript">
@@ -324,15 +294,15 @@ For Gmail, call `execute_tool` with the built-in `gmail_fetch_mails` action. Sca
         maxResults: z.number().optional().default(5),
       }),
       execute: async ({ maxResults }) => {
-        const response = await scalekit.tools.executeTool({
+        const response = await actions.executeTool({
           toolName: 'gmail_fetch_mails',
           connectedAccountId: gmailAccount?.id,
-          params: {
+          toolInput: {
             query: 'is:unread',
             max_results: maxResults,
           },
         });
-        return response.data?.toJson() ?? {};
+        return response.data ?? {};
       },
     });
     ```
@@ -349,12 +319,12 @@ For Gmail, call `execute_tool` with the built-in `gmail_fetch_mails` action. Sca
                 "max_results": max_results,
             },
         )
-        return response.result
+        return response.data
     ```
   </TabItem>
 </Tabs>
 
-The built-in action pattern trades flexibility for brevity. You can't customize headers or pagination, but you also don't need to read Gmail API documentation — the tool parameters are consistent across all Scalekit connectors. See [all supported agent connectors](/agentkit/connectors/) for the full list of built-in tools.
+You do not need Google Calendar or Gmail API docs for the common path — tool names and parameters are consistent across Scalekit connectors. Browse [all supported agent connectors](/agentkit/connectors/) for the full tool list.
 
 ### 8. Wire the agent together
 
@@ -374,7 +344,7 @@ Pass both tools to the LLM and ask for a daily summary.
       ensureConnected('gmail'),
     ]);
 
-    const calendarToken = await getAccessToken('googlecalendar');
+    const today = new Date();
 
     const { text } = await generateText({
       model: anthropic('claude-sonnet-4-6'),
@@ -397,9 +367,8 @@ Pass both tools to the LLM and ask for a daily summary.
 
     ```python
     def run_agent():
+        calendar_account = ensure_connected("googlecalendar")
         gmail_account = ensure_connected("gmail")
-        ensure_connected("googlecalendar")
-        calendar_token = get_access_token("googlecalendar")
 
         client = anthropic.Anthropic()
         today = datetime.now().strftime("%A, %B %d, %Y")
@@ -407,7 +376,7 @@ Pass both tools to the LLM and ask for a daily summary.
         tools = [
             {
                 "name": "get_calendar_events",
-                "description": "Fetch today's events from Google Calendar",
+                "description": "Fetch today's events from Google Calendar via Scalekit",
                 "input_schema": {
                     "type": "object",
                     "properties": {"max_results": {"type": "integer", "default": 5}},
@@ -450,7 +419,7 @@ Pass both tools to the LLM and ask for a daily summary.
                 if block.type == "tool_use":
                     max_results = block.input.get("max_results", 5)
                     if block.name == "get_calendar_events":
-                        result = fetch_calendar_events(calendar_token, max_results)
+                        result = fetch_calendar_events(calendar_account.id, max_results)
                     elif block.name == "get_unread_emails":
                         result = fetch_unread_emails(gmail_account.id, max_results)
                     else:
@@ -551,15 +520,6 @@ On subsequent runs, both authorization prompts are skipped. Scalekit returns the
 </details>
 
 <details>
-<summary>Python naive datetimes in API calls</summary>
-
-- **Symptom**: Google Calendar returns a `400` error for your event query
-- **Cause**: A naive `datetime` produces an ISO string without timezone information
-- **Fix**: Use `datetime.now(timezone.utc)` and call `.astimezone()` so the generated timestamps are timezone-aware
-
-</details>
-
-<details>
 <summary>`maxSteps` missing in the Vercel AI SDK</summary>
 
 - **Symptom**: `generateText` stops after the first tool call instead of returning a final summary
@@ -569,30 +529,30 @@ On subsequent runs, both authorization prompts are skipped. Scalekit returns the
 </details>
 
 <details>
-<summary>`toolInput` used instead of `params`</summary>
+<summary>Tool called before authorization finishes</summary>
 
-- **Symptom**: `executeTool` succeeds but the Gmail tool receives no parameters
-- **Cause**: `@scalekit-sdk/node` expects a `params` field, not `toolInput`
-- **Fix**: Pass tool arguments in `params`, for example `{ query: 'is:unread', max_results: 5 }`
+- **Symptom**: First run prints an auth link, then `execute_tool` fails because the account is not `ACTIVE`
+- **Cause**: The sample continued to the tool call without waiting for the browser OAuth flow
+- **Fix**: Block until the user completes authorization (for example `input(...)` in Python or a stdin wait in Node), then re-fetch the connected account before calling tools
 
 </details>
 
 ## Production notes
 
-**User ID from session** — Both implementations hardcode `USER_ID = "user_123"`. In production, replace this with the real user identifier from your application's session. A mismatch means Scalekit looks up the wrong user's tokens.
+**User ID from session** — Both implementations hardcode `USER_ID = "user_123"`. In production, replace this with the real user identifier from your application's session. A mismatch means Scalekit looks up the wrong user's connected accounts.
 
-**Token freshness** — `getConnectedAccountByIdentifier` (TypeScript) and `get_connected_account` (Python) always return a fresh token — Scalekit refreshes it before returning if it has expired. You do not need to track expiry or call a refresh endpoint.
+**Token freshness** — Scalekit refreshes OAuth tokens automatically before tool execution. You do not fetch provider tokens or call a refresh endpoint in application code.
 
 **First-run blocking** — The authorization prompt blocks the process until the user completes OAuth in the browser. In a web application, redirect the user to `link` instead of printing it, and handle the callback before proceeding.
 
-**`execute_tool` response shape** — In Python, `response.result` is a dictionary whose structure depends on the tool. In TypeScript, `response.data?.toJson()` converts the protobuf response to a plain object. Log the raw response on first use to understand the shape before passing it to the LLM.
+**`execute_tool` response shape** — Tool output lives under `response.data` (Python and Node). Keys inside `data` depend on the tool. Log the raw response once when integrating a new tool, then pass that structure to the LLM.
 
-**Rate limits** — The Google Calendar API and Gmail API both have per-user daily quotas. If your agent runs frequently, add exponential backoff around the API calls and cache calendar events across requests where freshness allows.
+**Rate limits** — Google Calendar and Gmail both enforce per-user quotas. If your agent runs frequently, avoid tight polling loops and cache briefing data where freshness allows.
 
 ## Next steps
 
-- **Add more connectors** — The same `ensureConnected` pattern works for any Scalekit-supported connector. Swap the connector name and replace the Google API calls with the target service's API. See [all supported connectors](/agentkit/connectors/).
-- **Use the built-in Calendar action** — Scalekit also provides a `googlecalendar_list_events` built-in action. If you don't need custom query parameters, switch the Calendar tool to `execute_tool` and remove the `getAccessToken` call entirely.
+- **Add more connectors** — The same `ensureConnected` + `execute_tool` pattern works for any Scalekit-supported connector. Swap the connection name and tool name. See [all supported connectors](/agentkit/connectors/).
+- **Need a raw provider call** — Prefer built-in tools first. If a tool does not cover your case, see [proxy API calls](/agentkit/advanced/proxy-api-calls/) rather than extracting tokens in app code.
 - **Stream the response** — Replace `generateText` with `streamText` in the Vercel AI SDK to stream the LLM's summary token-by-token instead of waiting for the full response.
 - **Handle re-authorization** — If a user revokes access, `getOrCreateConnectedAccount` returns an inactive account. Add a re-authorization path to recover gracefully instead of crashing.
 - **Review the agent auth quickstart** — For a broader overview of the connected-accounts model and supported providers, see the [agent auth quickstart](/agentkit/quickstart/).


### PR DESCRIPTION
## Summary

Improves the `/hackathon` hub based on first-run feedback and aligns linked AgentKit snippets with the current `actions` SDK.

- Move FAQ to the end so the main journey finishes first
- Fix Node/Python snippets so tool calls wait for OAuth (`ACTIVE`) and re-fetch the connected account
- Change connector count copy from a fixed `324` to `300+`
- Remove unvalidated cookbook promos (daily briefing, CrewAI triage, meeting+email, Mastra) from the hub; keep quickstart, framework examples, MCP setup, and core AgentKit docs
- Align AgentKit quickstart + daily briefing / CrewAI cookbook snippets with tool-calling and Virtual MCP create-first guidance (code-doctor pass)

## Preview

- https://deploy-preview-895--scalekit-starlight.netlify.app/hackathon/
- Local: `pnpm start` → http://localhost:4321/hackathon/

## Test plan

- [ ] Open `/hackathon/` and confirm FAQ is only at the bottom
- [ ] Confirm free-plan / catalog copy says **300+** connectors
- [ ] Confirm popular templates / resources / build ideas do **not** link to daily-briefing, crewai-triage, schedule-meeting, or mastra cookbooks
- [ ] Read manual Node + Python snippets: auth link → wait → re-fetch → `executeTool` / `execute_tool` with `connectedAccountId` / `connected_account_id`
- [ ] Spot-check AgentKit quickstart auth + tool call steps
- [ ] Spot-check daily briefing uses `googlecalendar_list_events` / `gmail_fetch_mails` (no direct Calendar REST)
- [ ] Spot-check CrewAI cookbook creates/mentions Virtual MCP config before `list_configs`

## Turns

- **Turn 2 — 3.1**: Auth snippet prints authorization link but does not wait for the user to finish OAuth
- **Turn 2 — 3.2**: Tool call runs immediately after printing the link, so first run fails before status is `ACTIVE`