### PR TITLE
fix(docs): correct IdP-init SSO code snippet marker overlap

### DIFF
--- a/src/content/docs/sso/guides/idp-init-sso.mdx
+++ b/src/content/docs/sso/guides/idp-init-sso.mdx
@@ -80,7 +80,7 @@ Use the extracted parameters to initiate a new SSO request. This converts the Id
 <Tabs syncKey="tech-stack">
 <TabItem value="nodejs" label="Node.js">
 
-```javascript title="Express.js" collapse={1-4,20-24} {"Extract JWT claims": 7-8} {"Generate authorization URL": 13-16}
+```javascript title="Express.js" collapse={1-5} {"Extract JWT claims":18-26} {"Generate authorization URL":34-39}
 // Security: ALWAYS verify requests are from Scalekit before processing
 // This prevents unauthorized parties from triggering your interceptor logic
 
@@ -136,7 +136,7 @@ app.get('/login', async (req, res) => {
 </TabItem>
 <TabItem value="python" label="Python">
 
-```python title="Flask" collapse={1-6,25-28} {"Extract JWT claims": 10-12} {"Generate authorization URL": 17-20}
+```python title="Flask" collapse={1-5} {"Extract JWT claims":21-24} {"Generate authorization URL":42-47}
 # Security: ALWAYS verify requests are from Scalekit before processing
 # This prevents unauthorized parties from triggering your interceptor logic
 
@@ -197,7 +197,7 @@ def login():
 </TabItem>
 <TabItem value="golang" label="Go">
 
-```go title="Gin" collapse={1-8,35-38} {"Extract JWT claims": 12-15} {"Generate authorization URL": 20-28}
+```go title="Gin" collapse={1-5} {"Extract JWT claims":23-30} {"Generate authorization URL":46-52}
 // Security: ALWAYS verify requests are from Scalekit before processing
 // This prevents unauthorized parties from triggering your interceptor logic
 
@@ -263,7 +263,7 @@ func (a *App) handleLogin(c *gin.Context) {
 </TabItem>
 <TabItem value="java" label="Java">
 
-```java title="Spring Boot" collapse={1-8,45-48} {"Extract JWT claims": 13-16} {"Generate authorization URL": 23-38}
+```java title="Spring Boot" collapse={1-5} {"Extract JWT claims":23-33} {"Generate authorization URL":49-53}
 // Security: ALWAYS verify requests are from Scalekit before processing
 // This prevents unauthorized parties from triggering your interceptor logic
 


### PR DESCRIPTION
## Summary
- Fixes Expressive Code label line ranges on the IdP-initiated SSO implementation examples so annotations no longer overlap code.
- Markers for **Extract JWT claims** and **Generate authorization URL** now start on blank lines and highlight the correct sections in Node.js, Python, Go, and Java.
- Simplifies collapse ranges to only hide the security/use-case preamble.

## Preview
https://deploy-preview-914--scalekit-starlight.netlify.app/sso/guides/idp-init-sso/

## Test plan
- [ ] Open the deploy preview for `/sso/guides/idp-init-sso/`
- [ ] Check Node.js, Python, Go, and Java tabs under Implementation examples
- [ ] Confirm labels sit above the code (no text-over-code overlap)
- [ ] Confirm labels highlight JWT claims extraction and authorization URL generation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SSO implementation examples for Express.js, Python, Go, and Java.
  * Improved code block collapsing and inline step callout highlighting for clearer guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->