### PR TITLE
docs(product): sync OpenAPI connector/connection enums with NO_AUTH

### DIFF
--- a/openapi/scalekit.yaml
+++ b/openapi/scalekit.yaml
@@ -6757,6 +6757,7 @@ components:
          - TRUSTED_IDP: Trusted Identity Provider federation (e.g. AWS STS AssumeRoleWithWebIdentity)
          - SMART_FHIR: SMART on FHIR (SMART App Launch) — OAuth 2.0 authorization
         for FHIR servers
+         - NO_AUTH: No authentication — connector requires no credentials (e.g. public docs MCP servers)
       type: string
       title: Type of authentication mechanism used for the connected account
       enum:
@@ -6771,6 +6772,7 @@ components:
         - GOOGLE_DWD
         - TRUSTED_IDP
         - SMART_FHIR
+        - NO_AUTH
     connected_accountsCreateConnectedAccountRequest:
       type: object
       properties:
@@ -7269,6 +7271,7 @@ components:
         - GOOGLE_DWD
         - TRUSTED_IDP
         - SMART_FHIR
+        - NO_AUTH
     connectionsGetConnectionResponse:
       type: object
       properties:
@@ -10916,6 +10919,7 @@ components:
             - GOOGLE_DWD
             - TRUSTED_IDP
             - SMART_FHIR
+            - NO_AUTH
           example: OAUTH
           description: The authorization type of the connected account
         status:
@@ -11859,6 +11863,7 @@ components:
             - GOOGLE_DWD
             - TRUSTED_IDP
             - SMART_FHIR
+            - NO_AUTH
           description: Authorization type of the connected account
         status:
           type: string

--- a/public/api/agentkit.scalar.json
+++ b/public/api/agentkit.scalar.json
@@ -1887,7 +1887,7 @@
         "enum": ["ACTIVE", "EXPIRED", "PENDING_AUTH", "PENDING_VERIFICATION", "DISCONNECTED"]
       },
       "connected_accountsConnectorType": {
-        "description": "- OAUTH: OAuth 2.0 authorization with access and refresh tokens\n - API_KEY: Static API key authentication\n - BASIC_AUTH: HTTP Basic Authentication (username/password)\n - BEARER_TOKEN: Bearer token authentication\n - CUSTOM: Custom authentication mechanism\n - BASIC: Basic authentication (alias)\n - OAUTH_M2M: OAuth 2.0 client credentials (machine-to-machine)\n - TRELLO_OAUTH1: Trello token-based OAuth1-style browser authorization\n - GOOGLE_DWD: Google Domain-Wide Delegation\n - TRUSTED_IDP: Trusted Identity Provider federation (e.g. AWS STS AssumeRoleWithWebIdentity)\n - SMART_FHIR: SMART on FHIR (SMART App Launch) — OAuth 2.0 authorization\nfor FHIR servers",
+        "description": "- OAUTH: OAuth 2.0 authorization with access and refresh tokens\n - API_KEY: Static API key authentication\n - BASIC_AUTH: HTTP Basic Authentication (username/password)\n - BEARER_TOKEN: Bearer token authentication\n - CUSTOM: Custom authentication mechanism\n - BASIC: Basic authentication (alias)\n - OAUTH_M2M: OAuth 2.0 client credentials (machine-to-machine)\n - TRELLO_OAUTH1: Trello token-based OAuth1-style browser authorization\n - GOOGLE_DWD: Google Domain-Wide Delegation\n - TRUSTED_IDP: Trusted Identity Provider federation (e.g. AWS STS AssumeRoleWithWebIdentity)\n - SMART_FHIR: SMART on FHIR (SMART App Launch) — OAuth 2.0 authorization\nfor FHIR servers\n - NO_AUTH: No authentication — connector requires no credentials (e.g. public docs MCP servers)",
         "type": "string",
         "title": "Type of authentication mechanism used for the connected account",
         "enum": [
@@ -1901,7 +1901,8 @@
           "TRELLO_OAUTH1",
           "GOOGLE_DWD",
           "TRUSTED_IDP",
-          "SMART_FHIR"
+          "SMART_FHIR",
+          "NO_AUTH"
         ]
       },
       "connected_accountsCreateConnectedAccountRequest": {
@@ -2921,7 +2922,8 @@
               "TRELLO_OAUTH1",
               "GOOGLE_DWD",
               "TRUSTED_IDP",
-              "SMART_FHIR"
+              "SMART_FHIR",
+              "NO_AUTH"
             ],
             "example": "OAUTH",
             "description": "The authorization type of the connected account"
@@ -2979,7 +2981,8 @@
               "TRELLO_OAUTH1",
               "GOOGLE_DWD",
               "TRUSTED_IDP",
-              "SMART_FHIR"
+              "SMART_FHIR",
+              "NO_AUTH"
             ],
             "description": "Authorization type of the connected account"
           },

