### PR TITLE
feat(nav): Enterprise Deployment topic label for mobile drawer

### DIFF
--- a/src/configs/sidebar.config.ts
+++ b/src/configs/sidebar.config.ts
@@ -289,7 +289,8 @@ export const sidebar = [
     ],
   },
   {
-    label: 'Self-hosted',
+    // TopicsDropdown (mobile drawer) + topic chrome — match desktop "Enterprise Deployment" language
+    label: 'Enterprise Deployment',
     id: 'self-hosted',
     link: '/self-hosted/overview/',
     icon: 'server',
@@ -617,7 +618,7 @@ export const topics = {
   // Modular SCIM (directory provisioning)
   'modular-scim': ['/directory/**/*'],
 
-  // Self-hosted deployment (dedicated sidebar for on-prem docs)
+  // Enterprise Deployment topic (on-prem / self-hosted docs; id stays self-hosted for paths)
   'self-hosted': ['/self-hosted/**/*'],
 
   // Agent connectors (dedicated connectors sidebar — must come before connect)


### PR DESCRIPTION
## Summary

- Renames the sidebar **topic** label from **Self-hosted** to **Enterprise Deployment**
- Affects mobile navigation where secondary nav is hidden and users rely on **TopicsDropdown** + the drawer
- Keeps `id: self-hosted` and `/self-hosted/**` paths unchanged

## Context

Desktop secondary nav (tracked separately) surfaces **Enterprise Deployment** as a tab. On mobile (≤50rem), that secondary row is hidden; suite/topic discovery uses the existing Starlight topics drawer. This PR is the small **M2** alignment: same language on mobile without a new sticky secondary row.

Related (separate PR): secondary-nav Enterprise Deployment work on `feat/self-hosted-deployment` (#931).

## Preview

- Self-hosted overview (topic label in drawer): https://deploy-preview-936--scalekit-starlight.netlify.app/self-hosted/overview/

## Test plan

- [ ] On a viewport ≤50rem, open the hamburger menu and confirm the topic is labeled **Enterprise Deployment** (not Self-hosted)
- [ ] Open the topic and confirm `/self-hosted/overview/` and in-section pages still load
- [ ] Desktop left topic chrome / topics plugin (if visible) shows the same label
- [ ] No URL or redirect changes under `/self-hosted/**`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Renamed the “Self-hosted” sidebar label to “Enterprise Deployment” for clearer navigation.
  * Updated the related topic description while preserving existing links and paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->