### PR TITLE
fix(agentkit): rebind tool search and page actions after soft navigation

### DIFF
--- a/src/components/ToolList.astro
+++ b/src/components/ToolList.astro
@@ -346,8 +346,11 @@ const { tools } = Astro.props
   // soft nav), guarded on the fresh `.tool-list` element itself rather than
   // a module-level flag — mirrors the pattern in ProviderCatalog.astro.
   function initToolList(): void {
-    const root = document.querySelector<HTMLElement>('.tool-list')
-    if (!root || root.dataset.toolListReady === 'true') return
+    document.querySelectorAll<HTMLElement>('.tool-list').forEach(initToolListRoot)
+  }
+
+  function initToolListRoot(root: HTMLElement): void {
+    if (root.dataset.toolListReady === 'true') return
     root.dataset.toolListReady = 'true'
 
     // Inject tool names into Starlight's right-sidebar TOC

--- a/src/components/ToolList.astro
+++ b/src/components/ToolList.astro
@@ -338,52 +338,92 @@ const { tools } = Astro.props
 </style>
 
 <script>
-  // Inject tool names into Starlight's right-sidebar TOC
-  document.addEventListener('DOMContentLoaded', () => {
+  // Astro's ClientRouter (view transitions) swaps in a fresh <body> on every
+  // soft navigation but only ever runs an inline script's identical
+  // textContent once per session (see swap-functions.js `scriptsAlreadyRan`).
+  // So every piece of setup below is wrapped in an idempotent init function
+  // that reruns on `astro:page-load` (fires on first load AND after every
+  // soft nav), guarded on the fresh `.tool-list` element itself rather than
+  // a module-level flag — mirrors the pattern in ProviderCatalog.astro.
+  function initToolList(): void {
+    const root = document.querySelector<HTMLElement>('.tool-list')
+    if (!root || root.dataset.toolListReady === 'true') return
+    root.dataset.toolListReady = 'true'
+
+    // Inject tool names into Starlight's right-sidebar TOC
     const tocNav = document.querySelector<HTMLElement>('starlight-toc nav > ul')
-    if (!tocNav) return
+    const toolListLink = tocNav
+      ? Array.from(tocNav.querySelectorAll<HTMLAnchorElement>(':scope > li a')).find(
+          (a) => a.getAttribute('href') === '#tool-list',
+        )
+      : undefined
+    const toolListItem = toolListLink?.closest('li')
+    // Guard against the TOC nav itself surviving a swap (unlikely, but keeps
+    // this idempotent even if Starlight ever reuses the sidebar DOM).
+    if (toolListItem && !toolListItem.querySelector('ul')) {
+      const cards = root.querySelectorAll<HTMLElement>('.tool-card[id]')
 
-    const toolListLink = Array.from(
-      tocNav.querySelectorAll<HTMLAnchorElement>(':scope > li a'),
-    ).find((a) => a.getAttribute('href') === '#tool-list')
-    if (!toolListLink) return
-    const toolListItem = toolListLink.closest('li')
-    if (!toolListItem) return
+      if (cards.length) {
+        const nestedUl = document.createElement('ul')
+        nestedUl.style.cssText =
+          'list-style:none;padding-inline-start:1rem;margin:0.25rem 0 0;display:flex;flex-direction:column;gap:0.125rem;'
 
-    const cards = document.querySelectorAll<HTMLElement>('.tool-list .tool-card[id]')
-    if (!cards.length) return
+        cards.forEach((card) => {
+          const name = card.querySelector('.tool-name')?.textContent?.trim() ?? card.id
+          const li = document.createElement('li')
+          const a = document.createElement('a')
+          a.href = `#${card.id}`
+          a.textContent = name
+          a.style.cssText =
+            'font-size:var(--sl-text-xs);font-family:var(--sl-font-system-mono);color:var(--sl-color-gray-2);text-decoration:none;display:block;padding:0.125rem 0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;'
+          a.addEventListener('mouseenter', () => (a.style.color = 'var(--sl-color-text-accent)'))
+          a.addEventListener('mouseleave', () => (a.style.color = 'var(--sl-color-gray-2)'))
+          a.addEventListener('click', (e) => {
+            e.preventDefault()
+            const target = document.getElementById(card.id) as HTMLDetailsElement | null
+            if (target) {
+              target.open = true
+              target.scrollIntoView({ behavior: 'smooth', block: 'start' })
+              history.pushState(null, '', `#${card.id}`)
+            }
+          })
+          li.appendChild(a)
+          nestedUl.appendChild(li)
+        })
 
-    const nestedUl = document.createElement('ul')
-    nestedUl.style.cssText =
-      'list-style:none;padding-inline-start:1rem;margin:0.25rem 0 0;display:flex;flex-direction:column;gap:0.125rem;'
+        toolListItem.appendChild(nestedUl)
+      }
+    }
 
-    cards.forEach((card) => {
-      const name = card.querySelector('.tool-name')?.textContent?.trim() ?? card.id
-      const li = document.createElement('li')
-      const a = document.createElement('a')
-      a.href = `#${card.id}`
-      a.textContent = name
-      a.style.cssText =
-        'font-size:var(--sl-text-xs);font-family:var(--sl-font-system-mono);color:var(--sl-color-gray-2);text-decoration:none;display:block;padding:0.125rem 0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;'
-      a.addEventListener('mouseenter', () => (a.style.color = 'var(--sl-color-text-accent)'))
-      a.addEventListener('mouseleave', () => (a.style.color = 'var(--sl-color-gray-2)'))
-      a.addEventListener('click', (e) => {
-        e.preventDefault()
-        const target = document.getElementById(card.id) as HTMLDetailsElement | null
-        if (target) {
-          target.open = true
-          target.scrollIntoView({ behavior: 'smooth', block: 'start' })
-          history.pushState(null, '', `#${card.id}`)
-        }
+    // Open and scroll to the target tool when navigating directly via URL hash
+    openFromHash()
+
+    // Simple client-side filter for the tool list (name + description)
+    const filterInput = root.querySelector<HTMLInputElement>('.tool-filter-input')
+    if (filterInput) {
+      filterInput.addEventListener('input', () => {
+        const q = filterInput.value.toLowerCase().trim()
+        const cards = root.querySelectorAll<HTMLElement>('.tool-card')
+
+        let visibleCount = 0
+
+        cards.forEach((card) => {
+          const n = card.dataset.toolName || ''
+          const d = card.dataset.toolDesc || ''
+          const show = !q || n.includes(q) || d.includes(q)
+          card.style.display = show ? '' : 'none'
+
+          if (show && q) {
+            if (visibleCount < 3) {
+              ;(card as HTMLDetailsElement).open = true
+            }
+            visibleCount++
+          }
+        })
       })
-      li.appendChild(a)
-      nestedUl.appendChild(li)
-    })
+    }
+  }
 
-    toolListItem.appendChild(nestedUl)
-  })
-
-  // Open and scroll to the target tool when navigating directly via URL hash
   function openFromHash(): void {
     const hash = location.hash.slice(1)
     if (!hash) return
@@ -394,31 +434,11 @@ const { tools } = Astro.props
     }
   }
 
-  openFromHash()
+  // `window` survives soft navigations, so these are registered once at
+  // module scope instead of inside initToolList (which would otherwise
+  // stack a duplicate listener on every navigation).
   window.addEventListener('hashchange', openFromHash)
 
-  // Simple client-side filter for the tool list (name + description)
-  const filterInput = document.querySelector<HTMLInputElement>('.tool-list .tool-filter-input')
-  if (filterInput) {
-    filterInput.addEventListener('input', () => {
-      const q = filterInput.value.toLowerCase().trim()
-      const cards = document.querySelectorAll<HTMLElement>('.tool-list .tool-card')
-
-      let visibleCount = 0
-
-      cards.forEach((card) => {
-        const n = card.dataset.toolName || ''
-        const d = card.dataset.toolDesc || ''
-        const show = !q || n.includes(q) || d.includes(q)
-        card.style.display = show ? '' : 'none'
-
-        if (show && q) {
-          if (visibleCount < 3) {
-            ;(card as HTMLDetailsElement).open = true
-          }
-          visibleCount++
-        }
-      })
-    })
-  }
+  initToolList()
+  document.addEventListener('astro:page-load', initToolList)
 </script>

--- a/src/components/overrides/PageTitle.astro
+++ b/src/components/overrides/PageTitle.astro
@@ -272,6 +272,18 @@ const isConnectorPage = Boolean(connectorIcon)
     })
   })
 
