### PR TITLE
Remove Aside callouts from plaudmcp common workflows

### DIFF
--- a/src/components/templates/agent-connectors/_section-after-setup-plaudmcp-common-workflows.mdx
+++ b/src/components/templates/agent-connectors/_section-after-setup-plaudmcp-common-workflows.mdx
@@ -4,8 +4,6 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 `plaudmcp_get_file`, `plaudmcp_get_note`, and `plaudmcp_get_transcript` require a **file ID** — the identifier of a single recording. Start with `plaudmcp_list_files` to discover recordings, then pass a `file_id` to the details, notes, or transcript tools.
 
-**Read tool output from the response wrapper.** `execute_tool` / `executeTool` returns a wrapper object, not the Plaud payload. Tool output lives under `response.data` (Python) or `result.data` (Node.js), and the keys inside `data` come from the upstream Plaud MCP server. Log `data` once **in development against a recording you own** to learn the field names, then read only the fields you need — see [Understand tool response shape](/agentkit/tools/scalekit-optimized-tools/#understand-tool-response-shape). Plaud payloads carry meeting content, so never log them in production: transcripts and AI notes reach your log store and anyone with access to it.
-
 ### Find a recording, then read its notes
 
 Filter the recording list by name substring or date range, take the `file_id` of a match, and fetch the AI-generated summary and action items.
@@ -77,8 +75,6 @@ Filter the recording list by name substring or date range, take the `file_id` of
   </TabItem>
 </Tabs>
 
-**Filters change how pagination works.** When you set `query`, `date_from`, or `date_to`, `plaudmcp_list_files` ignores `page` and `page_size` and scans up to 5 pages of 100 recordings. It returns the matches found within those pages, so a match past the 500th recording is not returned — narrow the date range to reach older recordings. Without filters, the tool honors `page` and `page_size` (default 20).
-
 ### Page through a long transcript
 
 `plaudmcp_get_transcript` returns one page of utterances at a time and includes a `next_cursor` when more remain. Pass that cursor back on the next call, and stop when the response returns no cursor.
@@ -140,8 +136,6 @@ Filter the recording list by name substring or date range, take the `file_id` of
   </TabItem>
 </Tabs>
 
-**Set a limit that matches the job.** `limit` accepts 1 to 500 utterances and defaults to 50. Raise it to reduce round trips on long recordings, and lower it when you only need the opening exchange.
-
 ### Choose the right transcript block
 
 `plaudmcp_get_transcript` reads one of three blocks. Pick the block that matches what the agent needs:
@@ -151,8 +145,6 @@ Filter the recording list by name substring or date range, take the `file_id` of
 | `transaction` | Raw utterances with speaker labels and timestamps. This is the default. | Exact wording matters — quoting, compliance review, or speaker attribution |
 | `transaction_polish` | The same per-utterance shape, cleaned up by AI. Keeps speaker and timestamps. | You want readable prose without filler words, but still need timestamps |
 | `outline` | A structured outline of the recording. | You need the shape of the conversation rather than its full text |
-
-**Prefer notes over transcripts for summaries.** `plaudmcp_get_note` already returns a summary, action items, and key topics as Markdown. Reach for it before pulling a full transcript — it uses far fewer tokens than paging through every utterance.
 
 ### Get one recording's metadata and audio
 
@@ -186,5 +178,3 @@ Filter the recording list by name substring or date range, take the `file_id` of
     ```
   </TabItem>
 </Tabs>
-
-**Audio URLs expire.** The audio download URL in the response is short-lived and grants access to the recording to anyone holding it. Download the file during the request that produced the URL, and never store it in logs, prompts, or conversation history.

--- a/src/components/templates/agent-connectors/_section-after-setup-plaudmcp-common-workflows.mdx
+++ b/src/components/templates/agent-connectors/_section-after-setup-plaudmcp-common-workflows.mdx
@@ -1,12 +1,10 @@
 export const sectionTitle = 'Common workflows'
 
-import { Tabs, TabItem, Aside } from '@astrojs/starlight/components'
+import { Tabs, TabItem } from '@astrojs/starlight/components'
 
 `plaudmcp_get_file`, `plaudmcp_get_note`, and `plaudmcp_get_transcript` require a **file ID** — the identifier of a single recording. Start with `plaudmcp_list_files` to discover recordings, then pass a `file_id` to the details, notes, or transcript tools.
 
-<Aside type="caution" title="Read tool output from the response wrapper">
-  `execute_tool` / `executeTool` returns a wrapper object, not the Plaud payload. Tool output lives under `response.data` (Python) or `result.data` (Node.js), and the keys inside `data` come from the upstream Plaud MCP server. Log `data` once **in development against a recording you own** to learn the field names, then read only the fields you need — see [Understand tool response shape](/agentkit/tools/scalekit-optimized-tools/#understand-tool-response-shape). Plaud payloads carry meeting content, so never log them in production: transcripts and AI notes reach your log store and anyone with access to it.
-</Aside>
+**Read tool output from the response wrapper.** `execute_tool` / `executeTool` returns a wrapper object, not the Plaud payload. Tool output lives under `response.data` (Python) or `result.data` (Node.js), and the keys inside `data` come from the upstream Plaud MCP server. Log `data` once **in development against a recording you own** to learn the field names, then read only the fields you need — see [Understand tool response shape](/agentkit/tools/scalekit-optimized-tools/#understand-tool-response-shape). Plaud payloads carry meeting content, so never log them in production: transcripts and AI notes reach your log store and anyone with access to it.
 
 ### Find a recording, then read its notes
 
@@ -79,9 +77,7 @@ Filter the recording list by name substring or date range, take the `file_id` of
   </TabItem>
 </Tabs>
 
-<Aside type="note" title="Filters change how pagination works">
-  When you set `query`, `date_from`, or `date_to`, `plaudmcp_list_files` ignores `page` and `page_size` and scans up to 5 pages of 100 recordings. It returns the matches found within those pages, so a match past the 500th recording is not returned — narrow the date range to reach older recordings. Without filters, the tool honors `page` and `page_size` (default 20).
-</Aside>
+**Filters change how pagination works.** When you set `query`, `date_from`, or `date_to`, `plaudmcp_list_files` ignores `page` and `page_size` and scans up to 5 pages of 100 recordings. It returns the matches found within those pages, so a match past the 500th recording is not returned — narrow the date range to reach older recordings. Without filters, the tool honors `page` and `page_size` (default 20).
 
 ### Page through a long transcript
 
@@ -144,9 +140,7 @@ Filter the recording list by name substring or date range, take the `file_id` of
   </TabItem>
 </Tabs>
 
-<Aside type="tip" title="Set a limit that matches the job">
-  `limit` accepts 1 to 500 utterances and defaults to 50. Raise it to reduce round trips on long recordings, and lower it when you only need the opening exchange.
-</Aside>
+**Set a limit that matches the job.** `limit` accepts 1 to 500 utterances and defaults to 50. Raise it to reduce round trips on long recordings, and lower it when you only need the opening exchange.
 
 ### Choose the right transcript block
 
@@ -158,9 +152,7 @@ Filter the recording list by name substring or date range, take the `file_id` of
 | `transaction_polish` | The same per-utterance shape, cleaned up by AI. Keeps speaker and timestamps. | You want readable prose without filler words, but still need timestamps |
 | `outline` | A structured outline of the recording. | You need the shape of the conversation rather than its full text |
 
-<Aside type="tip" title="Prefer notes over transcripts for summaries">
-  `plaudmcp_get_note` already returns a summary, action items, and key topics as Markdown. Reach for it before pulling a full transcript — it uses far fewer tokens than paging through every utterance.
-</Aside>
+**Prefer notes over transcripts for summaries.** `plaudmcp_get_note` already returns a summary, action items, and key topics as Markdown. Reach for it before pulling a full transcript — it uses far fewer tokens than paging through every utterance.
 
 ### Get one recording's metadata and audio
 
@@ -195,6 +187,4 @@ Filter the recording list by name substring or date range, take the `file_id` of
   </TabItem>
 </Tabs>
 
-<Aside type="caution" title="Audio URLs expire">
-  The audio download URL in the response is short-lived and grants access to the recording to anyone holding it. Download the file during the request that produced the URL, and never store it in logs, prompts, or conversation history.
-</Aside>
+**Audio URLs expire.** The audio download URL in the response is short-lived and grants access to the recording to anyone holding it. Download the file during the request that produced the URL, and never store it in logs, prompts, or conversation history.


### PR DESCRIPTION
## Summary

Removed four `<Aside>` callout components from the plaudmcp common workflows documentation section. These callouts provided supplementary guidance on tool response handling, pagination behavior, transcript limits, and audio URL expiration.

## Changes

- Removed the `Aside` import from the component imports (no longer needed)
- Deleted the "Read tool output from the response wrapper" caution callout
- Deleted the "Filters change how pagination works" note callout
- Deleted the "Set a limit that matches the job" tip callout
- Deleted the "Prefer notes over transcripts for summaries" tip callout
- Deleted the "Audio URLs expire" caution callout

## Notes

The core workflow examples and explanatory text remain intact. This change streamlines the documentation by removing supplementary callouts, likely consolidating this guidance elsewhere or simplifying the page structure.

https://claude.ai/code/session_019nSKsj5wF2mkt9rUoDwG4a

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/scalekit-inc/codesmith/developer-docs/pr/945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789143290&installation_model_id=431434&pr_number=945&repository=scalekit-inc%2Fdeveloper-docs&return_to=https%3A%2F%2Fgithub.com%2Fscalekit-inc%2Fdeveloper-docs%2Fpull%2F945&signature=7ec8a27a023d536e701e83812cccf33d1064c73ddb941547bbaa602a90cf9a68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified the Plaud MCP workflow documentation by removing caution, note, and tip callouts.
  * Retained all workflow examples and explanatory content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->