### PR TITLE
docs(product): document listAppConnections query filter in SDK reference

### DIFF
--- a/src/content/docs/saaskit/sdks/node/connections.mdx
+++ b/src/content/docs/saaskit/sdks/node/connections.mdx
@@ -121,7 +121,7 @@ response.connections.forEach(conn => {
       Lists app-level connections configured for the account (not scoped to an organization).
 
       <CB.ClassMethodInput name="params" type="object" hint="pageSize, pageToken, provider, query">
-        Common fields: `pageSize`, `pageToken`, `provider`. Pass `query` for a free-text search that matches connections by connection name or provider (3–100 characters).
+        Common fields: `pageSize`, `pageToken`, `provider`. Pass `query` for a free-text search that matches connections by connection name (key ID) or provider (3–100 characters).
       </CB.ClassMethodInput>
       <CB.ClassMethodOutput type="ListAppConnectionsResponse">
         Paginated connections.

--- a/src/content/docs/saaskit/sdks/node/connections.mdx
+++ b/src/content/docs/saaskit/sdks/node/connections.mdx
@@ -120,8 +120,8 @@ response.connections.forEach(conn => {
 
       Lists app-level connections configured for the account (not scoped to an organization).
 
-      <CB.ClassMethodInput name="params" type="object" hint="pageSize, pageToken, provider">
-        Required or common fields: `pageSize`, `pageToken`, `provider`.
+      <CB.ClassMethodInput name="params" type="object" hint="pageSize, pageToken, provider, query">
+        Common fields: `pageSize`, `pageToken`, `provider`. Pass `query` for a free-text search that matches connections by connection name or provider (3–100 characters).
       </CB.ClassMethodInput>
       <CB.ClassMethodOutput type="ListAppConnectionsResponse">
         Paginated connections.

--- a/src/content/docs/saaskit/sdks/python/connection.mdx
+++ b/src/content/docs/saaskit/sdks/python/connection.mdx
@@ -241,6 +241,9 @@ scalekit_client.connection.delete_connection('org_123456', 'conn_123456')
       <CB.ClassMethodInput name="provider" type="Optional[str]">
         Optional. Filter by provider (e.g. 'HUBSPOT')
       </CB.ClassMethodInput>
+      <CB.ClassMethodInput name="query" type="Optional[str]">
+        Optional. Free-text search matching connections by connection name (key ID) or provider (3–100 characters).
+      </CB.ClassMethodInput>
       <CB.ClassMethodOutput type="ListAppConnectionsResponse">
         List App Connections Response
       </CB.ClassMethodOutput>
@@ -253,6 +256,9 @@ for conn in response[0].connections:
 
 # Filter by provider
 response = scalekit_client.connection.list_app_connections(provider='HUBSPOT', page_size=10)
+
+# Search by connection name or provider
+response = scalekit_client.connection.list_app_connections(query='hubspot')
 ```
 
     </CB.ClassMethod>


### PR DESCRIPTION
**Why:** The SaaSKit SDK reference for `listAppConnections` / `list_app_connections` lists only `pageSize`, `pageToken`, and `provider`, but the SDKs shipped a `query` free-text search filter that the reference never documents.

**What:** Add the `query` parameter (3–100 chars; matches connections by connection name / key ID or provider) to two SDK reference pages, plus a search example on the Python page. Scoped to the SaaSKit `connection` client only — the AgentKit `actions` facade (`listConnections`) does not forward `query`, so its pages are untouched. Skills invoked: docs-engineering, scalekit-code-doctor, docs-writing-style.

- `src/content/docs/saaskit/sdks/node/connections.mdx`
- `src/content/docs/saaskit/sdks/python/connection.mdx`

**Evidence:** Param verified against shipped SDK source at `main`: Node `src/connection.ts` (`listAppConnections(params?: { pageSize?, pageToken?, provider?, query? })`, released 2.10.0+, SK-1262/#210) and Python `scalekit/connection.py` (`list_app_connections(..., query=None)` with docstring "matches by connection name (key ID) or provider, 3-100 characters", v2.15.0/#182). Backend contract: `ListAppConnectionsRequest.query` added at proto v0.1.138.0. proto/OpenAPI compared: n/a (SDK-reference MDX surface only).

**Check:** Docs-only MDX change reusing the existing `<CB.ClassMethodInput>` pattern. verification: needs-human — run `pnpm build` (Astro/Starlight) to confirm the SDK reference pages render. Preview once CI builds: https://deploy-preview-{PR_NUMBER}--scalekit-starlight.netlify.app/saaskit/sdks/python/connection/

---
_Generated by [Claude Code](https://claude.ai/code/session_01QWogsEceZf2Mfg3LgeekTq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that listing app connections supports free-text searches by connection name (key ID) or provider.
  * Updated the Node SDK guidance to include the `query` parameter and its search behavior.
  * Updated the Python SDK example to demonstrate using `query` for searching connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->