### PR TITLE
docs(agentkit): add create_environment_connection to Python SDK reference

### DIFF
--- a/src/components/sdk-reference/agentkit/python/Connections.mdx
+++ b/src/components/sdk-reference/agentkit/python/Connections.mdx
@@ -1,0 +1,48 @@
+import * as CB from '@gesslar/starlight-class-browser'
+
+<CB.ClassBrowser
+  name="Connection"
+  type="client"
+  source="https://github.com/scalekit-inc/scalekit-sdk-python/blob/main/scalekit/connection.py"
+  language="python"
+>
+
+  <CB.ClassMethod name="create_environment_connection">
+    Creates a new environment-level connection. Pass `Flags(is_app=True)` to register it as an app connection that AgentKit connectors can use.
+
+  </CB.ClassMethod>
+
+```python
+import os
+from scalekit.v1.connections.connections_pb2 import (
+    CreateConnection, ConnectionType, Flags, UpdateConnection, OAuthConnectionConfig
+)
+
+# Register the connection at the environment level. is_app=True marks it as an
+# app connection, which is what AgentKit connectors resolve against.
+response = scalekit_client.connection.create_environment_connection(
+    connection=CreateConnection(
+        provider_key='HUBSPOT',
+        type=ConnectionType.OAUTH,
+    ),
+    flags=Flags(is_app=True),
+)
+connection = response[0].connection
+
+# Attach your own OAuth app credentials from the environment — never hard-code a
+# client secret.
+scalekit_client.connection.update_environment_connection(
+    connection_id=connection.id,
+    connection=UpdateConnection(
+        provider_key='HUBSPOT',
+        key_id=connection.key_id,
+        type=ConnectionType.OAUTH,
+        oauth_config=OAuthConnectionConfig(
+            client_id={'value': os.environ['HUBSPOT_CLIENT_ID']},
+            client_secret={'value': os.environ['HUBSPOT_CLIENT_SECRET']},
+        ),
+    ),
+)
+```
+
+</CB.ClassBrowser>

--- a/src/components/sdk-reference/agentkit/python/Connections.mdx
+++ b/src/components/sdk-reference/agentkit/python/Connections.mdx
@@ -1,5 +1,7 @@
 import * as CB from '@gesslar/starlight-class-browser'
 
+Environment-level app connections on `scalekit_client.connection`. Create, list, get, and update AgentKit connections in code.
+
 <CB.ClassBrowser
   name="Connection"
   type="client"
@@ -10,16 +12,22 @@ import * as CB from '@gesslar/starlight-class-browser'
   <CB.ClassMethod name="create_environment_connection">
     Creates a new environment-level connection. Pass `Flags(is_app=True)` to register it as an app connection that AgentKit connectors can use.
 
+    <CB.ClassMethodInput name="connection" type="CreateConnection">
+      CreateConnection object with the provider key and connection type.
+    </CB.ClassMethodInput>
+    <CB.ClassMethodInput name="flags" type="Optional[Flags]">
+      Optional. Connection flags (`is_login`, `is_app`).
+    </CB.ClassMethodInput>
+    <CB.ClassMethodOutput type="CreateConnectionResponse">
+      Create Connection Response
+    </CB.ClassMethodOutput>
   </CB.ClassMethod>
 
-```python
-import os
+```python title="create_connection.py"
 from scalekit.v1.connections.connections_pb2 import (
-    CreateConnection, ConnectionType, Flags, UpdateConnection, OAuthConnectionConfig
+    CreateConnection, ConnectionType, Flags
 )
 
