### PR TITLE
docs(agentkit): switch AgentKit docs to GitHub as the default connector

### DIFF
--- a/public/hackathon/index.html
+++ b/public/hackathon/index.html
@@ -1396,7 +1396,7 @@ scalekit setup</code></pre>
                     target="_blank"
                     rel="noopener"
                   >
-                    Slack agent <span class="time">~15 min</span>
+                    GitHub agent <span class="time">~15 min</span>
                   </a>
                   <a
                     class="chip"
@@ -1436,7 +1436,7 @@ scalekit setup</code></pre>
                 </div>
                 <div>
                   <dt>Tools</dt>
-                  <dd>Actions like <code>slack_list_channels</code> with LLM-ready schemas.</dd>
+                  <dd>Actions like <code>github_repo_star</code> with LLM-ready schemas.</dd>
                 </div>
                 <div>
                   <dt>Any framework</dt>
@@ -1507,12 +1507,12 @@ scalekit setup</code></pre>
 
             <article class="step-card">
               <div class="step-num">STEP 02</div>
-              <h3>Free account + Slack connection</h3>
+              <h3>Free account + GitHub connection</h3>
               <p>
                 Sign up at
                 <a href="https://app.scalekit.com" target="_blank" rel="noopener"
                   >app.scalekit.com</a
-                >. Slack is enabled by default in new environments, so the connection is already
+                >. GitHub is enabled by default in new environments, so the connection is already
                 under AgentKit → Connections. Copy the exact Connection name and API credentials.
               </p>
               <a class="step-link" href="https://app.scalekit.com" target="_blank" rel="noopener"
@@ -1525,7 +1525,7 @@ scalekit setup</code></pre>
 SCALEKIT_CLIENT_SECRET=...
 # Copy exact env URL from dashboard (.scalekit.com or .scalekit.dev)
 SCALEKIT_ENV_URL=https://yourorg.scalekit.com
-SLACK_CONNECTION_NAME=your-exact-connection-name</code></pre>
+GITHUB_CONNECTION_NAME=your-exact-connection-name</code></pre>
             </article>
 
             <article class="step-card">
@@ -1533,8 +1533,8 @@ SLACK_CONNECTION_NAME=your-exact-connection-name</code></pre>
               <h3>Paste the prompt and make your first tool call</h3>
               <p>
                 In your coding agent, paste the prompt below. You&rsquo;re done when status is
-                <code>ACTIVE</code> and <code>slack_list_channels</code> returns structured channel
-                data.
+                <code>ACTIVE</code> and <code>github_repo_star</code> succeeds — the star shows up
+                on the repo.
               </p>
               <a
                 class="step-link"
@@ -1546,9 +1546,9 @@ SLACK_CONNECTION_NAME=your-exact-connection-name</code></pre>
               <div class="term-chrome" aria-hidden="true">
                 <span></span><span></span><span></span>
               </div>
-              <pre><code>Configure Scalekit agent authentication for Slack. Provide code to create a
+              <pre><code>Configure Scalekit agent authentication for GitHub. Provide code to create a
 connected account, generate an authorization link, and, once the user authorizes,
-list the workspace's first 10 channels using Scalekit's tool API.</code></pre>
+star Scalekit's SDK repo (scalekit-inc/scalekit-sdk-python) using Scalekit's tool API.</code></pre>
             </article>
           </div>
 
@@ -1602,7 +1602,7 @@ list the workspace's first 10 channels using Scalekit's tool API.</code></pre>
                 <p style="margin: 0">
                   Confirm the connection in AgentKit → Connections before running code. Pass the
                   exact Connection name from the dashboard, not a guessed slug like
-                  <code>slack</code>.
+                  <code>github-connect</code>.
                 </p>
               </div>
             </div>
@@ -1710,7 +1710,7 @@ list the workspace's first 10 channels using Scalekit's tool API.</code></pre>
                 rel="noopener"
               >
                 <strong>AgentKit quickstart</strong>
-                <span>End-to-end Slack agent: authorize and list channels.</span>
+                <span>End-to-end GitHub agent: authorize and star a repo.</span>
               </a>
               <a
                 class="res-card"
@@ -1834,9 +1834,9 @@ list the workspace's first 10 channels using Scalekit's tool API.</code></pre>
           </p>
           <div class="grid-2" style="text-align: left; max-width: 56rem; margin-inline: auto">
             <div class="callout" style="margin: 0">
-              <h3>Slack-powered agent</h3>
+              <h3>GitHub-powered agent</h3>
               <p class="muted" style="margin: 0; font-size: 0.88rem">
-                List channels, summarize conversations, or post updates. Start from the
+                Star repos, open issues, or review pull requests. Start from the
                 <a
                   href="https://docs.scalekit.com/agentkit/quickstart"
                   target="_blank"
@@ -1848,7 +1848,7 @@ list the workspace's first 10 channels using Scalekit's tool API.</code></pre>
             <div class="callout" style="margin: 0">
               <h3>Multi-connector demo</h3>
               <p class="muted" style="margin: 0; font-size: 0.88rem">
-                Add Calendar, Gmail, or GitHub after Slack works. Browse the
+                Add Calendar, Gmail, or Slack after GitHub works. Browse the
                 <a
                   href="https://docs.scalekit.com/agentkit/connectors/"
                   target="_blank"
@@ -1904,8 +1904,8 @@ list the workspace's first 10 channels using Scalekit's tool API.</code></pre>
           <h2 id="start-title">Manual setup: SDK step by step</h2>
           <p class="lead">
             Hand-written Node or Python. Same finish line: an <code>ACTIVE</code> account and a
-            successful <code>slack_list_channels</code> call. If you have not tried the CLI path,
-            start at <a href="#fast-start">Quick Start</a>.
+            successful <code>github_repo_star</code> call. If you have not tried the CLI path, start
+            at <a href="#fast-start">Quick Start</a>.
           </p>
 
           <p class="muted" style="margin: 1.25rem 0 0; font-size: 0.9rem">
@@ -1915,7 +1915,7 @@ list the workspace's first 10 channels using Scalekit's tool API.</code></pre>
           <pre><code>SCALEKIT_CLIENT_ID=skc_...
 SCALEKIT_CLIENT_SECRET=...
 SCALEKIT_ENV_URL=https://yourorg.scalekit.com
-SLACK_CONNECTION_NAME=your-exact-connection-name</code></pre>
+GITHUB_CONNECTION_NAME=your-exact-connection-name</code></pre>
 
           <div class="tabs" data-tabs style="margin-top: 1.5rem">
             <div class="tablist" role="tablist" aria-label="SDK language">
@@ -1956,7 +1956,7 @@ const scalekit = new ScalekitClient(
 );
 
 const actions = scalekit.actions;