--- a/public/api/agentkit.scalar.yaml
+++ b/public/api/agentkit.scalar.yaml
@@ -1430,6 +1430,7 @@ components:
          - TRUSTED_IDP: Trusted Identity Provider federation (e.g. AWS STS AssumeRoleWithWebIdentity)
          - SMART_FHIR: SMART on FHIR (SMART App Launch) — OAuth 2.0 authorization
         for FHIR servers
+         - NO_AUTH: No authentication — connector requires no credentials (e.g. public docs MCP servers)
       type: string
       title: Type of authentication mechanism used for the connected account
       enum:
@@ -1444,6 +1445,7 @@ components:
         - GOOGLE_DWD
         - TRUSTED_IDP
         - SMART_FHIR
+        - NO_AUTH
     connected_accountsCreateConnectedAccountRequest:
       type: object
       properties:
@@ -2274,6 +2276,7 @@ components:
             - GOOGLE_DWD
             - TRUSTED_IDP
             - SMART_FHIR
+            - NO_AUTH
           example: OAUTH
           description: The authorization type of the connected account
         status:
@@ -2336,6 +2339,7 @@ components:
             - GOOGLE_DWD
             - TRUSTED_IDP
             - SMART_FHIR
+            - NO_AUTH
           description: Authorization type of the connected account
         status:
           type: string

--- a/public/api/saaskit.scalar.json
+++ b/public/api/saaskit.scalar.json
@@ -8132,7 +8132,8 @@
           "TRELLO_OAUTH1",
           "GOOGLE_DWD",
           "TRUSTED_IDP",
-          "SMART_FHIR"
+          "SMART_FHIR",
+          "NO_AUTH"
         ]
       },
       "connectionsGetConnectionResponse": {

--- a/public/api/saaskit.scalar.yaml
+++ b/public/api/saaskit.scalar.yaml
@@ -7049,6 +7049,7 @@ components:
         - GOOGLE_DWD
         - TRUSTED_IDP
         - SMART_FHIR
+        - NO_AUTH
     connectionsGetConnectionResponse:
       type: object
       properties:

--- a/public/api/scalekit.scalar.json
+++ b/public/api/scalekit.scalar.json
@@ -9808,7 +9808,7 @@
         "enum": ["ACTIVE", "EXPIRED", "PENDING_AUTH", "PENDING_VERIFICATION", "DISCONNECTED"]
       },
       "connected_accountsConnectorType": {
-        "description": "- OAUTH: OAuth 2.0 authorization with access and refresh tokens\n - API_KEY: Static API key authentication\n - BASIC_AUTH: HTTP Basic Authentication (username/password)\n - BEARER_TOKEN: Bearer token authentication\n - CUSTOM: Custom authentication mechanism\n - BASIC: Basic authentication (alias)\n - OAUTH_M2M: OAuth 2.0 client credentials (machine-to-machine)\n - TRELLO_OAUTH1: Trello token-based OAuth1-style browser authorization\n - GOOGLE_DWD: Google Domain-Wide Delegation\n - TRUSTED_IDP: Trusted Identity Provider federation (e.g. AWS STS AssumeRoleWithWebIdentity)\n - SMART_FHIR: SMART on FHIR (SMART App Launch) — OAuth 2.0 authorization\nfor FHIR servers",
+        "description": "- OAUTH: OAuth 2.0 authorization with access and refresh tokens\n - API_KEY: Static API key authentication\n - BASIC_AUTH: HTTP Basic Authentication (username/password)\n - BEARER_TOKEN: Bearer token authentication\n - CUSTOM: Custom authentication mechanism\n - BASIC: Basic authentication (alias)\n - OAUTH_M2M: OAuth 2.0 client credentials (machine-to-machine)\n - TRELLO_OAUTH1: Trello token-based OAuth1-style browser authorization\n - GOOGLE_DWD: Google Domain-Wide Delegation\n - TRUSTED_IDP: Trusted Identity Provider federation (e.g. AWS STS AssumeRoleWithWebIdentity)\n - SMART_FHIR: SMART on FHIR (SMART App Launch) — OAuth 2.0 authorization\nfor FHIR servers\n - NO_AUTH: No authentication — connector requires no credentials (e.g. public docs MCP servers)",
         "type": "string",
         "title": "Type of authentication mechanism used for the connected account",
         "enum": [
@@ -9822,7 +9822,8 @@
           "TRELLO_OAUTH1",
           "GOOGLE_DWD",
           "TRUSTED_IDP",
-          "SMART_FHIR"
+          "SMART_FHIR",
+          "NO_AUTH"
         ]
       },
       "connected_accountsCreateConnectedAccountRequest": {
@@ -10389,7 +10390,8 @@
           "TRELLO_OAUTH1",
           "GOOGLE_DWD",
           "TRUSTED_IDP",
-          "SMART_FHIR"
+          "SMART_FHIR",
+          "NO_AUTH"
         ]
       },
       "connectionsGetConnectionResponse": {
@@ -14482,7 +14484,8 @@
               "TRELLO_OAUTH1",
               "GOOGLE_DWD",
               "TRUSTED_IDP",
-              "SMART_FHIR"
+              "SMART_FHIR",
+              "NO_AUTH"
             ],
             "example": "OAUTH",
             "description": "The authorization type of the connected account"
