### PR TITLE
Add Plaud MCP agent connector documentation

### DIFF
--- a/src/components/templates/agent-connectors/_section-after-setup-plaudmcp-common-workflows.mdx
+++ b/src/components/templates/agent-connectors/_section-after-setup-plaudmcp-common-workflows.mdx
@@ -2,20 +2,24 @@ export const sectionTitle = 'Common workflows'
 
 import { Tabs, TabItem, Aside } from '@astrojs/starlight/components'
 
-Every Plaud tool except `plaudmcp_get_current_user` works from a **file ID** — the identifier of a single recording. Start with `plaudmcp_list_files` to find the recording, then pass its `file_id` to the transcript, notes, or details tools.
+`plaudmcp_get_file`, `plaudmcp_get_note`, and `plaudmcp_get_transcript` require a **file ID** — the identifier of a single recording. Start with `plaudmcp_list_files` to discover recordings, then pass a `file_id` to the details, notes, or transcript tools.
+
+<Aside type="caution" title="Read tool output from the response wrapper">
+  `execute_tool` / `executeTool` returns a wrapper object, not the Plaud payload. Tool output lives under `response.data` (Python) or `result.data` (Node.js), and the keys inside `data` come from the upstream Plaud MCP server. Log `data` once when you integrate a tool, then read the fields you need — see [Understand tool response shape](/agentkit/tools/scalekit-optimized-tools/#understand-tool-response-shape).
+</Aside>
 
 ### Find a recording, then read its notes
 
-Filter the recording list by name substring or date range, take the `file_id` of the match, and fetch the AI-generated summary and action items.
+Filter the recording list by name substring or date range, take the `file_id` of a match, and fetch the AI-generated summary and action items.
 
 <Tabs syncKey="tech-stack">
   <TabItem label="Node.js">
     ```typescript
     // Step 1 — find the recording. `query` matches the name, case-insensitively.
-    const recordings = await actions.executeTool({
-      connectionName: 'plaudmcp',
-      identifier: 'user_123',
+    const listResult = await scalekit.actions.executeTool({
       toolName: 'plaudmcp_list_files',
+      identifier: 'user_123',
+      connector: 'plaudmcp',
       toolInput: {
         query: 'weekly sync',
         date_from: '2026-01-01',
@@ -23,23 +27,28 @@ Filter the recording list by name substring or date range, take the `file_id` of
       },
     });
 
-    // Step 2 — read the AI notes for the first match.
-    const notes = await actions.executeTool({
-      connectionName: 'plaudmcp',
-      identifier: 'user_123',
+    // Inspect the payload once to learn how Plaud names the recording list and
+    // its file IDs, then read those fields directly in your own code.
+    // Security: Log only in development; recording names may expose user data.
+    console.log(listResult.data);
+
+    // Step 2 — read the AI notes for a recording you picked from that payload.
+    const noteResult = await scalekit.actions.executeTool({
       toolName: 'plaudmcp_get_note',
-      toolInput: { file_id: recordings[0].id },
+      identifier: 'user_123',
+      connector: 'plaudmcp',
+      toolInput: { file_id: '66f2b1c8e4b0a1d2c3e4f5a6' },
     });
-    console.log(notes);
+    console.log(noteResult.data);
     ```
   </TabItem>
   <TabItem label="Python">
     ```python
     # Step 1 — find the recording. `query` matches the name, case-insensitively.
-    recordings = actions.execute_tool(
-        connection_name="plaudmcp",
-        identifier="user_123",
+    list_response = actions.execute_tool(
         tool_name="plaudmcp_list_files",
+        identifier="user_123",
+        connection_name="plaudmcp",
         tool_input={
             "query": "weekly sync",
             "date_from": "2026-01-01",
@@ -47,37 +56,42 @@ Filter the recording list by name substring or date range, take the `file_id` of
         },
     )
 
-    # Step 2 — read the AI notes for the first match.
-    notes = actions.execute_tool(
-        connection_name="plaudmcp",
-        identifier="user_123",
+    # Inspect the payload once to learn how Plaud names the recording list and
+    # its file IDs, then read those fields directly in your own code.
+    # Security: Log only in development; recording names may expose user data.
+    print(list_response.data)
+
+    # Step 2 — read the AI notes for a recording you picked from that payload.
+    note_response = actions.execute_tool(
         tool_name="plaudmcp_get_note",
-        tool_input={"file_id": recordings[0]["id"]},
+        identifier="user_123",
+        connection_name="plaudmcp",
+        tool_input={"file_id": "66f2b1c8e4b0a1d2c3e4f5a6"},
     )
-    print(notes)
+    print(note_response.data)
     ```
   </TabItem>
 </Tabs>
 
 <Aside type="note" title="Filters change how pagination works">
-  When you set `query`, `date_from`, or `date_to`, `plaudmcp_list_files` ignores `page` and `page_size` and scans up to 5 pages of 100 recordings to return every match. Without filters, it honors `page` and `page_size` (default 20).
+  When you set `query`, `date_from`, or `date_to`, `plaudmcp_list_files` ignores `page` and `page_size` and scans up to 5 pages of 100 recordings. It returns the matches found within those pages, so a match past the 500th recording is not returned — narrow the date range to reach older recordings. Without filters, the tool honors `page` and `page_size` (default 20).
 </Aside>
 
 ### Page through a long transcript
 
-`plaudmcp_get_transcript` returns one page of utterances at a time. Pass the `next_cursor` from the previous response to fetch the following page, and stop when the response returns no cursor.
+`plaudmcp_get_transcript` returns one page of utterances at a time and includes a `next_cursor` when more remain. Pass that cursor back on the next call, and stop when the response returns no cursor.
 
 <Tabs syncKey="tech-stack">
   <TabItem label="Node.js">
     ```typescript
-    const utterances = [];
-    let cursor = undefined;
+    const pages = [];
+    let cursor: string | undefined = undefined;
 
     do {
-      const page = await actions.executeTool({
-        connectionName: 'plaudmcp',
-        identifier: 'user_123',
+      const result = await scalekit.actions.executeTool({
         toolName: 'plaudmcp_get_transcript',
+        identifier: 'user_123',
+        connector: 'plaudmcp',
         toolInput: {
           file_id: '66f2b1c8e4b0a1d2c3e4f5a6',
           block: 'transaction', // raw transcript with speaker names and timestamps
@@ -85,16 +99,17 @@ Filter the recording list by name substring or date range, take the `file_id` of
           ...(cursor ? { cursor } : {}),
         },
       });
-      utterances.push(...page.items);
-      cursor = page.next_cursor;
+
+      pages.push(result.data);
+      cursor = (result.data as { next_cursor?: string }).next_cursor;
     } while (cursor);
 
-    console.log(`Fetched ${utterances.length} utterances`);
+    console.log(`Fetched ${pages.length} transcript page(s)`);
     ```
   </TabItem>
   <TabItem label="Python">
     ```python
-    utterances = []
+    pages = []
     cursor = None
 
     while True:
@@ -106,21 +121,26 @@ Filter the recording list by name substring or date range, take the `file_id` of
         if cursor:
             tool_input["cursor"] = cursor
 
-        page = actions.execute_tool(
-            connection_name="plaudmcp",
-            identifier="user_123",
+        response = actions.execute_tool(
             tool_name="plaudmcp_get_transcript",
+            identifier="user_123",
+            connection_name="plaudmcp",
             tool_input=tool_input,
         )
-        utterances.extend(page["items"])
-        cursor = page.get("next_cursor")
+
+        pages.append(response.data)
+        cursor = response.data.get("next_cursor")
         if not cursor:
             break
 
-    print(f"Fetched {len(utterances)} utterances")
+    print(f"Fetched {len(pages)} transcript page(s)")
     ```
   </TabItem>
 </Tabs>
+
+<Aside type="tip" title="Set a limit that matches the job">
+  `limit` accepts 1 to 500 utterances and defaults to 50. Raise it to reduce round trips on long recordings, and lower it when you only need the opening exchange.
+</Aside>
 
 ### Choose the right transcript block
 
@@ -143,24 +163,28 @@ Filter the recording list by name substring or date range, take the `file_id` of
 <Tabs syncKey="tech-stack">
   <TabItem label="Node.js">
     ```typescript
-    const recording = await actions.executeTool({
-      connectionName: 'plaudmcp',
-      identifier: 'user_123',
+    const result = await scalekit.actions.executeTool({
       toolName: 'plaudmcp_get_file',
+      identifier: 'user_123',
+      connector: 'plaudmcp',
       toolInput: { file_id: '66f2b1c8e4b0a1d2c3e4f5a6' },
     });
-    console.log(recording.name, recording.duration);
+
+    // Security: Log only in development; recordings may contain sensitive content.
+    console.log(result.data);
     ```
   </TabItem>
   <TabItem label="Python">
     ```python
-    recording = actions.execute_tool(
-        connection_name="plaudmcp",
-        identifier="user_123",
+    response = actions.execute_tool(
         tool_name="plaudmcp_get_file",
+        identifier="user_123",
+        connection_name="plaudmcp",
         tool_input={"file_id": "66f2b1c8e4b0a1d2c3e4f5a6"},
     )
-    print(recording["name"], recording["duration"])
+
+    # Security: Log only in development; recordings may contain sensitive content.
+    print(response.data)
     ```
   </TabItem>
 </Tabs>

--- a/src/components/templates/agent-connectors/_section-after-setup-plaudmcp-common-workflows.mdx
+++ b/src/components/templates/agent-connectors/_section-after-setup-plaudmcp-common-workflows.mdx
@@ -5,7 +5,7 @@ import { Tabs, TabItem, Aside } from '@astrojs/starlight/components'
 `plaudmcp_get_file`, `plaudmcp_get_note`, and `plaudmcp_get_transcript` require a **file ID** — the identifier of a single recording. Start with `plaudmcp_list_files` to discover recordings, then pass a `file_id` to the details, notes, or transcript tools.
 
 <Aside type="caution" title="Read tool output from the response wrapper">
-  `execute_tool` / `executeTool` returns a wrapper object, not the Plaud payload. Tool output lives under `response.data` (Python) or `result.data` (Node.js), and the keys inside `data` come from the upstream Plaud MCP server. Log `data` once when you integrate a tool, then read the fields you need — see [Understand tool response shape](/agentkit/tools/scalekit-optimized-tools/#understand-tool-response-shape).
+  `execute_tool` / `executeTool` returns a wrapper object, not the Plaud payload. Tool output lives under `response.data` (Python) or `result.data` (Node.js), and the keys inside `data` come from the upstream Plaud MCP server. Log `data` once **in development against a recording you own** to learn the field names, then read only the fields you need — see [Understand tool response shape](/agentkit/tools/scalekit-optimized-tools/#understand-tool-response-shape). Plaud payloads carry meeting content, so never log them in production: transcripts and AI notes reach your log store and anyone with access to it.
 </Aside>
 
 ### Find a recording, then read its notes
@@ -39,6 +39,9 @@ Filter the recording list by name substring or date range, take the `file_id` of
       connector: 'plaudmcp',
       toolInput: { file_id: '66f2b1c8e4b0a1d2c3e4f5a6' },
     });
+
+    // Security: AI notes summarize the recording. Log only in development, and
+    // pass the notes to your agent rather than persisting them.
     console.log(noteResult.data);
     ```
   </TabItem>
@@ -68,6 +71,9 @@ Filter the recording list by name substring or date range, take the `file_id` of
         connection_name="plaudmcp",
         tool_input={"file_id": "66f2b1c8e4b0a1d2c3e4f5a6"},
     )
+
+    # Security: AI notes summarize the recording. Log only in development, and
+    # pass the notes to your agent rather than persisting them.
     print(note_response.data)
     ```
   </TabItem>

--- a/src/components/templates/agent-connectors/_section-after-setup-plaudmcp-common-workflows.mdx
+++ b/src/components/templates/agent-connectors/_section-after-setup-plaudmcp-common-workflows.mdx
@@ -1,0 +1,170 @@
+export const sectionTitle = 'Common workflows'
+
+import { Tabs, TabItem, Aside } from '@astrojs/starlight/components'
+
+Every Plaud tool except `plaudmcp_get_current_user` works from a **file ID** — the identifier of a single recording. Start with `plaudmcp_list_files` to find the recording, then pass its `file_id` to the transcript, notes, or details tools.
+
+### Find a recording, then read its notes
+
+Filter the recording list by name substring or date range, take the `file_id` of the match, and fetch the AI-generated summary and action items.
+
+<Tabs syncKey="tech-stack">
+  <TabItem label="Node.js">
+    ```typescript
+    // Step 1 — find the recording. `query` matches the name, case-insensitively.
+    const recordings = await actions.executeTool({
+      connectionName: 'plaudmcp',
+      identifier: 'user_123',
+      toolName: 'plaudmcp_list_files',
+      toolInput: {
+        query: 'weekly sync',
+        date_from: '2026-01-01',
+        date_to: '2026-01-31',
+      },
+    });
+
+    // Step 2 — read the AI notes for the first match.
+    const notes = await actions.executeTool({
+      connectionName: 'plaudmcp',
+      identifier: 'user_123',
+      toolName: 'plaudmcp_get_note',
+      toolInput: { file_id: recordings[0].id },
+    });
+    console.log(notes);
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    # Step 1 — find the recording. `query` matches the name, case-insensitively.
+    recordings = actions.execute_tool(
+        connection_name="plaudmcp",
+        identifier="user_123",
+        tool_name="plaudmcp_list_files",
+        tool_input={
+            "query": "weekly sync",
+            "date_from": "2026-01-01",
+            "date_to": "2026-01-31",
+        },
+    )
+
+    # Step 2 — read the AI notes for the first match.
+    notes = actions.execute_tool(
+        connection_name="plaudmcp",
+        identifier="user_123",
+        tool_name="plaudmcp_get_note",
+        tool_input={"file_id": recordings[0]["id"]},
+    )
+    print(notes)
+    ```
+  </TabItem>
+</Tabs>
+
+<Aside type="note" title="Filters change how pagination works">
+  When you set `query`, `date_from`, or `date_to`, `plaudmcp_list_files` ignores `page` and `page_size` and scans up to 5 pages of 100 recordings to return every match. Without filters, it honors `page` and `page_size` (default 20).
+</Aside>
+
+### Page through a long transcript
+
+`plaudmcp_get_transcript` returns one page of utterances at a time. Pass the `next_cursor` from the previous response to fetch the following page, and stop when the response returns no cursor.
+
+<Tabs syncKey="tech-stack">
+  <TabItem label="Node.js">
+    ```typescript
+    const utterances = [];
+    let cursor = undefined;
+
+    do {
+      const page = await actions.executeTool({
+        connectionName: 'plaudmcp',
+        identifier: 'user_123',
+        toolName: 'plaudmcp_get_transcript',
+        toolInput: {
+          file_id: '66f2b1c8e4b0a1d2c3e4f5a6',
+          block: 'transaction', // raw transcript with speaker names and timestamps
+          limit: 200,
+          ...(cursor ? { cursor } : {}),
+        },
+      });
+      utterances.push(...page.items);
+      cursor = page.next_cursor;
+    } while (cursor);
+
+    console.log(`Fetched ${utterances.length} utterances`);
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    utterances = []
+    cursor = None
+
+    while True:
+        tool_input = {
+            "file_id": "66f2b1c8e4b0a1d2c3e4f5a6",
+            "block": "transaction",  # raw transcript with speaker names and timestamps
+            "limit": 200,
+        }
+        if cursor:
+            tool_input["cursor"] = cursor
+
+        page = actions.execute_tool(
+            connection_name="plaudmcp",
+            identifier="user_123",
+            tool_name="plaudmcp_get_transcript",
+            tool_input=tool_input,
+        )
+        utterances.extend(page["items"])
+        cursor = page.get("next_cursor")
+        if not cursor:
+            break
+
+    print(f"Fetched {len(utterances)} utterances")
+    ```
+  </TabItem>
+</Tabs>
+
+### Choose the right transcript block
+
+`plaudmcp_get_transcript` reads one of three blocks. Pick the block that matches what the agent needs:
+
+| Block | Returns | Use it when |
+| --- | --- | --- |
+| `transaction` | Raw utterances with speaker labels and timestamps. This is the default. | Exact wording matters — quoting, compliance review, or speaker attribution |
+| `transaction_polish` | The same per-utterance shape, cleaned up by AI. Keeps speaker and timestamps. | You want readable prose without filler words, but still need timestamps |
+| `outline` | A structured outline of the recording. | You need the shape of the conversation rather than its full text |
+
+<Aside type="tip" title="Prefer notes over transcripts for summaries">
+  `plaudmcp_get_note` already returns a summary, action items, and key topics as Markdown. Reach for it before pulling a full transcript — it uses far fewer tokens than paging through every utterance.
+</Aside>
+
+### Get one recording's metadata and audio
+
+`plaudmcp_get_file` returns everything about a single recording in one call: name, timestamps, duration, transcript segments, AI notes, and a temporary audio download URL.
+
+<Tabs syncKey="tech-stack">
+  <TabItem label="Node.js">
+    ```typescript
+    const recording = await actions.executeTool({
+      connectionName: 'plaudmcp',
+      identifier: 'user_123',
+      toolName: 'plaudmcp_get_file',
+      toolInput: { file_id: '66f2b1c8e4b0a1d2c3e4f5a6' },
+    });
+    console.log(recording.name, recording.duration);
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    recording = actions.execute_tool(
+        connection_name="plaudmcp",
+        identifier="user_123",
+        tool_name="plaudmcp_get_file",
+        tool_input={"file_id": "66f2b1c8e4b0a1d2c3e4f5a6"},
+    )
+    print(recording["name"], recording["duration"])
+    ```
+  </TabItem>
+</Tabs>
+
+<Aside type="caution" title="Audio URLs expire">
+  The audio download URL in the response is short-lived and grants access to the recording to anyone holding it. Download the file during the request that produced the URL, and never store it in logs, prompts, or conversation history.
+</Aside>

--- a/src/components/templates/agent-connectors/index.ts
+++ b/src/components/templates/agent-connectors/index.ts
@@ -214,6 +214,7 @@ export { default as SectionAfterSetupOnenoteCommonWorkflows } from './_section-a
 export { default as SectionAfterSetupOutlookCommonWorkflows } from './_section-after-setup-outlook-common-workflows.mdx'
 export { default as SectionAfterSetupParallelaitaskmcpCommonWorkflows } from './_section-after-setup-parallelaitaskmcp-common-workflows.mdx'
 export { default as SectionAfterSetupPhantombusterCommonWorkflows } from './_section-after-setup-phantombuster-common-workflows.mdx'
+export { default as SectionAfterSetupPlaudmcpCommonWorkflows } from './_section-after-setup-plaudmcp-common-workflows.mdx'
 export { default as SectionAfterSetupPosthogmcpCommonWorkflows } from './_section-after-setup-posthogmcp-common-workflows.mdx'
 export { default as SectionAfterSetupQuickbooksCommonWorkflows } from './_section-after-setup-quickbooks-common-workflows.mdx'
 export { default as SectionAfterSetupSalesforceCommonWorkflows } from './_section-after-setup-salesforce-common-workflows.mdx'

--- a/src/content/docs/agentkit/connectors/plaudmcp.mdx
+++ b/src/content/docs/agentkit/connectors/plaudmcp.mdx
@@ -1,0 +1,76 @@
+---
+title: 'Plaud MCP connector'
+tableOfContents: true
+description: 'Connect to Plaud MCP. Browse your Plaud recordings, read AI-generated notes, and pull timestamped transcripts with speaker labels into your AI workflows.'
+sidebar:
+  label: 'Plaud MCP'
+overviewTitle: 'Quickstart'
+connectorIcon: https://docs.plaud.ai/mintlify-assets/_mintlify/favicons/plaud/nlLfkc9tz92mhJFv/_generated/favicon/android-chrome-192x192.png
+connectorAuthType: OAuth 2.1/DCR
+connectorCategories: [Transcription, Productivity, Media]
+head:
+  - tag: style
+    content: |
+      .sl-markdown-content h2 {
+        font-size: var(--sl-text-xl);
+      }
+      .sl-markdown-content h3 {
+        font-size: var(--sl-text-lg);
+      }
+---
+
+import ToolList from '@/components/ToolList.astro'
+import { tools } from '@/data/agent-connectors/plaudmcp'
+import { Steps, Tabs, TabItem } from '@astrojs/starlight/components'
+import { AgentKitCredentials } from '@components/templates'
+import { QuickstartGenericOauthSection } from '@components/templates'
+import { SectionAfterSetupPlaudmcpCommonWorkflows } from '@components/templates'
+
+<Steps>
+
+1. ### Install the SDK
+
+   <Tabs syncKey="tech-stack">
+     <TabItem label="Node.js">
+       ```bash frame="terminal"
+       npm install @scalekit-sdk/node
+       ```
+     </TabItem>
+     <TabItem label="Python">
+       ```bash frame="terminal"
+       pip install scalekit
+       ```
+     </TabItem>
+   </Tabs>
+
+   Full SDK reference: [Node.js](/agentkit/sdks/node/) | [Python](/agentkit/sdks/python/)
+
+2. ### Set your credentials
+
+   <AgentKitCredentials />
+
+3. ### Authorize and make your first call
+
+   <QuickstartGenericOauthSection connector="plaudmcp" toolName="plaudmcp_get_current_user" providerName="Plaud MCP" />
+
+</Steps>
+
+## What you can do
+
+Connect this agent connector to let your agent:
+
+- **List recordings** — browse Plaud recordings, narrowed by a name substring and an inclusive `date_from`/`date_to` range
+- **Get recording details** — read a recording's name, timestamps, duration, transcript segments, AI notes, and temporary audio download URL
+- **Read timestamped transcripts** — fetch raw or AI-cleaned transcripts with speaker attribution, one cursor-paginated page of utterances at a time
+- **Read AI-generated notes** — retrieve the summary, action items, and key topics for a recording as Markdown blocks
+- **Identify the connected account** — confirm which Plaud account the current tool calls run against
+
+## Common workflows
+
+<SectionAfterSetupPlaudmcpCommonWorkflows />
+
+## Tool list
+
+Use the exact tool names from the **Tool list** below when you call `execute_tool`. If you're not sure which name to use, list the tools available for the current user first.
+
+<ToolList tools={tools} />

--- a/src/data/agent-connectors/capabilities.json
+++ b/src/data/agent-connectors/capabilities.json
@@ -174,5 +174,12 @@
     "Manage canvases \u2014 create, read, and update Slack Canvas documents",
     "React to messages \u2014 add and retrieve emoji reactions on any message",
     "Schedule messages \u2014 deliver messages to channels at a specified future time"
+  ],
+  "plaudmcp": [
+    "**List recordings** \u2014 browse Plaud recordings, narrowed by a name substring and an inclusive `date_from`/`date_to` range",
+    "**Get recording details** \u2014 read a recording's name, timestamps, duration, transcript segments, AI notes, and temporary audio download URL",
+    "**Read timestamped transcripts** \u2014 fetch raw or AI-cleaned transcripts with speaker attribution, one cursor-paginated page of utterances at a time",
+    "**Read AI-generated notes** \u2014 retrieve the summary, action items, and key topics for a recording as Markdown blocks",
+    "**Identify the connected account** \u2014 confirm which Plaud account the current tool calls run against"
   ]
 }

