### PR TITLE
chore(deps): security bump @opentelemetry/core (Dependabot) (SK-1438)

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
     "overrides": {
       "@astrojs/starlight-docsearch": "file:./vendor/docsearch",
       "glob": "^11.0.0",
-      "mdast-util-to-hast": "^13.2.1"
+      "mdast-util-to-hast": "^13.2.1",
+      "@opentelemetry/core": "^2.8.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   '@astrojs/starlight-docsearch': file:./vendor/docsearch
   glob: ^11.0.0
   mdast-util-to-hast: ^13.2.1
+  '@opentelemetry/core': ^2.8.0
 
 importers:
 
@@ -2082,8 +2083,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/core@2.7.1':
-    resolution: {integrity: sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==}
+  '@opentelemetry/core@2.10.0':
+    resolution: {integrity: sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -10471,7 +10472,7 @@ snapshots:
   '@netlify/otel@6.0.3(supports-color@10.2.2)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.0)(supports-color@10.2.2)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-node': 2.7.1(@opentelemetry/api@1.9.0)
@@ -10799,7 +10800,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
 
-  '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -10816,13 +10817,13 @@ snapshots:
   '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.40.0
 
@@ -10830,7 +10831,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/context-async-hooks': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/semantic-conventions@1.40.0': {}


### PR DESCRIPTION
## Summary
- Resolves open Dependabot alert [#135](https://github.com/scalekit-inc/developer-docs/security/dependabot/135) (`GHSA-8988-4f7v-96qf` / `CVE-2026-54285`) on transitive `@opentelemetry/core` (`< 2.8.0`).
- Adds a pnpm override `@opentelemetry/core: ^2.8.0` (lockfile resolves to **2.10.0**).
- Source of the transitive dep: `@netlify/otel` via `netlify-cli` (dev tooling). Security-only; no other dependency ranges changed.

## Security
| Package | Before | After | Advisory |
|---------|--------|-------|----------|
| `@opentelemetry/core` | 2.7.1 | 2.10.0 | Unbounded memory allocation in W3C Baggage propagation |

## Test plan
- [x] `pnpm install` succeeds with override
- [x] Lockfile contains only `@opentelemetry/core@2.10.0` (no `<2.8.0`)
- [ ] CI green on this PR
- [ ] Dependabot alert #135 auto-closes after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the internal OpenTelemetry core package version constraint for improved dependency consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->