### PR TITLE
fix(agentkit): collapse API ref, align SDK nav labels, fix connectors search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -533,7 +533,7 @@ SDK client pages (topic `saaskit-sdks` / `agentkit-sdks`) use `@gesslar/starligh
 
 - Method headings: `### methodName` **without** backticks (no Starlight code pills)
 - Method H3s stay plain mono — no left rails, filled title boxes, or solid “AI slop” badge chrome
-- Left nav labels: `src/components/sdk-reference/**/_nav.json` + matching `sidebar.label` — outcome/object-focused, self-explanatory; never class names like `ScalekitClient` (use **Create client**, **Accounts & tools**, **Tool schemas**, **Error handling**)
+- Left nav labels: `src/components/sdk-reference/**/_nav.json` + matching `sidebar.label` — outcome/object-focused, self-explanatory, and aligned with the matching API reference section names; never class names like `ScalekitClient` (use **Create client**, **Connected accounts**, **Tool calling**, **Error handling**)
 - Language install pages: shared `SDKInstallPanel` + `GitHubSourceLink` — do not reintroduce FoldCard install heroes or fat Nova “View on GitHub” `LinkButton`s
 
 ---
@@ -643,7 +643,7 @@ Durable rules recorded via `dora memory`. Agents should treat weight ≥ 7 as ha
   Prefer plugin --cb-\* CSS variables before structural selectors. Keep ClassBrowser theme rules in src/styles/sdk-reference.css. Do not scatter ClassBrowser overrides across custom.css layers or page-local style blocks.
 
 - **SDK nav labels must be self-explanatory outcomes** (w8)
-  Labels come from src/components/sdk-reference/\*\*/\_nav.json and matching page sidebar.label. Prefer 1-3 word outcome- or object-focused labels. Never use class names like ScalekitClient as nav items — use Create client, Accounts & tools, Tool schemas, Error handling.
+  Labels come from src/components/sdk-reference/\*\*/\_nav.json and matching page sidebar.label. Prefer 1-3 word outcome- or object-focused labels that align with the corresponding API reference section names. Never use class names like ScalekitClient as nav items — use Create client, Connected accounts, Tool calling, Error handling.
 
 - **SDK install pages use SDKInstallPanel shared chrome** (w7)
   Use shared SDKInstallPanel + GitHubSourceLink on language install pages. Do not reintroduce FoldCard install heroes or fat Nova LinkButton View on GitHub CTAs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -533,7 +533,7 @@ SDK client pages (topic `saaskit-sdks` / `agentkit-sdks`) use `@gesslar/starligh
 
 - Method headings: `### methodName` **without** backticks (no Starlight code pills)
 - Method H3s stay plain mono — no left rails, filled title boxes, or solid “AI slop” badge chrome
-- Left nav labels: `src/components/sdk-reference/**/_nav.json` + matching `sidebar.label` — outcome/object-focused, self-explanatory; never class names like `ScalekitClient` (use **Create client**, **Accounts & tools**, **Tool schemas**, **Error handling**)
+- Left nav labels: `src/components/sdk-reference/**/_nav.json` + matching `sidebar.label` — outcome/object-focused, self-explanatory, and aligned with the matching API reference section names; never class names like `ScalekitClient` (use **Create client**, **Connected accounts**, **Tool calling**, **Error handling**)
 - Language install pages: shared `SDKInstallPanel` + `GitHubSourceLink` — do not reintroduce FoldCard install heroes or fat Nova “View on GitHub” `LinkButton`s
 
 ---
@@ -661,7 +661,7 @@ Durable rules recorded via `dora memory`. Agents should treat weight ≥ 7 as ha
   Prefer plugin --cb-\* CSS variables before structural selectors. Keep ClassBrowser theme rules in src/styles/sdk-reference.css. Do not scatter ClassBrowser overrides across custom.css layers or page-local style blocks.
 
 - **SDK nav labels must be self-explanatory outcomes** (w8)
-  Labels come from src/components/sdk-reference/\*\*/\_nav.json and matching page sidebar.label. Prefer 1-3 word outcome- or object-focused labels. Never use class names like ScalekitClient as nav items — use Create client, Accounts & tools, Tool schemas, Error handling.
+  Labels come from src/components/sdk-reference/\*\*/\_nav.json and matching page sidebar.label. Prefer 1-3 word outcome- or object-focused labels that align with the corresponding API reference section names. Never use class names like ScalekitClient as nav items — use Create client, Connected accounts, Tool calling, Error handling.
 
 - **SDK install pages use SDKInstallPanel shared chrome** (w7)
   Use shared SDKInstallPanel + GitHubSourceLink on language install pages. Do not reintroduce FoldCard install heroes or fat Nova LinkButton View on GitHub CTAs.

--- a/public/d2/docs/agentkit/overview-0.svg
+++ b/public/d2/docs/agentkit/overview-0.svg
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" data-d2-version="0.7.1" preserveAspectRatio="xMinYMin meet" viewBox="0 0 1366 398"><svg class="d2-2124456674 d2-svg" width="1366" height="398" viewBox="6 6 1366 398"><rect x="6.000000" y="6.000000" width="1366.000000" height="398.000000" rx="0.000000" class=" fill-N7" stroke-width="0" /><style type="text/css"><![CDATA[
+<?xml version="1.0" encoding="utf-8"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" data-d2-version="v0.7.1" preserveAspectRatio="xMinYMin meet" viewBox="0 0 1366 398"><svg class="d2-2124456674 d2-svg" width="1366" height="398" viewBox="6 6 1366 398"><rect x="6.000000" y="6.000000" width="1366.000000" height="398.000000" rx="0.000000" class=" fill-N7" stroke-width="0" /><style type="text/css"><![CDATA[
 .d2-2124456674 .text {
 	font-family: "d2-2124456674-font-regular";
 }

--- a/public/d2/docs/agentkit/user-verification-0.svg
+++ b/public/d2/docs/agentkit/user-verification-0.svg
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" data-d2-version="0.7.1" preserveAspectRatio="xMinYMin meet" viewBox="0 0 945 1690"><svg class="d2-1381664539 d2-svg" width="945" height="1690" viewBox="-25 -28 945 1690"><rect x="-25.000000" y="-28.000000" width="945.000000" height="1690.000000" rx="0.000000" class=" fill-N7" stroke-width="0" /><style type="text/css"><![CDATA[
+<?xml version="1.0" encoding="utf-8"?><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" data-d2-version="v0.7.1" preserveAspectRatio="xMinYMin meet" viewBox="0 0 945 1690"><svg class="d2-1381664539 d2-svg" width="945" height="1690" viewBox="-25 -28 945 1690"><rect x="-25.000000" y="-28.000000" width="945.000000" height="1690.000000" rx="0.000000" class=" fill-N7" stroke-width="0" /><style type="text/css"><![CDATA[
 .d2-1381664539 .text {
 	font-family: "d2-1381664539-font-regular";
 }

