### PR TITLE
docs(product): sync openapi after user update contract change

### DIFF
--- a/openapi/scalekit.yaml
+++ b/openapi/scalekit.yaml
@@ -5227,6 +5227,12 @@ paths:
           name: id
           in: path
           required: true
+        - schema:
+            type: string
+            format: field-mask
+          description: Optional. By default, every field present in `user` is updated automatically - this mask is not required for ordinary updates, including clearing a field via an empty string. Set it explicitly only if you want to control precisely which fields are touched.
+          name: update_mask
+          in: query
       responses:
         '200':
           description: User updated successfully. Returns the modified user object with updated timestamps.
@@ -5518,6 +5524,12 @@ paths:
           name: external_id
           in: path
           required: true
+        - schema:
+            type: string
+            format: field-mask
+          description: Optional. By default, every field present in `user` is updated automatically - this mask is not required for ordinary updates, including clearing a field via an empty string. Set it explicitly only if you want to control precisely which fields are touched.
+          name: update_mask
+          in: query
       responses:
         '200':
           description: User updated successfully. Returns the modified user object with updated timestamps.
@@ -9968,6 +9980,14 @@ components:
           examples:
             - department: engineering
               security_clearance: level2
+        email_verified:
+          type: boolean
+          readOnly: true
+        external_identities:
+          type: array
+          items:
+            $ref: '#/components/schemas/commonsExternalIdentity'
+          readOnly: true
         family_name:
           description: Updates the user's family name (last name or surname). Use this field to modify how the user's last name appears throughout the system. Maximum 255 characters allowed.
           type: string
@@ -9996,6 +10016,14 @@ components:
           examples:
             - - engineering
               - managers
+        id:
+          description: |-
+            id, email_verified, phone_number_verified, and external_identities are OUTPUT_ONLY -
+            never written by an update. They exist here (rather than reserved/absent) solely so a
+            client that reads a profile and PATCHes the same object back (a common pattern) doesn't
+            get a validation error for including fields your own GET response returned.
+          type: string
+          readOnly: true
         last_name:
           description: "[DEPRECATED] Use family_name instead. User's family name. Maximum 200 characters."
           type: string
@@ -10024,6 +10052,9 @@ components:
           type: string
           examples:
             - '+14155552671'
+        phone_number_verified:
+          type: boolean
+          readOnly: true
         picture:
           description: Updates the URL to the user's profile picture or avatar image. Use this field to set or change the user's profile photo that appears in user interfaces, directory listings, and collaborative features. The URL should point to a publicly accessible image file. Supported formats typically include JPEG, PNG, and GIF. Maximum URL length is 2048 characters.
           type: string
@@ -10541,11 +10572,39 @@ components:
     v1usersUpdateUser:
       type: object
       properties:
+        create_time:
+          type: string
+          format: date-time
+          readOnly: true
+        email:
+          type: string
+          readOnly: true
+        environment_id:
+          type: string
+          readOnly: true
         external_id:
-          description: Your application's unique identifier for this organization, used to link Scalekit with your system.
+          description: Your application's unique identifier for this user, used to link Scalekit with your system.
           type: string
           examples:
             - ext_12345a67b89c
+        id:
+          description: |-
+            id, environment_id, create_time, update_time, email, memberships, and last_login_time are
+            OUTPUT_ONLY - never written by an update. They exist here (rather than reserved/absent) so
+            that a client which reads a User and PATCHes the same object back (a common read-modify-
+            write pattern) doesn't get a validation error for including fields its own GET response
+            returned.
+          type: string
+          readOnly: true
+        last_login_time:
+          type: string
+          format: date-time
+          readOnly: true
+        memberships:
+          type: array
+          items:
+            $ref: '#/components/schemas/commonsOrganizationMembership'
+          readOnly: true
         metadata:
           description: Custom key-value pairs for storing additional user context. Keys (3-25 chars), values (1-256 chars).
           type: object
@@ -10554,6 +10613,10 @@ components:
           examples:
             - department: engineering
               location: nyc-office
+        update_time:
+          type: string
+          format: date-time
+          readOnly: true
         user_profile:
           description: User's personal information including name, address, and other profile attributes.
           $ref: '#/components/schemas/usersUpdateUserProfile'

--- a/public/api/saaskit.scalar.json
+++ b/public/api/saaskit.scalar.json
@@ -4793,6 +4793,15 @@
             "name": "id",
             "in": "path",
             "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "field-mask"
+            },
+            "description": "Optional. By default, every field present in `user` is updated automatically - this mask is not required for ordinary updates, including clearing a field via an empty string. Set it explicitly only if you want to control precisely which fields are touched.",
+            "name": "update_mask",
+            "in": "query"
           }
         ],
         "responses": {
@@ -5073,6 +5082,15 @@
             "name": "external_id",
             "in": "path",
             "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "field-mask"
+            },
+            "description": "Optional. By default, every field present in `user` is updated automatically - this mask is not required for ordinary updates, including clearing a field via an empty string. Set it explicitly only if you want to control precisely which fields are touched.",
+            "name": "update_mask",
+            "in": "query"
           }
         ],
         "responses": {
@@ -10911,6 +10929,17 @@
               }
             ]
           },
