### PR TITLE
docs(signal): clarify BYOA login validity and handoff timeout

### DIFF
--- a/src/content/docs/authenticate/mcp/custom-auth.mdx
+++ b/src/content/docs/authenticate/mcp/custom-auth.mdx
@@ -84,6 +84,8 @@ shape: sequence_diagram
    https://<SCALEKIT_ENVIRONMENT_URL>/login?login_request_id=<reqid>&state=<state>
    ```
 
+   The login request and its `state` stay valid for approximately 10 minutes. Complete authentication and redirect the user back to Scalekit within that window. If the request expires, the user lands on an `invalid_state` error page and must restart the connection from their MCP client.
+
 
 2. ## Authenticate the user in your system
 
@@ -183,3 +185,21 @@ shape: sequence_diagram
 
 
 Your MCP server now supports federated authentication with your existing auth system
+
+## Troubleshooting
+
+<details>
+<summary>The user lands on an invalid_state error page</summary>
+
+Scalekit redirects the user to a callback with `error=invalid_state` when the login request has expired or the returned `state` does not match the value from step 1. The login request stays valid for approximately 10 minutes.
+
+The error most often appears when a first-time user takes longer than 10 minutes to finish signing up in your system before completing the handshake. Ask the user to start the connection again from their MCP client. The default error page cannot be replaced with a custom page.
+
+</details>
+
+<details>
+<summary>The handoff request times out with a gateway timeout error</summary>
+
+Create the Scalekit client once at application startup and reuse that single instance across requests. Constructing a new client on every request re-runs the full bootstrap, which opens a fresh connection and fetches a new access token before the request can proceed. That extra work adds latency and can exceed the request deadline, which surfaces as a `deadline_exceeded` gateway timeout on the user-details call. A shared client caches its token and refreshes it internally.
+
+</details>

--- a/src/content/docs/authenticate/mcp/custom-auth.mdx
+++ b/src/content/docs/authenticate/mcp/custom-auth.mdx
@@ -84,7 +84,7 @@ shape: sequence_diagram
    https://<SCALEKIT_ENVIRONMENT_URL>/login?login_request_id=<reqid>&state=<state>
    ```
 
-   The login request and its `state` stay valid for approximately 10 minutes. Complete authentication and redirect the user back to Scalekit within that window. If the request expires, the user lands on an `invalid_state` error page and must restart the connection from their MCP client.
+   The login request and its `state` stay valid for approximately 10 minutes. Complete authentication and send the callback to Scalekit within that window. If the request expires, Scalekit shows an `invalid_state` error page and the connection must be restarted from the MCP client.
 
 
 2. ## Authenticate the user in your system
@@ -189,11 +189,14 @@ Your MCP server now supports federated authentication with your existing auth sy
 ## Troubleshooting
 
 <details>
-<summary>The user lands on an invalid_state error page</summary>
+<summary>`invalid_state` error page after login</summary>
 
-Scalekit redirects the user to a callback with `error=invalid_state` when the login request has expired or the returned `state` does not match the value from step 1. The login request stays valid for approximately 10 minutes.
+Scalekit returns `error=invalid_state` when the login request has expired or the returned `state` does not match the value from step 1. The login request stays valid for approximately 10 minutes.
 
-The error most often appears when a first-time user takes longer than 10 minutes to finish signing up in your system before completing the handshake. Ask the user to start the connection again from their MCP client. The default error page cannot be replaced with a custom page.
+Treat the two causes separately:
+
+- **Expired request:** First-time signup often takes longer than 10 minutes. Restart the connection from the MCP client. The default error page cannot be replaced with a custom page.
+- **Mismatched `state`:** Confirm your application stores the `state` value from step 1 and returns it unchanged. Do not drop, overwrite, or rewrite it. Keep state validation enabled. Restarting the MCP connection does not fix a mismatch.
 
 </details>
 


### PR DESCRIPTION
**Why:** A few users hit avoidable failures on the bring-your-own-auth (BYOA) MCP handoff. Some saw an `invalid_state` error page when a first-time user took longer than the login window to finish signing up; another hit gateway timeouts when a new SDK client was constructed on every request. The page described the `state` round-trip but never stated how long the login request stays valid or what error a timeout produces.

**What:** Surgical edit in `src/content/docs/authenticate/mcp/custom-auth.mdx`. Added a line to step 1 noting the login request and `state` stay valid for approximately 10 minutes (and expiry surfaces as `invalid_state`), plus a short Troubleshooting section covering the `invalid_state` error page and the `deadline_exceeded` handoff timeout (reuse a single Scalekit client instead of building one per request). Copy-only, no nav or config changes. Skills applied: docs-engineering, docs-contribution-router, docs-writing-style.

**Check:** Open `/authenticate/mcp/custom-auth/`; confirm step 1 states the ~10-minute validity window and the Troubleshooting section explains `invalid_state` and the handoff-timeout fix.

**Preview:** https://deploy-preview-927--scalekit-starlight.netlify.app/authenticate/mcp/custom-auth/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented the 10-minute validity window for login requests and authentication state.
  * Added guidance for restarting authentication after expiration.
  * Added troubleshooting steps for `invalid_state` errors and gateway timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->