### PR TITLE
docs(signal): explain invalid_client on token revoke for public MCP clients

### DIFF
--- a/src/components/templates/agent-connectors/_setup-zohocrm.mdx
+++ b/src/components/templates/agent-connectors/_setup-zohocrm.mdx
@@ -1,4 +1,4 @@
-import { Steps, Badge } from '`@astrojs/starlight/components`'
+import { Steps, Badge } from '@astrojs/starlight/components'
 
 Register your Scalekit environment with the Zoho CRM connector so Scalekit handles the authentication flow and token lifecycle for you. The connection name you create will be used to identify and invoke the connection programmatically. Then complete the configuration in your application as follows:
 

--- a/src/content/docs/authenticate/mcp/managing-mcp-clients.mdx
+++ b/src/content/docs/authenticate/mcp/managing-mcp-clients.mdx
@@ -154,10 +154,10 @@ Once revoked, the user will need to go through the authorization flow again to g
 
 ### Revoke access from a public MCP client
 
-Public MCP clients cannot revoke tokens through the OAuth token revocation endpoint. Clients registered through Dynamic Client Registration (DCR) or a Client ID Metadata Document (CIMD) are **public clients**: they have no client secret. The revocation endpoint requires client authentication, so a direct revoke call from these clients returns an `invalid_client` error. This response is expected, not a misconfiguration.
+On Scalekit, MCP clients registered through Dynamic Client Registration (`DCR`) or a Client ID Metadata Document (`CIMD`) are public clients: they have no client secret. Scalekit's OAuth token revocation endpoint requires client authentication, so a direct revoke call from these clients returns `invalid_client`. That response is expected, not a misconfiguration.
 
 To revoke access, use one of the supported paths instead:
 
-- **Revoke consent from the dashboard**: revoke the user's consent from the **Consents** tab, as described in [Revoke user access](#revoke-user-access).
-- **Disconnect in the client**: most MCP clients expose a **Disconnect** action that clears the stored tokens on the client side.
-- **Revoke the session in your own system**: when you use bring your own auth, revoke the user's session in your auth system. The next request that reaches the MCP server returns `401 Unauthorized`, which prompts the client to authenticate again.
+- **Revoke consent from the dashboard**: revoke the user's consent from the **Consents** tab, as described in [Revoke user access](/authenticate/mcp/managing-mcp-clients/#revoke-user-access).
+- **Disconnect in the client**: most MCP clients expose a **Disconnect** action that clears tokens stored on the client. This is local sign-out only; it does not revoke the grant on Scalekit.
+- **Revoke the session in your own system**: when you use [Bring your own auth](/authenticate/mcp/custom-auth/), revoke the user's session in your auth system. After your MCP server rejects that session, the next request returns `401 Unauthorized` and the client must authenticate again.

--- a/src/content/docs/authenticate/mcp/managing-mcp-clients.mdx
+++ b/src/content/docs/authenticate/mcp/managing-mcp-clients.mdx
@@ -151,3 +151,13 @@ As an administrator, you can revoke a user's consent for a specific MCP Client a
 4. Click the **Revoke** or **Delete** action for that user.
 
 Once revoked, the user will need to go through the authorization flow again to grant consent if they want to use the MCP Client.
+
+### Revoke access from a public MCP client
+
+Public MCP clients cannot revoke tokens through the OAuth token revocation endpoint. Clients registered through Dynamic Client Registration (DCR) or a Client ID Metadata Document (CIMD) are **public clients**: they have no client secret. The revocation endpoint requires client authentication, so a direct revoke call from these clients returns an `invalid_client` error. This response is expected, not a misconfiguration.
+
+To revoke access, use one of the supported paths instead:
+
+- **Revoke consent from the dashboard**: revoke the user's consent from the **Consents** tab, as described in [Revoke user access](#revoke-user-access).
+- **Disconnect in the client**: most MCP clients expose a **Disconnect** action that clears the stored tokens on the client side.
+- **Revoke the session in your own system**: when you use bring your own auth, revoke the user's session in your auth system. The next request that reaches the MCP server returns `401 Unauthorized`, which prompts the client to authenticate again.


### PR DESCRIPTION
**Why:** A few developers integrating MCP over bring-your-own-auth were confused when a direct call to the OAuth token revocation endpoint returned `invalid_client`. Public MCP clients (registered via DCR or a CIMD) have no client secret, so the revoke endpoint — which requires client authentication — legitimately rejects them. The `managing-mcp-clients.mdx` page documented dashboard revocation but never explained this, so the error read as a bug.

**What:** Surgical addition of a short "Revoke access from a public MCP client" subsection in `src/content/docs/authenticate/mcp/managing-mcp-clients.mdx`, right after the existing "Revoke user access" section. It states why a direct revoke returns `invalid_client` for public clients and lists the three supported paths: dashboard consent revoke, client-side Disconnect, and server-side session revocation (next MCP call returns `401`). Prose only, no code sample, no nav/config changes. Verified against the backend: `internal/oidc/storage.go` `RevokeToken` returns `invalid_client`, the OP advertises only client-authenticated token-endpoint auth methods, and `internal/xaa/handler.go` treats DCR/CIMD MCP clients as public. Skills applied: docs-engineering, docs-contribution-router, docs-writing-style.

**Check:** Open `/authenticate/mcp/managing-mcp-clients/`; confirm a new "Revoke access from a public MCP client" subsection appears after "Revoke user access" with the `invalid_client` explanation and the three supported revoke paths.

**Preview:** https://deploy-preview-933--scalekit-starlight.netlify.app/authenticate/mcp/managing-mcp-clients/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for revoking access from public MCP clients.
  * Explained why DCR- and CIMD-registered clients cannot use the token revocation endpoint.
  * Documented the `invalid_client` response and alternative revocation methods, including dashboard controls, client-side disconnects, and custom-auth session revocation.

* **Bug Fixes**
  * Fixed an issue preventing the Zoho CRM connector setup documentation from loading correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->