--- a/src/data/agent-connectors/catalog.ts
+++ b/src/data/agent-connectors/catalog.ts
@@ -1700,4 +1700,10 @@ export const catalog: Record<string, ProviderMeta> = {
     authType: 'Bearer Token',
     categories: ['Communication', 'Marketing', 'Developer Tools'],
   },
+  plaudmcp: {
+    iconUrl:
+      'https://docs.plaud.ai/mintlify-assets/_mintlify/favicons/plaud/nlLfkc9tz92mhJFv/_generated/favicon/android-chrome-192x192.png',
+    authType: 'OAuth 2.1/DCR',
+    categories: ['Transcription', 'Productivity', 'Media'],
+  },
 }

--- a/src/data/agent-connectors/plaudmcp.ts
+++ b/src/data/agent-connectors/plaudmcp.ts
@@ -1,0 +1,99 @@
+import type { Tool } from '../../types/agent-connectors'
+
+export const tools: Tool[] = [
+  {
+    name: 'plaudmcp_get_current_user',
+    description: `Get details of the currently authenticated Plaud account.`,
+    params: [],
+  },
+  {
+    name: 'plaudmcp_get_file',
+    description: `Get details of a specific Plaud recording by ID, including name, timestamps, duration, transcript segments, AI notes, and a temporary audio download URL.`,
+    params: [
+      {
+        name: 'file_id',
+        type: 'string',
+        required: true,
+        description: `The file ID of the recording to retrieve. Use list_files to look up IDs.`,
+      },
+    ],
+  },
+  {
+    name: 'plaudmcp_get_note',
+    description: `Fetch AI-generated notes for a Plaud recording - compact summary, action items, and key topics, returned as Markdown blocks.`,
+    params: [
+      {
+        name: 'file_id',
+        type: 'string',
+        required: true,
+        description: `The file ID of the recording to retrieve notes for. Use list_files to look up IDs.`,
+      },
+    ],
+  },
+  {
+    name: 'plaudmcp_get_transcript',
+    description: `Fetch the timestamped transcript with speaker attribution for a Plaud recording. Defaults to the \`transaction\` block (raw transcript with speaker names and timestamps), returned one page of utterances at a time - call again with the returned \`next_cursor\` to fetch the next page. Set \`block\` to \`outline\` or \`transaction_polish\` to fetch those blocks instead.`,
+    params: [
+      {
+        name: 'file_id',
+        type: 'string',
+        required: true,
+        description: `The file ID of the recording to retrieve the transcript for. Use list_files to look up IDs.`,
+      },
+      {
+        name: 'block',
+        type: 'string',
+        required: false,
+        description: `Which source block to fetch: \`transaction\` (default; raw transcript with speaker and timestamps), \`transaction_polish\` (AI-cleaned transcript; same per-utterance shape, keeps speaker and timestamps), or \`outline\`.`,
+      },
+      {
+        name: 'cursor',
+        type: 'string',
+        required: false,
+        description: `Opaque pagination cursor from a previous call's \`next_cursor\`. Omit to start from the first utterance.`,
+      },
+      {
+        name: 'limit',
+        type: 'integer',
+        required: false,
+        description: `Maximum number of utterances to return in this page (default 50, max 500). Only applies to blocks returned as an utterance list.`,
+      },
+    ],
+  },
+  {
+    name: 'plaudmcp_list_files',
+    description: `List Plaud recordings. Supports optional filtering: \`query\` (case-insensitive name substring), \`date_from\`/\`date_to\` (YYYY-MM-DD, inclusive). When any filter is set, paginates up to 5 pages x 100 recordings and returns all matches.`,
+    params: [
+      {
+        name: 'date_from',
+        type: 'string',
+        required: false,
+        description: `Start date, inclusive, in YYYY-MM-DD format. Interpreted in the server's timezone.`,
+      },
+      {
+        name: 'date_to',
+        type: 'string',
+        required: false,
+        description: `End date, inclusive, in YYYY-MM-DD format. Interpreted in the server's timezone.`,
+      },
+      {
+        name: 'page',
+        type: 'integer',
+        required: false,
+        description: `Page number (ignored when filters are set). Defaults to 1.`,
+      },
+      {
+        name: 'page_size',
+        type: 'integer',
+        required: false,
+        description: `Number of recordings to return per page (ignored when filters are set). Defaults to 20.`,
+      },
+      {
+        name: 'query',
+        type: 'string',
+        required: false,
+        description: `Case-insensitive substring match on the recording name.`,
+      },
+    ],
+  },
+]