-const connectionName = process.env.SLACK_CONNECTION_NAME;
+const connectionName = process.env.GITHUB_CONNECTION_NAME;
 
 const response = await actions.getOrCreateConnectedAccount({
   connectionName,
@@ -1970,8 +1970,8 @@ if (connectedAccount?.status !== ConnectorStatus.ACTIVE) {
     connectionName,
     identifier: 'user_123',
   });
-  console.log('Authorize Slack:', linkResponse.link);
-  console.log('Press Enter after authorizing Slack...');
+  console.log('Authorize GitHub:', linkResponse.link);
+  console.log('Press Enter after authorizing GitHub...');
   await new Promise((resolve) =&gt; {
     process.stdin.resume();
     process.stdin.once('data', () =&gt; {
@@ -1988,13 +1988,13 @@ if (connectedAccount?.status !== ConnectorStatus.ACTIVE) {
 }
 
 if (connectedAccount?.status !== ConnectorStatus.ACTIVE) {
-  throw new Error('Slack is still not ACTIVE. Complete authorization and try again.');
+  throw new Error('GitHub is still not ACTIVE. Complete authorization and try again.');
 }
 
 const toolResponse = await actions.executeTool({
-  toolName: 'slack_list_channels',
+  toolName: 'github_repo_star',
   connectedAccountId: connectedAccount.id,
-  toolInput: { limit: 10 },
+  toolInput: { owner: 'scalekit-inc', repo: 'scalekit-sdk-node' },
 });
 console.log(toolResponse.data);</code></pre>
             </div>
@@ -2021,7 +2021,7 @@ scalekit_client = ScalekitClient(
     os.getenv("SCALEKIT_CLIENT_SECRET"),
 )
 actions = scalekit_client.actions
-connection_name = os.getenv("SLACK_CONNECTION_NAME")
+connection_name = os.getenv("GITHUB_CONNECTION_NAME")
 
 response = actions.get_or_create_connected_account(
     connection_name=connection_name,
@@ -2035,7 +2035,7 @@ if connected_account.status != "ACTIVE":
         connection_name=connection_name,
         identifier="user_123",
     )
-    print("Authorize Slack:", link_response.link)
+    print("Authorize GitHub:", link_response.link)
     input("Press Enter after authorizing...")
     response = actions.get_or_create_connected_account(
         connection_name=connection_name,
@@ -2044,14 +2044,14 @@ if connected_account.status != "ACTIVE":
     connected_account = response.connected_account
 
 if connected_account.status != "ACTIVE":
-    raise RuntimeError("Slack is still not ACTIVE. Complete authorization and try again.")
+    raise RuntimeError("GitHub is still not ACTIVE. Complete authorization and try again.")
 
 # Prefer connected_account_id after authorize. If you use identifier instead,
 # also pass connection_name — the pair is required for account resolution.
 tool_response = actions.execute_tool(
-    tool_name="slack_list_channels",
+    tool_name="github_repo_star",
     connected_account_id=connected_account.id,
-    tool_input={"limit": 10},
+    tool_input={"owner": "scalekit-inc", "repo": "scalekit-sdk-python"},
 )
 print(tool_response.data)</code></pre>
             </div>

--- a/public/hackathon/index.html
+++ b/public/hackathon/index.html
@@ -1396,7 +1396,7 @@ scalekit setup</code></pre>
                     target="_blank"
                     rel="noopener"
                   >
-                    Gmail agent <span class="time">~15 min</span>
+                    Slack agent <span class="time">~15 min</span>
                   </a>
                   <a
                     class="chip"
@@ -1436,7 +1436,7 @@ scalekit setup</code></pre>
                 </div>
                 <div>
                   <dt>Tools</dt>
-                  <dd>Actions like <code>gmail_fetch_mails</code> with LLM-ready schemas.</dd>
+                  <dd>Actions like <code>slack_list_channels</code> with LLM-ready schemas.</dd>
                 </div>
                 <div>
                   <dt>Any framework</dt>
@@ -1507,13 +1507,13 @@ scalekit setup</code></pre>
 
             <article class="step-card">
               <div class="step-num">STEP 02</div>
-              <h3>Free account + Gmail connection</h3>
+              <h3>Free account + Slack connection</h3>
               <p>
                 Sign up at
                 <a href="https://app.scalekit.com" target="_blank" rel="noopener"
                   >app.scalekit.com</a
-                >. Create a Gmail connection under AgentKit → Connections (Gmail is enabled by
-                default in new environments). Copy the exact Connection name and API credentials.
+                >. Slack is enabled by default in new environments, so the connection is already
+                under AgentKit → Connections. Copy the exact Connection name and API credentials.
               </p>
               <a class="step-link" href="https://app.scalekit.com" target="_blank" rel="noopener"
                 >Open dashboard</a
@@ -1525,7 +1525,7 @@ scalekit setup</code></pre>
 SCALEKIT_CLIENT_SECRET=...
 # Copy exact env URL from dashboard (.scalekit.com or .scalekit.dev)
 SCALEKIT_ENV_URL=https://yourorg.scalekit.com
-GMAIL_CONNECTION_NAME=your-exact-connection-name</code></pre>
+SLACK_CONNECTION_NAME=your-exact-connection-name</code></pre>
             </article>
 
             <article class="step-card">
@@ -1533,7 +1533,7 @@ GMAIL_CONNECTION_NAME=your-exact-connection-name</code></pre>
               <h3>Paste the prompt and make your first tool call</h3>
               <p>
                 In your coding agent, paste the prompt below. You&rsquo;re done when status is
-                <code>ACTIVE</code> and <code>gmail_fetch_mails</code> returns structured email
+                <code>ACTIVE</code> and <code>slack_list_channels</code> returns structured channel
                 data.
               </p>
               <a
@@ -1546,9 +1546,9 @@ GMAIL_CONNECTION_NAME=your-exact-connection-name</code></pre>
               <div class="term-chrome" aria-hidden="true">
                 <span></span><span></span><span></span>
               </div>
-              <pre><code>Configure Scalekit agent authentication for Gmail. Provide code to create a
+              <pre><code>Configure Scalekit agent authentication for Slack. Provide code to create a
 connected account, generate an authorization link, and, once the user authorizes,
-fetch the last 5 unread emails using Scalekit's tool API.</code></pre>
+list the workspace's first 10 channels using Scalekit's tool API.</code></pre>
             </article>
           </div>
 
@@ -1600,9 +1600,9 @@ fetch the last 5 unread emails using Scalekit's tool API.</code></pre>
                 hidden
               >
                 <p style="margin: 0">
-                  Create the connection in AgentKit → Connections before running code. Pass the
+                  Confirm the connection in AgentKit → Connections before running code. Pass the
                   exact Connection name from the dashboard, not a guessed slug like
-                  <code>gmail</code>.
+                  <code>slack</code>.
                 </p>
               </div>
             </div>
@@ -1710,7 +1710,7 @@ fetch the last 5 unread emails using Scalekit's tool API.</code></pre>
                 rel="noopener"
               >
                 <strong>AgentKit quickstart</strong>
-                <span>End-to-end Gmail agent: authorize and fetch unread mail.</span>
+                <span>End-to-end Slack agent: authorize and list channels.</span>
               </a>
               <a
                 class="res-card"
@@ -1834,9 +1834,9 @@ fetch the last 5 unread emails using Scalekit's tool API.</code></pre>
           </p>
           <div class="grid-2" style="text-align: left; max-width: 56rem; margin-inline: auto">
             <div class="callout" style="margin: 0">
-              <h3>Gmail-powered agent</h3>
+              <h3>Slack-powered agent</h3>
               <p class="muted" style="margin: 0; font-size: 0.88rem">
-                Fetch unread mail, summarize, or draft replies. Start from the
+                List channels, summarize conversations, or post updates. Start from the
                 <a
                   href="https://docs.scalekit.com/agentkit/quickstart"
                   target="_blank"
@@ -1848,7 +1848,7 @@ fetch the last 5 unread emails using Scalekit's tool API.</code></pre>
             <div class="callout" style="margin: 0">
               <h3>Multi-connector demo</h3>
               <p class="muted" style="margin: 0; font-size: 0.88rem">
-                Add Calendar, Slack, or GitHub after Gmail works. Browse the
+                Add Calendar, Gmail, or GitHub after Slack works. Browse the
                 <a
                   href="https://docs.scalekit.com/agentkit/connectors/"
                   target="_blank"
@@ -1904,7 +1904,7 @@ fetch the last 5 unread emails using Scalekit's tool API.</code></pre>
           <h2 id="start-title">Manual setup: SDK step by step</h2>
           <p class="lead">
             Hand-written Node or Python. Same finish line: an <code>ACTIVE</code> account and a
-            successful <code>gmail_fetch_mails</code> call. If you have not tried the CLI path,
+            successful <code>slack_list_channels</code> call. If you have not tried the CLI path,
             start at <a href="#fast-start">Quick Start</a>.
           </p>
 
@@ -1915,7 +1915,7 @@ fetch the last 5 unread emails using Scalekit's tool API.</code></pre>
           <pre><code>SCALEKIT_CLIENT_ID=skc_...
 SCALEKIT_CLIENT_SECRET=...
 SCALEKIT_ENV_URL=https://yourorg.scalekit.com
-GMAIL_CONNECTION_NAME=your-exact-connection-name</code></pre>
+SLACK_CONNECTION_NAME=your-exact-connection-name</code></pre>
 
           <div class="tabs" data-tabs style="margin-top: 1.5rem">
             <div class="tablist" role="tablist" aria-label="SDK language">
@@ -1956,7 +1956,7 @@ const scalekit = new ScalekitClient(
 );
 
 const actions = scalekit.actions;
-const connectionName = process.env.GMAIL_CONNECTION_NAME;
+const connectionName = process.env.SLACK_CONNECTION_NAME;
 
 const response = await actions.getOrCreateConnectedAccount({
   connectionName,
@@ -1970,8 +1970,8 @@ if (connectedAccount?.status !== ConnectorStatus.ACTIVE) {
     connectionName,
     identifier: 'user_123',
   });
-  console.log('Authorize Gmail:', linkResponse.link);
-  console.log('Press Enter after authorizing Gmail...');
+  console.log('Authorize Slack:', linkResponse.link);
+  console.log('Press Enter after authorizing Slack...');
   await new Promise((resolve) =&gt; {
     process.stdin.resume();
     process.stdin.once('data', () =&gt; {
@@ -1988,13 +1988,13 @@ if (connectedAccount?.status !== ConnectorStatus.ACTIVE) {
 }
 
 if (connectedAccount?.status !== ConnectorStatus.ACTIVE) {
-  throw new Error('Gmail is still not ACTIVE. Complete authorization and try again.');
+  throw new Error('Slack is still not ACTIVE. Complete authorization and try again.');
 }
 
 const toolResponse = await actions.executeTool({
-  toolName: 'gmail_fetch_mails',
+  toolName: 'slack_list_channels',
   connectedAccountId: connectedAccount.id,
-  toolInput: { query: 'is:unread', max_results: 5 },
+  toolInput: { limit: 10 },
 });
 console.log(toolResponse.data);</code></pre>
             </div>
@@ -2021,7 +2021,7 @@ scalekit_client = ScalekitClient(
     os.getenv("SCALEKIT_CLIENT_SECRET"),
 )
 actions = scalekit_client.actions
-connection_name = os.getenv("GMAIL_CONNECTION_NAME")
+connection_name = os.getenv("SLACK_CONNECTION_NAME")
 
 response = actions.get_or_create_connected_account(
     connection_name=connection_name,
@@ -2035,7 +2035,7 @@ if connected_account.status != "ACTIVE":
         connection_name=connection_name,
         identifier="user_123",
     )
-    print("Authorize Gmail:", link_response.link)
+    print("Authorize Slack:", link_response.link)
     input("Press Enter after authorizing...")
     response = actions.get_or_create_connected_account(
         connection_name=connection_name,
@@ -2044,14 +2044,14 @@ if connected_account.status != "ACTIVE":
     connected_account = response.connected_account
 
 if connected_account.status != "ACTIVE":
-    raise RuntimeError("Gmail is still not ACTIVE. Complete authorization and try again.")
+    raise RuntimeError("Slack is still not ACTIVE. Complete authorization and try again.")
 
 # Prefer connected_account_id after authorize. If you use identifier instead,
 # also pass connection_name — the pair is required for account resolution.
 tool_response = actions.execute_tool(
-    tool_name="gmail_fetch_mails",
+    tool_name="slack_list_channels",
     connected_account_id=connected_account.id,
-    tool_input={"query": "is:unread", "max_results": 5},
+    tool_input={"limit": 10},
 )
 print(tool_response.data)</code></pre>
             </div>
@@ -2451,7 +2451,6 @@ print(tool_response.data)</code></pre>
         window.addEventListener('scroll', onScroll, { passive: true })
         onScroll()
       })()
-
       ;(function () {
         var items = Array.prototype.slice.call(document.querySelectorAll('.nav-item'))
         function setOpen(item, open) {
@@ -2495,7 +2494,6 @@ print(tool_response.data)</code></pre>
           if (e.key === 'Escape') closeAll()
         })
       })()
-
       ;(function () {
         var icon =
           '<svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="8.5" y="8.5" width="11.5" height="11.5" rx="2"/><path d="M15.5 8.5V6a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v7.5a2 2 0 0 0 2 2h2.5"/></svg>'

--- a/src/content/docs/agentkit/connected-accounts.mdx
+++ b/src/content/docs/agentkit/connected-accounts.mdx
@@ -39,7 +39,7 @@ Use `get_or_create_connected_account` as the safe default when a user may be con
   <TabItem label="Python">
 ```python
 response = actions.get_or_create_connected_account(
-    connection_name="slack",
+    connection_name="github-connect",
     identifier="user_123"
 )
 connected_account = response.connected_account
@@ -49,7 +49,7 @@ print(f"Status: {connected_account.status}")
   <TabItem label="Node.js">
 ```typescript
 const response = await actions.getOrCreateConnectedAccount({
-  connectionName: 'slack',
+  connectionName: 'github-connect',
   identifier: 'user_123',
 });
 
@@ -74,7 +74,7 @@ Your code is the same regardless of connector type. Scalekit determines the righ
 ```python
 if connected_account.status != "ACTIVE":
     link_response = actions.get_authorization_link(
-        connection_name="slack",
+        connection_name="github-connect",
         identifier="user_123"
     )
     # Redirect or send link_response.link to the user
@@ -86,7 +86,7 @@ import { ConnectorStatus } from '@scalekit-sdk/node/lib/pkg/grpc/scalekit/v1/con
 
 if (connectedAccount?.status !== ConnectorStatus.ACTIVE) {
   const linkResponse = await actions.getAuthorizationLink({
-    connectionName: 'slack',
+    connectionName: 'github-connect',
     identifier: 'user_123',
   });
   // Redirect or send linkResponse.link to the user
@@ -130,8 +130,8 @@ The `connected_account.status_updated` event fires on every status transition an
     "id": "ca_133400349586228019",
     "identifier": "john@acmecorp.com",
     "connection_id": "conn_133400101014995480",
-    "connection_name": "slack",
-    "provider": "SLACK",
+    "connection_name": "github-connect",
+    "provider": "GITHUB",
     "authorization_type": "OAUTH",
     "status": "EXPIRED",
     "old_status": "ACTIVE"
@@ -163,7 +163,7 @@ When you receive this event, [generate a new authorization link](#handle-inactiv
 
 ```typescript
 const listResponse = await actions.listConnectedAccounts({
-  connectionName: 'slack',
+  connectionName: 'github-connect',
 });
 console.log('Connected accounts:', listResponse);
 ```
@@ -174,7 +174,7 @@ Deleting a connected account removes the user's credentials and authorization st
 
 ```typescript
 await actions.deleteConnectedAccount({
-  connectionName: 'slack',
+  connectionName: 'github-connect',
   identifier: 'user_123',
 });
 ```

--- a/src/content/docs/agentkit/connected-accounts.mdx
+++ b/src/content/docs/agentkit/connected-accounts.mdx
@@ -39,7 +39,7 @@ Use `get_or_create_connected_account` as the safe default when a user may be con
   <TabItem label="Python">
 ```python
 response = actions.get_or_create_connected_account(
-    connection_name="gmail",
+    connection_name="slack",
     identifier="user_123"
 )
 connected_account = response.connected_account
@@ -49,7 +49,7 @@ print(f"Status: {connected_account.status}")
   <TabItem label="Node.js">
 ```typescript
 const response = await actions.getOrCreateConnectedAccount({
-  connectionName: 'gmail',
+  connectionName: 'slack',
   identifier: 'user_123',
 });
 
@@ -74,7 +74,7 @@ Your code is the same regardless of connector type. Scalekit determines the righ
 ```python
 if connected_account.status != "ACTIVE":
     link_response = actions.get_authorization_link(
-        connection_name="gmail",
+        connection_name="slack",
         identifier="user_123"
     )
     # Redirect or send link_response.link to the user
@@ -86,7 +86,7 @@ import { ConnectorStatus } from '@scalekit-sdk/node/lib/pkg/grpc/scalekit/v1/con
 
 if (connectedAccount?.status !== ConnectorStatus.ACTIVE) {
   const linkResponse = await actions.getAuthorizationLink({
-    connectionName: 'gmail',
+    connectionName: 'slack',
     identifier: 'user_123',
   });
   // Redirect or send linkResponse.link to the user
@@ -130,8 +130,8 @@ The `connected_account.status_updated` event fires on every status transition an
     "id": "ca_133400349586228019",
     "identifier": "john@acmecorp.com",
     "connection_id": "conn_133400101014995480",
-    "connection_name": "gmail",
-    "provider": "GMAIL",
+    "connection_name": "slack",
+    "provider": "SLACK",
     "authorization_type": "OAUTH",
     "status": "EXPIRED",
     "old_status": "ACTIVE"
@@ -163,7 +163,7 @@ When you receive this event, [generate a new authorization link](#handle-inactiv
 
 ```typescript
 const listResponse = await actions.listConnectedAccounts({
-  connectionName: 'gmail',
+  connectionName: 'slack',
 });
 console.log('Connected accounts:', listResponse);
 ```
@@ -174,7 +174,7 @@ Deleting a connected account removes the user's credentials and authorization st
 
 ```typescript
 await actions.deleteConnectedAccount({
-  connectionName: 'gmail',
+  connectionName: 'slack',
   identifier: 'user_123',
 });
 ```

--- a/src/content/docs/agentkit/examples/index.mdx
+++ b/src/content/docs/agentkit/examples/index.mdx
@@ -10,7 +10,7 @@ tableOfContents: false
 import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 import FoldCard from '@components/ui/FoldCard.astro';
 
-Each example builds a working agent that reads a user's Gmail inbox using Scalekit-authenticated tools.
+Each example builds a working agent that calls a connector's tools on a user's behalf, authenticated by Scalekit. The samples below use Gmail as their connector; the same pattern applies to any connector in the catalog.
 
 ## No agent loop to build
 

--- a/src/content/docs/agentkit/quickstart.mdx
+++ b/src/content/docs/agentkit/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: "AgentKit: Connect my agent to apps"
-description: Build a working agent that makes authenticated tool calls on behalf of users, using Gmail as the example connector.
+description: Build a working agent that makes authenticated tool calls on behalf of users, using Slack as the example connector.
 tags: [agent-auth, quickstart, ai-agents, oauth, token-vault, tool-integration, delegated-oauth]
 sidebar:
   order: 1
@@ -12,14 +12,14 @@ import quickstartArchitecture from '@/assets/pages/hero/agentkit.svg';
 
 <img
   src={quickstartArchitecture.src}
-  alt="Architecture diagram: an AI agent connects through Scalekit MCP Gateway with delegated auth, scoped permissions, and tool calls to SaaS apps such as Gmail, Slack, and Salesforce."
+  alt="Architecture diagram: an AI agent connects through Scalekit MCP Gateway with delegated auth, scoped permissions, and tool calls to SaaS apps such as Slack, Gmail, and Salesforce."
   width={quickstartArchitecture.width}
   height={quickstartArchitecture.height}
   loading="eager"
   decoding="async"
 />
 
-By the end of this guide, you'll have a working agent that fetches a user's last 5 unread Gmail messages (authenticated with their real account). Scalekit manages the OAuth flow, token storage, and API proxy so you focus on agent logic.
+By the end of this guide, you'll have a working agent that lists a user's Slack channels (authenticated with their real account). Scalekit manages the OAuth flow, token storage, and API proxy so you focus on agent logic.
 
 
 
@@ -28,17 +28,17 @@ By the end of this guide, you'll have a working agent that fetches a user's last
 Complete these steps in the Scalekit dashboard before writing any code:
 
 1. **Create a Scalekit account** at [app.scalekit.com](https://app.scalekit.com).
-2. **Configure a Gmail connector** at Dashboard → **AgentKit** > **Connections** > **Create Connection** → select **Gmail**.
+2. **Confirm the Slack connector** at Dashboard → **AgentKit** > **Connections**.
 
-   Create the connection in the dashboard before running any code. Then copy the exact **Connection name** from that connection and use that value in your code. It must match the dashboard exactly, and it is not always the provider slug `gmail`.
+   Slack is enabled by default in new Scalekit environments, so the connection is already there. Copy the exact **Connection name** from that connection and use that value in your code. It must match the dashboard exactly, and it is not always the provider slug `slack`.
 
-   Gmail is enabled by default in new Scalekit environments. To connect to other services, create a connection for each app under **AgentKit** > **Connections** > **Create Connection**.
+   If the Slack connection is missing, create it at **AgentKit** > **Connections** > **Create Connection** → select **Slack**. To connect to other services, create a connection for each app the same way.
 
-3. **Copy your API credentials** at Dashboard → **Developers → Settings → API Credentials**. Save these three values as environment variables:
+3. **Copy your API credentials** at Dashboard → **Developers → Settings → API Credentials**. Save these four values as environment variables:
    - `SCALEKIT_CLIENT_ID`
    - `SCALEKIT_CLIENT_SECRET`
    - `SCALEKIT_ENV_URL`
-   - `GMAIL_CONNECTION_NAME` (copy the exact Connection name from **AgentKit** > **Connections**)
+   - `SLACK_CONNECTION_NAME` (copy the exact Connection name from **AgentKit** > **Connections**)
 
 ## Build your agent
 
@@ -54,7 +54,7 @@ Complete these steps in the Scalekit dashboard before writing any code:
     The wizard sets up the right plugins and skills for your editors. Complete any browser authorization for the Scalekit MCP server when prompted. Then use the prompt below (or describe your goal in natural language).
 
     ```md title="Implementation prompt" wrap showLineNumbers=false
-    Configure Scalekit agent authentication for Gmail. Provide code to create a connected account, generate an authorization link, and, once the user authorizes, fetch the last 5 unread emails using Scalekit's tool API.
+    Configure Scalekit agent authentication for Slack. Provide code to create a connected account, generate an authorization link, and, once the user authorizes, list the workspace's first 10 channels using Scalekit's tool API.
     ```
 
     <Aside type="caution" title="Review generated code before deploying">
@@ -95,7 +95,7 @@ Complete these steps in the Scalekit dashboard before writing any code:
             os.environ["SCALEKIT_CLIENT_SECRET"],
         )
         actions = scalekit_client.actions
-        connection_name = os.getenv("GMAIL_CONNECTION_NAME")  # must match the Connection name in the dashboard exactly
+        connection_name = os.getenv("SLACK_CONNECTION_NAME")  # must match the Connection name in the dashboard exactly
         ```
       </TabItem>
       <TabItem label="Node.js">
@@ -112,19 +112,19 @@ Complete these steps in the Scalekit dashboard before writing any code:
         );
 
         const actions = scalekit.actions;
-        const connectionName = process.env.GMAIL_CONNECTION_NAME!; // must match the Connection name in the dashboard exactly
+        const connectionName = process.env.SLACK_CONNECTION_NAME!; // must match the Connection name in the dashboard exactly
         ```
       </TabItem>
     </Tabs>
 
     ### 2. Create a connected account
 
-    Scalekit tracks each user's third-party connection as a connected account. This is the record that holds their OAuth tokens. Creating it tells Scalekit to start managing the user's Gmail access on your behalf. This step fails if the Gmail connection has not been created in **AgentKit** > **Connections** yet, or if `connection_name` / `connectionName` does not match the dashboard exactly.
+    Scalekit tracks each user's third-party connection as a connected account. This is the record that holds their OAuth tokens. Creating it tells Scalekit to start managing the user's Slack access on your behalf. This step fails if the Slack connection is missing from **AgentKit** > **Connections**, or if `connection_name` / `connectionName` does not match the dashboard exactly.
 
     <Tabs syncKey="tech-stack">
       <TabItem label="Python">
         ```python wrap {2} showLineNumbers=false frame="none"
-        # Create or retrieve the user's connected Gmail account
+        # Create or retrieve the user's connected Slack account
         response = actions.get_or_create_connected_account(
             connection_name=connection_name,
             identifier="user_123"  # Replace with your system's unique user ID
@@ -135,7 +135,7 @@ Complete these steps in the Scalekit dashboard before writing any code:
       </TabItem>
       <TabItem label="Node.js">
         ```typescript showLineNumbers=false frame="none"
-        // Create or retrieve the user's connected Gmail account
+        // Create or retrieve the user's connected Slack account
         const response = await actions.getOrCreateConnectedAccount({
           connectionName,
           identifier: 'user_123',  // Replace with your system's unique user ID
@@ -157,13 +157,13 @@ Complete these steps in the Scalekit dashboard before writing any code:
         # Generate authorization link if user hasn't authorized or token is expired.
         # Do not call tools until status is ACTIVE — wait for the user to finish OAuth first.
         if connected_account.status != "ACTIVE":
-            print(f"Gmail is not connected: {connected_account.status}")
+            print(f"Slack is not connected: {connected_account.status}")
             link_response = actions.get_authorization_link(
                 connection_name=connection_name,
                 identifier="user_123",
             )
-            print("🔗 click on the link to authorize Gmail", link_response.link)
-            input("⎆ Press Enter after authorizing Gmail...")
+            print("🔗 click on the link to authorize Slack", link_response.link)
+            input("⎆ Press Enter after authorizing Slack...")
             # Re-fetch so connected_account reflects ACTIVE status and a valid id
             response = actions.get_or_create_connected_account(
                 connection_name=connection_name,
@@ -174,7 +174,7 @@ Complete these steps in the Scalekit dashboard before writing any code:
 
         if connected_account.status != "ACTIVE":
             raise RuntimeError(
-                "Gmail is still not ACTIVE. Complete authorization and try again."
+                "Slack is still not ACTIVE. Complete authorization and try again."
             )
         ```
       </TabItem>
@@ -183,13 +183,13 @@ Complete these steps in the Scalekit dashboard before writing any code:
         // Generate authorization link if user hasn't authorized or token is expired.
         // Do not call tools until status is ACTIVE — wait for the user to finish OAuth first.
         if (connectedAccount?.status !== ConnectorStatus.ACTIVE) {
-          console.log('gmail is not connected:', connectedAccount?.status);
+          console.log('slack is not connected:', connectedAccount?.status);
           const linkResponse = await actions.getAuthorizationLink({
             connectionName,
             identifier: 'user_123',
           });
-          console.log('🔗 click on the link to authorize gmail', linkResponse.link);
-          console.log('Press Enter after authorizing Gmail...');
+          console.log('🔗 click on the link to authorize slack', linkResponse.link);
+          console.log('Press Enter after authorizing Slack...');
           await new Promise<void>((resolve) => {
             process.stdin.resume();
             process.stdin.once('data', () => {
@@ -207,17 +207,17 @@ Complete these steps in the Scalekit dashboard before writing any code:
         }
 
         if (connectedAccount?.status !== ConnectorStatus.ACTIVE) {
-          throw new Error('Gmail is still not ACTIVE. Complete authorization and try again.');
+          throw new Error('Slack is still not ACTIVE. Complete authorization and try again.');
         }
         ```
       </TabItem>
     </Tabs>
 
-    Open the link in a browser and authorize the Gmail connection. Once complete, the connected account status updates to `ACTIVE` and your agent can act on the user's behalf. In CLI samples, wait for that step (for example with `input()` or stdin) before calling tools — otherwise the first run fails because the account is still inactive.
+    Open the link in a browser and authorize the Slack connection. Once complete, the connected account status updates to `ACTIVE` and your agent can act on the user's behalf. In CLI samples, wait for that step (for example with `input()` or stdin) before calling tools — otherwise the first run fails because the account is still inactive.
 
-    ### 4. Fetch emails via tool call
+    ### 4. List Slack channels via tool call
 
-    Pass the tool name and your inputs to Scalekit. It handles the request to Gmail and returns a structured response your agent can reason over directly: no endpoint URLs, auth headers, or response parsing required.
+    Pass the tool name and your inputs to Scalekit. It handles the request to Slack and returns a structured response your agent can reason over directly: no endpoint URLs, auth headers, or response parsing required.
 
     <Tabs syncKey="tech-stack">
       <TabItem label="Python">
@@ -225,11 +225,10 @@ Complete these steps in the Scalekit dashboard before writing any code:
         # Prefer connected_account_id after authorize. If you use identifier instead,
         # also pass connection_name — the pair is required for account resolution.
         tool_response = actions.execute_tool(
-            tool_name="gmail_fetch_mails",
+            tool_name="slack_list_channels",
             connected_account_id=connected_account.id,
             tool_input={
-                "query": "is:unread",
-                "max_results": 5,
+                "limit": 10,
             },
         )
         # Tool output lives under data
@@ -239,15 +238,14 @@ Complete these steps in the Scalekit dashboard before writing any code:
       <TabItem label="Node.js">
         ```typescript showLineNumbers=false frame="none" wrap
         const toolResponse = await actions.executeTool({
-          toolName: 'gmail_fetch_mails',
+          toolName: 'slack_list_channels',
           connectedAccountId: connectedAccount?.id,
           toolInput: {
-            query: 'is:unread',
-            max_results: 5,
+            limit: 10,
           },
         });
         // Tool output lives under data
-        console.log('Recent emails:', toolResponse.data);
+        console.log('Your Slack channels:', toolResponse.data);
         ```
       </TabItem>
     </Tabs>
@@ -259,8 +257,8 @@ Complete these steps in the Scalekit dashboard before writing any code:
 
 Run your agent and confirm:
 
-- The connected account status is `ACTIVE` after the user completes the Gmail OAuth flow.
-- The tool response contains structured email data (subject, sender, snippet, and timestamp) ready for your agent to process.
+- The connected account status is `ACTIVE` after the user completes the Slack OAuth flow.
+- The tool response contains structured channel data (name, ID, topic, and member count) ready for your agent to process.
 
 If the connected account stays in a `non-ACTIVE` state, the user has not completed the OAuth flow. Regenerate the authorization link and try again.
 

--- a/src/content/docs/agentkit/quickstart.mdx
+++ b/src/content/docs/agentkit/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: "AgentKit: Connect my agent to apps"
-description: Build a working agent that makes authenticated tool calls on behalf of users, using Slack as the example connector.
+description: Build a working agent that makes authenticated tool calls on behalf of users, using GitHub as the example connector.
 tags: [agent-auth, quickstart, ai-agents, oauth, token-vault, tool-integration, delegated-oauth]
 sidebar:
   order: 1
@@ -12,14 +12,14 @@ import quickstartArchitecture from '@/assets/pages/hero/agentkit.svg';
 
 <img
   src={quickstartArchitecture.src}
-  alt="Architecture diagram: an AI agent connects through Scalekit MCP Gateway with delegated auth, scoped permissions, and tool calls to SaaS apps such as Slack, Gmail, and Salesforce."
+  alt="Architecture diagram: an AI agent connects through Scalekit MCP Gateway with delegated auth, scoped permissions, and tool calls to SaaS apps such as GitHub, Slack, and Salesforce."
   width={quickstartArchitecture.width}
   height={quickstartArchitecture.height}
   loading="eager"
   decoding="async"
 />
 
-By the end of this guide, you'll have a working agent that lists a user's Slack channels (authenticated with their real account). Scalekit manages the OAuth flow, token storage, and API proxy so you focus on agent logic.
+By the end of this guide, you'll have a working agent that stars a GitHub repository on a user's behalf (authenticated with their real account). Scalekit manages the OAuth flow, token storage, and API proxy so you focus on agent logic.
 
 
 
@@ -28,17 +28,19 @@ By the end of this guide, you'll have a working agent that lists a user's Slack 
 Complete these steps in the Scalekit dashboard before writing any code:
 
 1. **Create a Scalekit account** at [app.scalekit.com](https://app.scalekit.com).
-2. **Confirm the Slack connector** at Dashboard → **AgentKit** > **Connections**.
+2. **Confirm the GitHub connector** at Dashboard → **AgentKit** > **Connections**.
 
-   Slack is enabled by default in new Scalekit environments, so the connection is already there. Copy the exact **Connection name** from that connection and use that value in your code. It must match the dashboard exactly, and it is not always the provider slug `slack`.
+   GitHub is enabled by default in new Scalekit environments, so the connection is already there under the name `github-connect`. Copy the exact **Connection name** from that connection and use that value in your code — it must match the dashboard exactly.
 
-   If the Slack connection is missing, create it at **AgentKit** > **Connections** > **Create Connection** → select **Slack**. To connect to other services, create a connection for each app the same way.
+   The seeded connection ships with the `user:email`, `repo`, and `public_repo` scopes, so repository tools work without editing scopes first.
+
+   If the GitHub connection is missing, create it at **AgentKit** > **Connections** > **Create Connection** → select **GitHub**. To connect to other services, create a connection for each app the same way.
 
 3. **Copy your API credentials** at Dashboard → **Developers → Settings → API Credentials**. Save these four values as environment variables:
    - `SCALEKIT_CLIENT_ID`
    - `SCALEKIT_CLIENT_SECRET`
    - `SCALEKIT_ENV_URL`
-   - `SLACK_CONNECTION_NAME` (copy the exact Connection name from **AgentKit** > **Connections**)
+   - `GITHUB_CONNECTION_NAME` (copy the exact Connection name from **AgentKit** > **Connections**)
 
 ## Build your agent
 
@@ -54,7 +56,7 @@ Complete these steps in the Scalekit dashboard before writing any code:
     The wizard sets up the right plugins and skills for your editors. Complete any browser authorization for the Scalekit MCP server when prompted. Then use the prompt below (or describe your goal in natural language).
 
     ```md title="Implementation prompt" wrap showLineNumbers=false
-    Configure Scalekit agent authentication for Slack. Provide code to create a connected account, generate an authorization link, and, once the user authorizes, list the workspace's first 10 channels using Scalekit's tool API.
+    Configure Scalekit agent authentication for GitHub. Provide code to create a connected account, generate an authorization link, and, once the user authorizes, star Scalekit's SDK repo (scalekit-inc/scalekit-sdk-python) using Scalekit's tool API.
     ```
 
     <Aside type="caution" title="Review generated code before deploying">
@@ -95,7 +97,7 @@ Complete these steps in the Scalekit dashboard before writing any code:
             os.environ["SCALEKIT_CLIENT_SECRET"],
         )
         actions = scalekit_client.actions
-        connection_name = os.getenv("SLACK_CONNECTION_NAME")  # must match the Connection name in the dashboard exactly
+        connection_name = os.getenv("GITHUB_CONNECTION_NAME")  # must match the Connection name in the dashboard exactly
         ```
       </TabItem>
       <TabItem label="Node.js">
@@ -112,19 +114,19 @@ Complete these steps in the Scalekit dashboard before writing any code:
         );
 
         const actions = scalekit.actions;
-        const connectionName = process.env.SLACK_CONNECTION_NAME!; // must match the Connection name in the dashboard exactly
+        const connectionName = process.env.GITHUB_CONNECTION_NAME!; // must match the Connection name in the dashboard exactly
         ```
       </TabItem>
     </Tabs>
 
     ### 2. Create a connected account
 
-    Scalekit tracks each user's third-party connection as a connected account. This is the record that holds their OAuth tokens. Creating it tells Scalekit to start managing the user's Slack access on your behalf. This step fails if the Slack connection is missing from **AgentKit** > **Connections**, or if `connection_name` / `connectionName` does not match the dashboard exactly.
+    Scalekit tracks each user's third-party connection as a connected account. This is the record that holds their OAuth tokens. Creating it tells Scalekit to start managing the user's GitHub access on your behalf. This step fails if the GitHub connection is missing from **AgentKit** > **Connections**, or if `connection_name` / `connectionName` does not match the dashboard exactly.
 
     <Tabs syncKey="tech-stack">
       <TabItem label="Python">
         ```python wrap {2} showLineNumbers=false frame="none"
-        # Create or retrieve the user's connected Slack account
+        # Create or retrieve the user's connected GitHub account
         response = actions.get_or_create_connected_account(
             connection_name=connection_name,
             identifier="user_123"  # Replace with your system's unique user ID
@@ -135,7 +137,7 @@ Complete these steps in the Scalekit dashboard before writing any code:
       </TabItem>
       <TabItem label="Node.js">
         ```typescript showLineNumbers=false frame="none"
-        // Create or retrieve the user's connected Slack account
+        // Create or retrieve the user's connected GitHub account
         const response = await actions.getOrCreateConnectedAccount({
           connectionName,
           identifier: 'user_123',  // Replace with your system's unique user ID
@@ -157,13 +159,13 @@ Complete these steps in the Scalekit dashboard before writing any code:
         # Generate authorization link if user hasn't authorized or token is expired.
         # Do not call tools until status is ACTIVE — wait for the user to finish OAuth first.
         if connected_account.status != "ACTIVE":
-            print(f"Slack is not connected: {connected_account.status}")
+            print(f"GitHub is not connected: {connected_account.status}")
             link_response = actions.get_authorization_link(
                 connection_name=connection_name,
                 identifier="user_123",
             )
-            print("🔗 click on the link to authorize Slack", link_response.link)
-            input("⎆ Press Enter after authorizing Slack...")
+            print("🔗 click on the link to authorize GitHub", link_response.link)
+            input("⎆ Press Enter after authorizing GitHub...")
             # Re-fetch so connected_account reflects ACTIVE status and a valid id
             response = actions.get_or_create_connected_account(
                 connection_name=connection_name,
@@ -174,7 +176,7 @@ Complete these steps in the Scalekit dashboard before writing any code:
 
         if connected_account.status != "ACTIVE":
             raise RuntimeError(
-                "Slack is still not ACTIVE. Complete authorization and try again."
+                "GitHub is still not ACTIVE. Complete authorization and try again."
             )
         ```
       </TabItem>
@@ -183,13 +185,13 @@ Complete these steps in the Scalekit dashboard before writing any code:
         // Generate authorization link if user hasn't authorized or token is expired.
         // Do not call tools until status is ACTIVE — wait for the user to finish OAuth first.
         if (connectedAccount?.status !== ConnectorStatus.ACTIVE) {
-          console.log('slack is not connected:', connectedAccount?.status);
+          console.log('github is not connected:', connectedAccount?.status);
           const linkResponse = await actions.getAuthorizationLink({
             connectionName,
             identifier: 'user_123',
           });
-          console.log('🔗 click on the link to authorize slack', linkResponse.link);
-          console.log('Press Enter after authorizing Slack...');
+          console.log('🔗 click on the link to authorize github', linkResponse.link);
+          console.log('Press Enter after authorizing GitHub...');
           await new Promise<void>((resolve) => {
             process.stdin.resume();
             process.stdin.once('data', () => {
@@ -207,28 +209,30 @@ Complete these steps in the Scalekit dashboard before writing any code:
         }
 
         if (connectedAccount?.status !== ConnectorStatus.ACTIVE) {
-          throw new Error('Slack is still not ACTIVE. Complete authorization and try again.');
+          throw new Error('GitHub is still not ACTIVE. Complete authorization and try again.');
         }
         ```
       </TabItem>
     </Tabs>
 
-    Open the link in a browser and authorize the Slack connection. Once complete, the connected account status updates to `ACTIVE` and your agent can act on the user's behalf. In CLI samples, wait for that step (for example with `input()` or stdin) before calling tools — otherwise the first run fails because the account is still inactive.
+    Open the link in a browser and authorize the GitHub connection. Once complete, the connected account status updates to `ACTIVE` and your agent can act on the user's behalf. In CLI samples, wait for that step (for example with `input()` or stdin) before calling tools — otherwise the first run fails because the account is still inactive.
 
-    ### 4. List Slack channels via tool call
+    ### 4. Star the Scalekit SDK repo via tool call
 
-    Pass the tool name and your inputs to Scalekit. It handles the request to Slack and returns a structured response your agent can reason over directly: no endpoint URLs, auth headers, or response parsing required.
+    Pass the tool name and your inputs to Scalekit. It handles the request to GitHub and returns a structured response your agent can reason over directly: no endpoint URLs, auth headers, or response parsing required.
 
     <Tabs syncKey="tech-stack">
       <TabItem label="Python">
         ```python showLineNumbers=false frame="none" wrap
+        # Star the Scalekit Python SDK repo on GitHub.
         # Prefer connected_account_id after authorize. If you use identifier instead,
         # also pass connection_name — the pair is required for account resolution.
         tool_response = actions.execute_tool(
-            tool_name="slack_list_channels",
+            tool_name="github_repo_star",
             connected_account_id=connected_account.id,
             tool_input={
-                "limit": 10,
+                "owner": "scalekit-inc",
+                "repo": "scalekit-sdk-python",
             },
         )
         # Tool output lives under data
@@ -237,15 +241,17 @@ Complete these steps in the Scalekit dashboard before writing any code:
       </TabItem>
       <TabItem label="Node.js">
         ```typescript showLineNumbers=false frame="none" wrap
+        // Star the Scalekit Node.js SDK repo on GitHub
         const toolResponse = await actions.executeTool({
-          toolName: 'slack_list_channels',
+          toolName: 'github_repo_star',
           connectedAccountId: connectedAccount?.id,
           toolInput: {
-            limit: 10,
+            owner: 'scalekit-inc',
+            repo: 'scalekit-sdk-node',
           },
         });
         // Tool output lives under data
-        console.log('Your Slack channels:', toolResponse.data);
+        console.log('Starred the repo:', toolResponse.data);
         ```
       </TabItem>
     </Tabs>
@@ -257,8 +263,8 @@ Complete these steps in the Scalekit dashboard before writing any code:
 
 Run your agent and confirm:
 
-- The connected account status is `ACTIVE` after the user completes the Slack OAuth flow.
-- The tool response contains structured channel data (name, ID, topic, and member count) ready for your agent to process.
+- The connected account status is `ACTIVE` after the user completes the GitHub OAuth flow.
+- The tool call returns success and the star appears on the Scalekit SDK repo on GitHub.
 
 If the connected account stays in a `non-ACTIVE` state, the user has not completed the OAuth flow. Regenerate the authorization link and try again.
 

--- a/src/content/docs/agentkit/tools/authorize.mdx
+++ b/src/content/docs/agentkit/tools/authorize.mdx
@@ -29,7 +29,7 @@ The flow is:
     ```python
     # Create or retrieve the connected account for this user
     response = actions.get_or_create_connected_account(
-        connection_name="slack",
+        connection_name="github-connect",
         identifier="user_123"  # your app's unique user ID
     )
     connected_account = response.connected_account
@@ -37,7 +37,7 @@ The flow is:
     # Generate the authorization link if the account is not yet active
     if connected_account.status != "ACTIVE":
         link_response = actions.get_authorization_link(
-            connection_name="slack",
+            connection_name="github-connect",
             identifier="user_123"
         )
         auth_url = link_response.link
@@ -50,7 +50,7 @@ The flow is:
 
     // Create or retrieve the connected account for this user
     const response = await actions.getOrCreateConnectedAccount({
-      connectionName: 'slack',
+      connectionName: 'github-connect',
       identifier: 'user_123',  // your app's unique user ID
     });
 
@@ -59,7 +59,7 @@ The flow is:
     // Generate the authorization link if the account is not yet active
     if (connectedAccount?.status !== ConnectorStatus.ACTIVE) {
       const linkResponse = await actions.getAuthorizationLink({
-        connectionName: 'slack',
+        connectionName: 'github-connect',
         identifier: 'user_123',
       });
       const authUrl = linkResponse.link;
@@ -75,7 +75,7 @@ How you deliver the link depends on your application:
 
 - **Web app:** redirect the user to `auth_url` directly if they're in an active browser session
 - **Email or notification:** send the link when the user isn't actively in your app, or when connecting at their own pace is acceptable
-- **In-app prompt:** show a button ("Connect Slack") when you want to prompt connection at a specific moment in the user's workflow
+- **In-app prompt:** show a button ("Connect GitHub") when you want to prompt connection at a specific moment in the user's workflow
 
 Once the user opens the link and approves the OAuth consent screen, Scalekit exchanges the authorization code for tokens and marks the connected account `ACTIVE`. You do not need to handle the OAuth callback yourself.
 
@@ -91,7 +91,7 @@ Check the connected account status before executing tools. Tokens can expire or 
   <TabItem label="Python">
     ```python
     response = actions.get_or_create_connected_account(
-        connection_name="slack",
+        connection_name="github-connect",
         identifier="user_123"
     )
     connected_account = response.connected_account
@@ -102,7 +102,7 @@ Check the connected account status before executing tools. Tokens can expire or 
 
     if connected_account.status != "ACTIVE":
         link_response = actions.get_authorization_link(
-            connection_name="slack",
+            connection_name="github-connect",
             identifier="user_123"
         )
         # Redirect or send link_response.link to the user
@@ -113,7 +113,7 @@ Check the connected account status before executing tools. Tokens can expire or 
     import { ConnectorStatus } from '@scalekit-sdk/node/lib/pkg/grpc/scalekit/v1/connected_accounts/connected_accounts_pb';
 
     const response = await actions.getOrCreateConnectedAccount({
-      connectionName: 'slack',
+      connectionName: 'github-connect',
       identifier: 'user_123',
     });
 
@@ -125,7 +125,7 @@ Check the connected account status before executing tools. Tokens can expire or 
 
     if (connectedAccount?.status !== ConnectorStatus.ACTIVE) {
       const linkResponse = await actions.getAuthorizationLink({
-        connectionName: 'slack',
+        connectionName: 'github-connect',
         identifier: 'user_123',
       });
       // Redirect or send linkResponse.link to the user

--- a/src/content/docs/agentkit/tools/authorize.mdx
+++ b/src/content/docs/agentkit/tools/authorize.mdx
@@ -29,7 +29,7 @@ The flow is:
     ```python
     # Create or retrieve the connected account for this user
     response = actions.get_or_create_connected_account(
-        connection_name="gmail",
+        connection_name="slack",
         identifier="user_123"  # your app's unique user ID
     )
     connected_account = response.connected_account
@@ -37,7 +37,7 @@ The flow is:
     # Generate the authorization link if the account is not yet active
     if connected_account.status != "ACTIVE":
         link_response = actions.get_authorization_link(
-            connection_name="gmail",
+            connection_name="slack",
             identifier="user_123"
         )
         auth_url = link_response.link
@@ -50,7 +50,7 @@ The flow is:
 
     // Create or retrieve the connected account for this user
     const response = await actions.getOrCreateConnectedAccount({
-      connectionName: 'gmail',
+      connectionName: 'slack',
       identifier: 'user_123',  // your app's unique user ID
     });
 
@@ -59,7 +59,7 @@ The flow is:
     // Generate the authorization link if the account is not yet active
     if (connectedAccount?.status !== ConnectorStatus.ACTIVE) {
       const linkResponse = await actions.getAuthorizationLink({
-        connectionName: 'gmail',
+        connectionName: 'slack',
         identifier: 'user_123',
       });
       const authUrl = linkResponse.link;
@@ -75,7 +75,7 @@ How you deliver the link depends on your application:
 
 - **Web app:** redirect the user to `auth_url` directly if they're in an active browser session
 - **Email or notification:** send the link when the user isn't actively in your app, or when connecting at their own pace is acceptable
-- **In-app prompt:** show a button ("Connect Gmail") when you want to prompt connection at a specific moment in the user's workflow
+- **In-app prompt:** show a button ("Connect Slack") when you want to prompt connection at a specific moment in the user's workflow
 
 Once the user opens the link and approves the OAuth consent screen, Scalekit exchanges the authorization code for tokens and marks the connected account `ACTIVE`. You do not need to handle the OAuth callback yourself.
 
@@ -91,7 +91,7 @@ Check the connected account status before executing tools. Tokens can expire or 
   <TabItem label="Python">
     ```python
     response = actions.get_or_create_connected_account(
-        connection_name="gmail",
+        connection_name="slack",
         identifier="user_123"
     )
     connected_account = response.connected_account
@@ -102,7 +102,7 @@ Check the connected account status before executing tools. Tokens can expire or 
 
     if connected_account.status != "ACTIVE":
         link_response = actions.get_authorization_link(
-            connection_name="gmail",
+            connection_name="slack",
             identifier="user_123"
         )
         # Redirect or send link_response.link to the user
@@ -113,7 +113,7 @@ Check the connected account status before executing tools. Tokens can expire or 
     import { ConnectorStatus } from '@scalekit-sdk/node/lib/pkg/grpc/scalekit/v1/connected_accounts/connected_accounts_pb';
 
     const response = await actions.getOrCreateConnectedAccount({
-      connectionName: 'gmail',
+      connectionName: 'slack',
       identifier: 'user_123',
     });
 
@@ -125,7 +125,7 @@ Check the connected account status before executing tools. Tokens can expire or 
 
     if (connectedAccount?.status !== ConnectorStatus.ACTIVE) {
       const linkResponse = await actions.getAuthorizationLink({
-        connectionName: 'gmail',
+        connectionName: 'slack',
         identifier: 'user_123',
       });
       // Redirect or send linkResponse.link to the user

--- a/src/content/docs/agentkit/tools/scalekit-optimized-tools.mdx
+++ b/src/content/docs/agentkit/tools/scalekit-optimized-tools.mdx
@@ -16,7 +16,7 @@ next:
 
 import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
 
-Scalekit ships pre-built tools for every connector in the catalog: Gmail, Slack, GitHub, Salesforce, Notion, Linear, HubSpot, and more. Each tool has an LLM-ready schema and returns structured output. Your agent passes inputs; Scalekit injects the user's credentials and handles the API call.
+Scalekit ships pre-built tools for every connector in the catalog: Slack, Gmail, GitHub, Salesforce, Notion, Linear, HubSpot, and more. Each tool has an LLM-ready schema and returns structured output. Your agent passes inputs; Scalekit injects the user's credentials and handles the API call.
 
 This page assumes you have an `ACTIVE` connected account for the user. If not, see [Authorize a user](/agentkit/tools/authorize/).
 
@@ -31,7 +31,7 @@ from google.protobuf.json_format import MessageToDict
 
 scoped_response, _ = actions.tools.list_scoped_tools(
     identifier="user_123",
-    filter={"connection_names": ["gmail"]},   # optional; omit for all connectors
+    filter={"connection_names": ["slack"]},   # optional; omit for all connectors
     page_size=100,                            # fetch beyond the default page
 )
 for scoped_tool in scoped_response.tools:
@@ -43,7 +43,7 @@ for scoped_tool in scoped_response.tools:
   <TabItem label="Node.js">
 ```typescript
 const { tools } = await scalekit.tools.listScopedTools('user_123', {
-  filter: { connectionNames: ['gmail'] },     // use filter: {} to list every connector
+  filter: { connectionNames: ['slack'] },     // use filter: {} to list every connector
   pageSize: 100,                              // fetch beyond the default page
 });
 for (const tool of tools) {
@@ -69,18 +69,18 @@ Use `execute_tool` / `executeTool` to run a named tool for a specific user. Scal
 ```python
 # connected account is selected using the user identifier and the connection name
 result = actions.execute_tool(
-    tool_name="gmail_fetch_mails",
+    tool_name="slack_list_channels",
     identifier="user_123",
-    connection_name="gmail",
-    tool_input={"query": "is:unread", "max_results": 5},
+    connection_name="slack",
+    tool_input={"limit": 10},
 )
 print(result.data)
 
 # alternatively, use the connected account ID
 # result = actions.execute_tool(
-#     tool_name="gmail_fetch_mails",
+#     tool_name="slack_list_channels",
 #     connected_account_id="ca_xxxxxx",
-#     tool_input={"query": "is:unread", "max_results": 5},
+#     tool_input={"limit": 10},
 # )
 ```
   </TabItem>
@@ -88,18 +88,18 @@ print(result.data)
 ```typescript
 // connected account is selected using the user identifier and the connector
 const result = await scalekit.actions.executeTool({
-  toolName: 'gmail_fetch_mails',
+  toolName: 'slack_list_channels',
   identifier: 'user_123',
-  connector: 'gmail',
-  toolInput: { query: 'is:unread', max_results: 5 },
+  connector: 'slack',
+  toolInput: { limit: 10 },
 });
 console.log(result.data);
 
 // alternatively, use the connected account ID
 // const result = await scalekit.actions.executeTool({
-//   toolName: 'gmail_fetch_mails',
+//   toolName: 'slack_list_channels',
 //   connectedAccountId: 'ca_xxxxxx',
-//   toolInput: { query: 'is:unread', max_results: 5 },
+//   toolInput: { limit: 10 },
 // });
 ```
   </TabItem>
@@ -167,7 +167,7 @@ client = anthropic.Anthropic()
 # 1. Fetch tools scoped to this user
 scoped_response, _ = actions.tools.list_scoped_tools(
     identifier="user_123",
-    filter={"connection_names": ["gmail"]},
+    filter={"connection_names": ["slack"]},
     page_size=100,  # fetch beyond the default page so no connector tools are missed
 )
 llm_tools = [
@@ -180,7 +180,7 @@ llm_tools = [
 ]
 
 # 2. Send to LLM
-messages = [{"role": "user", "content": "Summarize my last 5 unread emails"}]
+messages = [{"role": "user", "content": "Summarize the channels in my Slack workspace"}]
 response = client.messages.create(
     model="claude-sonnet-4-6",
     max_tokens=1024,
@@ -211,7 +211,7 @@ const anthropic = new Anthropic();
 
 // 1. Fetch tools scoped to this user
 const { tools } = await scalekit.tools.listScopedTools('user_123', {
-  filter: { connectionNames: ['gmail'] },
+  filter: { connectionNames: ['slack'] },
   pageSize: 100, // fetch beyond the default page so no connector tools are missed
 });
 const llmTools = tools.map((t) => ({
@@ -222,7 +222,7 @@ const llmTools = tools.map((t) => ({
 
 // 2. Send to LLM
 const messages: Anthropic.MessageParam[] = [
-  { role: 'user', content: 'Summarize my last 5 unread emails' },
+  { role: 'user', content: 'Summarize the channels in my Slack workspace' },
 ];
 const response = await anthropic.messages.create({
   model: 'claude-sonnet-4-6',
@@ -262,12 +262,12 @@ from langchain.agents import create_agent
 
 tools = actions.langchain.get_tools(
     identifier="user_123",
-    connection_names=["gmail"],
+    connection_names=["slack"],
     page_size=100,  # avoid missing tools when a connector has more than the default page
 )
 llm = ChatOpenAI(model="claude-sonnet-4-6")
 agent = create_agent(model=llm, tools=tools, system_prompt="You are a helpful assistant.")
-result = agent.invoke({"messages": [{"role": "user", "content": "Fetch my last 5 unread emails"}]})
+result = agent.invoke({"messages": [{"role": "user", "content": "List the channels in my Slack workspace"}]})
 ```
   </TabItem>
   <TabItem label="Google ADK">
@@ -275,15 +275,15 @@ result = agent.invoke({"messages": [{"role": "user", "content": "Fetch my last 5
 from google.adk.agents import Agent
 from google.adk.models.lite_llm import LiteLlm
 
-gmail_tools = actions.google.get_tools(
+slack_tools = actions.google.get_tools(
     identifier="user_123",
-    connection_names=["gmail"],
+    connection_names=["slack"],
     page_size=100,  # avoid missing tools when a connector has more than the default page
 )
 agent = Agent(
-    name="gmail_assistant",
+    name="slack_assistant",
     model=LiteLlm(model="claude-sonnet-4-6"),
-    tools=gmail_tools,
+    tools=slack_tools,
 )
 ```
   </TabItem>
@@ -292,7 +292,7 @@ agent = Agent(
 import { generateText, jsonSchema, tool } from 'ai';
 
 const { tools: scopedTools } = await scalekit.tools.listScopedTools('user_123', {
-  filter: { connectionNames: ['gmail'] },
+  filter: { connectionNames: ['slack'] },
   pageSize: 100, // fetch beyond the default page so no connector tools are missed
 });
 const tools = Object.fromEntries(
@@ -342,7 +342,7 @@ Check three things:
 <details>
 <summary>Connection names differ across environments</summary>
 
-Connection names are workspace-specific. Don't hard-code them. Use environment variables (`GMAIL_CONNECTION_NAME`, `GITHUB_CONNECTION_NAME`) and reference those in API calls.
+Connection names are workspace-specific. Don't hard-code them. Use environment variables (`SLACK_CONNECTION_NAME`, `GITHUB_CONNECTION_NAME`) and reference those in API calls.
 
 </details>
 

--- a/src/content/docs/agentkit/tools/scalekit-optimized-tools.mdx
+++ b/src/content/docs/agentkit/tools/scalekit-optimized-tools.mdx
@@ -16,7 +16,7 @@ next:
 
 import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
 
-Scalekit ships pre-built tools for every connector in the catalog: Slack, Gmail, GitHub, Salesforce, Notion, Linear, HubSpot, and more. Each tool has an LLM-ready schema and returns structured output. Your agent passes inputs; Scalekit injects the user's credentials and handles the API call.
+Scalekit ships pre-built tools for every connector in the catalog: GitHub, Slack, Gmail, Salesforce, Notion, Linear, HubSpot, and more. Each tool has an LLM-ready schema and returns structured output. Your agent passes inputs; Scalekit injects the user's credentials and handles the API call.
 
 This page assumes you have an `ACTIVE` connected account for the user. If not, see [Authorize a user](/agentkit/tools/authorize/).
 
@@ -31,7 +31,7 @@ from google.protobuf.json_format import MessageToDict
 
 scoped_response, _ = actions.tools.list_scoped_tools(
     identifier="user_123",
-    filter={"connection_names": ["slack"]},   # optional; omit for all connectors
+    filter={"connection_names": ["github-connect"]},   # optional; omit for all connectors
     page_size=100,                            # fetch beyond the default page
 )
 for scoped_tool in scoped_response.tools:
@@ -43,7 +43,7 @@ for scoped_tool in scoped_response.tools:
   <TabItem label="Node.js">
 ```typescript
 const { tools } = await scalekit.tools.listScopedTools('user_123', {
-  filter: { connectionNames: ['slack'] },     // use filter: {} to list every connector
+  filter: { connectionNames: ['github-connect'] },     // use filter: {} to list every connector
   pageSize: 100,                              // fetch beyond the default page
 });
 for (const tool of tools) {
@@ -69,18 +69,18 @@ Use `execute_tool` / `executeTool` to run a named tool for a specific user. Scal
 ```python
 # connected account is selected using the user identifier and the connection name
 result = actions.execute_tool(
-    tool_name="slack_list_channels",
+    tool_name="github_repo_star",
     identifier="user_123",
-    connection_name="slack",
-    tool_input={"limit": 10},
+    connection_name="github-connect",
+    tool_input={"owner": "scalekit-inc", "repo": "scalekit-sdk-python"},
 )
 print(result.data)
 
 # alternatively, use the connected account ID
 # result = actions.execute_tool(
-#     tool_name="slack_list_channels",
+#     tool_name="github_repo_star",
 #     connected_account_id="ca_xxxxxx",
-#     tool_input={"limit": 10},
+#     tool_input={"owner": "scalekit-inc", "repo": "scalekit-sdk-python"},
 # )
 ```
   </TabItem>
@@ -88,18 +88,18 @@ print(result.data)
 ```typescript
 // connected account is selected using the user identifier and the connector
 const result = await scalekit.actions.executeTool({
-  toolName: 'slack_list_channels',
+  toolName: 'github_repo_star',
   identifier: 'user_123',
-  connector: 'slack',
-  toolInput: { limit: 10 },
+  connector: 'github-connect',
+  toolInput: { owner: 'scalekit-inc', repo: 'scalekit-sdk-node' },
 });
 console.log(result.data);
 
 // alternatively, use the connected account ID
 // const result = await scalekit.actions.executeTool({
-//   toolName: 'slack_list_channels',
+//   toolName: 'github_repo_star',
 //   connectedAccountId: 'ca_xxxxxx',
-//   toolInput: { limit: 10 },
+//   toolInput: { owner: 'scalekit-inc', repo: 'scalekit-sdk-node' },
 // });
 ```
   </TabItem>
@@ -167,7 +167,7 @@ client = anthropic.Anthropic()
 # 1. Fetch tools scoped to this user
 scoped_response, _ = actions.tools.list_scoped_tools(
     identifier="user_123",
-    filter={"connection_names": ["slack"]},
+    filter={"connection_names": ["github-connect"]},
     page_size=100,  # fetch beyond the default page so no connector tools are missed
 )
 llm_tools = [
@@ -180,7 +180,7 @@ llm_tools = [
 ]
 
 # 2. Send to LLM
-messages = [{"role": "user", "content": "Summarize the channels in my Slack workspace"}]
+messages = [{"role": "user", "content": "List my 5 most recently updated GitHub repositories"}]
 response = client.messages.create(
     model="claude-sonnet-4-6",
     max_tokens=1024,
@@ -211,7 +211,7 @@ const anthropic = new Anthropic();
 
 // 1. Fetch tools scoped to this user
 const { tools } = await scalekit.tools.listScopedTools('user_123', {
-  filter: { connectionNames: ['slack'] },
+  filter: { connectionNames: ['github-connect'] },
   pageSize: 100, // fetch beyond the default page so no connector tools are missed
 });
 const llmTools = tools.map((t) => ({
@@ -222,7 +222,7 @@ const llmTools = tools.map((t) => ({
 
 // 2. Send to LLM
 const messages: Anthropic.MessageParam[] = [
-  { role: 'user', content: 'Summarize the channels in my Slack workspace' },
+  { role: 'user', content: 'List my 5 most recently updated GitHub repositories' },
 ];
 const response = await anthropic.messages.create({
   model: 'claude-sonnet-4-6',
@@ -262,12 +262,12 @@ from langchain.agents import create_agent
 
 tools = actions.langchain.get_tools(
     identifier="user_123",
-    connection_names=["slack"],
+    connection_names=["github-connect"],
     page_size=100,  # avoid missing tools when a connector has more than the default page
 )
 llm = ChatOpenAI(model="claude-sonnet-4-6")
 agent = create_agent(model=llm, tools=tools, system_prompt="You are a helpful assistant.")
-result = agent.invoke({"messages": [{"role": "user", "content": "List the channels in my Slack workspace"}]})
+result = agent.invoke({"messages": [{"role": "user", "content": "List my 5 most recently updated GitHub repositories"}]})
 ```
   </TabItem>
   <TabItem label="Google ADK">
@@ -275,15 +275,15 @@ result = agent.invoke({"messages": [{"role": "user", "content": "List the channe
 from google.adk.agents import Agent
 from google.adk.models.lite_llm import LiteLlm
 
-slack_tools = actions.google.get_tools(
+github_tools = actions.google.get_tools(
     identifier="user_123",
-    connection_names=["slack"],
+    connection_names=["github-connect"],
     page_size=100,  # avoid missing tools when a connector has more than the default page
 )
 agent = Agent(
-    name="slack_assistant",
+    name="github_assistant",
     model=LiteLlm(model="claude-sonnet-4-6"),
-    tools=slack_tools,
+    tools=github_tools,
 )
 ```
   </TabItem>
@@ -292,7 +292,7 @@ agent = Agent(
 import { generateText, jsonSchema, tool } from 'ai';
 
 const { tools: scopedTools } = await scalekit.tools.listScopedTools('user_123', {
-  filter: { connectionNames: ['slack'] },
+  filter: { connectionNames: ['github-connect'] },
   pageSize: 100, // fetch beyond the default page so no connector tools are missed
 });
 const tools = Object.fromEntries(
@@ -342,7 +342,7 @@ Check three things:
 <details>
 <summary>Connection names differ across environments</summary>
 
-Connection names are workspace-specific. Don't hard-code them. Use environment variables (`SLACK_CONNECTION_NAME`, `GITHUB_CONNECTION_NAME`) and reference those in API calls.
+Connection names are workspace-specific. Don't hard-code them. Use environment variables (`GITHUB_CONNECTION_NAME`, `GMAIL_CONNECTION_NAME`) and reference those in API calls.
 
 </details>
 


### PR DESCRIPTION
## What changed

Six documentation pages now use **GitHub** as the default AgentKit connector, replacing Gmail.

Tracks three upstream PRs:
- **scalekit-inc/scalekit#2503** — new environments seed a GitHub app connection with `key_id` `github-connect`
- **scalekit-inc/scalekit#2508** — adds `repo` and `public_repo` to that connection, so its scopes are `user:email`, `repo`, `public_repo`
- **scalekit-inc/scalekit-web-ui#778** — dashboard quickstart pivots to a GitHub star-repo flow using `github_repo_star`

| Was | Now |
|---|---|
| `gmail` connection | `github-connect` |
| `GMAIL_CONNECTION_NAME` | `GITHUB_CONNECTION_NAME` |
| `gmail_fetch_mails` | `github_repo_star` |
| `{query: "is:unread", max_results: 5}` | `{owner: "scalekit-inc", repo: "scalekit-sdk-python\|node"}` |

The Python and Node tabs star their own language's SDK repo, mirroring web-ui#778 (which ships a test asserting they are not cross-wired).

## Why

The quickstart told readers "Gmail is enabled by default in new Scalekit environments" and instructed them to create a Gmail connection. Both are wrong for a fresh environment after #2503. The `/hackathon` page carried the same false claim.

## Pages changed

- https://deploy-preview-929--scalekit-starlight.netlify.app/agentkit/quickstart/
- https://deploy-preview-929--scalekit-starlight.netlify.app/hackathon/
- https://deploy-preview-929--scalekit-starlight.netlify.app/agentkit/tools/scalekit-optimized-tools/
- https://deploy-preview-929--scalekit-starlight.netlify.app/agentkit/examples/
- https://deploy-preview-929--scalekit-starlight.netlify.app/agentkit/tools/authorize/
- https://deploy-preview-929--scalekit-starlight.netlify.app/agentkit/connected-accounts/

## Note on commit history

This branch's first two commits (`f4b7549`, `2e2f0a8`) documented **Slack**, because that is what #2503 and #778 targeted at the time. Those PRs were later retargeted to GitHub. The third commit re-points everything to GitHub, so the net diff against `main` is GitHub-only — but the Commits tab and those two commit messages still refer to Slack. History was intentionally not rewritten.

## Verification

- `pnpm run build` completes clean
- All five built pages contain zero Slack-connector references; `github_repo_star` / `github-connect` / `GITHUB_CONNECTION_NAME` present on each
- Both language-matched SDK repos render in the quickstart tabs
- Prettier passes on all changed `.mdx` files

Three Slack mentions remain by design, all factual multi-connector lists where GitHub already leads: the connector catalog enumeration, the architecture diagram alt text, and "Add Calendar, Gmail, or Slack after GitHub works". The ~10 Scalekit **community Slack** links on `/hackathon/` are the support channel, not the connector, and are untouched.

## Known issues, not fixed here

- **`github_repo_star` is missing from this repo's connector catalog.** `src/data/agent-connectors/github.ts` was last synced 2026-07-07 and contains `github_repo_unstar` with the same `owner`+`repo` params, but no `github_repo_star`. This follows web-ui#778, whose tests assert the name — but the catalog needs re-syncing via `scripts/sync-agent-connectors.js`, or the GitHub connector page's `ToolList` will not list the tool this quickstart tells readers to call.
- **`connector:` vs `connectionName:`** — `scalekit-optimized-tools.mdx` passes `connector:` to `executeTool` while `authorize.mdx` and `quickstart.mdx` pass `connectionName:`. One is wrong; pre-existing and left untouched.

## Sequencing

All three upstream PRs are still **open**, so this documents a default that is not live yet. Hold the merge until #2503 and #2508 ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AgentKit guides and examples to use GitHub instead of Gmail.
  * Revised setup instructions, environment variables, authorization flows, connected-account examples, OAuth messaging, and troubleshooting guidance.
  * Updated tool usage examples to star Scalekit’s GitHub SDK repositories.
  * Refreshed hackathon materials, framework examples, and connector-tool descriptions to demonstrate GitHub workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->