### PR TITLE
fix(docs-ui): remount Algolia DocSearch after ClientRouter soft-nav

### DIFF
--- a/vendor/docsearch/DocSearch.astro
+++ b/vendor/docsearch/DocSearch.astro
@@ -125,81 +125,136 @@ const docsearchTranslations: DocSearchTranslationProps = {
 
 <script>
   import config from 'virtual:starlight/docsearch-config'
+  import type docsearch from '@docsearch/js'
+
+  type DocSearchProps = Parameters<typeof docsearch>[0]
+  type DocSearchInstance = ReturnType<typeof docsearch>
+
+  /**
+   * Single live DocSearch instance for the page.
+   * ClientRouter soft navigations replace the header (and therefore `sl-doc-search`)
+   * without firing DOMContentLoaded again — so we remount on connectedCallback and
+   * tear down the previous instance so the Search button and Cmd/Ctrl+K stay wired.
+   */
+  let activeInstance: DocSearchInstance | null = null
+  let activeContainer: HTMLElement | null = null
+  let mountQueue: Promise<void> = Promise.resolve()
+
+  function buildOptions(host: HTMLElement): DocSearchProps {
+    let translations
+    try {
+      translations = JSON.parse(host.dataset.translations || '{}')
+    } catch {
+      translations = undefined
+    }
+
+    // Extract the page language (e.g. <html lang="en">) and pass it to DocSearch
+    // as an Algolia facet filter so that the search results are scoped to the current
+    // language. If users already defined facet filters we preserve them while appending
+    // the new one.
+    let searchParameters: DocSearchProps['searchParameters']
+
+    // Rebuild the askAi prop as an object:
+    // If the askAi prop is a string, treat it as the assistantId and use
+    // the default indexName, apiKey and appId from the main options.
+    // If the askAi prop is an object, preserve its properties while filling
+    // missing defaults, including searchParameters.
+    const askAiProp = config.askAi
+    const isAskAiString = typeof askAiProp === 'string'
+
+    const askAi = askAiProp
+      ? isAskAiString
+        ? {
+            indexName: config.indexName,
+            apiKey: config.apiKey,
+            appId: config.appId,
+            assistantId: askAiProp,
+            searchParameters: {},
+          }
+        : {
+            ...askAiProp,
+            indexName: askAiProp.indexName ?? config.indexName,
+            apiKey: askAiProp.apiKey ?? config.apiKey,
+            appId: askAiProp.appId ?? config.appId,
+            assistantId: askAiProp.assistantId,
+            searchParameters: askAiProp.searchParameters ?? {},
+          }
+      : undefined
+
+    const pageLang = document.documentElement.getAttribute('lang')
+
+    // Initialize searchParameters unconditionally
+    searchParameters = config.searchParameters || {}
+
+    if (pageLang) {
+      const existingFilters = searchParameters?.facetFilters ?? []
+      // Ensure facetFilters is always an array of strings for simplicity.
+      searchParameters.facetFilters = Array.isArray(existingFilters)
+        ? [...existingFilters, `lang:${pageLang}`]
+        : [existingFilters, `lang:${pageLang}`].filter(Boolean)
+
+      if (askAi) {
+        // Re-use the merged facetFilters from the search parameters so that
+        // Ask AI uses the same language filtering as the regular search.
+        askAi.searchParameters = { facetFilters: searchParameters.facetFilters }
+      }
+    }
+
+    return {
+      ...config,
+      // Mount into this specific host element (not a tag selector). After soft
+      // navigation there can be a brief moment with zero or two hosts in the tree.
+      container: host,
+      translations,
+      searchParameters,
+      askAi,
+    } as DocSearchProps
+  }
+
+  async function mountDocSearch(host: HTMLElement) {
+    // Serialize mounts so rapid soft-navs cannot leave two live instances.
+    mountQueue = mountQueue.then(async () => {
+      if (!host.isConnected) return
+
+      // Already mounted on this exact host (e.g. reconnect without replacement).
+      if (activeContainer === host && activeInstance) return
+
+      if (activeInstance) {
+        try {
+          activeInstance.destroy()
+        } catch {
+          // DocSearch may throw if the previous container was already removed.
+        }
+        activeInstance = null
+        activeContainer = null
+      }
+
+      const { default: docsearch } = await import('@docsearch/js')
+      if (!host.isConnected) return
+
+      activeInstance = docsearch(buildOptions(host))
+      activeContainer = host
+    })
+    await mountQueue
+  }
 
   class StarlightDocSearch extends HTMLElement {
-    constructor() {
-      super()
-      window.addEventListener('DOMContentLoaded', async () => {
-        const { default: docsearch } = await import('@docsearch/js')
-        type DocSearchProps = Parameters<typeof docsearch>[0]
-
-        let translations
-        try {
-          translations = JSON.parse(this.dataset.translations || '{}')
-        } catch {}
-
-        // Extract the page language (e.g. <html lang="en">) and pass it to DocSearch
-        // as an Algolia facet filter so that the search results are scoped to the current
-        // language. If users already defined facet filters we preserve them while appending
-        // the new one.
-        let searchParameters: DocSearchProps['searchParameters']
-
-        // Rebuild the askAi prop as an object:
-        // If the askAi prop is a string, treat it as the assistantId and use
-        // the default indexName, apiKey and appId from the main options.
-        // If the askAi prop is an object, preserve its properties while filling
-        // missing defaults, including searchParameters.
-        const askAiProp = config.askAi
-        const isAskAiString = typeof askAiProp === 'string'
-
-        const askAi = askAiProp
-          ? isAskAiString
-            ? {
-                indexName: config.indexName,
-                apiKey: config.apiKey,
-                appId: config.appId,
-                assistantId: askAiProp,
-                searchParameters: {},
-              }
-            : {
-                ...askAiProp,
-                indexName: askAiProp.indexName ?? config.indexName,
-                apiKey: askAiProp.apiKey ?? config.apiKey,
-                appId: askAiProp.appId ?? config.appId,
-                assistantId: askAiProp.assistantId,
-                searchParameters: askAiProp.searchParameters ?? {},
-              }
-          : undefined
-
-        const pageLang = document.documentElement.getAttribute('lang')
-
-        // Initialize searchParameters unconditionally
-        searchParameters = config.searchParameters || {}
-
-        if (pageLang) {
-          const existingFilters = searchParameters?.facetFilters ?? []
-          // Ensure facetFilters is always an array of strings for simplicity.
-          searchParameters.facetFilters = Array.isArray(existingFilters)
-            ? [...existingFilters, `lang:${pageLang}`]
-            : [existingFilters, `lang:${pageLang}`].filter(Boolean)
-
-          if (askAi) {
-            // Re-use the merged facetFilters from the search parameters so that
-            // Ask AI uses the same language filtering as the regular search.
-            askAi.searchParameters = { facetFilters: searchParameters.facetFilters }
-          }
-        }
-
-        const options = {
-          ...config,
-          container: 'sl-doc-search',
-          translations,
-          searchParameters,
-          askAi,
-        }
-        docsearch(options as DocSearchProps)
-      })
+    connectedCallback() {
+      // DOMContentLoaded-only init breaks under ClientRouter: the event never
+      // re-fires, and the SSR placeholder button has no click handler.
+      // readyState covers the case where this module runs after the event.
+      const start = () => {
+        void mountDocSearch(this)
+      }
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', start, { once: true })
+      } else {
+        start()
+      }
     }
   }
-  customElements.define('sl-doc-search', StarlightDocSearch)
+
+  if (!customElements.get('sl-doc-search')) {
+    customElements.define('sl-doc-search', StarlightDocSearch)
+  }
 </script>

--- a/vendor/docsearch/DocSearch.astro
+++ b/vendor/docsearch/DocSearch.astro
@@ -138,8 +138,22 @@ const docsearchTranslations: DocSearchTranslationProps = {
    */
   let activeInstance: DocSearchInstance | null = null
   let activeContainer: HTMLElement | null = null
+  /** Serializes remounts; always recovered to a resolved promise after each job. */
   let mountQueue: Promise<void> = Promise.resolve()
 
+  /**
+   * Build DocSearch client options for a specific host element.
+   *
+   * Clones config-owned search parameters so soft-nav remounts never mutate the
+   * shared virtual config (which would stack duplicate `lang:*` facet filters).
+   * When Ask AI is enabled, merges language facet filters into existing Ask AI
+   * search parameters instead of replacing them.
+   *
+   * @param host - Connected `sl-doc-search` element that owns the button and
+   *   `data-translations` payload. Used as the DocSearch `container`.
+   * @returns Options suitable for `docsearch(options)`. Does not throw on bad
+   *   translation JSON (falls back to undefined translations).
+   */
   function buildOptions(host: HTMLElement): DocSearchProps {
     let translations
     try {
@@ -147,12 +161,6 @@ const docsearchTranslations: DocSearchTranslationProps = {
     } catch {
       translations = undefined
     }
-
-    // Extract the page language (e.g. <html lang="en">) and pass it to DocSearch
-    // as an Algolia facet filter so that the search results are scoped to the current
-    // language. If users already defined facet filters we preserve them while appending
-    // the new one.
-    let searchParameters: DocSearchProps['searchParameters']
 
     // Rebuild the askAi prop as an object:
     // If the askAi prop is a string, treat it as the assistantId and use
@@ -177,26 +185,31 @@ const docsearchTranslations: DocSearchTranslationProps = {
             apiKey: askAiProp.apiKey ?? config.apiKey,
             appId: askAiProp.appId ?? config.appId,
             assistantId: askAiProp.assistantId,
-            searchParameters: askAiProp.searchParameters ?? {},
+            // Clone so remounts do not mutate the shared config object.
+            searchParameters: { ...(askAiProp.searchParameters ?? {}) },
           }
       : undefined
 
     const pageLang = document.documentElement.getAttribute('lang')
 
-    // Initialize searchParameters unconditionally
-    searchParameters = config.searchParameters || {}
+    // Clone config parameters — never mutate `config.searchParameters` in place.
+    const searchParameters: DocSearchProps['searchParameters'] = {
+      ...(config.searchParameters ?? {}),
+    }
 
     if (pageLang) {
-      const existingFilters = searchParameters?.facetFilters ?? []
+      const existingFilters = searchParameters.facetFilters ?? []
       // Ensure facetFilters is always an array of strings for simplicity.
       searchParameters.facetFilters = Array.isArray(existingFilters)
         ? [...existingFilters, `lang:${pageLang}`]
         : [existingFilters, `lang:${pageLang}`].filter(Boolean)
 
       if (askAi) {
-        // Re-use the merged facetFilters from the search parameters so that
-        // Ask AI uses the same language filtering as the regular search.
-        askAi.searchParameters = { facetFilters: searchParameters.facetFilters }
+        // Merge language filters into Ask AI params; keep any existing keys.
+        askAi.searchParameters = {
+          ...(askAi.searchParameters ?? {}),
+          facetFilters: searchParameters.facetFilters,
+        }
       }
     }
 
@@ -211,30 +224,50 @@ const docsearchTranslations: DocSearchTranslationProps = {
     } as DocSearchProps
   }
 
+  /**
+   * Destroy any previous DocSearch instance and mount a fresh one into `host`.
+   *
+   * Soft navigations create a new `sl-doc-search` node while the module-level
+   * DocSearch JS (and its keyboard listeners) would otherwise stay tied to a
+   * removed DOM node. Jobs are serialized on `mountQueue` so concurrent
+   * connect/disconnect pairs cannot leave two live instances.
+   *
+   * @param host - The custom element that just connected (or reconnected).
+   * @returns Resolves when this host's mount attempt finishes. Failures from
+   *   dynamic import or `docsearch()` are logged and do not poison later mounts.
+   */
   async function mountDocSearch(host: HTMLElement) {
-    // Serialize mounts so rapid soft-navs cannot leave two live instances.
-    mountQueue = mountQueue.then(async () => {
-      if (!host.isConnected) return
-
-      // Already mounted on this exact host (e.g. reconnect without replacement).
-      if (activeContainer === host && activeInstance) return
-
-      if (activeInstance) {
+    // Recover from a prior rejected job so the chain never permanently stalls.
+    mountQueue = mountQueue
+      .catch(() => undefined)
+      .then(async () => {
         try {
-          activeInstance.destroy()
-        } catch {
-          // DocSearch may throw if the previous container was already removed.
+          if (!host.isConnected) return
+
+          // Already mounted on this exact host (e.g. reconnect without replacement).
+          if (activeContainer === host && activeInstance) return
+
+          if (activeInstance) {
+            try {
+              activeInstance.destroy()
+            } catch {
+              // DocSearch may throw if the previous container was already removed.
+            }
+            activeInstance = null
+            activeContainer = null
+          }
+
+          const { default: docsearch } = await import('@docsearch/js')
+          if (!host.isConnected) return
+
+          activeInstance = docsearch(buildOptions(host))
+          activeContainer = host
+        } catch (error) {
+          console.error('[sl-doc-search] Failed to mount Algolia DocSearch', error)
+          activeInstance = null
+          activeContainer = null
         }
-        activeInstance = null
-        activeContainer = null
-      }
-
-      const { default: docsearch } = await import('@docsearch/js')
-      if (!host.isConnected) return
-
-      activeInstance = docsearch(buildOptions(host))
-      activeContainer = host
-    })
+      })
     await mountQueue
   }
 


### PR DESCRIPTION
## Summary

- Fixes the site-wide header **Search** button (Algolia DocSearch) going dead after ClientRouter soft navigations.
- DocSearch only mounted on `DOMContentLoaded`, so soft-nav replaced the button with an unwired SSR shell. **Cmd+K** could still work from leftover keyboard listeners; click did not.
- Remounts on `connectedCallback`, destroys the previous instance, and mounts onto the host element.

### Isolation (important)

| Search UI | Touched? |
|-----------|----------|
| Header Algolia DocSearch (`vendor/docsearch/DocSearch.astro`) | **Yes** |
| Connectors overview search (`ProviderCatalog.astro`) | **No** |

Connectors catalog search was already fixed separately in #901. This PR does not change that path.

### Regression source

Introduced ~16 Jul with ClientRouter (#882) and removal of `transition:persist` on the search chrome (#884).

## Test plan

- [ ] Hard load any docs page → click **Search** → Algolia modal opens
- [ ] Soft-nav via secondary nav / product switch → click **Search** again → modal still opens
- [ ] **Cmd+K** still opens search after soft-nav
- [ ] Visit `/agentkit/connectors/` → catalog “Search connectors or tools…” still filters (unchanged)

## Preview

After Netlify builds this PR:

`https://deploy-preview-{PR_NUMBER}--scalekit-starlight.netlify.app/`

(Use any page header Search control to verify.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved documentation search reliability during client-side navigation.
  - Search now remounts correctly when pages or components reconnect.
  - Prevented duplicate search instances and stale search interfaces.
  - Preserved language-specific filtering and custom search translations across navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->