### PR TITLE
docs(signal): clearer MCP consent-screen scopes and per-user authorization

### DIFF
--- a/src/content/docs/authenticate/mcp/overview.mdx
+++ b/src/content/docs/authenticate/mcp/overview.mdx
@@ -190,3 +190,11 @@ MCP’s OAuth 2.1 profile reduces a few common risks in the authorization code f
 - **Strict redirect URI validation**: Servers must only allow pre-registered redirect URIs and enforce an exact match to reduce redirect attacks.
 - **Short-lived tokens**: Authorization servers should issue short-lived access tokens to limit impact if a token leaks.
 - **Granular scopes**: Use narrow scopes (for example, `todo:read`, `todo:write`) so apps request only what they need and users can understand what they’re granting.
+
+## Scopes and the consent screen
+
+Scopes on an MCP authorization request describe what the **client** — Claude, ChatGPT, Cursor, or your own app — is allowed to do. The client requests them, and Scalekit shows them to the user on the consent screen.
+
+**Every sign-in includes a set of standard scopes you cannot remove.** Alongside the custom scopes you define for your server (for example, `todo:read`), a request carries the OpenID Connect scopes `openid`, `profile`, and `email` so the client can identify the user it acts for, plus `offline_access` so Scalekit can issue a refresh token and keep the connection alive without re-prompting the user. These are platform defaults and do not appear as removable options on the consent screen. On a [bring-your-own-auth](/authenticate/mcp/custom-auth/) server, `profile` and `email` expose only the values you send in the user-details handoff — a placeholder email, for example — never data you do not provide.
+
+**Scopes are not per-user permissions.** A scope reflects what the client requested, not what an individual user is allowed to do, and the consent screen does not currently let a user grant a subset of the requested scopes. Do not rely on consent-time scope selection to enforce per-user access. Instead, enforce authority when a tool runs: check the acting user's role or permission inside each tool handler before executing, and reject the call otherwise. Consent decides what is granted; a runtime check decides what is actually usable. This is the model major identity providers use, and it stays correct when a user's role changes after they first consent.

--- a/src/content/docs/authenticate/mcp/overview.mdx
+++ b/src/content/docs/authenticate/mcp/overview.mdx
@@ -193,7 +193,7 @@ MCP’s OAuth 2.1 profile reduces a few common risks in the authorization code f
 
 ## Scopes and the consent screen
 
-Scopes on an MCP authorization request describe what the **client** — Claude, ChatGPT, Cursor, or your own app — is allowed to do. The client requests them, and Scalekit shows them to the user on the consent screen.
+Scopes on an MCP authorization request describe what the **client** (Claude, ChatGPT, Cursor, or your own app) requests to access. The client requests them, and Scalekit shows them to the user on the consent screen.
 
 **Every sign-in includes a set of standard scopes you cannot remove.** Alongside the custom scopes you define for your server (for example, `todo:read`), a request carries the OpenID Connect scopes `openid`, `profile`, and `email` so the client can identify the user it acts for, plus `offline_access` so Scalekit can issue a refresh token and keep the connection alive without re-prompting the user. These are platform defaults and do not appear as removable options on the consent screen. On a [bring-your-own-auth](/authenticate/mcp/custom-auth/) server, `profile` and `email` expose only the values you send in the user-details handoff — a placeholder email, for example — never data you do not provide.
 

--- a/src/content/docs/authenticate/mcp/troubleshooting.mdx
+++ b/src/content/docs/authenticate/mcp/troubleshooting.mdx
@@ -56,9 +56,9 @@ To find your `connection_id`, open **Dashboard > MCP Servers > [your server] > A
 <details>
 <summary>Access token issued but no refresh token</summary>
 
-Add the `offline_access` scope to your authorization request. Without it, Scalekit does not issue a refresh token alongside the access token.
+Scalekit's MCP authorize request already includes `offline_access`, so hosted MCP login issues a refresh token with the access token. You do not add this scope yourself on that path.
 
-Include it with your other scopes:
+If you send your own authorization URL and omit `offline_access`, Scalekit does not issue a refresh token. Include it:
 
 ```
 openid profile email offline_access

--- a/src/content/docs/authenticate/mcp/xmcp-quickstart.mdx
+++ b/src/content/docs/authenticate/mcp/xmcp-quickstart.mdx
@@ -506,6 +506,10 @@ MCP Server -> MCP Client: Tool response
      xmcp automatically loads <code>src/middleware.ts</code> as a special entry point. Tools cannot import from this file directly — shared code like <code>getSession()</code> lives in <code>src/lib/</code> instead.
    </Aside>
 
+   <Aside type="note" title="Scalekit requests offline_access on authorize">
+     The <code>scopes</code> array above is <code>scopes_supported</code> on your protected-resource metadata. Scalekit still requests <code>offline_access</code> on the authorize request so it can issue a refresh token. Leave <code>offline_access</code> out of this list.
+   </Aside>
+
 7. ## Add tools
 
    xmcp uses file-based routing — each file in `src/tools/` becomes an MCP tool. Create two tools that use the authenticated session.


### PR DESCRIPTION
**Why:** A few users asked the same two things about the MCP consent screen — what the default scopes (`profile`, `offline_access`) mean and whether they can be removed, and how to show or enforce per-user permissions when scopes are requested by the client. The MCP docs explained scopes at the OAuth-flow level but never covered the default consent scopes or the scopes-vs-per-user-authority distinction.

**What:** Surgical addition of a short "Scopes and the consent screen" concept section in `src/content/docs/authenticate/mcp/overview.mdx`, right after the existing security-enhancements section. It states that the standard identity scopes (`openid`, `profile`, `email`) plus `offline_access` are always present and cannot be removed, notes what `profile`/`email` expose on a bring-your-own-auth server, and explains that scopes reflect what the client requested — so per-user authority should be enforced at tool-execution time, not via consent-time scope selection. Prose only, no code sample. Skills applied: docs-engineering, docs-contribution-router, docs-writing-style.

**Check:** Open `/authenticate/mcp/overview/`; confirm a new "Scopes and the consent screen" section appears after "Key security enhancements in MCP OAuth 2.1", with the two bold-led paragraphs on default scopes and per-user authorization.

Preview: https://deploy-preview-928--scalekit-starlight.netlify.app/authenticate/mcp/overview/

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy7wuj97rofPckRmd42GgS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on OAuth scopes and the consent screen for MCP authentication.
  * Documented standard OpenID Connect and offline access scopes.
  * Clarified bring-your-own-auth behavior and that consent scopes do not replace per-user authorization checks.
  * Recommended enforcing permissions at runtime based on the acting user’s role or permissions.
  * Clarified when to include `offline_access` for refresh tokens, including hosted and custom authorization flows.
  * Explained that `offline_access` should not be listed among protected-resource scopes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->