### PR DESCRIPTION
## Summary

Adds comprehensive documentation and configuration for the Plaud MCP agent connector, enabling users to integrate Plaud recording management into their AI workflows.

## Changes

- **New connector documentation** (`src/content/docs/agentkit/connectors/plaudmcp.mdx`): Complete quickstart guide with OAuth 2.1/DCR setup instructions, capability overview, and links to common workflows
- **Tool definitions** (`src/data/agent-connectors/plaudmcp.ts`): Defined all five Plaud MCP tools with parameter schemas:
  - `plaudmcp_get_current_user` — authenticate and identify the connected account
  - `plaudmcp_list_files` — browse recordings with optional filtering by name and date range
  - `plaudmcp_get_file` — retrieve full recording metadata, transcript segments, notes, and audio URL
  - `plaudmcp_get_note` — fetch AI-generated summary, action items, and key topics
  - `plaudmcp_get_transcript` — paginate through timestamped transcripts with speaker attribution
- **Common workflows section** (`src/components/templates/agent-connectors/_section-after-setup-plaudmcp-common-workflows.mdx`): Four practical examples with Node.js and Python code samples:
  - Find a recording and read its notes
  - Page through a long transcript with cursor pagination
  - Choose the right transcript block (raw, polished, or outline)
  - Get recording metadata and audio
