### PR TITLE
docs(signal): distinguish AgentKit tool-execution errors from Scalekit auth failures

### DIFF
--- a/src/content/docs/agentkit/sdks/node/errors.mdx
+++ b/src/content/docs/agentkit/sdks/node/errors.mdx
@@ -55,6 +55,51 @@ try {
 
 `ScalekitServerException` is the base type. Prefer checking subclasses first so not-found and auth failures get the right UX.
 
+## Tool execution errors
+
+A failure during `scalekit.tools.executeTool` comes from one of two places, and the fix differs for each:
+
+- **The upstream provider rejected the call** (Gmail, Slack, Salesforce, and so on). Scalekit raises a dedicated `ScalekitTool*` exception. The most common is `ScalekitToolUnauthorizedException`, which means the connected account's provider token was expired or revoked — re-authorize the connected account. Do not change your client credentials.
+- **Scalekit rejected the call.** A plain `ScalekitUnauthorizedException` (no tool details) means your `client_id`/`client_secret` or Scalekit token is invalid. The SDK already refreshed and retried before surfacing it, so fix the credentials.
+
+Each tool exception subclasses its plain counterpart — `ScalekitToolUnauthorizedException` extends `ScalekitUnauthorizedException` — so **catch the tool type first**. Use `isToolException()` to detect any upstream tool failure, and read `toolErrorCode`, `toolErrorMessage`, and `executionId` for logging.
+
+```ts wrap showLineNumbers=false
+import {
+  ScalekitToolUnauthorizedException,
+  ScalekitToolRateLimitException,
+  ScalekitUnauthorizedException,
+  isToolException,
+} from '@scalekit-sdk/node'
+
+try {
+  const result = await scalekit.tools.executeTool({
+    toolName: 'gmail_send_email',
+    identifier: 'user@example.com',
+  })
+} catch (err) {
+  if (err instanceof ScalekitToolUnauthorizedException) {
+    // Upstream provider rejected the token — re-authorize the connected account
+  } else if (err instanceof ScalekitToolRateLimitException) {
+    // Upstream provider rate limit — back off, then retry the tool call
+  } else if (err instanceof ScalekitUnauthorizedException) {
+    // Scalekit-side credentials are invalid — fix client ID/secret
+  } else if (isToolException(err)) {
+    // Any other upstream tool failure — inspect the provider's error code
+    console.error(err.toolErrorCode, err.executionId)
+  } else {
+    throw err
+  }
+}
+```
+
+| Exception | When it is raised | Typical response |
+| --- | --- | --- |
+| `ScalekitToolUnauthorizedException` | Upstream provider returned 401 during tool execution | Re-authorize the connected account |
+| `ScalekitToolForbiddenException` | Upstream provider returned 403 during tool execution | Add the missing provider scope, then re-authorize |
+| `ScalekitToolRateLimitException` | Upstream provider returned 429 during tool execution | Back off and retry the tool call |
+| `ScalekitToolException` | Any other upstream provider error during tool execution | Log `toolErrorCode` and `executionId`; surface a clear message |
+
 ## Related
 
 - [Connected accounts](/agentkit/sdks/node/actions/) — connect accounts and execute tools  

--- a/src/content/docs/agentkit/sdks/node/errors.mdx
+++ b/src/content/docs/agentkit/sdks/node/errors.mdx
@@ -64,7 +64,7 @@ A failure during `scalekit.tools.executeTool` comes from one of two places, and 
 
 Each tool exception subclasses its plain counterpart — `ScalekitToolUnauthorizedException` extends `ScalekitUnauthorizedException` — so **catch the tool type first**. Use `isToolException()` to detect any upstream tool failure, and read `toolErrorCode`, `toolErrorMessage`, and `executionId` for logging.
 
-```ts wrap showLineNumbers=false
+```ts title="handle-tool-errors.ts" wrap showLineNumbers=false
 import {
   ScalekitToolUnauthorizedException,
   ScalekitToolRateLimitException,
@@ -76,6 +76,11 @@ try {
   const result = await scalekit.tools.executeTool({
     toolName: 'gmail_send_email',
     identifier: 'user@example.com',
+    params: {
+      to: 'team@example.com',
+      subject: 'Hello from Scalekit',
+      body: 'Tool execution succeeded.',
+    },
   })
 } catch (err) {
   if (err instanceof ScalekitToolUnauthorizedException) {
@@ -85,8 +90,8 @@ try {
   } else if (err instanceof ScalekitUnauthorizedException) {
     // Scalekit-side credentials are invalid — fix client ID/secret
   } else if (isToolException(err)) {
-    // Any other upstream tool failure — inspect the provider's error code
-    console.error(err.toolErrorCode, err.executionId)
+    // Any other upstream tool failure — inspect the provider's error
+    console.error(err.toolErrorCode, err.toolErrorMessage, err.executionId)
   } else {
     throw err
   }
@@ -98,7 +103,7 @@ try {
 | `ScalekitToolUnauthorizedException` | Upstream provider returned 401 during tool execution | Re-authorize the connected account |
 | `ScalekitToolForbiddenException` | Upstream provider returned 403 during tool execution | Add the missing provider scope, then re-authorize |
 | `ScalekitToolRateLimitException` | Upstream provider returned 429 during tool execution | Back off and retry the tool call |
-| `ScalekitToolException` | Any other upstream provider error during tool execution | Log `toolErrorCode` and `executionId`; surface a clear message |
+| `ScalekitToolException` | Any other upstream provider error during tool execution | Log `toolErrorCode`, `toolErrorMessage`, and `executionId`; surface a clear message |
 
 ## Related
 

--- a/src/content/docs/agentkit/sdks/python/errors.mdx
+++ b/src/content/docs/agentkit/sdks/python/errors.mdx
@@ -53,6 +53,49 @@ except ScalekitServerException as e:
 
 `ScalekitServerException` is the base type. Prefer checking subclasses first so not-found and auth failures get the right UX.
 
+## Tool execution errors
+
+A failure during `scalekit_client.tools.execute_tool` comes from one of two places, and the fix differs for each:
+
+- **The upstream provider rejected the call** (Gmail, Slack, Salesforce, and so on). Scalekit raises a dedicated `ScalekitTool*` exception. The most common is `ScalekitToolUnauthorizedException`, which means the connected account's provider token was expired or revoked — re-authorize the connected account. Do not change your client credentials.
+- **Scalekit rejected the call.** A plain `ScalekitUnauthorizedException` (no tool details) means your `client_id`/`client_secret` or Scalekit token is invalid. The SDK already refreshed and retried before surfacing it, so fix the credentials.
+
+Each tool exception subclasses both `ScalekitToolException` and its plain counterpart — `ScalekitToolUnauthorizedException` extends `ScalekitUnauthorizedException` — so **catch the tool type first**. Catch the `ScalekitToolException` base to handle any upstream tool failure, and read `tool_error_code`, `tool_error_message`, and `execution_id` for logging.
+
+```python wrap showLineNumbers=false
+from scalekit.common.exceptions import (
+    ScalekitToolUnauthorizedException,
+    ScalekitToolRateLimitException,
+    ScalekitUnauthorizedException,
+    ScalekitToolException,
+)
+
+try:
+    result = scalekit_client.tools.execute_tool(
+        tool_name="gmail_send_email",
+        identifier="user@example.com",
+    )
+except ScalekitToolUnauthorizedException:
+    # Upstream provider rejected the token — re-authorize the connected account
+    pass
+except ScalekitToolRateLimitException:
+    # Upstream provider rate limit — back off, then retry the tool call
+    pass
+except ScalekitUnauthorizedException:
+    # Scalekit-side credentials are invalid — fix client ID/secret
+    pass
+except ScalekitToolException as e:
+    # Any other upstream tool failure — inspect the provider's error code
+    print(e.tool_error_code, e.execution_id)
+```
+
+| Exception | When it is raised | Typical response |
+| --- | --- | --- |
+| `ScalekitToolUnauthorizedException` | Upstream provider returned 401 during tool execution | Re-authorize the connected account |
+| `ScalekitToolForbiddenException` | Upstream provider returned 403 during tool execution | Add the missing provider scope, then re-authorize |
+| `ScalekitToolRateLimitException` | Upstream provider returned 429 during tool execution | Back off and retry the tool call |
+| `ScalekitToolException` | Base class for any upstream provider error during tool execution | Log `tool_error_code` and `execution_id`; surface a clear message |
+
 ## Related
 
 - [Connected accounts](/agentkit/sdks/python/actions/) — connect accounts and execute tools  

--- a/src/content/docs/agentkit/sdks/python/errors.mdx
+++ b/src/content/docs/agentkit/sdks/python/errors.mdx
@@ -62,7 +62,7 @@ A failure during `scalekit_client.tools.execute_tool` comes from one of two plac
 
 Each tool exception subclasses both `ScalekitToolException` and its plain counterpart — `ScalekitToolUnauthorizedException` extends `ScalekitUnauthorizedException` — so **catch the tool type first**. Catch the `ScalekitToolException` base to handle any upstream tool failure, and read `tool_error_code`, `tool_error_message`, and `execution_id` for logging.
 
-```python wrap showLineNumbers=false
+```python title="handle_tool_errors.py" wrap showLineNumbers=false
 from scalekit.common.exceptions import (
     ScalekitToolUnauthorizedException,
     ScalekitToolRateLimitException,
@@ -74,6 +74,11 @@ try:
     result = scalekit_client.tools.execute_tool(
         tool_name="gmail_send_email",
         identifier="user@example.com",
+        params={
+            "to": "team@example.com",
+            "subject": "Hello from Scalekit",
+            "body": "Tool execution succeeded.",
+        },
     )
 except ScalekitToolUnauthorizedException:
     # Upstream provider rejected the token — re-authorize the connected account
@@ -85,8 +90,8 @@ except ScalekitUnauthorizedException:
     # Scalekit-side credentials are invalid — fix client ID/secret
     pass
 except ScalekitToolException as e:
-    # Any other upstream tool failure — inspect the provider's error code
-    print(e.tool_error_code, e.execution_id)
+    # Any other upstream tool failure — inspect the provider's error
+    print(e.tool_error_code, e.tool_error_message, e.execution_id)
 ```
 
 | Exception | When it is raised | Typical response |
@@ -94,7 +99,7 @@ except ScalekitToolException as e:
 | `ScalekitToolUnauthorizedException` | Upstream provider returned 401 during tool execution | Re-authorize the connected account |
 | `ScalekitToolForbiddenException` | Upstream provider returned 403 during tool execution | Add the missing provider scope, then re-authorize |
 | `ScalekitToolRateLimitException` | Upstream provider returned 429 during tool execution | Back off and retry the tool call |
-| `ScalekitToolException` | Base class for any upstream provider error during tool execution | Log `tool_error_code` and `execution_id`; surface a clear message |
+| `ScalekitToolException` | Base class for any upstream provider error during tool execution | Log `tool_error_code`, `tool_error_message`, and `execution_id`; surface a clear message |
 
 ## Related
 


### PR DESCRIPTION
**Why:** A developer asked how to tell, in code, whether a failing AgentKit tool call means the upstream provider rejected the connected account's token (needs re-authorization) or their own Scalekit credentials are wrong. The error-handling reference only listed the base exceptions and described `ScalekitUnauthorizedException` as "fix client ID/secret," which conflates the two cases.

**What:** Surgical addition of a "Tool execution errors" section to the Node and Python AgentKit error-handling pages. It documents the shipped tool-exception hierarchy — `ScalekitToolUnauthorizedException`, `ScalekitToolForbiddenException`, `ScalekitToolRateLimitException`, `ScalekitToolException` — that Scalekit raises when the upstream provider rejects an `executeTool` / `execute_tool` call. It explains that a tool 401 means re-authorize the connected account, while a plain `ScalekitUnauthorizedException` means fix client credentials, and shows how to read `toolErrorCode` / `executionId` (Node `isToolException()`; Python catches the `ScalekitToolException` base). Verified against `@scalekit-sdk/node` v2.11.0 and `scalekit-sdk-python` source; Go and Java SDKs do not yet ship this hierarchy, so their pages are unchanged. Skills applied: docs-engineering, docs-contribution-router, scalekit-code-doctor, docs-writing-style.

**Check:** Open the two preview links below; confirm a new "Tool execution errors" section appears after "Exception types" with the upstream-vs-Scalekit distinction and the tool-exception table.

**Preview:**
- https://deploy-preview-939--scalekit-starlight.netlify.app/agentkit/sdks/node/errors/
- https://deploy-preview-939--scalekit-starlight.netlify.app/agentkit/sdks/python/errors/

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for handling tool execution failures in the Node.js and Python SDKs.
  - Clarified the differences between upstream provider errors and credential-related errors.
  - Documented tool-specific exceptions, detection methods, catch-order guidance, logging fields, and retry recommendations.
  - Added reference tables covering unauthorized, forbidden, rate-limit, and general tool failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->