--- a/src/components/ProviderCatalog.astro
+++ b/src/components/ProviderCatalog.astro
@@ -209,333 +209,356 @@ function cardAttrs(item: (typeof items)[0]) {
 </div>
 
 <script>
-  const catalogEl = document.querySelector('.provider-catalog') as HTMLElement
-  const searchInput = catalogEl?.querySelector('.search-input') as HTMLInputElement | null
-  const categorySelect = catalogEl?.querySelector('#category-select') as HTMLSelectElement | null
-  const authSelect = catalogEl?.querySelector('#auth-select') as HTMLSelectElement | null
-  const noResults = catalogEl?.querySelector('.no-results') as HTMLElement | null
-  const resultMeta = catalogEl?.querySelector('.result-meta') as HTMLElement | null
-  const browseSurface = catalogEl?.querySelector('.browse-surface') as HTMLElement | null
-  const searchSurface = catalogEl?.querySelector('.search-surface') as HTMLElement | null
-  const connectorsBand = catalogEl?.querySelector('[data-band="connectors"]') as HTMLElement | null
-  const toolsBand = catalogEl?.querySelector('[data-band="tools"]') as HTMLElement | null
-  const toolResultsList = toolsBand?.querySelector('.tool-results-list') as HTMLElement | null
-  const searchGrid = catalogEl?.querySelector('[data-search-grid]') as HTMLElement | null
-  const connectorCountEl = catalogEl?.querySelector(
-    '[data-count="connectors"]',
-  ) as HTMLElement | null
-  const toolCountEl = catalogEl?.querySelector('[data-count="tools"]') as HTMLElement | null
+  // ClientRouter re-init: this bundled module executes only once, but the catalog DOM is
+  // destroyed and recreated on every soft navigation. Binding at module scope leaves the
+  // search input on a soft-nav-loaded page wired to a removed element (or not wired at all if
+  // the user types before the module first runs) — search appears dead until a full refresh.
+  // So (re)bind inside a function, guarded per element instance, run on load and page-load.
+  // Mirrors the pattern already used in AgentConnectorsSection.astro.
+  function initProviderCatalog() {
+    const catalogEl = document.querySelector('.provider-catalog') as HTMLElement | null
+    if (!catalogEl || catalogEl.dataset.catalogReady === 'true') return
+    catalogEl.dataset.catalogReady = 'true'
 
-  let slugToTitle: Record<string, string> = {}
-  try {
-    const raw = catalogEl?.dataset.slugMap
-    if (raw) slugToTitle = JSON.parse(raw)
-  } catch {}
+    const searchInput = catalogEl?.querySelector('.search-input') as HTMLInputElement | null
+    const categorySelect = catalogEl?.querySelector('#category-select') as HTMLSelectElement | null
+    const authSelect = catalogEl?.querySelector('#auth-select') as HTMLSelectElement | null
+    const noResults = catalogEl?.querySelector('.no-results') as HTMLElement | null
+    const resultMeta = catalogEl?.querySelector('.result-meta') as HTMLElement | null
+    const browseSurface = catalogEl?.querySelector('.browse-surface') as HTMLElement | null
+    const searchSurface = catalogEl?.querySelector('.search-surface') as HTMLElement | null
+    const connectorsBand = catalogEl?.querySelector(
+      '[data-band="connectors"]',
+    ) as HTMLElement | null
+    const toolsBand = catalogEl?.querySelector('[data-band="tools"]') as HTMLElement | null
+    const toolResultsList = toolsBand?.querySelector('.tool-results-list') as HTMLElement | null
+    const searchGrid = catalogEl?.querySelector('[data-search-grid]') as HTMLElement | null
+    const connectorCountEl = catalogEl?.querySelector(
+      '[data-count="connectors"]',
+    ) as HTMLElement | null
+    const toolCountEl = catalogEl?.querySelector('[data-count="tools"]') as HTMLElement | null
 
-  let activeCategory = 'all'
-  let activeAuth = 'all'
-  let searchQuery = ''
-  let toolIndexCache: Array<{ slug: string; name: string; description: string }> | null = null
+    let slugToTitle: Record<string, string> = {}
+    try {
+      const raw = catalogEl?.dataset.slugMap
+      if (raw) slugToTitle = JSON.parse(raw)
+    } catch {}
 
-  function truncate(str: string, n: number) {
-    if (!str) return ''
-    return str.length > n ? str.slice(0, n - 1) + '…' : str
-  }
+    let activeCategory = 'all'
+    let activeAuth = 'all'
+    let searchQuery = ''
+    let toolIndexCache: Array<{ slug: string; name: string; description: string }> | null = null
 
-  function cardMatches(card: HTMLElement, query: string): boolean {
-    if (!query) return true
-    return (card.dataset.name ?? '').includes(query) || (card.dataset.desc ?? '').includes(query)
-  }
+    function truncate(str: string, n: number) {
+      if (!str) return ''
+      return str.length > n ? str.slice(0, n - 1) + '…' : str
+    }
 
-  function cardMatchesAuth(card: HTMLElement): boolean {
-    return activeAuth === 'all' || card.dataset.auth === activeAuth
-  }
+    function cardMatches(card: HTMLElement, query: string): boolean {
+      if (!query) return true
+      return (card.dataset.name ?? '').includes(query) || (card.dataset.desc ?? '').includes(query)
+    }
 
-  function cardMatchesCategory(card: HTMLElement): boolean {
-    if (activeCategory === 'all') return true
-    const cats = (card.dataset.categories ?? '').split(',').map((c) => c.trim())
-    return cats.includes(activeCategory)
-  }
+    function cardMatchesAuth(card: HTMLElement): boolean {
+      return activeAuth === 'all' || card.dataset.auth === activeAuth
+    }
 
-  /** Browse mode: filter category rails in place */
-  function applyBrowseFilters(): number {
-    const sections = browseSurface?.querySelectorAll<HTMLElement>('.category-section')
-    let totalVisible = 0
+    function cardMatchesCategory(card: HTMLElement): boolean {
+      if (activeCategory === 'all') return true
+      const cats = (card.dataset.categories ?? '').split(',').map((c) => c.trim())
+      return cats.includes(activeCategory)
+    }
 
-    sections?.forEach((section) => {
-      const sectionCategory = section.dataset.category ?? ''
-      const categoryMatch = activeCategory === 'all' || sectionCategory === activeCategory
+    /** Browse mode: filter category rails in place */
+    function applyBrowseFilters(): number {
+      const sections = browseSurface?.querySelectorAll<HTMLElement>('.category-section')
+      let totalVisible = 0
 
-      if (!categoryMatch) {
-        section.style.display = 'none'
+      sections?.forEach((section) => {
+        const sectionCategory = section.dataset.category ?? ''
+        const categoryMatch = activeCategory === 'all' || sectionCategory === activeCategory
+
+        if (!categoryMatch) {
+          section.style.display = 'none'
+          return
+        }
+
+        const cards = section.querySelectorAll<HTMLElement>('.provider-card')
+        let sectionVisible = 0
+
+        cards.forEach((card) => {
+          const show = cardMatchesAuth(card)
+          card.style.display = show ? '' : 'none'
+          if (show) sectionVisible++
+        })
+
+        section.style.display = sectionVisible > 0 ? '' : 'none'
+        totalVisible += sectionVisible
+      })
+
+      return totalVisible
+    }
+
+    /**
+     * Search mode: unique connectors only (one card per slug), then tools.
+     * Multi-category connectors never appear more than once.
+     */
+    function applySearchFilters(): number {
+      if (!searchGrid) return 0
+      let visible = 0
+
+      searchGrid.querySelectorAll<HTMLElement>('.provider-card').forEach((card) => {
+        const show =
+          cardMatches(card, searchQuery) && cardMatchesAuth(card) && cardMatchesCategory(card)
+        card.style.display = show ? '' : 'none'
+        if (show) visible++
+      })
+
+      if (connectorsBand) connectorsBand.hidden = visible === 0
+      if (connectorCountEl) connectorCountEl.textContent = visible > 0 ? String(visible) : ''
+
+      return visible
+    }
+
+    async function loadToolIndex(): Promise<
+      Array<{ slug: string; name: string; description: string }>
+    > {
+      if (toolIndexCache) return toolIndexCache
+      try {
+        const res = await fetch('/data/agent-tools-index.json')
+        if (!res.ok) return []
+        toolIndexCache = await res.json()
+        return toolIndexCache || []
+      } catch {
+        return []
+      }
+    }
+
+    function scoreToolMatches(
+      index: Array<{ slug: string; name: string; description: string }>,
+      query: string,
+    ) {
+      if (!query || !index?.length) return []
+      const q = query.toLowerCase().trim()
+      if (!q) return []
+
+      const terms = q.split(/\s+/).filter(Boolean)
+      const scored: Array<{
+        slug: string
+        name: string
+        description: string
+        title: string
+        score: number
+        href: string
+      }> = []
+
+      // Dedupe tools by connector slug + tool name
+      const seen = new Set<string>()
+
+      for (const entry of index) {
+        const key = `${entry.slug}::${entry.name}`
+        if (seen.has(key)) continue
+        seen.add(key)
+
+        const name = (entry.name || '').toLowerCase()
+        const desc = (entry.description || '').toLowerCase()
+        let score = 0
+
+        if (name.includes(q)) score += 12
+        if (name.startsWith(q)) score += 6
+
+        for (const t of terms) {
+          if (name.includes(t)) score += 4
+          if (desc.includes(t)) score += 1
+        }
+
+        if (score > 0) {
+          const title = slugToTitle[entry.slug] || entry.slug
+          scored.push({
+            ...entry,
+            title,
+            score,
+            href: `/agentkit/connectors/${entry.slug}/#${encodeURIComponent(entry.name)}`,
+          })
+        }
+      }
+
+      scored.sort((a, b) => b.score - a.score || a.name.localeCompare(b.name))
+      return scored
+    }
+
+    function renderToolResults(matches: ReturnType<typeof scoreToolMatches>) {
+      if (!toolResultsList || !toolsBand) return
+
+      toolResultsList.innerHTML = ''
+
+      if (!matches.length) {
+        toolsBand.hidden = true
+        if (toolCountEl) toolCountEl.textContent = ''
         return
       }
 
-      const cards = section.querySelectorAll<HTMLElement>('.provider-card')
-      let sectionVisible = 0
+      const MAX = 25
+      const toShow = matches.slice(0, MAX)
 
-      cards.forEach((card) => {
-        const show = cardMatchesAuth(card)
-        card.style.display = show ? '' : 'none'
-        if (show) sectionVisible++
+      toShow.forEach((m) => {
+        const el = document.createElement('a')
+        el.className = 'tool-result'
+        el.href = m.href
+
+        const head = document.createElement('div')
+        head.className = 'tool-result-head'
+
+        const nameEl = document.createElement('code')
+        nameEl.className = 'tool-result-name'
+        nameEl.textContent = m.name
+
+        const connectorEl = document.createElement('span')
+        connectorEl.className = 'tool-result-connector'
+        connectorEl.textContent = m.title
+
+        const descEl = document.createElement('div')
+        descEl.className = 'tool-result-desc'
+        descEl.textContent = truncate(m.description, 160)
+
+        head.append(nameEl, connectorEl)
+        el.append(head, descEl)
+        toolResultsList.appendChild(el)
       })
 
-      section.style.display = sectionVisible > 0 ? '' : 'none'
-      totalVisible += sectionVisible
-    })
-
-    return totalVisible
-  }
-
-  /**
-   * Search mode: unique connectors only (one card per slug), then tools.
-   * Multi-category connectors never appear more than once.
-   */
-  function applySearchFilters(): number {
-    if (!searchGrid) return 0
-    let visible = 0
-
-    searchGrid.querySelectorAll<HTMLElement>('.provider-card').forEach((card) => {
-      const show =
-        cardMatches(card, searchQuery) && cardMatchesAuth(card) && cardMatchesCategory(card)
-      card.style.display = show ? '' : 'none'
-      if (show) visible++
-    })
-
-    if (connectorsBand) connectorsBand.hidden = visible === 0
-    if (connectorCountEl) connectorCountEl.textContent = visible > 0 ? String(visible) : ''
-
-    return visible
-  }
-
-  async function loadToolIndex(): Promise<
-    Array<{ slug: string; name: string; description: string }>
-  > {
-    if (toolIndexCache) return toolIndexCache
-    try {
-      const res = await fetch('/data/agent-tools-index.json')
-      if (!res.ok) return []
-      toolIndexCache = await res.json()
-      return toolIndexCache || []
-    } catch {
-      return []
-    }
-  }
-
-  function scoreToolMatches(
-    index: Array<{ slug: string; name: string; description: string }>,
-    query: string,
-  ) {
-    if (!query || !index?.length) return []
-    const q = query.toLowerCase().trim()
-    if (!q) return []
-
-    const terms = q.split(/\s+/).filter(Boolean)
-    const scored: Array<{
-      slug: string
-      name: string
-      description: string
-      title: string
-      score: number
-      href: string
-    }> = []
-
-    // Dedupe tools by connector slug + tool name
-    const seen = new Set<string>()
-
-    for (const entry of index) {
-      const key = `${entry.slug}::${entry.name}`
-      if (seen.has(key)) continue
-      seen.add(key)
-
-      const name = (entry.name || '').toLowerCase()
-      const desc = (entry.description || '').toLowerCase()
-      let score = 0
-
-      if (name.includes(q)) score += 12
-      if (name.startsWith(q)) score += 6
-
-      for (const t of terms) {
-        if (name.includes(t)) score += 4
-        if (desc.includes(t)) score += 1
+      if (matches.length > MAX) {
+        const more = document.createElement('div')
+        more.className = 'tool-result-more'
+        more.textContent = `+ ${matches.length - MAX} more — refine your query`
+        toolResultsList.appendChild(more)
       }
 
-      if (score > 0) {
-        const title = slugToTitle[entry.slug] || entry.slug
-        scored.push({
-          ...entry,
-          title,
-          score,
-          href: `/agentkit/connectors/${entry.slug}/#${encodeURIComponent(entry.name)}`,
-        })
+      toolsBand.hidden = false
+      if (toolCountEl) toolCountEl.textContent = String(matches.length)
+    }
+
+    function setMode(isSearching: boolean) {
+      catalogEl?.classList.toggle('is-searching', isSearching)
+      if (browseSurface) browseSurface.hidden = isSearching
+      if (searchSurface) searchSurface.hidden = !isSearching
+      if (categorySelect) {
+        // Category still filters search results; keep visible
+        categorySelect.disabled = false
       }
     }
 
-    scored.sort((a, b) => b.score - a.score || a.name.localeCompare(b.name))
-    return scored
-  }
+    function updateMeta(connectorCount: number, toolCount: number) {
+      if (!resultMeta) return
+      const isSearching = searchQuery.length > 0
+      if (!isSearching) {
+        resultMeta.hidden = true
+        resultMeta.textContent = ''
+        return
+      }
 
-  function renderToolResults(matches: ReturnType<typeof scoreToolMatches>) {
-    if (!toolResultsList || !toolsBand) return
+      const parts: string[] = []
+      if (connectorCount > 0) {
+        parts.push(`${connectorCount} connector${connectorCount === 1 ? '' : 's'}`)
+      }
+      if (toolCount > 0) {
+        parts.push(`${toolCount} tool${toolCount === 1 ? '' : 's'}`)
+      }
 
-    toolResultsList.innerHTML = ''
+      if (parts.length === 0) {
+        resultMeta.hidden = true
+        resultMeta.textContent = ''
+        return
+      }
 
-    if (!matches.length) {
-      toolsBand.hidden = true
-      if (toolCountEl) toolCountEl.textContent = ''
-      return
+      resultMeta.hidden = false
+      resultMeta.textContent = parts.join(' · ')
     }
 
-    const MAX = 25
-    const toShow = matches.slice(0, MAX)
-
-    toShow.forEach((m) => {
-      const el = document.createElement('a')
-      el.className = 'tool-result'
-      el.href = m.href
-
-      const head = document.createElement('div')
-      head.className = 'tool-result-head'
-
-      const nameEl = document.createElement('code')
-      nameEl.className = 'tool-result-name'
-      nameEl.textContent = m.name
-
-      const connectorEl = document.createElement('span')
-      connectorEl.className = 'tool-result-connector'
-      connectorEl.textContent = m.title
-
-      const descEl = document.createElement('div')
-      descEl.className = 'tool-result-desc'
-      descEl.textContent = truncate(m.description, 160)
-
-      head.append(nameEl, connectorEl)
-      el.append(head, descEl)
-      toolResultsList.appendChild(el)
-    })
-
-    if (matches.length > MAX) {
-      const more = document.createElement('div')
-      more.className = 'tool-result-more'
-      more.textContent = `+ ${matches.length - MAX} more — refine your query`
-      toolResultsList.appendChild(more)
+    function updateNoResults(connectorVisible: number, toolCount: number) {
+      if (!noResults) return
+      const isSearching = searchQuery.length > 0
+      noResults.hidden = !isSearching || connectorVisible > 0 || toolCount > 0
     }
 
-    toolsBand.hidden = false
-    if (toolCountEl) toolCountEl.textContent = String(matches.length)
-  }
+    // Bump on every run so a slower earlier loadToolIndex cannot overwrite newer results
+    let searchRevision = 0
 
-  function setMode(isSearching: boolean) {
-    catalogEl?.classList.toggle('is-searching', isSearching)
-    if (browseSurface) browseSurface.hidden = isSearching
-    if (searchSurface) searchSurface.hidden = !isSearching
-    if (categorySelect) {
-      // Category still filters search results; keep visible
-      categorySelect.disabled = false
-    }
-  }
+    async function runSearch() {
+      const revision = ++searchRevision
+      const isSearching = searchQuery.length > 0
+      setMode(isSearching)
 
-  function updateMeta(connectorCount: number, toolCount: number) {
-    if (!resultMeta) return
-    const isSearching = searchQuery.length > 0
-    if (!isSearching) {
-      resultMeta.hidden = true
-      resultMeta.textContent = ''
-      return
-    }
+      if (!isSearching) {
+        const browseVisible = applyBrowseFilters()
+        renderToolResults([])
+        updateMeta(0, 0)
+        updateNoResults(browseVisible, 0)
+        return
+      }
 
-    const parts: string[] = []
-    if (connectorCount > 0) {
-      parts.push(`${connectorCount} connector${connectorCount === 1 ? '' : 's'}`)
-    }
-    if (toolCount > 0) {
-      parts.push(`${toolCount} tool${toolCount === 1 ? '' : 's'}`)
-    }
+      const connectorVisible = applySearchFilters()
 
-    if (parts.length === 0) {
-      resultMeta.hidden = true
-      resultMeta.textContent = ''
-      return
-    }
+      // Tools join at 2+ chars so short connector lookups stay clean
+      let toolCount = 0
+      if (searchQuery.length >= 2) {
+        const idx = await loadToolIndex()
+        // Discard if a newer search started while the index was loading
+        if (revision !== searchRevision) return
+        const matches = scoreToolMatches(idx, searchQuery)
+        // If category filter is active, only show tools for connectors in that category
+        let filtered = matches
+        if (activeCategory !== 'all') {
+          const allowed = new Set<string>()
+          searchGrid?.querySelectorAll<HTMLElement>('.provider-card').forEach((card) => {
+            if (cardMatchesCategory(card)) allowed.add(card.dataset.slug ?? '')
+          })
+          filtered = matches.filter((m) => allowed.has(m.slug))
+        }
+        renderToolResults(filtered)
+        toolCount = filtered.length
+      } else {
+        renderToolResults([])
+      }
 
-    resultMeta.hidden = false
-    resultMeta.textContent = parts.join(' · ')
-  }
-
-  function updateNoResults(connectorVisible: number, toolCount: number) {
-    if (!noResults) return
-    const isSearching = searchQuery.length > 0
-    noResults.hidden = !isSearching || connectorVisible > 0 || toolCount > 0
-  }
-
-  // Bump on every run so a slower earlier loadToolIndex cannot overwrite newer results
-  let searchRevision = 0
-
-  async function runSearch() {
-    const revision = ++searchRevision
-    const isSearching = searchQuery.length > 0
-    setMode(isSearching)
-
-    if (!isSearching) {
-      const browseVisible = applyBrowseFilters()
-      renderToolResults([])
-      updateMeta(0, 0)
-      updateNoResults(browseVisible, 0)
-      return
-    }
-
-    const connectorVisible = applySearchFilters()
-
-    // Tools join at 2+ chars so short connector lookups stay clean
-    let toolCount = 0
-    if (searchQuery.length >= 2) {
-      const idx = await loadToolIndex()
-      // Discard if a newer search started while the index was loading
       if (revision !== searchRevision) return
-      const matches = scoreToolMatches(idx, searchQuery)
-      // If category filter is active, only show tools for connectors in that category
-      let filtered = matches
-      if (activeCategory !== 'all') {
-        const allowed = new Set<string>()
-        searchGrid?.querySelectorAll<HTMLElement>('.provider-card').forEach((card) => {
-          if (cardMatchesCategory(card)) allowed.add(card.dataset.slug ?? '')
-        })
-        filtered = matches.filter((m) => allowed.has(m.slug))
-      }
-      renderToolResults(filtered)
-      toolCount = filtered.length
-    } else {
-      renderToolResults([])
+      updateMeta(connectorVisible, toolCount)
+      updateNoResults(connectorVisible, toolCount)
     }
 
-    if (revision !== searchRevision) return
-    updateMeta(connectorVisible, toolCount)
-    updateNoResults(connectorVisible, toolCount)
+    searchInput?.addEventListener('input', (e) => {
+      searchQuery = (e.target as HTMLInputElement).value.toLowerCase().trim()
+      void runSearch()
+    })
+
+    categorySelect?.addEventListener('change', () => {
+      activeCategory = categorySelect.value
+      void runSearch()
+    })
+
+    authSelect?.addEventListener('change', () => {
+      activeAuth = authSelect.value
+      void runSearch()
+    })
+
+    catalogEl?.querySelectorAll<HTMLImageElement>('.provider-logo img').forEach((img) => {
+      img.addEventListener('error', () => {
+        img.style.display = 'none'
+      })
+    })
+
+    // Initial browse state
+    void runSearch()
   }
 
-  searchInput?.addEventListener('input', (e) => {
-    searchQuery = (e.target as HTMLInputElement).value.toLowerCase().trim()
-    void runSearch()
-  })
-
-  categorySelect?.addEventListener('change', () => {
-    activeCategory = categorySelect.value
-    void runSearch()
-  })
-
-  authSelect?.addEventListener('change', () => {
-    activeAuth = authSelect.value
-    void runSearch()
-  })
-
-  catalogEl?.querySelectorAll<HTMLImageElement>('.provider-logo img').forEach((img) => {
-    img.addEventListener('error', () => {
-      img.style.display = 'none'
-    })
-  })
-
-  // Initial browse state
-  void runSearch()
+  // Run when the module first executes (initial load or the soft nav that first loads it), then
+  // again after every subsequent ClientRouter navigation. The astro:page-load listener is
+  // registered once and persists across navigations; the per-element guard prevents double-init.
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initProviderCatalog, { once: true })
+  } else {
+    initProviderCatalog()
+  }
+  document.addEventListener('astro:page-load', initProviderCatalog)
 </script>
 
 <style>

--- a/src/components/sdk-reference/agentkit/node/_nav.json
+++ b/src/components/sdk-reference/agentkit/node/_nav.json
@@ -7,14 +7,14 @@
   "clients": [
     {
       "id": "actions",
-      "label": "Accounts & tools",
+      "label": "Connected accounts",
       "accessor": "actions",
       "order": 10,
       "summary": "Connect accounts, auth links, and run tools"
     },
     {
       "id": "tools",
-      "label": "Tool schemas",
+      "label": "Tool calling",
       "accessor": "tools",
       "order": 20,
       "summary": "List raw tool schemas for custom adapters"

--- a/src/components/sdk-reference/agentkit/python/_nav.json
+++ b/src/components/sdk-reference/agentkit/python/_nav.json
@@ -7,21 +7,21 @@
   "clients": [
     {
       "id": "actions",
-      "label": "Accounts & tools",
+      "label": "Connected accounts",
       "accessor": "actions",
       "order": 10,
       "summary": "Connect accounts, auth links, and run tools"
     },
     {
       "id": "tools",
-      "label": "Tool schemas",
+      "label": "Tool calling",
       "accessor": "tools",
       "order": 20,
       "summary": "List raw tool schemas for custom adapters"
     },
     {
       "id": "mcp",
-      "label": "MCP server",
+      "label": "MCP configurations",
       "order": 30,
       "summary": "Expose AgentKit tools over MCP"
     },

--- a/src/components/sdk-reference/saaskit/go/_nav.json
+++ b/src/components/sdk-reference/saaskit/go/_nav.json
@@ -31,7 +31,7 @@
     },
     {
       "id": "connections",
-      "label": "SSO connections",
+      "label": "Connections",
       "order": 50,
       "summary": "Configure enterprise SSO connections"
     },
@@ -43,7 +43,7 @@
     },
     {
       "id": "directories",
-      "label": "Directory sync",
+      "label": "Directory",
       "order": 70,
       "summary": "Sync users and groups with SCIM"
     },
@@ -61,7 +61,7 @@
     },
     {
       "id": "passwordless",
-      "label": "Passwordless login",
+      "label": "Magic link & OTP",
       "order": 100,
       "summary": "Send and verify passwordless login codes"
     },

--- a/src/components/sdk-reference/saaskit/java/_nav.json
+++ b/src/components/sdk-reference/saaskit/java/_nav.json
@@ -31,7 +31,7 @@
     },
     {
       "id": "connections",
-      "label": "SSO connections",
+      "label": "Connections",
       "order": 50,
       "summary": "Configure enterprise SSO connections"
     },
@@ -43,7 +43,7 @@
     },
     {
       "id": "directories",
-      "label": "Directory sync",
+      "label": "Directory",
       "order": 70,
       "summary": "Sync users and groups with SCIM"
     },
@@ -61,7 +61,7 @@
     },
     {
       "id": "passwordless",
-      "label": "Passwordless login",
+      "label": "Magic link & OTP",
       "order": 100,
       "summary": "Send and verify passwordless login codes"
     },

--- a/src/components/sdk-reference/saaskit/node/_nav.json
+++ b/src/components/sdk-reference/saaskit/node/_nav.json
@@ -34,7 +34,7 @@
     },
     {
       "id": "connections",
-      "label": "SSO connections",
+      "label": "Connections",
       "accessor": "connection",
       "order": 50,
       "summary": "Configure enterprise SSO connections"
@@ -48,7 +48,7 @@
     },
     {
       "id": "directories",
-      "label": "Directory sync",
+      "label": "Directory",
       "accessor": "directory",
       "order": 70,
       "summary": "Sync users and groups with SCIM"
@@ -69,7 +69,7 @@
     },
     {
       "id": "passwordless",
-      "label": "Passwordless login",
+      "label": "Magic link & OTP",
       "accessor": "passwordless",
       "order": 100,
       "summary": "Send and verify passwordless login codes"

--- a/src/components/sdk-reference/saaskit/python/_nav.json
+++ b/src/components/sdk-reference/saaskit/python/_nav.json
@@ -31,7 +31,7 @@
     },
     {
       "id": "connection",
-      "label": "SSO connections",
+      "label": "Connections",
       "order": 50,
       "summary": "Configure enterprise SSO connections"
     },
@@ -43,7 +43,7 @@
     },
     {
       "id": "directory",
-      "label": "Directory sync",
+      "label": "Directory",
       "order": 70,
       "summary": "Sync users and groups with SCIM"
     },
@@ -61,7 +61,7 @@
     },
     {
       "id": "passwordless",
-      "label": "Passwordless login",
+      "label": "Magic link & OTP",
       "order": 100,
       "summary": "Send and verify passwordless login codes"
     },

--- a/src/content/docs/agentkit/sdks/node/actions.mdx
+++ b/src/content/docs/agentkit/sdks/node/actions.mdx
@@ -1,12 +1,12 @@
 ---
-title: Accounts & tools
+title: Connected accounts
 description: Connect accounts, start auth, and execute tools with scalekit.actions
 topic: agentkit-sdks
 tableOfContents:
   minHeadingLevel: 3
   maxHeadingLevel: 3
 sidebar:
-  label: Accounts & tools
+  label: Connected accounts
 prev: false
 next: false
 ---
@@ -21,7 +21,7 @@ import '@/styles/sdk-reference.css'
 
 **Common path:** create or look up a connected account → get an authorization link → verify the user after redirect → run tools with `executeTool`.
 
-For raw tool schemas used by custom adapters, see [Tool schemas](/agentkit/sdks/node/tools/). For exception types, see [Error handling](/agentkit/sdks/node/errors/).
+For raw tool schemas used by custom adapters, see [Tool calling](/agentkit/sdks/node/tools/). For exception types, see [Error handling](/agentkit/sdks/node/errors/).
 
 ### verifyConnectedAccountUser
 <div class="sdk-method-section">

--- a/src/content/docs/agentkit/sdks/node/errors.mdx
+++ b/src/content/docs/agentkit/sdks/node/errors.mdx
@@ -57,6 +57,6 @@ try {
 
 ## Related
 
-- [Accounts & tools](/agentkit/sdks/node/actions/) — connect accounts and execute tools  
-- [Tool schemas](/agentkit/sdks/node/tools/) — list tool definitions  
+- [Connected accounts](/agentkit/sdks/node/actions/) — connect accounts and execute tools  
+- [Tool calling](/agentkit/sdks/node/tools/) — list tool definitions  
 - [Install](/agentkit/sdks/node/) — create the Scalekit client  

--- a/src/content/docs/agentkit/sdks/node/index.mdx
+++ b/src/content/docs/agentkit/sdks/node/index.mdx
@@ -10,8 +10,8 @@ tableOfContents: false
 
 Install the Node.js SDK, create a `ScalekitClient`, then use the sidebar clients for AgentKit.
 
-- **Accounts & tools** (`scalekit.actions`) — connect end-user accounts and execute tools  
-- **Tool schemas** (`scalekit.tools`) — raw tool definitions for custom adapters  
+- **Connected accounts** (`scalekit.actions`) — connect end-user accounts and execute tools  
+- **Tool calling** (`scalekit.tools`) — raw tool definitions for custom adapters  
 - **Error handling** — typed exceptions for API failures  
 
 ## Install
@@ -35,6 +35,6 @@ const scalekit = new ScalekitClient(
 
 ## Next steps
 
-1. [Accounts & tools](/agentkit/sdks/node/actions/) — authorization links, connected accounts, `executeTool`  
-2. [Tool schemas](/agentkit/sdks/node/tools/) — list tools for custom adapters  
+1. [Connected accounts](/agentkit/sdks/node/actions/) — authorization links, connected accounts, `executeTool`  
+2. [Tool calling](/agentkit/sdks/node/tools/) — list tools for custom adapters  
 3. [Error handling](/agentkit/sdks/node/errors/) — catch `ScalekitNotFoundException` and related types  

--- a/src/content/docs/agentkit/sdks/node/tools.mdx
+++ b/src/content/docs/agentkit/sdks/node/tools.mdx
@@ -1,12 +1,12 @@
 ---
-title: Tool schemas
+title: Tool calling
 description: List raw tool schemas for custom adapters
 topic: agentkit-sdks
 tableOfContents:
   minHeadingLevel: 3
   maxHeadingLevel: 3
 sidebar:
-  label: Tool schemas
+  label: Tool calling
 prev: false
 next: false
 ---
@@ -19,7 +19,7 @@ import '@/styles/sdk-reference.css'
 
 `scalekit.tools` returns raw tool schemas so you can build custom agent adapters instead of using `scalekit.actions.executeTool` directly.
 
-Use this client when you need tool definitions (name, parameters, connector) for frameworks or your own executor. For connect + execute flows, prefer [Accounts & tools](/agentkit/sdks/node/actions/). See [Error handling](/agentkit/sdks/node/errors/) for exceptions.
+Use this client when you need tool definitions (name, parameters, connector) for frameworks or your own executor. For connect + execute flows, prefer [Connected accounts](/agentkit/sdks/node/actions/). See [Error handling](/agentkit/sdks/node/errors/) for exceptions.
 
 ### listTools
 <div class="sdk-method-section">

--- a/src/content/docs/agentkit/sdks/python/actions.mdx
+++ b/src/content/docs/agentkit/sdks/python/actions.mdx
@@ -1,12 +1,12 @@
 ---
-title: Accounts & tools
+title: Connected accounts
 description: Connect accounts, start auth, and execute tools with scalekit.actions
 topic: agentkit-sdks
 tableOfContents:
   minHeadingLevel: 3
   maxHeadingLevel: 3
 sidebar:
-  label: Accounts & tools
+  label: Connected accounts
 prev: false
 next: false
 head:
@@ -31,7 +31,7 @@ import '@/styles/sdk-reference.css'
 
 **Common path:** create or look up a connected account → get an authorization link → verify the user after redirect → run tools.
 
-For raw tool schemas, see [Tool schemas](/agentkit/sdks/python/tools/). For exceptions, see [Error handling](/agentkit/sdks/python/errors/).
+For raw tool schemas, see [Tool calling](/agentkit/sdks/python/tools/). For exceptions, see [Error handling](/agentkit/sdks/python/errors/).
 
 ### get_authorization_link
 <div class="sdk-method-section">

--- a/src/content/docs/agentkit/sdks/python/errors.mdx
+++ b/src/content/docs/agentkit/sdks/python/errors.mdx
@@ -55,6 +55,6 @@ except ScalekitServerException as e:
 
 ## Related
 
-- [Accounts & tools](/agentkit/sdks/python/actions/) — connect accounts and execute tools  
-- [Tool schemas](/agentkit/sdks/python/tools/) — list tool definitions  
+- [Connected accounts](/agentkit/sdks/python/actions/) — connect accounts and execute tools  
+- [Tool calling](/agentkit/sdks/python/tools/) — list tool definitions  
 - [Install](/agentkit/sdks/python/) — create the Scalekit client  

--- a/src/content/docs/agentkit/sdks/python/framework-adapters.mdx
+++ b/src/content/docs/agentkit/sdks/python/framework-adapters.mdx
@@ -19,7 +19,7 @@ import '@/styles/sdk-reference.css'
 
 Framework adapters map Scalekit tools into popular agent frameworks so you can register tools without hand-writing schema conversion.
 
-Pick the adapter for your stack, pass the Scalekit client, and register tools on the agent. See [Accounts & tools](/agentkit/sdks/python/actions/) for the underlying client and [Error handling](/agentkit/sdks/python/errors/) for exceptions.
+Pick the adapter for your stack, pass the Scalekit client, and register tools on the agent. See [Connected accounts](/agentkit/sdks/python/actions/) for the underlying client and [Error handling](/agentkit/sdks/python/errors/) for exceptions.
 
 ### actions.langchain.get_tools
 <div class="sdk-method-section">

--- a/src/content/docs/agentkit/sdks/python/index.mdx
+++ b/src/content/docs/agentkit/sdks/python/index.mdx
@@ -10,8 +10,8 @@ tableOfContents: false
 
 Install the Python SDK, create a `ScalekitClient`, then use the sidebar for AgentKit clients.
 
-- **Accounts & tools** (`scalekit_client.actions`) — connect end-user accounts and execute tools  
-- **Tool schemas** — raw tool definitions for custom adapters  
+- **Connected accounts** (`scalekit_client.actions`) — connect end-user accounts and execute tools  
+- **Tool calling** — raw tool definitions for custom adapters  
 - **MCP server**, **Frameworks**, **Request modifiers**, **Custom OAuth** — advanced surfaces  
 - **Error handling** — typed exceptions for API failures  
 
@@ -40,8 +40,8 @@ actions = scalekit_client.actions
 
 ## Next steps
 
-- [Accounts & tools](/agentkit/sdks/python/actions/)  
-- [Tool schemas](/agentkit/sdks/python/tools/)  
+- [Connected accounts](/agentkit/sdks/python/actions/)  
+- [Tool calling](/agentkit/sdks/python/tools/)  
 - [MCP](/agentkit/sdks/python/mcp/)  
 - [Framework adapters](/agentkit/sdks/python/framework-adapters/)  
 - [Error handling](/agentkit/sdks/python/errors/)  

--- a/src/content/docs/agentkit/sdks/python/mcp.mdx
+++ b/src/content/docs/agentkit/sdks/python/mcp.mdx
@@ -1,12 +1,12 @@
 ---
-title: MCP server
+title: MCP configurations
 description: Expose AgentKit tools over MCP.
 topic: agentkit-sdks
 tableOfContents:
   minHeadingLevel: 3
   maxHeadingLevel: 3
 sidebar:
-  label: MCP server
+  label: MCP configurations
 prev: false
 next: false
 head:

--- a/src/content/docs/agentkit/sdks/python/tools.mdx
+++ b/src/content/docs/agentkit/sdks/python/tools.mdx
@@ -1,12 +1,12 @@
 ---
-title: Tool schemas
+title: Tool calling
 description: List raw tool schemas for custom adapters
 topic: agentkit-sdks
 tableOfContents:
   minHeadingLevel: 3
   maxHeadingLevel: 3
 sidebar:
-  label: Tool schemas
+  label: Tool calling
 prev: false
 next: false
 head:
@@ -29,7 +29,7 @@ import '@/styles/sdk-reference.css'
 
 `scalekit.tools` returns raw tool schemas for custom agent adapters.
 
-Use this when you need tool definitions for frameworks or your own executor. For connect + execute, use [Accounts & tools](/agentkit/sdks/python/actions/). See [Error handling](/agentkit/sdks/python/errors/).
+Use this when you need tool definitions for frameworks or your own executor. For connect + execute, use [Connected accounts](/agentkit/sdks/python/actions/). See [Error handling](/agentkit/sdks/python/errors/).
 
 ### tools.list_tools
 <div class="sdk-method-section">

--- a/src/content/docs/saaskit/sdks/go/connections.mdx
+++ b/src/content/docs/saaskit/sdks/go/connections.mdx
@@ -1,12 +1,12 @@
 ---
-title: SSO connections
+title: Connections
 description: Configure enterprise SSO connections
 topic: saaskit-sdks
 tableOfContents:
   minHeadingLevel: 3
   maxHeadingLevel: 3
 sidebar:
-  label: SSO connections
+  label: Connections
 prev: false
 next: false
 ---

--- a/src/content/docs/saaskit/sdks/go/directories.mdx
+++ b/src/content/docs/saaskit/sdks/go/directories.mdx
@@ -1,12 +1,12 @@
 ---
-title: Directory sync
+title: Directory
 description: Sync users and groups via SCIM directories
 topic: saaskit-sdks
 tableOfContents:
   minHeadingLevel: 3
   maxHeadingLevel: 3
 sidebar:
-  label: Directory sync
+  label: Directory
 prev: false
 next: false
 ---

--- a/src/content/docs/saaskit/sdks/go/passwordless.mdx
+++ b/src/content/docs/saaskit/sdks/go/passwordless.mdx
@@ -1,12 +1,12 @@
 ---
-title: Passwordless login
+title: Magic link & OTP
 description: Send and verify passwordless login codes
 topic: saaskit-sdks
 tableOfContents:
   minHeadingLevel: 3
   maxHeadingLevel: 3
 sidebar:
-  label: Passwordless login
+  label: Magic link & OTP
 prev: false
 next: false
 ---

--- a/src/content/docs/saaskit/sdks/java/connections.mdx
+++ b/src/content/docs/saaskit/sdks/java/connections.mdx
@@ -1,12 +1,12 @@
 ---
-title: SSO connections
+title: Connections
 description: Configure enterprise SSO connections
 topic: saaskit-sdks
 tableOfContents:
   minHeadingLevel: 3
   maxHeadingLevel: 3
 sidebar:
-  label: SSO connections
+  label: Connections
 prev: false
 next: false
 ---

--- a/src/content/docs/saaskit/sdks/java/directories.mdx
+++ b/src/content/docs/saaskit/sdks/java/directories.mdx
@@ -1,12 +1,12 @@
 ---
-title: Directory sync
+title: Directory
 description: Sync users and groups via SCIM directories
 topic: saaskit-sdks
 tableOfContents:
   minHeadingLevel: 3
   maxHeadingLevel: 3
 sidebar:
-  label: Directory sync
+  label: Directory
 prev: false
 next: false
 ---

--- a/src/content/docs/saaskit/sdks/java/passwordless.mdx
+++ b/src/content/docs/saaskit/sdks/java/passwordless.mdx
@@ -1,12 +1,12 @@
 ---
-title: Passwordless login
+title: Magic link & OTP
 description: Send and verify passwordless login codes
 topic: saaskit-sdks
 tableOfContents:
   minHeadingLevel: 3
   maxHeadingLevel: 3
 sidebar:
-  label: Passwordless login
+  label: Magic link & OTP
 prev: false
 next: false
 ---

--- a/src/content/docs/saaskit/sdks/node/connections.mdx
+++ b/src/content/docs/saaskit/sdks/node/connections.mdx
@@ -1,12 +1,12 @@
 ---
-title: SSO connections
+title: Connections
 description: Configure enterprise SSO connections
 topic: saaskit-sdks
 tableOfContents:
   minHeadingLevel: 3
   maxHeadingLevel: 3
 sidebar:
-  label: SSO connections
+  label: Connections
 prev: false
 next: false
 ---

--- a/src/content/docs/saaskit/sdks/node/directories.mdx
+++ b/src/content/docs/saaskit/sdks/node/directories.mdx
@@ -1,12 +1,12 @@
 ---
-title: Directory sync
+title: Directory
 description: Sync users and groups via SCIM directories
 topic: saaskit-sdks
 tableOfContents:
   minHeadingLevel: 3
   maxHeadingLevel: 3
 sidebar:
-  label: Directory sync
+  label: Directory
 prev: false
 next: false
 ---

--- a/src/content/docs/saaskit/sdks/node/passwordless.mdx
+++ b/src/content/docs/saaskit/sdks/node/passwordless.mdx
@@ -1,12 +1,12 @@
 ---
-title: Passwordless login
+title: Magic link & OTP
 description: Send and verify passwordless login codes
 topic: saaskit-sdks
 tableOfContents:
   minHeadingLevel: 3
   maxHeadingLevel: 3
 sidebar:
-  label: Passwordless login
+  label: Magic link & OTP
 prev: false
 next: false
 ---

--- a/src/content/docs/saaskit/sdks/python/connection.mdx
+++ b/src/content/docs/saaskit/sdks/python/connection.mdx
@@ -1,12 +1,12 @@
 ---
-title: SSO connections
+title: Connections
 description: Configure enterprise SSO connections
 topic: saaskit-sdks
 tableOfContents:
   minHeadingLevel: 3
   maxHeadingLevel: 3
 sidebar:
-  label: SSO connections
+  label: Connections
 prev: false
 next: false
 ---

--- a/src/content/docs/saaskit/sdks/python/directory.mdx
+++ b/src/content/docs/saaskit/sdks/python/directory.mdx
@@ -1,12 +1,12 @@
 ---
-title: Directory sync
+title: Directory
 description: Sync users and groups via SCIM directories
 topic: saaskit-sdks
 tableOfContents:
   minHeadingLevel: 3
   maxHeadingLevel: 3
 sidebar:
-  label: Directory sync
+  label: Directory
 prev: false
 next: false
 ---

--- a/src/content/docs/saaskit/sdks/python/passwordless.mdx
+++ b/src/content/docs/saaskit/sdks/python/passwordless.mdx
@@ -1,12 +1,12 @@
 ---
-title: Passwordless login
+title: Magic link & OTP
 description: Send and verify passwordless login codes
 topic: saaskit-sdks
 tableOfContents:
   minHeadingLevel: 3
   maxHeadingLevel: 3
 sidebar:
-  label: Passwordless login
+  label: Magic link & OTP
 prev: false
 next: false
 ---

--- a/src/pages/agentkit/apis.astro
+++ b/src/pages/agentkit/apis.astro
@@ -148,7 +148,7 @@ const frontmatter = {
       hideDarkModeToggle: true,
       darkMode: false,
       proxyUrl: 'https://proxy.scalar.com',
-      defaultOpenAllTags: true,
+      defaultOpenAllTags: false,
       tagsSorter: (a, b) => {
         // Logical order for the AgentKit API reference in Scalar (per SK-399 split).
         // Matches the clean tags produced by the backend (Connectors, Tool Calling, MCP groups).


### PR DESCRIPTION
## Summary

- Collapse AgentKit API reference tag sections by default (defaultOpenAllTags: false), matching SaaSKit
- Align SDK reference nav labels with API reference section names (AgentKit: Connected accounts, Tool calling, MCP configurations; SaaSKit: Connections, Directory, Magic link & OTP)
- Fix in-page connectors catalog search being dead on first visit / return navigation: ProviderCatalog.astro now re-initializes on the astro:page-load ClientRouter hook

## Preview
- https://deploy-preview-901--scalekit-starlight.netlify.app/agentkit/connectors/
- https://deploy-preview-901--scalekit-starlight.netlify.app/agentkit/apis/
- https://deploy-preview-901--scalekit-starlight.netlify.app/agentkit/sdks/node/actions/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified SDK reference labels, including Connected accounts, Tool calling, MCP configurations, Connections, Directory, and Magic link & OTP.
  * Updated related links and page titles across supported SDK guides for consistent navigation.
* **Bug Fixes**
  * Provider catalog search and browsing now continue working after in-app page navigation.
* **Improvements**
  * API reference sections are collapsed by default for easier scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->