### PR TITLE
docs(product): update Node SDK reference for listConnectedAccounts connectionNames filter

### DIFF
--- a/src/content/docs/agentkit/sdks/node/actions.mdx
+++ b/src/content/docs/agentkit/sdks/node/actions.mdx
@@ -60,8 +60,8 @@ await scalekit.actions.verifyConnectedAccountUser({
 
       List connected accounts with optional filters.
 
-      <CB.ClassMethodInput name="params" type="object" hint="connectionName, identifier, provider, organizationId, userId, pageSize, pageToken, query">
-        Required or common fields: `connectionName`, `identifier`, `provider`, `organizationId`, `userId`, `pageSize`, `pageToken`, `query`.
+      <CB.ClassMethodInput name="params" type="object" hint="connectionName, identifier, provider, organizationId, userId, pageSize, pageToken, query, connectionNames">
+        Common fields: `connectionName`, `identifier`, `provider`, `organizationId`, `userId`, `pageSize`, `pageToken`, `query`. Pass `connectionNames` (string array) to filter to connected accounts belonging to any of the listed connections (exact match, max 20).
       </CB.ClassMethodInput>
       <CB.ClassMethodOutput type="ListConnectedAccountsResponse">
         Paginated connected accounts.


### PR DESCRIPTION
**Why:** The shipped Node SDK `ActionsClient.listConnectedAccounts` accepts a `connectionNames` string-array filter (scalekit-sdk-node `src/actions.ts`, forwarded from `src/connected-accounts.ts`), but the Node AgentKit SDK reference at `src/content/docs/agentkit/sdks/node/actions.mdx` did not list it. The Python reference (`agentkit/sdks/python/actions.mdx` → `connection_names`) and the published AgentKit OpenAPI (`public/api/agentkit.scalar.yaml` → `connection_names`) already document it, so the Node page was the lone out-of-sync surface.

**What:** Surgical edit to one method block — added `connectionNames` to the `listConnectedAccounts` params hint and description, matching the existing SaaSKit Node "Common fields … Pass `x` for …" idiom. No other methods, files, or pages touched. Skills: docs-engineering, api-reference.

**Evidence:** Node SDK filter added in scalekit-sdk-node#206; backend contract in scalekit#2415 (`ListConnectedAccounts` / `connection_names`). Node source at `main` (`src/connected-accounts.ts` `listConnectedAccounts` params include `connectionNames?: string[]`) confirms the surface. OpenAPI/proto compared: yes — `connection_names` present in `public/api/agentkit.scalar.yaml` with matching "max 20 names, cannot combine with `connector`" semantics.

**Check:** Text-only change inside an existing, valid `<CB.ClassMethodInput>` block (no structural MDX change). verification: needs-human — run `pnpm build` (or `pnpm start` and open `/agentkit/sdks/node/actions/`) to confirm the ClassBrowser renders the new field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZ4eVpK6rk5z571yTVJuzW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `listConnectedAccounts` documentation to include the `connectionNames` filter.
  * Clarified that the filter supports exact matches and up to 20 connection names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->