### PR TITLE
docs(product): revert user update_mask and output-only fields after BE rollback

### DIFF
--- a/openapi/scalekit.yaml
+++ b/openapi/scalekit.yaml
@@ -5227,12 +5227,6 @@ paths:
           name: id
           in: path
           required: true
-        - schema:
-            type: string
-            format: field-mask
-          description: Optional. By default, every field present in `user` is updated automatically - this mask is not required for ordinary updates, including clearing a field via an empty string. Set it explicitly only if you want to control precisely which fields are touched.
-          name: update_mask
-          in: query
       responses:
         '200':
           description: User updated successfully. Returns the modified user object with updated timestamps.
@@ -5524,12 +5518,6 @@ paths:
           name: external_id
           in: path
           required: true
-        - schema:
-            type: string
-            format: field-mask
-          description: Optional. By default, every field present in `user` is updated automatically - this mask is not required for ordinary updates, including clearing a field via an empty string. Set it explicitly only if you want to control precisely which fields are touched.
-          name: update_mask
-          in: query
       responses:
         '200':
           description: User updated successfully. Returns the modified user object with updated timestamps.
@@ -9980,14 +9968,6 @@ components:
           examples:
             - department: engineering
               security_clearance: level2
-        email_verified:
-          type: boolean
-          readOnly: true
-        external_identities:
-          type: array
-          items:
-            $ref: '#/components/schemas/commonsExternalIdentity'
-          readOnly: true
         family_name:
           description: Updates the user's family name (last name or surname). Use this field to modify how the user's last name appears throughout the system. Maximum 255 characters allowed.
           type: string
@@ -10016,14 +9996,6 @@ components:
           examples:
             - - engineering
               - managers
-        id:
-          description: |-
-            id, email_verified, phone_number_verified, and external_identities are OUTPUT_ONLY -
-            never written by an update. They exist here (rather than reserved/absent) solely so a
-            client that reads a profile and PATCHes the same object back (a common pattern) doesn't
-            get a validation error for including fields your own GET response returned.
-          type: string
-          readOnly: true
         last_name:
           description: "[DEPRECATED] Use family_name instead. User's family name. Maximum 200 characters."
           type: string
@@ -10052,9 +10024,6 @@ components:
           type: string
           examples:
             - '+14155552671'
-        phone_number_verified:
-          type: boolean
-          readOnly: true
         picture:
           description: Updates the URL to the user's profile picture or avatar image. Use this field to set or change the user's profile photo that appears in user interfaces, directory listings, and collaborative features. The URL should point to a publicly accessible image file. Supported formats typically include JPEG, PNG, and GIF. Maximum URL length is 2048 characters.
           type: string
@@ -10572,39 +10541,11 @@ components:
     v1usersUpdateUser:
       type: object
       properties:
-        create_time:
-          type: string
-          format: date-time
-          readOnly: true
-        email:
-          type: string
-          readOnly: true
-        environment_id:
-          type: string
-          readOnly: true
         external_id:
           description: Your application's unique identifier for this user, used to link Scalekit with your system.
           type: string
           examples:
             - ext_12345a67b89c
-        id:
-          description: |-
-            id, environment_id, create_time, update_time, email, memberships, and last_login_time are
-            OUTPUT_ONLY - never written by an update. They exist here (rather than reserved/absent) so
-            that a client which reads a User and PATCHes the same object back (a common read-modify-
-            write pattern) doesn't get a validation error for including fields its own GET response
-            returned.
-          type: string
-          readOnly: true
-        last_login_time:
-          type: string
-          format: date-time
-          readOnly: true
-        memberships:
-          type: array
-          items:
-            $ref: '#/components/schemas/commonsOrganizationMembership'
-          readOnly: true
         metadata:
           description: Custom key-value pairs for storing additional user context. Keys (3-25 chars), values (1-256 chars).
           type: object
@@ -10613,10 +10554,6 @@ components:
           examples:
             - department: engineering
               location: nyc-office
-        update_time:
-          type: string
-          format: date-time
-          readOnly: true
         user_profile:
           description: User's personal information including name, address, and other profile attributes.
           $ref: '#/components/schemas/usersUpdateUserProfile'

--- a/public/api/saaskit.scalar.json
+++ b/public/api/saaskit.scalar.json
@@ -4793,15 +4793,6 @@
             "name": "id",
             "in": "path",
             "required": true
-          },
-          {
-            "schema": {
-              "type": "string",
-              "format": "field-mask"
-            },
-            "description": "Optional. By default, every field present in `user` is updated automatically - this mask is not required for ordinary updates, including clearing a field via an empty string. Set it explicitly only if you want to control precisely which fields are touched.",
-            "name": "update_mask",
-            "in": "query"
           }
         ],
         "responses": {
@@ -5082,15 +5073,6 @@
             "name": "external_id",
             "in": "path",
             "required": true
-          },
-          {
-            "schema": {
-              "type": "string",
-              "format": "field-mask"
-            },
-            "description": "Optional. By default, every field present in `user` is updated automatically - this mask is not required for ordinary updates, including clearing a field via an empty string. Set it explicitly only if you want to control precisely which fields are touched.",
-            "name": "update_mask",
-            "in": "query"
           }
         ],
         "responses": {
@@ -10929,17 +10911,6 @@
               }
             ]
           },
