### PR TITLE
fix(auth): send POST with an explicit body on every /auth/refresh call

### DIFF
--- a/netlify/edge-functions/serve-markdown.ts
+++ b/netlify/edge-functions/serve-markdown.ts
@@ -165,6 +165,10 @@ export const config: Config = {
     '/images/*',
     '/fonts/*',
     '/favicon*',
+    // Auth routes serve JSON, never HTML→markdown, and the local edge proxy
+    // mishandles their empty-body POSTs. `/api/*` needs no entry — the handler
+    // only rewrites `text/html` responses, so spec files pass straight through.
+    '/auth/*',
     '/*.js',
     '/*.css',
     '/*.json',

--- a/netlify/edge-functions/track-agents.ts
+++ b/netlify/edge-functions/track-agents.ts
@@ -38,6 +38,11 @@ export const config = {
     '/fonts/*',
     '/favicon*',
     '/og/*',
+    // Auth routes only: the local Netlify edge proxy mishandles empty-body POSTs
+    // (e.g. /auth/refresh) and surfaces TypeError: fetch failed as unhandled rejections.
+    // `/api/*` stays tracked — agents fetch the OpenAPI specs under it, which is
+    // exactly the traffic this function exists to measure.
+    '/auth/*',
     '/*.js',
     '/*.css',
     '/*.png',

--- a/src/components/auth/AuthCTA.astro
+++ b/src/components/auth/AuthCTA.astro
@@ -119,6 +119,8 @@ const loginHref = '/auth/login'
         const refreshResponse = await fetch('/auth/refresh', {
           method: 'POST',
           credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: '{}',
         })
         if (refreshResponse.ok) {
           response = await fetch('/auth/session', { credentials: 'include' })

--- a/src/components/auth/AuthValue.astro
+++ b/src/components/auth/AuthValue.astro
@@ -47,7 +47,12 @@ const { path = '' } = Astro.props
 
       // Handle 401 by attempting token refresh
       if (response.status === 401) {
-        const refreshResponse = await fetch('/auth/refresh', { credentials: 'include' })
+        const refreshResponse = await fetch('/auth/refresh', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: '{}',
+        })
 
         if (!refreshResponse.ok) {
           clearCache()

--- a/src/utils/auth/session-client.ts
+++ b/src/utils/auth/session-client.ts
@@ -57,6 +57,8 @@ export const getSession = async (): Promise<AuthSession> => {
       const refreshResponse = await fetch('/auth/refresh', {
         method: 'POST',
         credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
       })
 
       if (refreshResponse.ok) {


### PR DESCRIPTION
## Summary

Splits an auth fix out of the #946 cookbook-sidebar prototype so it can ship on its own merits, independent of whether that prototype lands.

`/auth/refresh` exports only a `POST` handler. `AuthValue.astro` called it with a default `GET`, so its refresh path could never succeed — an expired session made the component fall back to unauthenticated instead of recovering.

Separately, the two callers that already used `POST` sent no body. The local Netlify edge proxy mishandles empty-body POSTs and surfaces `TypeError: fetch failed` as an unhandled rejection on every page load's session probe.

## Changes

| File | Change |
| --- | --- |
| `AuthValue.astro` | Add the missing `method: 'POST'` |
| `AuthCTA.astro`, `session-client.ts` | Send an explicit `{}` body with a JSON content type |
| `serve-markdown.ts`, `track-agents.ts` | Exclude `/auth/*` from edge functions |

The edge-function exclusion is deliberately narrow. `/api/*` stays covered, because agents fetch the OpenAPI specs under it and that is exactly the traffic `track-agents` exists to measure.

## Test plan

- [x] Confirmed `src/pages/auth/refresh.ts` exports `POST` only, so the `GET` call in `AuthValue.astro` could never have worked
- [x] Prettier clean on all five files
- [ ] Deploy preview: no `TypeError: fetch failed` in function logs on page load
- [ ] Deploy preview: signed-in state survives an access-token expiry on a page using `AuthValue`

Preview: https://deploy-preview-947--scalekit-starlight.netlify.app/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication token refresh requests for more reliable session renewal.
  - Updated refresh requests to use the expected JSON format.
  - Prevented authentication routes from being processed by unrelated page transformation and tracking handlers.
  - Continued tracking applicable API requests while excluding authentication traffic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->