### PR TITLE
fix(header): keep "I'm working on..." placeholder on non-product pages

### DIFF
--- a/src/components/overrides/HeaderProductToggle.astro
+++ b/src/components/overrides/HeaderProductToggle.astro
@@ -158,8 +158,10 @@ const productLinks = [
     } else if (location.pathname.startsWith('/agentkit/')) {
       knownProduct = 'agentkit'
     } else if (!isShared && hasProductContext) {
-      // Unambiguous non-AgentKit docs page → SaaS product context
-      knownProduct = 'saaskit'
+      // The server already resolved this page's product from its path or its
+      // frontmatter topic — topic 'connect' is AgentKit even outside /agentkit/.
+      // Mirror that instead of assuming SaaS.
+      knownProduct = ssrProduct === 'agentkit' ? 'agentkit' : 'saaskit'
     }
 
     if (knownProduct) {

--- a/src/components/overrides/HeaderProductToggle.astro
+++ b/src/components/overrides/HeaderProductToggle.astro
@@ -54,6 +54,7 @@ const productLinks = [
   id="product-phrase"
   data-shared-path={isSharedPath ? 'true' : 'false'}
   data-ssr-product={activeProduct}
+  data-has-product-context={hasSelection ? 'true' : 'false'}
   data-storage-key={PRODUCT_STORAGE_KEY}
 >
   <div class="product-dropdown" id="product-dropdown">
@@ -144,6 +145,10 @@ const productLinks = [
 
     const isShared = phrase.getAttribute('data-shared-path') === 'true'
     const ssrProduct = phrase.getAttribute('data-ssr-product')
+    // The server already decided whether this page sits inside a product's doc
+    // system. Pages outside it (home, 404, standalone landers) resolve to the
+    // 'saaskit' default in getActiveProduct() but must still read as unselected.
+    const hasProductContext = phrase.getAttribute('data-has-product-context') === 'true'
     const paramProduct = new URLSearchParams(location.search).get('product')
     const storageKey = getStorageKey()
 
@@ -152,7 +157,7 @@ const productLinks = [
       knownProduct = paramProduct
     } else if (location.pathname.startsWith('/agentkit/')) {
       knownProduct = 'agentkit'
-    } else if (!isShared) {
+    } else if (!isShared && hasProductContext) {
       // Unambiguous non-AgentKit docs page → SaaS product context
       knownProduct = 'saaskit'
     }
@@ -176,6 +181,10 @@ const productLinks = [
       }
       return ssrProduct === 'saaskit' ? 'saaskit' : 'agentkit'
     }
+
+    // Nothing on this page identifies a product: leave the placeholder alone
+    // rather than falling back to the 'saaskit' SSR default.
+    if (!knownProduct && !hasProductContext) return null
 
     return knownProduct || ssrProduct
   }


### PR DESCRIPTION
## Summary

The header product toggle showed **Auth for SaaS** next to the logo on the homepage, instead of the intended **I'm working on...** placeholder.

The server rendered the placeholder correctly (`is-placeholder`, `data-has-selection="false"`). Hydration then overwrote it: `resolveClientProduct()` in `HeaderProductToggle.astro` treated every non-AgentKit, non-self-hosted path as SaaS product context, and `/` matched that branch. The final `return knownProduct || ssrProduct` fell back to the same default even when nothing on the page identified a product.

Two effects:

- The label flipped from the placeholder to **Auth for SaaS** on every page outside a product's doc system (homepage, 404, standalone landers).
- Visiting the homepage wrote `saaskit` into `sessionStorage`, so shared self-hosted pages later showed a product the visitor never picked.

## Changes

- Expose the server's product-context decision as `data-has-product-context` on `#product-phrase`.
- Require that flag before the client claims a SaaS selection, and return `null` instead of falling back to the SSR default when no product context exists.

## Verification

Ran the dev-server-served client script against a stubbed DOM for six page states. Before the fix, `/` resolved to `Auth for SaaS` with `sessionStorage=saaskit`; after the fix it stays `I'm working on...` with nothing stored. Product pages, self-hosted pages, and `?product=` overrides are unchanged.

| Page | Label after hydration | sessionStorage |
|------|----------------------|----------------|
| `/` | `I'm working on...` | none |
| `/authenticate/fsa/quickstart/` | `Auth for SaaS` | `saaskit` |
| `/agentkit/quickstart/` | `AgentKit` | `agentkit` |
| `/self-hosted/…` (cold) | `AgentKit` | none |
| `/?product=agentkit` | `AgentKit` | `agentkit` |

## Preview

https://deploy-preview-941--scalekit-starlight.netlify.app/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved product selection behavior on pages without an explicit product context.
  * Prevented context-free pages from incorrectly displaying the SaaS product as a fallback.
  * Preserved the placeholder state when no product context is available.
  * Ensured pages with an explicit product selection continue displaying the correct product consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->