### PR TITLE
docs(product): sync organization feature name to dir_sync (SDK ref + OpenAPI)

### DIFF
--- a/openapi/scalekit.yaml
+++ b/openapi/scalekit.yaml
@@ -1918,7 +1918,7 @@ paths:
                     - enabled: true
                       name: sso
                     - enabled: false
-                      name: directory_sync
+                      name: dir_sync
         required: true
       x-codeSamples:
         - label: Node.js SDK
@@ -9017,13 +9017,13 @@ components:
             - - enabled: true
                 name: sso
               - enabled: false
-                name: directory_sync
+                name: dir_sync
       examples:
         - features:
             - enabled: true
               name: sso
             - enabled: false
-              name: directory_sync
+              name: dir_sync
     organizationsOrganizationSettingsFeature:
       description: Controls the activation state of a specific organization feature
       type: object
@@ -9038,7 +9038,7 @@ components:
           examples:
             - true
         name:
-          description: 'Feature identifier. Supported values include: "sso" (Single Sign-On), "directory_sync" (Directory Synchronization), "domain_verification" (Domain Verification), "session_policy" (Organization-level session policy override)'
+          description: 'Feature identifier. Supported values include: "sso" (Single Sign-On), "dir_sync" (Directory Synchronization), "domain_verification" (Domain Verification), "session_policy" (Organization-level session policy override)'
           type: string
           examples:
             - sso

--- a/public/api/saaskit.scalar.json
+++ b/public/api/saaskit.scalar.json
@@ -1187,7 +1187,7 @@
                       },
                       {
                         "enabled": false,
-                        "name": "directory_sync"
+                        "name": "dir_sync"
                       }
                     ]
                   }
@@ -10770,7 +10770,7 @@
                 },
                 {
                   "enabled": false,
-                  "name": "directory_sync"
+                  "name": "dir_sync"
                 }
               ]
             ]
@@ -10785,7 +10785,7 @@
               },
               {
                 "enabled": false,
-                "name": "directory_sync"
+                "name": "dir_sync"
               }
             ]
           }
@@ -10808,7 +10808,7 @@
             ]
           },
           "name": {
-            "description": "Feature identifier. Supported values include: \"sso\" (Single Sign-On), \"directory_sync\" (Directory Synchronization), \"domain_verification\" (Domain Verification), \"session_policy\" (Organization-level session policy override)",
+            "description": "Feature identifier. Supported values include: \"sso\" (Single Sign-On), \"dir_sync\" (Directory Synchronization), \"domain_verification\" (Domain Verification), \"session_policy\" (Organization-level session policy override)",
             "type": "string",
             "examples": [
               "sso"

--- a/public/api/saaskit.scalar.yaml
+++ b/public/api/saaskit.scalar.yaml
@@ -978,7 +978,7 @@ paths:
                     - enabled: true
                       name: sso
                     - enabled: false
-                      name: directory_sync
+                      name: dir_sync
         required: true
       x-codeSamples:
         - label: Node.js SDK
@@ -8646,13 +8646,13 @@ components:
             - - enabled: true
                 name: sso
               - enabled: false
-                name: directory_sync
+                name: dir_sync
       examples:
         - features:
             - enabled: true
               name: sso
             - enabled: false
-              name: directory_sync
+              name: dir_sync
     organizationsOrganizationSettingsFeature:
       description: Controls the activation state of a specific organization feature
       type: object
@@ -8667,7 +8667,7 @@ components:
           examples:
             - true
         name:
-          description: 'Feature identifier. Supported values include: "sso" (Single Sign-On), "directory_sync" (Directory Synchronization), "domain_verification" (Domain Verification), "session_policy" (Organization-level session policy override)'
+          description: 'Feature identifier. Supported values include: "sso" (Single Sign-On), "dir_sync" (Directory Synchronization), "domain_verification" (Domain Verification), "session_policy" (Organization-level session policy override)'
           type: string
           examples:
             - sso

--- a/public/api/scalekit.scalar.json
+++ b/public/api/scalekit.scalar.json
@@ -2525,7 +2525,7 @@
                       },
                       {
                         "enabled": false,
-                        "name": "directory_sync"
+                        "name": "dir_sync"
                       }
                     ]
                   }
@@ -13405,7 +13405,7 @@
                 },
                 {
                   "enabled": false,
-                  "name": "directory_sync"
+                  "name": "dir_sync"
                 }
               ]
             ]
@@ -13420,7 +13420,7 @@
               },
               {
                 "enabled": false,
-                "name": "directory_sync"
+                "name": "dir_sync"
               }
             ]
           }
