### PR TITLE
docs(signal): explain EXPIRED connected account needs offline-access scope

### DIFF
--- a/src/content/docs/agentkit/authentication/troubleshooting.mdx
+++ b/src/content/docs/agentkit/authentication/troubleshooting.mdx
@@ -113,6 +113,8 @@ See [Verify user identity](/agentkit/user-verification/) for configuration and A
 
 The access token expired and Scalekit could not refresh it automatically. Try a manual refresh first. If refresh fails, send the user a new authorization link.
 
+If manual refresh always fails, or the account returns to `EXPIRED` soon after each re-authorization, the connection never received a refresh token. A provider issues one only when the connection requests offline access, so re-authorizing without it produces another short-lived token that expires again. Add the provider's offline-access scope (for example `offline_access` or `refresh_token`) in [Configure scopes](/agentkit/connections/#configure-scopes), then have the user reconnect. See [why OAuth accounts expire](/agentkit/connected-accounts/#detect-when-re-authentication-is-needed) for the full list of causes.
+
 <Tabs syncKey="tech-stack">
   <TabItem label="Python">
 


### PR DESCRIPTION
**Why:** A few developers hit a loop where an AgentKit connected account keeps dropping to `EXPIRED` — manual refresh fails and re-authorizing only produces another short-lived token. The root cause is that the connection never requested offline access, so no refresh token is ever issued. The `EXPIRED` entry in the AgentKit troubleshooting guide stopped at "refresh, else re-authorize" and never pointed to that cause or fix, so a careful reader could not resolve it from docs.

**What:** Surgical two-line addition to the `Status is EXPIRED` block in `src/content/docs/agentkit/authentication/troubleshooting.mdx`. Explains the no-refresh-token symptom and links to the existing **Configure scopes** step and the **why OAuth accounts expire** explanation on the connected-accounts page (no new behavior invented; matches support resolutions). Skills applied: docs-engineering, docs-contribution-router, docs-writing-style.

**Check:** Open `/agentkit/authentication/troubleshooting/`, expand **Status is `EXPIRED`**, and confirm the new paragraph and its two cross-links render. Preview: `https://deploy-preview-{PR_NUMBER}--scalekit-starlight.netlify.app/agentkit/authentication/troubleshooting/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXCqLjeTXvpmgFNjCRkJCy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for repeated token refresh failures.
  * Explained how missing offline access can cause short-lived tokens to expire.
  * Instructed users to enable offline access and reconnect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->