### PR TITLE
fix(docs-ui): restore code block borders after soft-nav

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -738,6 +738,20 @@ body {
   border-radius: 0;
 }
 
+/*
+ * Expressive Code: the real edge is on `pre` (`border: var(--ec-brdWd) solid
+ * var(--ec-brdCol)` in starlight.components). ClientRouter soft-nav can drop
+ * or reorder that layered sheet, leaving only the frame's offset box-shadow
+ * (0.1rem 0.1rem …) — looks like a missing left/top border until hard refresh.
+ * Unlayered so this always wins after soft-nav (same class of bug as Nova above).
+ */
+.sl-markdown-content .expressive-code pre,
+.expressive-code pre {
+  border: var(--ec-brdWd, 1px) solid var(--ec-brdCol, var(--sl-color-gray-5));
+  border-radius: calc(var(--ec-brdRad, 0.375rem) + var(--ec-brdWd, 1px));
+  box-sizing: border-box;
+}
+
 /* =============================================================================
    VIEW TRANSITIONS — simple full-page fade only
    -----------------------------------------------------------------------------

--- a/src/styles/sdk-reference.css
+++ b/src/styles/sdk-reference.css
@@ -811,7 +811,11 @@
 /*
  * Example fences in ClassBrowser method bodies ONLY.
  * Scope: .sdk-client-page .cb-method-body — never restyle site-wide fences.
- * Do not use overflow-x: visible (breaks rounded frame borders after reflow).
+ *
+ * Do not set overflow on figure.frame — non-visible overflow clips EC's frame
+ * box-shadow and, after expand/collapse reflow, can make the pre edge look like
+ * a missing left hairline. Keep scroll on the pre only; site-wide pre border is
+ * reasserted unlayered in custom.css (ClientRouter soft-nav recovery).
  */
 .sdk-client-page .cb-method-body .expressive-code {
   margin-block: 0.75rem 0.25rem;
@@ -825,11 +829,14 @@
   overflow-wrap: anywhere;
 }
 
-.sdk-client-page .cb-method-body .expressive-code figure.frame,
+.sdk-client-page .cb-method-body .expressive-code figure.frame {
+  overflow: visible;
+  box-sizing: border-box;
+}
+
 .sdk-client-page .cb-method-body .expressive-code pre {
+  /* Long unwrapped lines scroll; avoid overflow-x: visible (reflow glitch). */
   overflow-x: auto;
-  overflow-y: hidden;
-  background-clip: padding-box;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
## Summary

After the ClassBrowser SDK reference landed, code block borders often looked incomplete (missing left/top edge) until a hard refresh.

**Root cause (verified on production):** Expressive Code draws the real edge on `pre` via layered `starlight.components` styles. ClientRouter soft-nav (e.g. leave `/sdks`) can drop or reorder that sheet so computed `pre` border becomes `0px`. Only the frame's offset box-shadow (`0.1rem 0.1rem …`) remains — which reads as a broken border.

**Fix:**
1. **Unlayered recovery** in `custom.css` for `.expressive-code pre` (same pattern as the existing Nova `[data-nova-code-container]` soft-nav fix).
2. **SDK method examples:** stop putting `overflow` on `figure.frame` (clips the frame shadow); keep horizontal scroll on `pre` only.

## Test plan

- [ ] Open `/sdks`, then soft-nav to `/authenticate/fsa/quickstart/` (do **not** hard refresh).
- [ ] Confirm code fences have a full 1px edge on all sides (not only a bottom-right shadow).
- [ ] Soft-nav between SaaSKit SDK client pages (e.g. Organizations → Users); ClassBrowser method examples keep full borders after expand/collapse.
- [ ] Hard refresh still looks correct (no double-border regression).

## Preview

https://deploy-preview-900--scalekit-starlight.netlify.app/authenticate/fsa/quickstart/

Reproduce path: visit `/sdks` first, then soft-nav to the quickstart URL above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed code block borders and rounded corners after in-app navigation.
  * Improved SDK example code blocks to prevent visual clipping and preserve horizontal scrolling.
* **Style**
  * Refined code block overflow and reflow behavior for a more consistent display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->