@@ -13443,7 +13443,7 @@
             ]
           },
           "name": {
-            "description": "Feature identifier. Supported values include: \"sso\" (Single Sign-On), \"directory_sync\" (Directory Synchronization), \"domain_verification\" (Domain Verification), \"session_policy\" (Organization-level session policy override)",
+            "description": "Feature identifier. Supported values include: \"sso\" (Single Sign-On), \"dir_sync\" (Directory Synchronization), \"domain_verification\" (Domain Verification), \"session_policy\" (Organization-level session policy override)",
             "type": "string",
             "examples": [
               "sso"

--- a/public/api/scalekit.scalar.yaml
+++ b/public/api/scalekit.scalar.yaml
@@ -1865,7 +1865,7 @@ paths:
                     - enabled: true
                       name: sso
                     - enabled: false
-                      name: directory_sync
+                      name: dir_sync
         required: true
       x-codeSamples:
         - label: Node.js SDK
@@ -10487,13 +10487,13 @@ components:
             - - enabled: true
                 name: sso
               - enabled: false
-                name: directory_sync
+                name: dir_sync
       examples:
         - features:
             - enabled: true
               name: sso
             - enabled: false
-              name: directory_sync
+              name: dir_sync
     organizationsOrganizationSettingsFeature:
       description: Controls the activation state of a specific organization feature
       type: object
@@ -10508,7 +10508,7 @@ components:
           examples:
             - true
         name:
-          description: 'Feature identifier. Supported values include: "sso" (Single Sign-On), "directory_sync" (Directory Synchronization), "domain_verification" (Domain Verification), "session_policy" (Organization-level session policy override)'
+          description: 'Feature identifier. Supported values include: "sso" (Single Sign-On), "dir_sync" (Directory Synchronization), "domain_verification" (Domain Verification), "session_policy" (Organization-level session policy override)'
           type: string
           examples:
             - sso

--- a/src/components/sdk-reference/saaskit/node/Organizations.mdx
+++ b/src/components/sdk-reference/saaskit/node/Organizations.mdx
@@ -122,7 +122,7 @@ app.get('/admin/sso-settings', async (req, res) => {
 const response = await scalekit.organization.updateOrganizationSettings('org_12345', {
   features: [
     { name: 'sso', enabled: true },
-    { name: 'directory_sync', enabled: true }
+    { name: 'dir_sync', enabled: true }
   ]
 });
 ```

--- a/src/content/docs/saaskit/sdks/node/organizations.mdx
+++ b/src/content/docs/saaskit/sdks/node/organizations.mdx
@@ -278,7 +278,7 @@ app.get('/admin/sso-settings', async (req, res) => {
 const response = await scalekit.organization.updateOrganizationSettings('org_12345', {
   features: [
     { name: 'sso', enabled: true },
-    { name: 'directory_sync', enabled: true }
+    { name: 'dir_sync', enabled: true }
   ]
 });
 ```


### PR DESCRIPTION
**Why:** Shipped change in `scalekit-inc/scalekit`@`b194c6bb` (PR #2489, merged to `main`) corrected the organization feature identifier from `directory_sync` to `dir_sync` in the proto/OpenAPI contract. developer-docs still taught `directory_sync` — a value the API does not recognize (a copy-paste sets an unrecognized/no-op feature) — across both the Node SDK reference and the landed OpenAPI spec.

**What:** Surgical `directory_sync` → `dir_sync` sync, no other changes:
- Node SDK reference examples (`updateOrganizationSettings`): `src/content/docs/saaskit/sdks/node/organizations.mdx`, `src/components/sdk-reference/saaskit/node/Organizations.mdx`
- OpenAPI working root `openapi/scalekit.yaml`: org-settings schema examples + the `OrganizationSettingsFeature.name` description enum (4 occurrences)
- Regenerated OpenAPI outputs kept in sync (same deterministic token): `public/api/scalekit.scalar.{json,yaml}`, `public/api/saaskit.scalar.{json,yaml}`

Skills: docs-engineering, scalekit-code-doctor, api-reference, docs-writing-style.

**Evidence:** Backend source of truth `db/environment_setting.go` — `FeatureDirectorySync = "dir_sync"` (@ `c368c6f0`). Contract correction: `scalekit`#2489 proto diff (`proto/scalekit/v1/organizations/organizations.proto`) and its generated OpenAPI (`third_party/OpenAPI/scalekit.scalar.*`). OpenAPI/proto compared: yes. Verified there is no legitimate `organization.directory_sync` event-name usage in these spec files, so the token swap is safe; repo-wide search now returns zero `directory_sync`.

**Check:** `grep -rn directory_sync openapi/ public/api/ src/` returns no matches; both `public/api/*.scalar.json` re-parse as valid JSON. Preview: `https://deploy-preview-{PR_NUMBER}--scalekit-starlight.netlify.app/saaskit/sdks/node/organizations/`. verification: values verified against BE constant + proto/OpenAPI diff at SHA. Generated `public/api/*.scalar.*` were synced by the identical deterministic token replacement rather than a full rebuild — a maintainer should re-run `pnpm run bundle:apis && pnpm run validate-api-split` to confirm no other spec drift (redocly is not installed in this environment). verification: needs-human for the bundle re-run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated organization settings examples and feature descriptions to use the `dir_sync` identifier.
  - Synchronized the identifier across API references and Node.js SDK documentation.
  - Corrected supported feature values in published API specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->