### PR TITLE
docs(agentkit): add OpenClaw MCP directory backlink

### DIFF
--- a/src/content/docs/agentkit/openclaw.mdx
+++ b/src/content/docs/agentkit/openclaw.mdx
@@ -7,18 +7,18 @@ sidebar:
   prev:
     label: "Claude Managed Agents"
     link: "/agentkit/examples/claude-managed-agents"
-  seeAlso:
-    expanded: true
-    items:
-      - title: "OpenClaw GitHub"
-        icon: "github"
-        url: "https://github.com/scalekit-inc/openclaw-skill"
-      - title: "ClawHub listing"
-        icon: "book"
-        url: "https://clawhub.dev/skills/scalekit-agent-auth"
-      - title: "OpenClaw MCP directory"
-        icon: "book"
-        url: "https://www.remoteopenclaw.com/plugins?q=scalekit+authstack"
+seeAlso:
+  expanded: true
+  items:
+    - title: "OpenClaw GitHub"
+      icon: "github"
+      url: "https://github.com/scalekit-inc/openclaw-skill"
+    - title: "ClawHub listing"
+      icon: "book"
+      url: "https://clawhub.dev/skills/scalekit-agent-auth"
+    - title: "OpenClaw MCP directory"
+      icon: "book"
+      url: "https://www.remoteopenclaw.com/plugins?q=scalekit+authstack"
 banner:
   content: |
     Join our dev community to connect with Scalekit engineers for questions or feedback

--- a/src/content/docs/agentkit/openclaw.mdx
+++ b/src/content/docs/agentkit/openclaw.mdx
@@ -16,6 +16,9 @@ sidebar:
       - title: "ClawHub listing"
         icon: "book"
         url: "https://clawhub.dev/skills/scalekit-agent-auth"
+      - title: "OpenClaw MCP directory"
+        icon: "book"
+        url: "https://www.remoteopenclaw.com/plugins?q=scalekit+authstack"
 banner:
   content: |
     Join our dev community to connect with Scalekit engineers for questions or feedback


### PR DESCRIPTION
## Summary

- Adds an expanded `seeAlso` item on `/agentkit/openclaw/` titled **OpenClaw MCP directory**
- Links to https://www.remoteopenclaw.com/plugins?q=scalekit+authstack as a reciprocal backlink

## Preview

https://deploy-preview-913--scalekit-starlight.netlify.app/agentkit/openclaw/

## Test plan

- [ ] Open the deploy preview for `/agentkit/openclaw/`
- [ ] Confirm the expanded seeAlso panel shows **OpenClaw MCP directory**
- [ ] Confirm the link opens the Remote OpenClaw plugins search for Scalekit AuthStack
- [ ] Confirm existing seeAlso items (OpenClaw GitHub, ClawHub listing) are unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an “OpenClaw MCP directory” reference link to the OpenClaw documentation page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->