+          "email_verified": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "external_identities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/commonsExternalIdentity"
+            },
+            "readOnly": true
+          },
           "family_name": {
             "description": "Updates the user's family name (last name or surname). Use this field to modify how the user's last name appears throughout the system. Maximum 255 characters allowed.",
             "type": "string",
@@ -10938,6 +10967,11 @@
               "type": "string"
             },
             "examples": [["engineering", "managers"]]
+          },
+          "id": {
+            "description": "id, email_verified, phone_number_verified, and external_identities are OUTPUT_ONLY -\nnever written by an update. They exist here (rather than reserved/absent) solely so a\nclient that reads a profile and PATCHes the same object back (a common pattern) doesn't\nget a validation error for including fields your own GET response returned.",
+            "type": "string",
+            "readOnly": true
           },
           "last_name": {
             "description": "[DEPRECATED] Use family_name instead. User's family name. Maximum 200 characters.",
@@ -10971,6 +11005,10 @@
             "description": "Updates the user's phone number in E.164 international format. Use this field to enable SMS-based authentication methods, two-factor authentication, or phone-based account recovery. The phone number must include the country code and be formatted according to E.164 standards (e.g., `+1` for US numbers). This field is required when enabling SMS authentication features.",
             "type": "string",
             "examples": ["+14155552671"]
+          },
+          "phone_number_verified": {
+            "type": "boolean",
+            "readOnly": true
           },
           "picture": {
             "description": "Updates the URL to the user's profile picture or avatar image. Use this field to set or change the user's profile photo that appears in user interfaces, directory listings, and collaborative features. The URL should point to a publicly accessible image file. Supported formats typically include JPEG, PNG, and GIF. Maximum URL length is 2048 characters.",
@@ -11442,10 +11480,40 @@
       "v1usersUpdateUser": {
         "type": "object",
         "properties": {
+          "create_time": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "email": {
+            "type": "string",
+            "readOnly": true
+          },
+          "environment_id": {
+            "type": "string",
+            "readOnly": true
+          },
           "external_id": {
-            "description": "Your application's unique identifier for this organization, used to link Scalekit with your system.",
+            "description": "Your application's unique identifier for this user, used to link Scalekit with your system.",
             "type": "string",
             "examples": ["ext_12345a67b89c"]
+          },
+          "id": {
+            "description": "id, environment_id, create_time, update_time, email, memberships, and last_login_time are\nOUTPUT_ONLY - never written by an update. They exist here (rather than reserved/absent) so\nthat a client which reads a User and PATCHes the same object back (a common read-modify-\nwrite pattern) doesn't get a validation error for including fields its own GET response\nreturned.",
+            "type": "string",
+            "readOnly": true
+          },
+          "last_login_time": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "memberships": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/commonsOrganizationMembership"
+            },
+            "readOnly": true
           },
           "metadata": {
             "description": "Custom key-value pairs for storing additional user context. Keys (3-25 chars), values (1-256 chars).",
@@ -11459,6 +11527,11 @@
                 "location": "nyc-office"
               }
             ]
+          },
+          "update_time": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
           },
           "user_profile": {
             "description": "User's personal information including name, address, and other profile attributes.",

--- a/public/api/scalekit.scalar.json
+++ b/public/api/scalekit.scalar.json
@@ -6091,6 +6091,15 @@
             "name": "id",
             "in": "path",
             "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "field-mask"
+            },
+            "description": "Optional. By default, every field present in `user` is updated automatically - this mask is not required for ordinary updates, including clearing a field via an empty string. Set it explicitly only if you want to control precisely which fields are touched.",
+            "name": "update_mask",
+            "in": "query"
           }
         ],
         "responses": {
@@ -6371,6 +6380,15 @@
             "name": "external_id",
             "in": "path",
             "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "field-mask"
+            },
+            "description": "Optional. By default, every field present in `user` is updated automatically - this mask is not required for ordinary updates, including clearing a field via an empty string. Set it explicitly only if you want to control precisely which fields are touched.",
+            "name": "update_mask",
+            "in": "query"
           }
         ],
         "responses": {
@@ -13518,6 +13536,17 @@
               }
             ]
           },
+          "email_verified": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "external_identities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/commonsExternalIdentity"
+            },
+            "readOnly": true
+          },
           "family_name": {
             "description": "Updates the user's family name (last name or surname). Use this field to modify how the user's last name appears throughout the system. Maximum 255 characters allowed.",
             "type": "string",
@@ -13545,6 +13574,11 @@
               "type": "string"
             },
             "examples": [["engineering", "managers"]]
