### PR TITLE
docs(product): sync Node/Python SDK reference for updateLoginUserDetails return type

### DIFF
--- a/src/content/docs/saaskit/sdks/node/auth.mdx
+++ b/src/content/docs/saaskit/sdks/node/auth.mdx
@@ -38,12 +38,12 @@ These methods sit next to session management—use them when implementing hosted
       <CB.ClassMethodInput name="user" type="UserInput">
         User profile fields.
       </CB.ClassMethodInput>
-      <CB.ClassMethodOutput type="object" hint="MessageShape(typeof EmptySchema)">
-        Empty response on successful update
+      <CB.ClassMethodOutput type="UpdateLoginUserDetailsResponse">
+        Response containing the auth request ID (`response.authRequestId`), which you can use to look up the user's authentication journey in the auth logs.
       </CB.ClassMethodOutput>
 
 ```typescript wrap showLineNumbers=false
-await scalekit.auth.updateLoginUserDetails(
+const response = await scalekit.auth.updateLoginUserDetails(
   'conn_abc123',
   'login_xyz789',
   {
@@ -51,6 +51,9 @@ await scalekit.auth.updateLoginUserDetails(
     sub: 'unique_user_id_456',
   }
 );
+
+// The auth request ID can be used to look up the authentication journey via auth logs.
+console.log(response.authRequestId);
 ```
 
     </CB.ClassMethod>

--- a/src/content/docs/saaskit/sdks/python/auth.mdx
+++ b/src/content/docs/saaskit/sdks/python/auth.mdx
@@ -38,12 +38,12 @@ These methods sit next to session management—use them when implementing hosted
       <CB.ClassMethodInput name="user" type="Optional[Mapping[str, Any]]">
         User profile fields.
       </CB.ClassMethodInput>
-      <CB.ClassMethodOutput type="Empty">
-        The updated resource.
+      <CB.ClassMethodOutput type="Tuple[UpdateLoginUserDetailsResponse, grpc.Call]">
+        Tuple of the response (carrying `auth_request_id`) and the gRPC call metadata. Use the auth request ID to look up the user's authentication journey in the auth logs.
       </CB.ClassMethodOutput>
 
 ```python wrap showLineNumbers=false
-scalekit_client.auth.update_login_user_details(
+response = scalekit_client.auth.update_login_user_details(
     'conn_abc123',
     'login_xyz789',
     {
@@ -51,6 +51,9 @@ scalekit_client.auth.update_login_user_details(
         'sub': 'unique_user_id_456',
     }
 )
+
+# The auth request ID can be used to look up the authentication journey via auth logs.
+print(response[0].auth_request_id)
 ```
 
     </CB.ClassMethod>


### PR DESCRIPTION
**Why:** Shipped change in `scalekit-sdk-node`@`8fd1e4e` (v2.11.0, PR #210) and `scalekit-sdk-python`@`67e8d99` (v2.16.0, PR #187) changed `updateLoginUserDetails` / `update_login_user_details` to return `UpdateLoginUserDetailsResponse` (carrying the auth request ID) instead of `Empty`. The SaaSKit SDK reference still taught the old `Empty` return, so developers could not discover `authRequestId` / `auth_request_id`. The Go page was already synced in #908; this completes the cross-SDK sync.

**What:** Surgical edit to two SDK reference pages — `src/content/docs/saaskit/sdks/node/auth.mdx` and `src/content/docs/saaskit/sdks/python/auth.mdx`. Updated `CB.ClassMethodOutput` type + description and the example to capture the response and read the auth request ID. Node example reads `response.authRequestId`; Python example reads `response[0].auth_request_id` (the tuple `(response, grpc.Call)` returned via `.with_call`). Skills: docs-engineering, scalekit-code-doctor, docs-writing-style.

**Evidence:** node `8fd1e4e` / PR #210 (`Promise<UpdateLoginUserDetailsResponse>`, `response.authRequestId`); python `67e8d99` / PR #187 (`response[0].auth_request_id`). Both examples mirror the shipped SDK `REFERENCE.md` verbatim. Proto/OpenAPI compared: n/a (SDK reference surface, not OpenAPI).

**Check:** Compared each page against the shipped SDK source (`src/auth.ts`, `scalekit/auth.py`) and each SDK's `REFERENCE.md` at the merged SHA. verification: needs-human — run `pnpm build` to confirm the MDX/ClassBrowser renders.

---
_Generated by [Claude Code](https://claude.ai/code/session_011eUJH7QyzNfF7DF2hmrU6s)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Node.js SDK documentation to reflect the response returned by `updateLoginUserDetails`, including the authentication request ID.
  * Updated Python SDK documentation to describe the returned response and gRPC metadata.
  * Revised examples to show how to capture, print, and use the authentication request ID for log lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->