### PR TITLE
docs(product): sync Go SDK reference for UpdateLoginUserDetails two-value return

### DIFF
--- a/src/components/sdk-reference/saaskit/go/Auth.mdx
+++ b/src/components/sdk-reference/saaskit/go/Auth.mdx
@@ -24,8 +24,10 @@ req := &scalekit.UpdateLoginUserDetailsRequest{
 
 resp, err := client.Auth().UpdateLoginUserDetails(ctx, req)
 if err != nil {
-  // handle
+  // handle the error, then stop
+  return
 }
+// resp is non-nil only on success
 _ = resp.GetAuthRequestId()
 ```
 

--- a/src/components/sdk-reference/saaskit/go/Auth.mdx
+++ b/src/components/sdk-reference/saaskit/go/Auth.mdx
@@ -22,9 +22,11 @@ req := &scalekit.UpdateLoginUserDetailsRequest{
   },
 }
 
-if err := client.Auth().UpdateLoginUserDetails(ctx, req); err != nil {
+resp, err := client.Auth().UpdateLoginUserDetails(ctx, req)
+if err != nil {
   // handle
 }
+_ = resp.GetAuthRequestId()
 ```
 
 </CB.ClassBrowser>

--- a/src/components/sdk-reference/saaskit/go/Auth.mdx
+++ b/src/components/sdk-reference/saaskit/go/Auth.mdx
@@ -22,7 +22,7 @@ req := &scalekit.UpdateLoginUserDetailsRequest{
   },
 }
 
-resp, err := client.Auth().UpdateLoginUserDetails(ctx, req)
+resp, err := scalekitClient.Auth().UpdateLoginUserDetails(ctx, req)
 if err != nil {
   // handle the error, then stop
   return

--- a/src/content/docs/mcp/auth-methods/custom-auth.mdx
+++ b/src/content/docs/mcp/auth-methods/custom-auth.mdx
@@ -156,7 +156,7 @@ func updateLoggedInUserDetails() error {
 		os.Getenv("SCALEKIT_CLIENT_ID"),
 		os.Getenv("SCALEKIT_CLIENT_SECRET"),
 	)
-	err := skClient.Auth().UpdateLoginUserDetails(context.Background(), &scalekit.UpdateLoginUserDetailsRequest{
+	_, err := skClient.Auth().UpdateLoginUserDetails(context.Background(), &scalekit.UpdateLoginUserDetailsRequest{
 		ConnectionId:   "{{connection_id}}",
 		LoginRequestId: "{{login_request_id}}", // this value is dynamic per login
 		User: &scalekit.LoggedInUserDetails{

--- a/src/content/docs/saaskit/sdks/go/auth.mdx
+++ b/src/content/docs/saaskit/sdks/go/auth.mdx
@@ -34,8 +34,8 @@ These methods sit next to session management—use them when implementing hosted
       <CB.ClassMethodInput name="req" type="UpdateLoginUserDetailsRequest">
         Req.
       </CB.ClassMethodInput>
-      <CB.ClassMethodOutput type="error">
-        error
+      <CB.ClassMethodOutput type="(*UpdateLoginUserDetailsResponse, error)">
+        Response carrying the auth request ID (`resp.GetAuthRequestId()`), plus an error.
       </CB.ClassMethodOutput>
 
 ```go wrap showLineNumbers=false
@@ -48,9 +48,11 @@ req := &scalekit.UpdateLoginUserDetailsRequest{
   },
 }
 
-if err := scalekitClient.Auth().UpdateLoginUserDetails(ctx, req); err != nil {
+resp, err := scalekitClient.Auth().UpdateLoginUserDetails(ctx, req)
+if err != nil {
   // handle
 }
+_ = resp.GetAuthRequestId()
 ```
 
     </CB.ClassMethod>

--- a/src/content/docs/saaskit/sdks/go/auth.mdx
+++ b/src/content/docs/saaskit/sdks/go/auth.mdx
@@ -50,8 +50,10 @@ req := &scalekit.UpdateLoginUserDetailsRequest{
 
 resp, err := scalekitClient.Auth().UpdateLoginUserDetails(ctx, req)
 if err != nil {
-  // handle
+  // handle the error, then stop
+  return
 }
+// resp is non-nil only on success
 _ = resp.GetAuthRequestId()
 ```
 


### PR DESCRIPTION
**Why:** Shipped change in `scalekit-sdk-go@a937767` (#88, v2.8.0) drifts from the Go SDK docs. `Auth().UpdateLoginUserDetails` now returns `(*UpdateLoginUserDetailsResponse, error)` instead of `error` — a documented BREAKING change carrying `auth_request_id`. The docs taught the old single-return form `if err := ...UpdateLoginUserDetails(ctx, req); err != nil`, which no longer compiles against v2.8.0.

**What:** Surgical Go-only edits in three files — the SDK reference component (`src/components/sdk-reference/saaskit/go/Auth.mdx`), the Authorization reference page (`src/content/docs/saaskit/sdks/go/auth.mdx`, code sample + `ClassMethodOutput` type), and the BYOA MCP guide's Go tab (`src/content/docs/mcp/auth-methods/custom-auth.mdx`). Node and Python `updateLoginUserDetails` still compile unchanged (the new return value is additive there; old calls stay valid), so they are left as-is. Skills: docs-engineering, scalekit-code-doctor, docs-writing-style.

**Evidence:** merge `a937767d7bfef54caddbbcac5dde5f12304eaead` (#88). New snippet mirrors the SDK's own `REFERENCE.md` at that SHA: `resp, err := client.Auth().UpdateLoginUserDetails(ctx, req)` then `resp.GetAuthRequestId()`. OpenAPI/proto compared: n/a (SDK surface, not a contract change).

**Check:** Compared line-for-line against `scalekit-sdk-go/REFERENCE.md` at the merge SHA. verification: needs-human — run `go build` of the snippet against `github.com/scalekit-inc/scalekit-sdk-go/v2@v2.8.0`; the docs repo has no Go module to compile the sample in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4mMUUaAuEhc45pzAKmhjR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Go SDK authentication examples for `UpdateLoginUserDetails` to reflect the new return pattern: `(*UpdateLoginUserDetailsResponse, error)`.
  * Revised code samples to capture the response on success and handle errors with early returns.
  * Added/clarified how to retrieve the authentication request ID from the returned response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->