-          "email_verified": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "external_identities": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/commonsExternalIdentity"
-            },
-            "readOnly": true
-          },
           "family_name": {
             "description": "Updates the user's family name (last name or surname). Use this field to modify how the user's last name appears throughout the system. Maximum 255 characters allowed.",
             "type": "string",
@@ -10967,11 +10938,6 @@
               "type": "string"
             },
             "examples": [["engineering", "managers"]]
-          },
-          "id": {
-            "description": "id, email_verified, phone_number_verified, and external_identities are OUTPUT_ONLY -\nnever written by an update. They exist here (rather than reserved/absent) solely so a\nclient that reads a profile and PATCHes the same object back (a common pattern) doesn't\nget a validation error for including fields your own GET response returned.",
-            "type": "string",
-            "readOnly": true
           },
           "last_name": {
             "description": "[DEPRECATED] Use family_name instead. User's family name. Maximum 200 characters.",
@@ -11005,10 +10971,6 @@
             "description": "Updates the user's phone number in E.164 international format. Use this field to enable SMS-based authentication methods, two-factor authentication, or phone-based account recovery. The phone number must include the country code and be formatted according to E.164 standards (e.g., `+1` for US numbers). This field is required when enabling SMS authentication features.",
             "type": "string",
             "examples": ["+14155552671"]
-          },
-          "phone_number_verified": {
-            "type": "boolean",
-            "readOnly": true
           },
           "picture": {
             "description": "Updates the URL to the user's profile picture or avatar image. Use this field to set or change the user's profile photo that appears in user interfaces, directory listings, and collaborative features. The URL should point to a publicly accessible image file. Supported formats typically include JPEG, PNG, and GIF. Maximum URL length is 2048 characters.",
@@ -11480,40 +11442,10 @@
       "v1usersUpdateUser": {
         "type": "object",
         "properties": {
-          "create_time": {
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          },
-          "email": {
-            "type": "string",
-            "readOnly": true
-          },
-          "environment_id": {
-            "type": "string",
-            "readOnly": true
-          },
           "external_id": {
             "description": "Your application's unique identifier for this user, used to link Scalekit with your system.",
             "type": "string",
             "examples": ["ext_12345a67b89c"]
-          },
-          "id": {
-            "description": "id, environment_id, create_time, update_time, email, memberships, and last_login_time are\nOUTPUT_ONLY - never written by an update. They exist here (rather than reserved/absent) so\nthat a client which reads a User and PATCHes the same object back (a common read-modify-\nwrite pattern) doesn't get a validation error for including fields its own GET response\nreturned.",
-            "type": "string",
-            "readOnly": true
-          },
-          "last_login_time": {
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          },
-          "memberships": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/commonsOrganizationMembership"
-            },
-            "readOnly": true
           },
           "metadata": {
             "description": "Custom key-value pairs for storing additional user context. Keys (3-25 chars), values (1-256 chars).",
@@ -11527,11 +11459,6 @@
                 "location": "nyc-office"
               }
             ]
-          },
-          "update_time": {
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
           },
           "user_profile": {
             "description": "User's personal information including name, address, and other profile attributes.",

--- a/public/api/scalekit.scalar.json
+++ b/public/api/scalekit.scalar.json
@@ -6091,15 +6091,6 @@
             "name": "id",
             "in": "path",
             "required": true
-          },
-          {
-            "schema": {
-              "type": "string",
-              "format": "field-mask"
-            },
-            "description": "Optional. By default, every field present in `user` is updated automatically - this mask is not required for ordinary updates, including clearing a field via an empty string. Set it explicitly only if you want to control precisely which fields are touched.",
-            "name": "update_mask",
-            "in": "query"
           }
         ],
         "responses": {
@@ -6380,15 +6371,6 @@
             "name": "external_id",
             "in": "path",
             "required": true
-          },
-          {
-            "schema": {
-              "type": "string",
-              "format": "field-mask"
-            },
-            "description": "Optional. By default, every field present in `user` is updated automatically - this mask is not required for ordinary updates, including clearing a field via an empty string. Set it explicitly only if you want to control precisely which fields are touched.",
-            "name": "update_mask",
-            "in": "query"
           }
         ],
         "responses": {
@@ -13536,17 +13518,6 @@
               }
             ]
           },
-          "email_verified": {
-            "type": "boolean",
-            "readOnly": true
-          },
-          "external_identities": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/commonsExternalIdentity"
-            },
-            "readOnly": true
-          },
           "family_name": {
             "description": "Updates the user's family name (last name or surname). Use this field to modify how the user's last name appears throughout the system. Maximum 255 characters allowed.",
             "type": "string",
@@ -13574,11 +13545,6 @@
               "type": "string"
             },
             "examples": [["engineering", "managers"]]
