### PR TITLE
Update Okta documentation link for group push issues

### DIFF
--- a/src/content/docs/guides/integrations/scim-integrations/okta-scim.mdx
+++ b/src/content/docs/guides/integrations/scim-integrations/okta-scim.mdx
@@ -109,7 +109,7 @@ By setting up these components, you enable seamless synchronization between your
 
    <Aside type="caution" title="IMPORTANT">
    For accurate group membership synchronization, ensure that the same groups are not configured for push groups and group assignments. If the same groups are configured in both assignments and push groups, manual group pushes may be required for accurate membership reflection.<br />
-   <a href="https://help.okta.com/en-us/content/topics/users-groups-profiles/app-assignments-group-push.htm" target="_blank" rel="noopener">Okta documentation</a>
+   <a href="https://support.okta.com/help/s/article/Group-Push-Common-Issues?language=en_US" target="_blank" rel="noopener">Okta documentation</a>
    </Aside>
 
 7. ## Group based Role Assignment Configuration


### PR DESCRIPTION
## Summary

Updated the Okta documentation reference link in the SCIM integration guide to point to the current support article about group push common issues.

## Changes

- Replaced outdated Okta help documentation URL (`help.okta.com/en-us/content/topics/users-groups-profiles/app-assignments-group-push.htm`) with the current support article URL (`support.okta.com/help/s/article/Group-Push-Common-Issues?language=en_US`)
- This ensures users are directed to the correct, up-to-date Okta documentation when troubleshooting group membership synchronization issues

## Details

The caution note about group membership synchronization now links to the appropriate Okta support article that addresses common group push issues, improving the accuracy and usefulness of the documentation for developers implementing SCIM integrations with Okta.

https://claude.ai/code/session_017uC2DbdLtN573L6EEgkU3h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Okta SCIM integration guide with a current link to Okta’s group push troubleshooting information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->