-# Register the connection at the environment level. is_app=True marks it as an
-# app connection, which is what AgentKit connectors resolve against.
 response = scalekit_client.connection.create_environment_connection(
     connection=CreateConnection(
         provider_key='HUBSPOT',
@@ -28,14 +36,77 @@ response = scalekit_client.connection.create_environment_connection(
     flags=Flags(is_app=True),
 )
 connection = response[0].connection
+```
 
-# Attach your own OAuth app credentials from the environment — never hard-code a
-# client secret.
+  <CB.ClassMethod name="list_app_connections">
+    Lists environment-level app connections. Filter by provider or search by connection name (key ID) or provider.
+
+    <CB.ClassMethodInput name="page_size" type="Optional[int]">
+      Results per page (max 30).
+    </CB.ClassMethodInput>
+    <CB.ClassMethodInput name="page_token" type="Optional[str]">
+      Optional. Token for pagination.
+    </CB.ClassMethodInput>
+    <CB.ClassMethodInput name="provider" type="Optional[str]">
+      Optional. Filter by provider (e.g. `HUBSPOT`).
+    </CB.ClassMethodInput>
+    <CB.ClassMethodInput name="query" type="Optional[str]">
+      Optional. Free-text search on connection name (key ID) or provider (3–100 characters).
+    </CB.ClassMethodInput>
+    <CB.ClassMethodOutput type="ListAppConnectionsResponse">
+      List App Connections Response
+    </CB.ClassMethodOutput>
+  </CB.ClassMethod>
+
+```python title="list_connections.py"
+response = scalekit_client.connection.list_app_connections()
+
+for conn in response[0].connections:
+    print(f"Connection: {conn.id}, Provider: {conn.provider_key}")
+```
+
+  <CB.ClassMethod name="get_environment_connection">
+    Returns an environment-level connection by its id.
+
+    <CB.ClassMethodInput name="connection_id" type="str">
+      Connection id to retrieve.
+    </CB.ClassMethodInput>
+    <CB.ClassMethodOutput type="GetConnectionResponse">
+      Get Connection Response
+    </CB.ClassMethodOutput>
+  </CB.ClassMethod>
+
+```python title="get_connection.py"
+response = scalekit_client.connection.get_environment_connection('conn_123456')
+conn = response[0].connection
+```
+
+  <CB.ClassMethod name="update_environment_connection">
+    Updates an environment-level connection. Use after create to attach OAuth app credentials from environment variables.
+
+    <CB.ClassMethodInput name="connection_id" type="str">
+      Connection id to update.
+    </CB.ClassMethodInput>
+    <CB.ClassMethodInput name="connection" type="UpdateConnection">
+      UpdateConnection object with fields to update.
+    </CB.ClassMethodInput>
+    <CB.ClassMethodOutput type="UpdateConnectionResponse">
+      Update Connection Response
+    </CB.ClassMethodOutput>
+  </CB.ClassMethod>
+
+```python title="update_connection.py"
+import os
+from scalekit.v1.connections.connections_pb2 import (
+    UpdateConnection, ConnectionType, OAuthConnectionConfig
+)
+
+# Never hard-code a client secret — read credentials from the environment.
 scalekit_client.connection.update_environment_connection(
-    connection_id=connection.id,
+    connection_id='conn_123456',
     connection=UpdateConnection(
         provider_key='HUBSPOT',
-        key_id=connection.key_id,
+        key_id='hubspot-key',
         type=ConnectionType.OAUTH,
         oauth_config=OAuthConnectionConfig(
             client_id={'value': os.environ['HUBSPOT_CLIENT_ID']},

--- a/src/components/sdk-reference/agentkit/python/_nav.json
+++ b/src/components/sdk-reference/agentkit/python/_nav.json
@@ -10,7 +10,7 @@
       "label": "Connections",
       "accessor": "connection",
       "order": 5,
-      "summary": "Create environment-level connections in code"
+      "summary": "Create, list, get, and update environment connections"
     },
     {
       "id": "actions",

--- a/src/components/sdk-reference/agentkit/python/_nav.json
+++ b/src/components/sdk-reference/agentkit/python/_nav.json
@@ -6,6 +6,13 @@
   },
   "clients": [
     {
+      "id": "connections",
+      "label": "Connections",
+      "accessor": "connection",
+      "order": 5,
+      "summary": "Create environment-level connections in code"
+    },
+    {
       "id": "actions",
       "label": "Connected accounts",
       "accessor": "actions",

--- a/src/content/docs/agentkit/sdks/python/connections.mdx
+++ b/src/content/docs/agentkit/sdks/python/connections.mdx
@@ -1,6 +1,6 @@
 ---
 title: Connections
-description: Create environment-level AgentKit connections with scalekit_client.connection
+description: Manage environment-level AgentKit connections with scalekit_client.connection
 topic: agentkit-sdks
 tableOfContents:
   minHeadingLevel: 3
@@ -27,20 +27,18 @@ import '@/styles/sdk-reference.css'
 <div class="sdk-client-page">
 
 
-`scalekit_client.connection` creates the environment-level connections that AgentKit connectors run on. A connection holds the OAuth app credentials, scopes, and redirect URI Scalekit uses when your users authorize a connector, and one connection serves every user in that environment.
+`scalekit_client.connection` manages the environment-level connections that AgentKit connectors run on. A connection holds the OAuth app credentials, scopes, and redirect URI Scalekit uses when your users authorize a connector, and one connection serves every user in that environment.
 
-**Common path:** create the connection once → connect end-user accounts with [`scalekit_client.actions`](/agentkit/sdks/python/actions/) → run tools.
+**Common path:** create the connection once → attach OAuth credentials with `update_environment_connection` → connect end-user accounts with [`scalekit_client.actions`](/agentkit/sdks/python/actions/) → run tools.
 
-Most teams create connections in the Scalekit Dashboard — see [Configure a connection](/agentkit/connections/). Use `create_environment_connection` when you provision environments in code, such as seeding a new environment from a setup script or CI job.
+Most teams create connections in the Scalekit Dashboard — see [Configure a connection](/agentkit/connections/). Use these methods when you provision or manage environments in code, such as seeding a new environment from a setup script or CI job.
 
-The same client also exposes `get_environment_connection`, `update_environment_connection`, and `list_app_connections` for reading and editing connections that already exist.
+These methods cover environment-level **app** connections (`Flags(is_app=True)`). Organization-scoped SSO connection APIs stay on the [SaaSKit connection reference](/saaskit/sdks/python/connection/).
 
 ### create_environment_connection
 <div class="sdk-method-section">
   <CB.ClassBrowser name="Connection" type="client" language="python" source="https://github.com/scalekit-inc/scalekit-sdk-python/blob/main/scalekit/connection.py">
     <CB.ClassMethod name="create_environment_connection" open={true}>
-      <CB.ClassModifier type="async" slot="modifiers" />
-
       Creates a new environment-level connection. Pass `Flags(is_app=True)` to register it as an app connection that AgentKit connectors can use.
 
       <CB.ClassMethodInput name="connection" type="CreateConnection">
@@ -53,10 +51,9 @@ The same client also exposes `get_environment_connection`, `update_environment_c
         Create Connection Response
       </CB.ClassMethodOutput>
 
-```python wrap showLineNumbers=false
-import os
+```python title="create_connection.py" wrap showLineNumbers=false
 from scalekit.v1.connections.connections_pb2 import (
-    CreateConnection, ConnectionType, Flags, UpdateConnection, OAuthConnectionConfig
+    CreateConnection, ConnectionType, Flags
 )
 
 # Register the connection at the environment level. is_app=True marks it as an
@@ -70,16 +67,107 @@ response = scalekit_client.connection.create_environment_connection(
 )
 connection = response[0].connection
 print(f"Created: {connection.id}, Key: {connection.key_id}")
+```
 
-# Attach your own OAuth app credentials so users see your brand on the consent
-# screen. Read them from the environment: a hard-coded client secret leaks to
+    </CB.ClassMethod>
+  </CB.ClassBrowser>
+</div>
+
+### list_app_connections
+<div class="sdk-method-section">
+  <CB.ClassBrowser name="Connection" type="client" language="python" source="https://github.com/scalekit-inc/scalekit-sdk-python/blob/main/scalekit/connection.py">
+    <CB.ClassMethod name="list_app_connections" open={true}>
+      Lists environment-level app connections. Filter by provider or search by connection name (key ID) or provider.
+
+      <CB.ClassMethodInput name="page_size" type="Optional[int]">
+        Results per page (max 30).
+      </CB.ClassMethodInput>
+      <CB.ClassMethodInput name="page_token" type="Optional[str]">
+        Optional. Token for pagination.
+      </CB.ClassMethodInput>
+      <CB.ClassMethodInput name="provider" type="Optional[str]">
+        Optional. Filter by provider (e.g. `HUBSPOT`).
+      </CB.ClassMethodInput>
+      <CB.ClassMethodInput name="query" type="Optional[str]">
+        Optional. Free-text search on connection name (key ID) or provider (3–100 characters).
+      </CB.ClassMethodInput>
+      <CB.ClassMethodOutput type="ListAppConnectionsResponse">
+        List App Connections Response
+      </CB.ClassMethodOutput>
+
+```python title="list_connections.py" wrap showLineNumbers=false
+response = scalekit_client.connection.list_app_connections()
+
+for conn in response[0].connections:
+    print(f"Connection: {conn.id}, Provider: {conn.provider_key}")
+
+# Filter by provider
+response = scalekit_client.connection.list_app_connections(
+    provider='HUBSPOT',
+    page_size=10,
+)
+
+# Search by connection name or provider
+response = scalekit_client.connection.list_app_connections(query='hubspot')
+```
+
+    </CB.ClassMethod>
+  </CB.ClassBrowser>
+</div>
+
+### get_environment_connection
+<div class="sdk-method-section">
+  <CB.ClassBrowser name="Connection" type="client" language="python" source="https://github.com/scalekit-inc/scalekit-sdk-python/blob/main/scalekit/connection.py">
+    <CB.ClassMethod name="get_environment_connection" open={true}>
+      Returns an environment-level connection by its id.
+
+      <CB.ClassMethodInput name="connection_id" type="str">
+        Connection id to retrieve.
+      </CB.ClassMethodInput>
+      <CB.ClassMethodOutput type="GetConnectionResponse">
+        Get Connection Response
+      </CB.ClassMethodOutput>
+
+```python title="get_connection.py" wrap showLineNumbers=false
+response = scalekit_client.connection.get_environment_connection('conn_123456')
+conn = response[0].connection
+print(f"Provider: {conn.provider_key}, Type: {conn.type}, Key: {conn.key_id}")
+```
+
+    </CB.ClassMethod>
+  </CB.ClassBrowser>
+</div>
+
+### update_environment_connection
+<div class="sdk-method-section">
+  <CB.ClassBrowser name="Connection" type="client" language="python" source="https://github.com/scalekit-inc/scalekit-sdk-python/blob/main/scalekit/connection.py">
+    <CB.ClassMethod name="update_environment_connection" open={true}>
+      Updates an environment-level connection. Use this after create to attach your own OAuth app credentials so users see your brand on the consent screen.
+
+      <CB.ClassMethodInput name="connection_id" type="str">
+        Connection id to update.
+      </CB.ClassMethodInput>
+      <CB.ClassMethodInput name="connection" type="UpdateConnection">
+        UpdateConnection object with fields to update.
+      </CB.ClassMethodInput>
+      <CB.ClassMethodOutput type="UpdateConnectionResponse">
+        Update Connection Response
+      </CB.ClassMethodOutput>
+
+```python title="update_connection.py" wrap showLineNumbers=false
+import os
+from scalekit.v1.connections.connections_pb2 import (
+    UpdateConnection, ConnectionType, OAuthConnectionConfig
+)
+
+# Read credentials from the environment: a hard-coded client secret leaks to
 # anyone with repository access and lets them impersonate your app with the
 # provider.
-scalekit_client.connection.update_environment_connection(
-    connection_id=connection.id,
+response = scalekit_client.connection.update_environment_connection(
+    connection_id='conn_123456',
     connection=UpdateConnection(
         provider_key='HUBSPOT',
-        key_id=connection.key_id,
+        key_id='hubspot-key',
         type=ConnectionType.OAUTH,
         oauth_config=OAuthConnectionConfig(
             client_id={'value': os.environ['HUBSPOT_CLIENT_ID']},
@@ -87,9 +175,16 @@ scalekit_client.connection.update_environment_connection(
         ),
     ),
 )
+conn = response[0].connection
+print(f"Updated: {conn.id}")
 ```
 
     </CB.ClassMethod>
   </CB.ClassBrowser>
 </div>
 </div>
+
+## Next steps
+
+- [Connected accounts](/agentkit/sdks/python/actions/) — connect end-user accounts and run tools on their behalf
+- [Configure a connection](/agentkit/connections/) — create connections in the Scalekit Dashboard

--- a/src/content/docs/agentkit/sdks/python/connections.mdx
+++ b/src/content/docs/agentkit/sdks/python/connections.mdx
@@ -1,0 +1,95 @@
+---
+title: Connections
+description: Create environment-level AgentKit connections with scalekit_client.connection
+topic: agentkit-sdks
+tableOfContents:
+  minHeadingLevel: 3
+  maxHeadingLevel: 3
+sidebar:
+  label: Connections
+prev: false
+next: false
+head:
+  - tag: style
+    content: |
+      starlight-toc a[href='#_top'],
+      starlight-toc li:has(> a[href='#_top']) > a[href='#_top'] {
+        display: none !important;
+      }
+      starlight-toc li:has(> a[href='#_top']) > ul {
+        padding-inline-start: 0 !important;
+      }
+---
+
+import * as CB from '@gesslar/starlight-class-browser'
+import '@/styles/sdk-reference.css'
+
+<div class="sdk-client-page">
+
+
+`scalekit_client.connection` creates the environment-level connections that AgentKit connectors run on. A connection holds the OAuth app credentials, scopes, and redirect URI Scalekit uses when your users authorize a connector, and one connection serves every user in that environment.
+
+**Common path:** create the connection once → connect end-user accounts with [`scalekit_client.actions`](/agentkit/sdks/python/actions/) → run tools.
+
+Most teams create connections in the Scalekit Dashboard — see [Configure a connection](/agentkit/connections/). Use `create_environment_connection` when you provision environments in code, such as seeding a new environment from a setup script or CI job.
+
+The same client also exposes `get_environment_connection`, `update_environment_connection`, and `list_app_connections` for reading and editing connections that already exist.
+
+### create_environment_connection
+<div class="sdk-method-section">
+  <CB.ClassBrowser name="Connection" type="client" language="python" source="https://github.com/scalekit-inc/scalekit-sdk-python/blob/main/scalekit/connection.py">
+    <CB.ClassMethod name="create_environment_connection" open={true}>
+      <CB.ClassModifier type="async" slot="modifiers" />
+
+      Creates a new environment-level connection. Pass `Flags(is_app=True)` to register it as an app connection that AgentKit connectors can use.
+
+      <CB.ClassMethodInput name="connection" type="CreateConnection">
+        CreateConnection object with the provider key and connection type.
+      </CB.ClassMethodInput>
+      <CB.ClassMethodInput name="flags" type="Optional[Flags]">
+        Optional. Connection flags (`is_login`, `is_app`).
+      </CB.ClassMethodInput>
+      <CB.ClassMethodOutput type="CreateConnectionResponse">
+        Create Connection Response
+      </CB.ClassMethodOutput>
+
+```python wrap showLineNumbers=false
+import os
+from scalekit.v1.connections.connections_pb2 import (
+    CreateConnection, ConnectionType, Flags, UpdateConnection, OAuthConnectionConfig
+)
+
+# Register the connection at the environment level. is_app=True marks it as an
+# app connection, which is what AgentKit connectors resolve against.
+response = scalekit_client.connection.create_environment_connection(
+    connection=CreateConnection(
+        provider_key='HUBSPOT',
+        type=ConnectionType.OAUTH,
+    ),
+    flags=Flags(is_app=True),
+)
+connection = response[0].connection
+print(f"Created: {connection.id}, Key: {connection.key_id}")
+
+# Attach your own OAuth app credentials so users see your brand on the consent
+# screen. Read them from the environment: a hard-coded client secret leaks to
+# anyone with repository access and lets them impersonate your app with the
+# provider.
+scalekit_client.connection.update_environment_connection(
+    connection_id=connection.id,
+    connection=UpdateConnection(
+        provider_key='HUBSPOT',
+        key_id=connection.key_id,
+        type=ConnectionType.OAUTH,
+        oauth_config=OAuthConnectionConfig(
+            client_id={'value': os.environ['HUBSPOT_CLIENT_ID']},
+            client_secret={'value': os.environ['HUBSPOT_CLIENT_SECRET']},
+        ),
+    ),
+)
+```
+
+    </CB.ClassMethod>
+  </CB.ClassBrowser>
+</div>
+</div>

--- a/src/content/docs/agentkit/sdks/python/index.mdx
+++ b/src/content/docs/agentkit/sdks/python/index.mdx
@@ -10,6 +10,7 @@ tableOfContents: false
 
 Install the Python SDK, create a `ScalekitClient`, then use the sidebar for AgentKit clients.
 
+- **Connections** (`scalekit_client.connection`) — create environment-level connections in code  
 - **Connected accounts** (`scalekit_client.actions`) — connect end-user accounts and execute tools  
 - **Tool calling** — raw tool definitions for custom adapters  
 - **MCP server**, **Frameworks**, **Request modifiers**, **Custom OAuth** — advanced surfaces  
@@ -40,6 +41,7 @@ actions = scalekit_client.actions
 
 ## Next steps
 
+- [Connections](/agentkit/sdks/python/connections/)  
 - [Connected accounts](/agentkit/sdks/python/actions/)  
 - [Tool calling](/agentkit/sdks/python/tools/)  
 - [MCP](/agentkit/sdks/python/mcp/)  

--- a/src/content/docs/agentkit/sdks/python/index.mdx
+++ b/src/content/docs/agentkit/sdks/python/index.mdx
@@ -10,7 +10,8 @@ tableOfContents: false
 
 Install the Python SDK, create a `ScalekitClient`, then use the sidebar for AgentKit clients.
 
-- **Connections** (`scalekit_client.connection`) — create environment-level connections in code  
+- **Connections** (`scalekit_client.connection`) — create, list, get, and update environment-level connections  
+
 - **Connected accounts** (`scalekit_client.actions`) — connect end-user accounts and execute tools  
 - **Tool calling** — raw tool definitions for custom adapters  
 - **MCP server**, **Frameworks**, **Request modifiers**, **Custom OAuth** — advanced surfaces  


### PR DESCRIPTION
## What changed

`create_environment_connection` was documented only in the SaaSKit Python SDK reference. It is equally an AgentKit method — it is the programmatic equivalent of adding a connection in **Dashboard > AgentKit > Connections** — so this adds it to the AgentKit SDKs reference.

- **New page** `src/content/docs/agentkit/sdks/python/connections.mdx` → `/agentkit/sdks/python/connections/`. Uses the one-ClassBrowser-per-method layout, `.sdk-client-page` wrapper, and the same frontmatter/TOC pattern as the sibling `actions.mdx` and `tools.mdx` pages.
- **Example** creates a HubSpot OAuth app connection with `Flags(is_app=True)`, then attaches the OAuth client ID and secret read from environment variables. The comment states the threat: a hard-coded client secret leaks to anyone with repository access and lets them impersonate your app with the provider.
- **Nav entry** in `src/components/sdk-reference/agentkit/python/_nav.json` at `order: 5`, ahead of Connected accounts, so the nav reads in journey order: connection → connected accounts → tool calling. Sidebar label is `Connections`, matching the AgentKit product term.
- **Partial** `src/components/sdk-reference/agentkit/python/Connections.mdx`, keeping the 1:1 partial-per-nav-client convention used by the other AgentKit clients.
- **Install page** `index.mdx` now lists Connections in both the client summary and Next steps.

Prose cross-links to [Configure a connection](https://docs.scalekit.com/agentkit/connections/) for the dashboard flow, and names the sibling methods (`get_environment_connection`, `update_environment_connection`, `list_app_connections`) without duplicating their reference entries.

## Scope

Python only. Verified against the SDK sources: `scalekit-sdk-python`'s connection client exposes `create_environment_connection(connection: CreateConnection, flags: Optional[Flags] = None) -> CreateConnectionResponse`; the Node SDK connection client has no `createEnvironmentConnection`, so the AgentKit Node reference is unchanged.

## Verification

- `pnpm run build` passes (exit 0), including the repo-wide Prettier check.
- The page renders at `dist/agentkit/sdks/python/connections/` and the new sidebar link appears on sibling SDK pages.
- Regenerated artifacts the build touched (`public/api/*`, `public/data/agent-tools-index.json`, `public/apis.md`) were reset — the commit contains only the four files above.

## Preview

https://deploy-preview-930--scalekit-starlight.netlify.app/agentkit/sdks/python/connections/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Python SDK reference documentation for managing environment-level connections.
  * Documented creating AgentKit app connections, listing and retrieving connections, and updating OAuth credentials with environment variables.
  * Added examples covering filtering, pagination, connection lookup, and credential configuration.
  * Added Connections to Python SDK navigation, feature overview, related API references, and next-step links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->