### PR TITLE
docs(signal): note Cloudflare proxied CNAME is unsupported for custom domains

### DIFF
--- a/src/content/docs/guides/custom-domain.mdx
+++ b/src/content/docs/guides/custom-domain.mdx
@@ -69,6 +69,10 @@ When configuring your CNAME record, you'll need to provide the following fields:
 Different DNS registrars use different names for these fields. The `Name` field might be called "Host" or "Label", and the `Value` field might be called "Target" or "Destination". The values you enter remain the same.
 </Aside>
 
+<Aside type="caution" title="Disable proxying on Cloudflare and similar providers">
+If your DNS provider proxies traffic (such as Cloudflare's "orange cloud"), set the CNAME record to **DNS only** so it resolves directly to Scalekit. Proxied CNAME records are not supported and block CNAME verification and SSL certificate provisioning.
+</Aside>
+
 ## Set up your custom domain
 
 Let's set up your custom domain by adding a CNAME record to your DNS registrar and verifying the configuration.


### PR DESCRIPTION
**Why:** A few users setting up a branded custom domain hit verification and SSL failures because their DNS provider was proxying the CNAME record; the guide never mentioned this constraint.

**What:** Surgical copy edit in `src/content/docs/guides/custom-domain.mdx` — adds a `caution` in the DNS record reference section noting that proxied CNAME records (for example, Cloudflare's "orange cloud") are not supported and must be set to **DNS only**. Skills applied: docs-engineering, docs-contribution-router, docs-writing-style.

**Check:** Open the Branded custom domains guide, DNS record reference section, and confirm the "Disable proxying on Cloudflare and similar providers" caution appears. Preview: `https://deploy-preview-924--scalekit-starlight.netlify.app/guides/custom-domain/`