@@ -15587,7 +15590,8 @@
               "TRELLO_OAUTH1",
               "GOOGLE_DWD",
               "TRUSTED_IDP",
-              "SMART_FHIR"
+              "SMART_FHIR",
+              "NO_AUTH"
             ],
             "description": "Authorization type of the connected account"
           },

--- a/public/api/scalekit.scalar.yaml
+++ b/public/api/scalekit.scalar.yaml
@@ -8237,6 +8237,7 @@ components:
          - TRUSTED_IDP: Trusted Identity Provider federation (e.g. AWS STS AssumeRoleWithWebIdentity)
          - SMART_FHIR: SMART on FHIR (SMART App Launch) — OAuth 2.0 authorization
         for FHIR servers
+         - NO_AUTH: No authentication — connector requires no credentials (e.g. public docs MCP servers)
       type: string
       title: Type of authentication mechanism used for the connected account
       enum:
@@ -8251,6 +8252,7 @@ components:
         - GOOGLE_DWD
         - TRUSTED_IDP
         - SMART_FHIR
+        - NO_AUTH
     connected_accountsCreateConnectedAccountRequest:
       type: object
       properties:
@@ -8747,6 +8749,7 @@ components:
         - GOOGLE_DWD
         - TRUSTED_IDP
         - SMART_FHIR
+        - NO_AUTH
     connectionsGetConnectionResponse:
       type: object
       properties:
@@ -12180,6 +12183,7 @@ components:
             - GOOGLE_DWD
             - TRUSTED_IDP
             - SMART_FHIR
+            - NO_AUTH
           example: OAUTH
           description: The authorization type of the connected account
         status:
@@ -13102,6 +13106,7 @@ components:
             - GOOGLE_DWD
             - TRUSTED_IDP
             - SMART_FHIR
+            - NO_AUTH
           description: Authorization type of the connected account
         status:
           type: string


### PR DESCRIPTION
**Why:** The backend added a `NO_AUTH` connector type in `scalekit-inc/scalekit@dc863c92` (SK-974, #2395, shipped as proto `v0.1.137.0` and pulled into the Node/Python/Go/Java SDKs on 2026-07-16/17). Its proto enums now carry `ConnectorType.NO_AUTH = 12` and `ConnectionType.NO_AUTH = 15`, and NO_AUTH connected accounts report `authorization_type = NO_AUTH`. The docs OpenAPI spec still stopped at `SMART_FHIR`, so `NO_AUTH` was undocumented across the connector/connection type enums and the connected-account webhook payloads. That PR's own description notes the Swagger/OpenAPI regen "could not run in the sandbox … should be re-run in CI," which is why the docs copy drifted.

**What:** Surgical enum sync in `openapi/scalekit.yaml` (the curated Redocly root), then rebundled `public/api/*.scalar.{yaml,json}` via `pnpm run bundle:apis`. Added `NO_AUTH` to: `connected_accountsConnectorType` (description bullet + enum), `connectionsConnectionType`, and the inline `authorization_type` enums on `ConnectedAccountStatusUpdatedEventData` and `ConnectedAccountEventData`. No new endpoints, no invented fields — only the missing enum value the server already emits. Skills invoked: docs-engineering, api-reference.

**Evidence:** Source of truth `scalekit-inc/scalekit` proto at `40e74fa` — `proto/scalekit/v1/connected_accounts/connected_accounts.proto` (`ConnectorType.NO_AUTH = 12`) and `proto/scalekit/v1/connections/connections.proto` (`ConnectionType.NO_AUTH = 15`). Backend merge `dc863c92` (#2395). OpenAPI/proto compared: yes.

**Check:** `pnpm run bundle:apis` + `pnpm run validate-api-split` both green locally; `NO_AUTH` present in all three regenerated scalar bundles; full diff is 33 insertions / 10 deletions (the only non-`NO_AUTH` lines are trailing commas after `SMART_FHIR`, now that it is no longer the last enum member). verification: ran bundle:apis + validate-api-split locally (redocly 2.31.2); reviewer should confirm rendering in Scalar via the deploy preview.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4KEs2hMAZh575YwAGAZFA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `NO_AUTH` as a supported connected-account and connection authorization type.
  - Updated API documentation and schemas to recognize `NO_AUTH`.
  - Connected-account webhook payloads now support `NO_AUTH` in authorization type fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->