-  initPageActions()
+  // define:vars forces this script to render as a plain synchronous inline
+  // script, which executes immediately while parsing — before the package's
+  // own <script type="module"> control scripts, which are deferred until
+  // after parsing. Calling initPageActions() immediately would clone the
+  // buttons before the package binds anything to strip, so the package's
+  // listener ends up bound to our clone too (double-fires copy/dropdown on
+  // first load). Wait for DOMContentLoaded on first load so the package's
+  // deferred scripts run first — mirrors SecondaryNav.astro.
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initPageActions, { once: true })
+  } else {
+    initPageActions()
+  }
   document.addEventListener('astro:page-load', initPageActions)
 </script>

--- a/src/components/overrides/PageTitle.astro
+++ b/src/components/overrides/PageTitle.astro
@@ -205,31 +205,73 @@ const isConnectorPage = Boolean(connectorIcon)
 </style>
 
 <script define:vars={{ agentPluginHeader: AGENT_PLUGIN_HEADER }}>
-  // Intercept the "Copy Markdown" button from starlight-page-actions to prepend
-  // agent plugin installation instructions before the copied content.
-  const copyBtn = document.querySelector('#copy-markdown')
-  if (copyBtn) {
-    copyBtn.addEventListener(
-      'click',
-      async (e) => {
-        e.stopImmediatePropagation()
-        copyBtn.disabled = true
+  // starlight-page-actions (Button.astro / Dropdown.astro, in node_modules)
+  // binds "Copy Markdown" and both dropdowns at module scope with no
+  // `astro:page-load` hook. Astro's ClientRouter swaps in a fresh <body> on
+  // every soft navigation but never reruns an inline script whose textContent
+  // already ran (see swap-functions.js `scriptsAlreadyRan`), so the package's
+  // own listeners go dead after the first navigation. We can't patch
+  // node_modules, so this override takes ownership of all three controls:
+  // clone each control to strip the package's listeners (a clone carries no
+  // event listeners), then bind our own — no capture-phase interception
+  // needed once we own the element outright. Reruns on `astro:page-load`
+  // (fires on first load AND after every soft nav), guarded per-render on
+  // the fresh `.actions-container` so it never double-binds.
+  function initPageActions() {
+    const container = document.querySelector('.actions-container')
+    if (!container || container.dataset.pageActionsReady === 'true') return
+    container.dataset.pageActionsReady = 'true'
+
+    const copyBtn = container.querySelector('#copy-markdown')
+    if (copyBtn) {
+      const clone = copyBtn.cloneNode(true)
+      copyBtn.replaceWith(clone)
+      clone.addEventListener('click', async () => {
+        clone.disabled = true
         let cls = 'copied'
         try {
-          const agentRes = await fetch(`${copyBtn.dataset.path}.agent.md`)
-          const res = agentRes.ok ? agentRes : await fetch(`${copyBtn.dataset.path}.md`)
+          const agentRes = await fetch(`${clone.dataset.path}.agent.md`)
+          const res = agentRes.ok ? agentRes : await fetch(`${clone.dataset.path}.md`)
           if (!res.ok) throw new Error(`Failed to fetch markdown: ${res.status}`)
           const md = await res.text()
           await navigator.clipboard.writeText(agentPluginHeader + md)
         } catch {
           cls = 'error'
         } finally {
-          copyBtn.classList.add(cls)
-          copyBtn.disabled = false
-          setTimeout(() => copyBtn.classList.remove(cls), 3000)
+          clone.disabled = false
+          clone.classList.add(cls)
+          setTimeout(() => clone.classList.remove(cls), 3000)
         }
-      },
-      true, // capture phase — fires before the package's own listener
-    )
+      })
+    }
+
+    for (const dropdownId of ['dropdown-0', 'dropdown-1']) {
+      const dropdown = container.querySelector(`#${dropdownId}`)
+      const toggle = dropdown?.querySelector('#dropdown-toggle')
+      const menu = dropdown?.querySelector('#dropdown-menu')
+      if (!toggle || !menu) continue
+
+      const toggleClone = toggle.cloneNode(true)
+      toggle.replaceWith(toggleClone)
+      toggleClone.addEventListener('click', (e) => {
+        e.stopPropagation()
+        container.querySelectorAll('#dropdown-menu.show').forEach((m) => m.classList.remove('show'))
+        menu.classList.toggle('show')
+      })
+
+      menu.addEventListener('click', (e) => e.stopPropagation())
+    }
   }
+
+  // `document` survives soft navigations, so the outside-click close is
+  // registered once at module scope instead of inside initPageActions
+  // (which would otherwise stack a duplicate listener per navigation).
+  document.addEventListener('click', () => {
+    document.querySelectorAll('.actions-container #dropdown-menu.show').forEach((m) => {
+      m.classList.remove('show')
+    })
+  })
+
+  initPageActions()
+  document.addEventListener('astro:page-load', initPageActions)
 </script>


### PR DESCRIPTION
## Summary
- Tool search on individual AgentKit connector pages (e.g. `/agentkit/connectors/zendesk/`) stopped working after navigating there via the sidebar/soft nav — the filter input, TOC tool links, and hash deep-links were bound once at page load and never rebound after Astro's ClientRouter swap.
- The "Copy page" button and both "Open in" dropdowns on `/agentkit/connectors/` stopped responding after the first soft navigation, and stayed dead on any other AgentKit page until a hard refresh.
- Root cause: Astro's ClientRouter (view transitions) replaces the `<body>` on soft navigation but does not rerun an inline script whose text content already executed once. Both `ToolList.astro` and `overrides/PageTitle.astro` bound their listeners at module scope with no re-init hook.
- Fix: wrap each script's setup in an idempotent `init()` guarded on the freshly-swapped-in root element, and rerun it on `astro:page-load` — the same pattern already used in `ProviderCatalog.astro`. For the page-actions buttons (whose live listeners come from the `starlight-page-actions` package in `node_modules`), each control is cloned to strip the package's dead listeners before our own handler is rebound.

Fixes Linear 1587 and 1588.

## Test plan
- [ ] From a fresh load, soft-navigate to a connector page (e.g. Zendesk) and confirm the "Filter tools…" box filters the tool list
- [ ] Soft-navigate to a second connector and confirm the filter still works
- [ ] From the connectors overview, search a tool and click a result — confirm it opens and scrolls to the right card on the connector page
- [ ] On `/agentkit/connectors/` click "Copy page" and confirm the clipboard gets the markdown
- [ ] Soft-navigate from `/agentkit/connectors/` to another AgentKit page (e.g. quickstart) and confirm "Copy page" and both dropdowns still work there
- [ ] Open a dropdown, click elsewhere on the page, confirm it closes

Preview: https://deploy-preview-944--scalekit-starlight.netlify.app/agentkit/connectors/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tool list filtering and table-of-contents links now continue working when navigating between pages without a full reload.
  * Prevented duplicate tool entries and repeated controls after page transitions.
  * Copy Markdown actions now remain available across navigation, with reliable success and error feedback.
  * Improved action menus so they open independently, close appropriately, and respond correctly to outside clicks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->