+          },
+          "id": {
+            "description": "id, email_verified, phone_number_verified, and external_identities are OUTPUT_ONLY -\nnever written by an update. They exist here (rather than reserved/absent) solely so a\nclient that reads a profile and PATCHes the same object back (a common pattern) doesn't\nget a validation error for including fields your own GET response returned.",
+            "type": "string",
+            "readOnly": true
           },
           "last_name": {
             "description": "[DEPRECATED] Use family_name instead. User's family name. Maximum 200 characters.",
@@ -13578,6 +13612,10 @@
             "description": "Updates the user's phone number in E.164 international format. Use this field to enable SMS-based authentication methods, two-factor authentication, or phone-based account recovery. The phone number must include the country code and be formatted according to E.164 standards (e.g., `+1` for US numbers). This field is required when enabling SMS authentication features.",
             "type": "string",
             "examples": ["+14155552671"]
+          },
+          "phone_number_verified": {
+            "type": "boolean",
+            "readOnly": true
           },
           "picture": {
             "description": "Updates the URL to the user's profile picture or avatar image. Use this field to set or change the user's profile photo that appears in user interfaces, directory listings, and collaborative features. The URL should point to a publicly accessible image file. Supported formats typically include JPEG, PNG, and GIF. Maximum URL length is 2048 characters.",
@@ -14208,10 +14246,40 @@
       "v1usersUpdateUser": {
         "type": "object",
         "properties": {
+          "create_time": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "email": {
+            "type": "string",
+            "readOnly": true
+          },
+          "environment_id": {
+            "type": "string",
+            "readOnly": true
+          },
           "external_id": {
-            "description": "Your application's unique identifier for this organization, used to link Scalekit with your system.",
+            "description": "Your application's unique identifier for this user, used to link Scalekit with your system.",
             "type": "string",
             "examples": ["ext_12345a67b89c"]
+          },
+          "id": {
+            "description": "id, environment_id, create_time, update_time, email, memberships, and last_login_time are\nOUTPUT_ONLY - never written by an update. They exist here (rather than reserved/absent) so\nthat a client which reads a User and PATCHes the same object back (a common read-modify-\nwrite pattern) doesn't get a validation error for including fields its own GET response\nreturned.",
+            "type": "string",
+            "readOnly": true
+          },
+          "last_login_time": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
+          },
+          "memberships": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/commonsOrganizationMembership"
+            },
+            "readOnly": true
           },
           "metadata": {
             "description": "Custom key-value pairs for storing additional user context. Keys (3-25 chars), values (1-256 chars).",
@@ -14225,6 +14293,11 @@
                 "location": "nyc-office"
               }
             ]
+          },
+          "update_time": {
+            "type": "string",
+            "format": "date-time",
+            "readOnly": true
           },
           "user_profile": {
             "description": "User's personal information including name, address, and other profile attributes.",


### PR DESCRIPTION
**Why:** Shipped change in `scalekit@0170b5e3` (#2462, proto v0.1.140.0) added an optional `update_mask` field and several OUTPUT_ONLY echo fields to the Update User contract, and fixed a copy bug on `external_id`. The developer-docs OpenAPI copy still taught the old shape (no `update_mask`, `external_id` mislabeled "for this organization"), so the Users → Update user reference in Scalar drifted from the shipped API.

**What:** Surgical merge into `openapi/scalekit.yaml` (plus regenerated `saaskit`/`scalekit` Scalar JSON bundles):
- Add optional `update_mask` query param to both Update User bindings (`UserService_UpdateUser`, `UserService_UpdateUser2`).
- Fix `v1usersUpdateUser.external_id` description: "for this organization" → "for this user".
- Add read-only OUTPUT_ONLY fields to `v1usersUpdateUser` (`id`, `environment_id`, `create_time`, `update_time`, `email`, `memberships`, `last_login_time`) and `usersUpdateUserProfile` (`id`, `email_verified`, `phone_number_verified`, `external_identities`), so a read-modify-write PATCH of a full user object no longer looks invalid in the reference.

Intentionally untouched: the MembersService update endpoints (internal — not published in the reference), and the `NO_AUTH` connector enum (already synced in #902). The `id` field descriptions mirror the generated contract minus one internal Go implementation-path sentence that should not surface in public API docs. `.yaml` Scalar artifacts regenerate on the `build` step (`bundle:apis`), so only the consumed `.json` bundles are committed here to avoid unrelated redocly quote-style churn.

Skills: docs-engineering, api-reference, docs-writing-style.

**Evidence:** `scalekit@0170b5e3` (#2462) — `proto/scalekit/v1/users/users.proto`, `third_party/OpenAPI/scalekit.openapi.yaml`, `third_party/OpenAPI/scalekit.swagger.json`. OpenAPI/proto compared at that SHA: yes. Field names and read-only semantics mirror the generated OpenAPI/swagger definitions (`v1usersUpdateUser`, `usersUpdateUserProfile`, `commonsExternalIdentity`, `commonsOrganizationMembership`).

**Check:** `pnpm run bundle:apis && pnpm run validate-api-split` → clean partition (combined=107, agentkit=20, saaskit=87, overlap=0). Bundles re-generate cleanly with all new fields and referenced components present. verification: ran `bundle:apis` + `validate-api-split` locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3QSnZeLHh2zVVTyhUoZio)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional field masks to user update requests, allowing callers to specify exactly which fields to modify.
  * Expanded user update responses with additional read-only profile and account details.
  * Improved support for updating previously retrieved user objects without validation issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->