### PR TITLE
docs(product): update Java SDK reference for updateLoginUserDetails

### DIFF
--- a/src/content/docs/saaskit/sdks/java/auth.mdx
+++ b/src/content/docs/saaskit/sdks/java/auth.mdx
@@ -160,5 +160,48 @@ String accessToken = result.getAccessToken();
   </CB.ClassBrowser>
 </div>
 
+### updateLoginUserDetails
+<div class="sdk-method-section">
+  <CB.ClassBrowser name="Auth" type="client" language="java" source="https://github.com/scalekit-inc/scalekit-sdk-java/blob/main/src/main/java/com/scalekit/api/LoginClient.java">
+    <CB.ClassMethod name="updateLoginUserDetails" open={true}>
+
+      Updates the user details for an in-progress login request, for example after collecting additional profile information, or marking the login as failed with `User.newBuilder().setLoginFailed(true)`.
+
+      <CB.ClassMethodInput name="connectionId" type="String">
+        The connection ID the login request belongs to.
+      </CB.ClassMethodInput>
+      <CB.ClassMethodInput name="loginRequestId" type="String">
+        The login request ID being updated.
+      </CB.ClassMethodInput>
+      <CB.ClassMethodInput name="user" type="User">
+        The user details to apply to the login request.
+      </CB.ClassMethodInput>
+      <CB.ClassMethodOutput type="UpdateLoginUserDetailsResult">
+        Result carrying the auth request ID (`result.getAuthRequestId()`), which you can use to look up the user's authentication journey in the auth logs.
+      </CB.ClassMethodOutput>
+
+```java wrap showLineNumbers=false
+import com.scalekit.grpc.scalekit.v1.auth.User;
+import com.scalekit.internal.http.UpdateLoginUserDetailsResult;
+
+User user = User.newBuilder()
+  .setSub("unique_user_id_456")
+  .setEmail("john.doe@company.com")
+  .build();
+
+UpdateLoginUserDetailsResult result = scalekitClient.login().updateLoginUserDetails(
+  "conn_abc123",
+  "login_xyz789",
+  user
+);
+
+// The auth request ID can be used to look up the authentication journey via auth logs.
+String authRequestId = result.getAuthRequestId();
+```
+
+    </CB.ClassMethod>
+  </CB.ClassBrowser>
+</div>
+
 
 </div>


### PR DESCRIPTION
**Why:** The typed `UpdateLoginUserDetailsResponse` (auth request ID) landed in proto `v0.1.139.x` (scalekit-inc/scalekit#2438, SK-1314). The Node (developer-docs#915) and Go (developer-docs#908) SDK references were synced for it, but the Java reference at `src/content/docs/saaskit/sdks/java/auth.mdx` never documented `updateLoginUserDetails` at all — a cross-SDK reference gap for a public method the Java SDK ships.

**What:** Surgical edit — add one `### updateLoginUserDetails` ClassBrowser section to the existing Java `auth.mdx`, mirroring the Node/Go blocks. No new page, nav, or sidebar changes. Method surface verified against `scalekit-sdk-java` `LoginClient.java` / `ScalekitLoginClient.java` / `UpdateLoginUserDetailsResult.java` and the SDK `REFERENCE.md`: `scalekitClient.login().updateLoginUserDetails(connectionId, loginRequestId, user) -> UpdateLoginUserDetailsResult` with `result.getAuthRequestId()`. Skills: docs-engineering, docs-writing-style.

**Evidence:** SDK source at ref `58242fca4c5a597a5b678bb6ebf56fe5009da537`; contract change scalekit-inc/scalekit#2438. Proto/OpenAPI compared: n/a (SDK-reference sync, verified against generated Java SDK surface + REFERENCE.md, not OpenAPI).

**Check:** `pnpm build` renders the page (Starlight + ClassBrowser). Deploy preview: `https://deploy-preview-{PR_NUMBER}--scalekit-starlight.netlify.app/saaskit/sdks/java/auth/`. verification: needs-human (no docs toolchain in this run) — command: `pnpm build`.

---
_Generated by [Claude Code](https://claude.ai/code/session_016dSjtHLFmztjYgzy6Z4a2u)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Java SDK documentation for updating user details during an in-progress login request.
  * Included required parameters, return type, and a usage example showing how to retrieve the authentication request ID for log lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->