### PR TITLE
Open docs in Claude Code instead of claude.ai

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -130,8 +130,20 @@ export default defineConfig({
           actions: {
             markdown: true,
             chatgpt: false,
-            claude: true,
+            // Built-in `claude` opens claude.ai. Claude Code uses custom
+            // schemes the plugin does not know about:
+            //   terminal: claude-cli://open?q=
+            //   VS Code tab: vscode://anthropic.claude-code/open?prompt=
+            claude: false,
             custom: {
+              claudeCode: {
+                label: 'Open in Claude Code',
+                href: 'claude-cli://open?q=',
+              },
+              claudeCodeVsCode: {
+                label: 'Open in VS Code',
+                href: 'vscode://anthropic.claude-code/open?prompt=',
+              },
               cursor: {
                 label: 'Open in Cursor',
                 href: 'https://cursor.com/link/prompt?text=',

--- a/src/configs/agent-instructions.ts
+++ b/src/configs/agent-instructions.ts
@@ -23,7 +23,7 @@ Full guide: https://docs.scalekit.com/dev-kit/build-with-ai/ -->
 
 `
 
-/** Plain-text block for the page-actions prompt (injected into "Open in Claude/Cursor" messages). */
+/** Plain-text install block. Not used by the Open-in-agent deep-link prompt (that lives in page-actions.config.ts). */
 export const AGENT_PLUGIN_INLINE = `Building with AI coding agents?
 Install the authstack plugin with one command:
 

--- a/src/configs/page-actions.config.ts
+++ b/src/configs/page-actions.config.ts
@@ -1,23 +1,11 @@
-import { AGENT_PLUGIN_INLINE } from './agent-instructions'
-
 /**
- * Prompt used when opening documentation pages in coding agents (ChatGPT, Claude, Cursor).
- * The {url} placeholder is replaced with the current page URL by starlight-page-actions.
- * Note: The plugin replaces only the first {url} occurrence, so we use it once.
+ * Prompt stuffed into Open-in-agent deep links (Claude Code `q=`,
+ * VS Code Claude Code `prompt=`, Cursor `text=`).
+ * starlight-page-actions replaces only the first `{url}` — use it once.
+ * Keep this short: Claude Code warns on prompts over 1,000 characters and caps `q` at 5,000.
  */
-export const pageActionsPrompt = `You are an expert technical assistant implementing Scalekit authentication.
+export const pageActionsPrompt = `Implement this Scalekit documentation in the current repository: {url}
 
-${AGENT_PLUGIN_INLINE}
-
-Your task with the documentation at {url}:
-1. Read and deeply analyze the content at that URL.
-2. Build a mental model of: the main concepts, key terminology, structure, and any code examples present.
-3. Enter Q&A mode — wait for my questions and answer them based ONLY on the content at that URL.
-
-Rules:
-- If I ask something not covered in the doc, say so explicitly instead of guessing.
-- Cite the specific section or heading your answer comes from.
-- Keep answers concise unless I ask you to elaborate.
-- If a question requires code, mirror the style and language shown in the doc.
-
-Ready?`
+1. Fetch the page (try the same path with .md if the HTML is noisy). Done when you can state the page's outcome and the steps it requires.
+2. Load Scalekit skills. If none are available, run \`npx @scalekit-inc/cli setup\`. Done when a Scalekit skill matches the page's product (agent-auth, full-stack-auth, mcp-auth, modular-sso, or modular-scim).
+3. Apply those steps to this repo. Use the page as the source of truth and match its code style and SDK names. Done when the page's verify step succeeds, or you name the first blocker only the developer can resolve (credentials, a dashboard click, or a missing app).`


### PR DESCRIPTION
## Summary
Replace the Open dropdown's **Open in Claude** (claude.ai web chat) with Claude Code, and keep Cursor.

- **Open in Claude Code** → `claude-cli://open?q=` (terminal; last interactive Claude Code session)
- **Open in VS Code** → `vscode://anthropic.claude-code/open?prompt=` (Claude Code editor tab)
- **Open in Cursor** → `https://cursor.com/link/prompt?text=` (custom `text=` so the prompt is not dropped)

The stuffed prompt asks the agent to implement the current docs page in the visitor's repository: fetch the page, load Scalekit skills (`npx @scalekit-inc/cli setup` if missing), then apply the page's steps.

Built-in `claude: true` stays off because it hardcodes `https://claude.ai/new?q=`.

## Preview
https://deploy-preview-950--scalekit-starlight.netlify.app/authenticate/fsa/quickstart/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added page actions for opening prompts directly in Claude Code and VS Code.
  - Retained the existing Cursor action.
  - Disabled the built-in Claude action in favor of the new Claude Code option.
  - Updated page action prompts to guide agents through implementing documented steps and verifying results.

- **Documentation**
  - Clarified guidance for using open-in-agent deep links and installation instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->