- **Catalog and capabilities registration**: Added Plaud MCP to the connector catalog with OAuth 2.1/DCR auth type and categories (Transcription, Productivity, Media); registered capabilities in `capabilities.json`
- **Component export**: Registered the common workflows section in the templates index for reuse

## Implementation Details

- All code examples follow the repository's multi-language standard (Node.js and Python) with consistent variable naming and error handling patterns
- Transcript pagination and filtering behavior is clearly documented, including the distinction between filtered and unfiltered list modes
- Security warnings included for short-lived audio URLs and pagination cursor handling
- Tool descriptions match the exact parameter names and types to ensure accurate SDK integration

https://claude.ai/code/session_012KZcFuW4oVcZx1k5gFftH1

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/scalekit-inc/codesmith/developer-docs/pr/943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789134726&installation_model_id=431434&pr_number=943&repository=scalekit-inc%2Fdeveloper-docs&return_to=https%3A%2F%2Fgithub.com%2Fscalekit-inc%2Fdeveloper-docs%2Fpull%2F943&signature=ba12c36fd272f72ae2162247df44a7c93bc20686dd827b9dc0670d39b5324f3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Plaud MCP connector support for accessing recordings, AI-generated notes, transcripts, metadata, audio, and connected-account details.
  * Added OAuth 2.1 authorization and SDK setup guidance for Node.js and Python.
  * Added filtering, pagination, and transcript block selection workflows.
  * Added Plaud MCP to the connector catalog with supported capabilities and tool descriptions.
* **Documentation**
  * Added comprehensive setup, authorization, workflow, security, and expiring audio URL guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->