### PR TITLE
docs(signal): explain CSP block when embedding admin portal

### DIFF
--- a/src/content/docs/guides/admin-portal.mdx
+++ b/src/content/docs/guides/admin-portal.mdx
@@ -219,12 +219,16 @@ Embed the portal in your application's settings or admin section where customers
 
 | Setting | Requirement |
 | ------- | ----------- |
-| **Redirect URI** | Add your application domain at **Dashboard > Authentication > Redirect URLs > Allowed callback URLs** |
+| **Redirect URI** | Register the domain that hosts the iframe (your application's own domain) as an **Allowed callback URL** at **Dashboard > Authentication > Redirect URLs** |
 | **iframe attributes** | Include `allow="clipboard-write"` for copy-paste functionality |
 | **Dimensions** | Minimum recommended height: 600px |
 | **Link expiration** | Generated links expire after 1 minute if not loaded |
 | **Session duration** | Portal session remains active for up to 6 hours once loaded |
 | **Single-use** | Each generated link can only be used once to initialize a session |
+
+<Aside type="caution" title="Register the embedding domain">
+The embedded portal loads only on domains you have registered. The domain of the page that hosts the iframe must be listed as an allowed callback URL (see the table above). If it is missing, the browser blocks the portal with a Content Security Policy (`frame-ancestors`) error and the iframe stays blank.
+</Aside>
 
 <Aside type="tip" title="Generate fresh links">
 Generate a new portal link on each page load rather than caching the URL. This ensures security and prevents expired link errors.

--- a/src/content/docs/guides/admin-portal.mdx
+++ b/src/content/docs/guides/admin-portal.mdx
@@ -219,7 +219,7 @@ Embed the portal in your application's settings or admin section where customers
 
 | Setting | Requirement |
 | ------- | ----------- |
-| **Redirect URI** | Register the domain that hosts the iframe (your application's own domain) as an **Allowed callback URL** at **Dashboard > Authentication > Redirect URLs** |
+| **Redirect URI** | Register the domain that hosts the iframe (your application's own domain) as an **Allowed callback URL** at **Dashboard > Authentication > Redirects > Allowed Callback URLs** |
 | **iframe attributes** | Include `allow="clipboard-write"` for copy-paste functionality |
 | **Dimensions** | Minimum recommended height: 600px |
 | **Link expiration** | Generated links expire after 1 minute if not loaded |


### PR DESCRIPTION
**Why:** A few users hit a Content Security Policy error when embedding the admin portal iframe and could not tell why the portal stayed blank. The embed guide listed the redirect-URL setting but never explained that the page's own (parent) domain must be registered, or that a missing entry blocks the iframe via CSP `frame-ancestors`.

**What:** Surgical edit in `src/content/docs/guides/admin-portal.mdx`. Clarified the "Redirect URI" row to name the embedding (parent) domain, and added one `caution` Aside describing the CSP `frame-ancestors` failure mode. No new page, no nav change. Skills applied: docs-engineering, docs-contribution-router, docs-writing-style.

**Check:** Open the Admin portal guide, "Embed the admin portal" > "Configuration and session"; confirm the caution explains that an unregistered parent domain triggers a CSP block and the fix is to add that domain as an allowed callback URL.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Roq1GSNqtF7jy91qriL4hh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that embedded admin portals require registering the iframe-hosting domain as an Allowed callback URL.
  - Added a caution that the portal loads only on registered domains.
  - Documented the browser `frame-ancestors` error and resulting blank iframe when the domain isn’t registered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->