-          },
-          "id": {
-            "description": "id, email_verified, phone_number_verified, and external_identities are OUTPUT_ONLY -\nnever written by an update. They exist here (rather than reserved/absent) solely so a\nclient that reads a profile and PATCHes the same object back (a common pattern) doesn't\nget a validation error for including fields your own GET response returned.",
-            "type": "string",
-            "readOnly": true
           },
           "last_name": {
             "description": "[DEPRECATED] Use family_name instead. User's family name. Maximum 200 characters.",
@@ -13612,10 +13578,6 @@
             "description": "Updates the user's phone number in E.164 international format. Use this field to enable SMS-based authentication methods, two-factor authentication, or phone-based account recovery. The phone number must include the country code and be formatted according to E.164 standards (e.g., `+1` for US numbers). This field is required when enabling SMS authentication features.",
             "type": "string",
             "examples": ["+14155552671"]
-          },
-          "phone_number_verified": {
-            "type": "boolean",
-            "readOnly": true
           },
           "picture": {
             "description": "Updates the URL to the user's profile picture or avatar image. Use this field to set or change the user's profile photo that appears in user interfaces, directory listings, and collaborative features. The URL should point to a publicly accessible image file. Supported formats typically include JPEG, PNG, and GIF. Maximum URL length is 2048 characters.",
@@ -14246,40 +14208,10 @@
       "v1usersUpdateUser": {
         "type": "object",
         "properties": {
-          "create_time": {
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          },
-          "email": {
-            "type": "string",
-            "readOnly": true
-          },
-          "environment_id": {
-            "type": "string",
-            "readOnly": true
-          },
           "external_id": {
             "description": "Your application's unique identifier for this user, used to link Scalekit with your system.",
             "type": "string",
             "examples": ["ext_12345a67b89c"]
-          },
-          "id": {
-            "description": "id, environment_id, create_time, update_time, email, memberships, and last_login_time are\nOUTPUT_ONLY - never written by an update. They exist here (rather than reserved/absent) so\nthat a client which reads a User and PATCHes the same object back (a common read-modify-\nwrite pattern) doesn't get a validation error for including fields its own GET response\nreturned.",
-            "type": "string",
-            "readOnly": true
-          },
-          "last_login_time": {
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
-          },
-          "memberships": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/commonsOrganizationMembership"
-            },
-            "readOnly": true
           },
           "metadata": {
             "description": "Custom key-value pairs for storing additional user context. Keys (3-25 chars), values (1-256 chars).",
@@ -14293,11 +14225,6 @@
                 "location": "nyc-office"
               }
             ]
-          },
-          "update_time": {
-            "type": "string",
-            "format": "date-time",
-            "readOnly": true
           },
           "user_profile": {
             "description": "User's personal information including name, address, and other profile attributes.",


### PR DESCRIPTION
**Why:** Shipped change in `scalekit@98d8bca` (#2482, merged 2026-07-31T05:26Z) reverts the proto v0.1.140.0 user-profile work — it removes the `update_mask` field from `UpdateUserRequest` and the OUTPUT_ONLY echo fields from `UpdateUser` / `UpdateUserProfile`, and regenerates `third_party/OpenAPI`. developer-docs#921 (`be17ec0b`, landed yesterday) had just synced those into `openapi/scalekit.yaml`, so the reference now teaches an `update_mask` query param and read-only fields (`id`, `email`, `environment_id`, `create_time`, `update_time`, `last_login_time`, `memberships`, `email_verified`, `phone_number_verified`, `external_identities`) that no longer exist in the shipped contract. P0 drift: docs teaching a removed surface.

**What:** Reverts #921's additions across `openapi/scalekit.yaml` (source of truth) and the `saaskit`/`scalekit` Scalar JSON bundles — the two Update User endpoints (by `id` and by `external_id`) and the `v1usersUpdateUser` + `usersUpdateUserProfile` schemas. Kept `external_id` described as "user" (the #2482 revert re-introduced the "organization" copy-paste bug on that one field; not propagated into the docs — flagged separately for a source-level proto fix). Skills: docs-engineering, api-reference.

**Evidence:** BE revert `scalekit@98d8bca98d65ea5e81e4c61009aa04263c383776` (#2482); docs commit reverted: `be17ec0b` (#921). OpenAPI/proto compared: yes — proto `users.proto`/`members.proto` and generated `third_party/OpenAPI/scalekit.*` at that SHA no longer carry these fields.

**Check:** Net diff is the exact inverse of #921 (a redocly-generated commit) minus the `external_id` line, so the JSON bundles stay byte-consistent with the YAML source; both bundles re-validated as parseable JSON; `grep` confirms no Scalekit user-update `update_mask` remains anywhere in the repo. verification: needs-human — run `pnpm run bundle:apis && pnpm run validate-api-split` in a full checkout to confirm the split passes (deps not installed in this unattended env).

---
_Generated by [Claude Code](https://claude.ai/code/session_014u2tTuCRXZBKjvi2W6PtmC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated user update API documentation to remove the unsupported `update_mask` query parameter.
  * Clarified update requests by removing read-only account and profile fields.
  * Retained editable fields, including external ID, metadata, and user profile information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->